### PR TITLE
Disable email confirmation for LAN deployment

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,8 +12,12 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+// Configure Identity without requiring confirmed accounts or external email services
+builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
     .AddEntityFrameworkStores<ApplicationDbContext>();
+
+// Register a no-op email sender to satisfy Identity's IEmailSender dependency
+builder.Services.AddSingleton<IEmailSender, NoOpEmailSender>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();

--- a/Services/NoOpEmailSender.cs
+++ b/Services/NoOpEmailSender.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Identity.UI.Services;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services
+{
+    public class NoOpEmailSender : IEmailSender
+    {
+        public Task SendEmailAsync(string email, string subject, string htmlMessage)
+        {
+            // Email sending disabled for private LAN; no operation performed.
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Allow users to register and sign in without email confirmation
- Add no-op email sender to avoid external email dependencies

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a80809c8329b9ad60aa22f2866c