### PR TITLE
Enable client validation and improve UI feedback

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -3,6 +3,10 @@
 <h3>Create user</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
+    <div class="visually-hidden" aria-live="polite">
+      <span asp-validation-summary="ModelOnly"></span>
+    </div>
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label asp-for="Input.UserName" class="form-label"></label>
       <input asp-for="Input.UserName" class="form-control" maxlength="32" pattern="^[a-zA-Z0-9_.-]+$" autocomplete="username" />
@@ -11,6 +15,7 @@
     <div class="mb-3">
       <label asp-for="Input.Password" class="form-label"></label>
       <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+      <span class="form-text pm-field-hint">Minimum 8 characters. No special rules enforced.</span>
       <span class="form-text pm-field-hint">Share this with the user. They will be forced to change it.</span>
       <span asp-validation-for="Input.Password" class="text-danger"></span>
     </div>
@@ -23,5 +28,3 @@
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
-
-@section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Areas/Admin/Pages/Users/Edit.cshtml
+++ b/Areas/Admin/Pages/Users/Edit.cshtml
@@ -4,6 +4,10 @@
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
     <input type="hidden" asp-for="Input.Id" />
+    <div class="visually-hidden" aria-live="polite">
+      <span asp-validation-summary="ModelOnly"></span>
+    </div>
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label asp-for="Input.Role" class="form-label"></label>
       <select asp-for="Input.Role" asp-items="new SelectList(Model.Roles)" class="form-select"></select>
@@ -17,5 +21,3 @@
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
-
-@section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -3,14 +3,17 @@
 <h3>Reset password</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
+    <div class="visually-hidden" aria-live="polite">
+      <span asp-validation-summary="ModelOnly"></span>
+    </div>
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label class="form-label">New password</label>
       <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
+      <span class="form-text pm-field-hint">Minimum 8 characters. No special rules enforced.</span>
       <span asp-validation-for="NewPassword" class="text-danger"></span>
     </div>
     <button class="btn btn-danger" type="submit">Reset</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
-
-@section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Areas/Identity/Pages/Account/Login.cshtml
@@ -6,6 +6,10 @@
 <h1>@ViewData["Title"]</h1>
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
+    <div class="visually-hidden" aria-live="polite">
+      <span asp-validation-summary="ModelOnly"></span>
+    </div>
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label asp-for="Input.UserName" class="form-label"></label>
       <input asp-for="Input.UserName" class="form-control" autocomplete="username" />
@@ -23,5 +27,3 @@
     <button type="submit" class="btn pm-btn-primary">Log in</button>
   </form>
 </div>
-
-@section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -6,6 +6,10 @@
 <h3>@ViewData["Title"]</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
+    <div class="visually-hidden" aria-live="polite">
+      <span asp-validation-summary="ModelOnly"></span>
+    </div>
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label asp-for="Input.OldPassword" class="form-label"></label>
       <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
@@ -24,5 +28,3 @@
     <button type="submit" class="btn pm-btn-primary">Change password</button>
   </form>
 </div>
-
-@section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -36,8 +36,18 @@
         </nav>
     </header>
     <div class="container">
-        @if (TempData["ok"] is string ok) { <div class="alert alert-success">@ok</div> }
-        @if (TempData["err"] is string err) { <div class="alert alert-danger">@err</div> }
+        @if (TempData["ok"] is string ok) {
+          <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @ok
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        }
+        @if (TempData["err"] is string err) {
+          <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @err
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+          </div>
+        }
         <main role="main" class="pb-3">
             @RenderBody()
         </main>
@@ -53,6 +63,7 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
 
+    <partial name="_ValidationScriptsPartial" />
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/Program.cs
+++ b/Program.cs
@@ -71,6 +71,10 @@ builder.Services.AddRazorPages(options =>
 {
     options.Conventions.AuthorizeFolder("/");
 })
+    .AddViewOptions(options =>
+    {
+        options.HtmlHelperOptions.ClientValidationEnabled = true;
+    })
     .AddMvcOptions(o => o.Filters.Add<EnforcePasswordChangeFilter>());
 
 var app = builder.Build();

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -28,5 +28,9 @@ body {
 body{background:var(--pm-bg);color:var(--pm-text)}
 .pm-card{background:var(--pm-card);border:1px solid var(--pm-border);border-radius:var(--pm-radius)}
 .pm-shadow{box-shadow:0 10px 24px rgba(0,0,0,.08)}
-.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent)}
+.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent);color:#fff}
+.pm-btn-primary:hover,
+.pm-btn-primary:focus{filter:brightness(.95);color:#fff}
+.pm-btn-primary:disabled{opacity:.65;color:#fff}
 .pm-field-hint{color:var(--pm-muted);font-size:.85rem}
+


### PR DESCRIPTION
## Summary
- Globally load validation scripts and enable client-side validation
- Show validation summaries and password hints across login and user pages
- Improve primary button contrast and display temp-data alerts with dismissible Bootstrap styling

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bcfe13c6848329a3024eada898d408