### PR TITLE
Allow username-based signup and enable EF migrations

### DIFF
--- a/Data/DesignTimeDbContextFactory.cs
+++ b/Data/DesignTimeDbContextFactory.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
+
+namespace ProjectManagement.Data
+{
+    // Provides a design-time DbContext factory so that `dotnet ef` can create
+    // the ApplicationDbContext without relying on the full host configuration.
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile("appsettings.Development.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("DefaultConnection")
+                                  ?? Environment.GetEnvironmentVariable("DefaultConnection");
+
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+            }
+
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            optionsBuilder.UseNpgsql(connectionString);
+
+            return new ApplicationDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -23,12 +23,13 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 AppContext.SetSwitch("Npgsql.DisableDateTimeInfinityConversions", true);
 
-// ---------- Identity (email confirmation, stricter passwords) ----------
+// ---------- Identity (username/password without email confirmation) ----------
 builder.Services
     .AddDefaultIdentity<IdentityUser>(options =>
     {
-        options.SignIn.RequireConfirmedAccount = true;
-        options.User.RequireUniqueEmail = true;
+        // Use simple username/password sign-up without email confirmation.
+        options.SignIn.RequireConfirmedAccount = false;
+        options.User.RequireUniqueEmail = false;
         options.Password.RequireDigit = true;
         options.Password.RequireNonAlphanumeric = true;
         options.Password.RequireUppercase = true;

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=ProjectManagement;Username=postgres;Password=postgres"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- disable email confirmation and unique email requirements for Identity
- add connection string to configuration
- introduce design-time ApplicationDbContext factory for EF tools

## Testing
- `dotnet ef migrations list`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc80e6bc5c832998acdf3691eb15c3