### PR TITLE
Hide admin nav link for non-admin users

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -24,11 +24,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                         </li>
-                        <authorize roles="Admin">
+                        @if (User.IsInRole("Admin"))
+                        {
                           <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="Admin" asp-page="/Index">Admin</a>
                           </li>
-                        </authorize>
+                        }
                     </ul>
                     <partial name="_LoginPartial" />
                 </div>


### PR DESCRIPTION
## Summary
- limit display of Admin nav item to users in the Admin role

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd0586b9288329899576ab745f2a64