### PR TITLE
Handle connection string environment variable

### DIFF
--- a/Data/DesignTimeDbContextFactory.cs
+++ b/Data/DesignTimeDbContextFactory.cs
@@ -20,6 +20,7 @@ namespace ProjectManagement.Data
                 .Build();
 
             var connectionString = configuration.GetConnectionString("DefaultConnection")
+                                  ?? Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
                                   ?? Environment.GetEnvironmentVariable("DefaultConnection");
 
             if (string.IsNullOrWhiteSpace(connectionString))

--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,8 @@ var builder = WebApplication.CreateBuilder(args);
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 if (string.IsNullOrWhiteSpace(connectionString))
 {
-    connectionString = Environment.GetEnvironmentVariable("DefaultConnection")
+    connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+        ?? Environment.GetEnvironmentVariable("DefaultConnection")
         ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 }
 


### PR DESCRIPTION
## Summary
- broaden connection string lookup to include `ConnectionStrings__DefaultConnection`
- keep Identity migrations functional when only env vars are present

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc835fe7208329b696c9ddabe44f01