### PR TITLE
Enable multi-role user management

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -1,30 +1,40 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Users.CreateModel
-<h3>Create user</h3>
+@{
+    ViewData["Title"] = "Create user";
+}
 <div class="pm-card pm-shadow p-4 p-md-5">
+  <h3 class="mb-4">Create user</h3>
+
   <form method="post">
-    <div class="visually-hidden" aria-live="polite">
-      <span asp-validation-summary="ModelOnly"></span>
-    </div>
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
     <div class="mb-3">
       <label asp-for="Input.UserName" class="form-label"></label>
-      <input asp-for="Input.UserName" class="form-control" maxlength="32" pattern="^[a-zA-Z0-9_.-]+$" autocomplete="username" />
+      <input asp-for="Input.UserName" class="form-control"
+             maxlength="32" pattern="^[a-zA-Z0-9_.-]+$" autocomplete="username" />
       <span asp-validation-for="Input.UserName" class="text-danger"></span>
     </div>
+
     <div class="mb-3">
       <label asp-for="Input.Password" class="form-label"></label>
       <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
-      <span class="form-text pm-field-hint">Minimum 8 characters. No special rules enforced.</span>
-      <span class="form-text pm-field-hint">Share this with the user. They will be forced to change it.</span>
+      <span class="form-text pm-field-hint">Minimum 8 characters. The user will be forced to change it at first login.</span>
       <span asp-validation-for="Input.Password" class="text-danger"></span>
     </div>
+
     <div class="mb-3">
-      <label asp-for="Input.Role" class="form-label"></label>
-      <select asp-for="Input.Role" asp-items="new SelectList(Model.Roles)" class="form-select"></select>
-      <span asp-validation-for="Input.Role" class="text-danger"></span>
+      <label asp-for="Input.Roles" class="form-label"></label>
+      <select asp-for="Input.Roles"
+              asp-items="new MultiSelectList(Model.Roles)"
+              class="form-select" multiple size="4"></select>
+      <span asp-validation-for="Input.Roles" class="text-danger"></span>
     </div>
-    <button class="btn pm-btn-primary" type="submit">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+
+    <div class="d-flex gap-2">
+      <button class="btn pm-btn-primary" type="submit">Create</button>
+      <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    </div>
   </form>
 </div>
+

--- a/Areas/Admin/Pages/Users/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Create.cshtml.cs
@@ -1,8 +1,9 @@
-using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
@@ -10,45 +11,43 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     [Authorize(Roles = "Admin")]
     public class CreateModel : PageModel
     {
-        private readonly IUserManagementService _userService;
-        public CreateModel(IUserManagementService userService) => _userService = userService;
+        private readonly IUserManagementService _users;
 
-        public IList<string> Roles { get; private set; } = new List<string>();
+        public CreateModel(IUserManagementService users) => _users = users;
 
         [BindProperty] public InputModel Input { get; set; } = new();
+        public IList<string> Roles { get; private set; } = new List<string>();
 
         public class InputModel
         {
-            [Required, StringLength(32, MinimumLength = 3)]
+            [Required, Display(Name = "Username")]
+            [StringLength(32, MinimumLength = 3)]
             [RegularExpression(@"^[a-zA-Z0-9_.-]+$", ErrorMessage = "Only letters, numbers, dot, underscore and hyphen.")]
             public string UserName { get; set; } = string.Empty;
 
-            [Required, StringLength(100, MinimumLength = 8)]
-            [DataType(DataType.Password)]
+            [Required, DataType(DataType.Password)]
+            [StringLength(100, MinimumLength = 8)]
             public string Password { get; set; } = "ChangeMe!123";
 
-            [Required]
-            public string Role { get; set; } = string.Empty;
+            [Required, Display(Name = "Roles")]
+            public List<string> Roles { get; set; } = new();
         }
 
-        public async Task OnGetAsync()
-        {
-            Roles = await _userService.GetRolesAsync();
-        }
+        public async Task OnGetAsync() => Roles = await _users.GetRolesAsync();
 
         public async Task<IActionResult> OnPostAsync()
         {
-            Roles = await _userService.GetRolesAsync();
+            Roles = await _users.GetRolesAsync();
             if (!ModelState.IsValid) return Page();
 
-            var result = await _userService.CreateUserAsync(Input.UserName, Input.Password, Input.Role);
-            if (result.Succeeded)
+            var res = await _users.CreateUserAsync(Input.UserName, Input.Password, Input.Roles);
+            if (res.Succeeded)
             {
                 TempData["ok"] = "User created.";
                 return RedirectToPage("Index");
             }
 
-            foreach (var e in result.Errors) ModelState.AddModelError(string.Empty, e.Description);
+            foreach (var e in res.Errors) ModelState.AddModelError(string.Empty, e.Description);
             return Page();
         }
     }

--- a/Areas/Admin/Pages/Users/Edit.cshtml
+++ b/Areas/Admin/Pages/Users/Edit.cshtml
@@ -1,23 +1,32 @@
 @page "{id}"
 @model ProjectManagement.Areas.Admin.Pages.Users.EditModel
-<h3>Edit user</h3>
+@{
+    ViewData["Title"] = "Edit user";
+}
 <div class="pm-card pm-shadow p-4 p-md-5">
+  <h3 class="mb-4">Edit user @Model.UserName</h3>
+
   <form method="post">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <input type="hidden" asp-for="Input.Id" />
-    <div class="visually-hidden" aria-live="polite">
-      <span asp-validation-summary="ModelOnly"></span>
-    </div>
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
     <div class="mb-3">
-      <label asp-for="Input.Role" class="form-label"></label>
-      <select asp-for="Input.Role" asp-items="new SelectList(Model.Roles)" class="form-select"></select>
-      <span asp-validation-for="Input.Role" class="text-danger"></span>
+      <label asp-for="Input.Roles" class="form-label"></label>
+      <select asp-for="Input.Roles"
+              asp-items="new MultiSelectList(Model.Roles, Model.Input.Roles)"
+              class="form-select" multiple size="4"></select>
+      <span asp-validation-for="Input.Roles" class="text-danger"></span>
     </div>
+
     <div class="form-check mb-3">
-      <input asp-for="Input.IsActive" class="form-check-input" />
-      <label asp-for="Input.IsActive" class="form-check-label">Active</label>
+      <input class="form-check-input" type="checkbox" asp-for="Input.IsActive" id="isActiveChk" />
+      <label class="form-check-label" for="isActiveChk">Active</label>
     </div>
-    <button class="btn pm-btn-primary" type="submit">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+
+    <div class="d-flex gap-2">
+      <button class="btn pm-btn-primary" type="submit">Save</button>
+      <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    </div>
   </form>
 </div>
+

--- a/Areas/Admin/Pages/Users/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Edit.cshtml.cs
@@ -1,10 +1,11 @@
 using System;
-using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
@@ -12,53 +13,59 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     [Authorize(Roles = "Admin")]
     public class EditModel : PageModel
     {
-        private readonly IUserManagementService _userService;
-        public EditModel(IUserManagementService userService) => _userService = userService;
+        private readonly IUserManagementService _users;
 
+        public EditModel(IUserManagementService users) => _users = users;
+
+        [BindProperty] public InputModel Input { get; set; } = new();
         public IList<string> Roles { get; private set; } = new List<string>();
-
-        [BindProperty]
-        public InputModel Input { get; set; } = new();
+        public string? UserName { get; private set; }
 
         public class InputModel
         {
-            public string Id { get; set; } = string.Empty;
-            [Required]
-            public string Role { get; set; } = string.Empty;
+            [Required] public string Id { get; set; } = string.Empty;
+
+            [Required, Display(Name = "Roles")]
+            public List<string> Roles { get; set; } = new();
+
+            [Display(Name = "Active")]
             public bool IsActive { get; set; }
         }
 
         public async Task<IActionResult> OnGetAsync(string id)
         {
-            var user = await _userService.GetUserByIdAsync(id);
+            var user = await _users.GetUserByIdAsync(id);
             if (user == null) return NotFound();
 
-            Roles = await _userService.GetRolesAsync();
-            var userRoles = await _userService.GetUserRolesAsync(id);
+            Roles = await _users.GetRolesAsync();
+            var userRoles = await _users.GetUserRolesAsync(id);
+
             Input = new InputModel
             {
                 Id = id,
-                Role = userRoles.FirstOrDefault() ?? string.Empty,
+                Roles = userRoles.ToList(),
                 IsActive = !user.LockoutEnd.HasValue || user.LockoutEnd <= DateTimeOffset.UtcNow
             };
+            UserName = user.UserName;
             return Page();
         }
 
         public async Task<IActionResult> OnPostAsync()
         {
-            Roles = await _userService.GetRolesAsync();
+            Roles = await _users.GetRolesAsync();
             if (!ModelState.IsValid) return Page();
 
-            var result = await _userService.UpdateUserRoleAsync(Input.Id, Input.Role);
-            if (result.Succeeded)
+            var rolesRes = await _users.UpdateUserRolesAsync(Input.Id, Input.Roles);
+            if (!rolesRes.Succeeded)
             {
-                await _userService.ToggleUserActivationAsync(Input.Id, Input.IsActive);
-                TempData["ok"] = "User updated.";
-                return RedirectToPage("Index");
+                foreach (var e in rolesRes.Errors) ModelState.AddModelError(string.Empty, e.Description);
+                return Page();
             }
 
-            foreach (var e in result.Errors) ModelState.AddModelError(string.Empty, e.Description);
-            return Page();
+            await _users.ToggleUserActivationAsync(Input.Id, Input.IsActive);
+
+            TempData["ok"] = "User updated.";
+            return RedirectToPage("Index");
         }
     }
 }

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -5,16 +5,16 @@
 <table class="table table-sm">
   <thead><tr><th>UserName</th><th>Roles</th><th>Status</th><th>Actions</th></tr></thead>
   <tbody>
-  @foreach (var u in Model.Users)
+  @foreach (var row in Model.Users)
   {
     <tr>
-      <td>@u.UserName</td>
-      <td>@u.Roles</td>
-      <td>@(u.IsActive ? "Active" : "Disabled")</td>
+      <td>@row.UserName</td>
+      <td>@row.Roles</td>
+      <td>@(row.IsActive ? "Active" : "Disabled")</td>
       <td>
-        <a asp-page="Edit" asp-route-id="@u.Id">Edit</a> |
-        <a asp-page="Reset" asp-route-id="@u.Id">Reset password</a> |
-        <a asp-page="Delete" asp-route-id="@u.Id">Delete</a>
+        <a asp-page="Edit" asp-route-id="@row.Id">Edit</a> |
+        <a asp-page="Reset" asp-route-id="@row.Id">Reset password</a> |
+        <a asp-page="Delete" asp-route-id="@row.Id">Delete</a>
       </td>
     </tr>
   }

--- a/Services/IUserManagementService.cs
+++ b/Services/IUserManagementService.cs
@@ -9,8 +9,10 @@ namespace ProjectManagement.Services
         Task<ApplicationUser?> GetUserByIdAsync(string userId);
         Task<IList<string>> GetRolesAsync();
         Task<IList<string>> GetUserRolesAsync(string userId);
-        Task<IdentityResult> CreateUserAsync(string userName, string password, string role);
-        Task<IdentityResult> UpdateUserRoleAsync(string userId, string role);
+
+        // Multi-role support
+        Task<IdentityResult> CreateUserAsync(string userName, string password, IEnumerable<string> roles);
+        Task<IdentityResult> UpdateUserRolesAsync(string userId, IEnumerable<string> roles);
         Task ToggleUserActivationAsync(string userId, bool isActive);
         Task<IdentityResult> ResetPasswordAsync(string userId, string newPassword);
         Task<IdentityResult> DeleteUserAsync(string userId);

--- a/Services/UserManagementService.cs
+++ b/Services/UserManagementService.cs
@@ -1,6 +1,8 @@
 using System;
-using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Models;
 
@@ -10,58 +12,85 @@ namespace ProjectManagement.Services
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly RoleManager<IdentityRole> _roleManager;
-        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly IHttpContextAccessor _http;
 
         public UserManagementService(
             UserManager<ApplicationUser> userManager,
             RoleManager<IdentityRole> roleManager,
-            IHttpContextAccessor contextAccessor)
+            IHttpContextAccessor httpContextAccessor)
         {
             _userManager = userManager;
             _roleManager = roleManager;
-            _contextAccessor = contextAccessor;
+            _http = httpContextAccessor;
         }
 
-        public async Task<IList<ApplicationUser>> GetUsersAsync()
-        {
-            return await _userManager.Users.OrderBy(u => u.UserName).ToListAsync();
-        }
+        public async Task<IList<ApplicationUser>> GetUsersAsync() =>
+            await _userManager.Users.OrderBy(u => u.UserName).ToListAsync();
 
-        public async Task<ApplicationUser?> GetUserByIdAsync(string userId)
-        {
-            return await _userManager.FindByIdAsync(userId);
-        }
+        public Task<ApplicationUser?> GetUserByIdAsync(string userId) =>
+            _userManager.Users.FirstOrDefaultAsync(u => u.Id == userId)!;
 
-        public async Task<IList<string>> GetRolesAsync()
-        {
-            return await _roleManager.Roles.Select(r => r.Name!).ToListAsync();
-        }
+        public async Task<IList<string>> GetRolesAsync() =>
+            await _roleManager.Roles.Select(r => r.Name!)
+                .OrderBy(n => n).ToListAsync();
 
         public async Task<IList<string>> GetUserRolesAsync(string userId)
         {
-            var user = await _userManager.FindByIdAsync(userId);
-            if (user == null) return new List<string>();
-            return await _userManager.GetRolesAsync(user);
+            var u = await _userManager.FindByIdAsync(userId);
+            return u is null ? new List<string>() : await _userManager.GetRolesAsync(u);
         }
 
-        public async Task<IdentityResult> CreateUserAsync(string userName, string password, string role)
+        // -------- multi-role aware create ----------
+        public async Task<IdentityResult> CreateUserAsync(string userName, string password, IEnumerable<string> roles)
         {
             var user = new ApplicationUser { UserName = userName, MustChangePassword = true };
             var result = await _userManager.CreateAsync(user, password);
             if (!result.Succeeded) return result;
-            if (!string.IsNullOrWhiteSpace(role))
-                await _userManager.AddToRoleAsync(user, role);
+
+            var targetRoles = (roles ?? Enumerable.Empty<string>())
+                .Where(r => !string.IsNullOrWhiteSpace(r))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (targetRoles.Length > 0)
+            {
+                var add = await _userManager.AddToRolesAsync(user, targetRoles);
+                if (!add.Succeeded) return add;
+            }
+
+            // Important: invalidate any cached tokens/sessions after role change
+            await _userManager.UpdateSecurityStampAsync(user);
             return result;
         }
 
-        public async Task<IdentityResult> UpdateUserRoleAsync(string userId, string role)
+        // -------- multi-role update ----------
+        public async Task<IdentityResult> UpdateUserRolesAsync(string userId, IEnumerable<string> roles)
         {
             var user = await _userManager.FindByIdAsync(userId);
-            if (user == null) return IdentityResult.Failed(new IdentityError { Description = "User not found" });
-            var currentRoles = await _userManager.GetRolesAsync(user);
-            var removeResult = await _userManager.RemoveFromRolesAsync(user, currentRoles);
-            if (!removeResult.Succeeded) return removeResult;
-            return await _userManager.AddToRoleAsync(user, role);
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "User not found." });
+
+            var current = await _userManager.GetRolesAsync(user);
+            var target = new HashSet<string>(
+                (roles ?? Enumerable.Empty<string>()).Where(r => !string.IsNullOrWhiteSpace(r)).Distinct(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var toRemove = current.Where(r => !target.Contains(r)).ToArray();
+            var toAdd    = target.Where(r => !current.Contains(r, StringComparer.OrdinalIgnoreCase)).ToArray();
+
+            if (toRemove.Length > 0)
+            {
+                var rr = await _userManager.RemoveFromRolesAsync(user, toRemove);
+                if (!rr.Succeeded) return rr;
+            }
+            if (toAdd.Length > 0)
+            {
+                var ar = await _userManager.AddToRolesAsync(user, toAdd);
+                if (!ar.Succeeded) return ar;
+            }
+
+            await _userManager.UpdateSecurityStampAsync(user);
+            return IdentityResult.Success;
         }
 
         public async Task ToggleUserActivationAsync(string userId, bool isActive)
@@ -74,20 +103,24 @@ namespace ProjectManagement.Services
             user.LockoutEnd = isActive ? null : DateTimeOffset.MaxValue;
 
             await _userManager.UpdateAsync(user);
+            await _userManager.UpdateSecurityStampAsync(user);
         }
 
         public async Task<IdentityResult> ResetPasswordAsync(string userId, string newPassword)
         {
             var user = await _userManager.FindByIdAsync(userId);
-            if (user == null) return IdentityResult.Failed(new IdentityError { Description = "User not found" });
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "User not found." });
+
             var token = await _userManager.GeneratePasswordResetTokenAsync(user);
-            var result = await _userManager.ResetPasswordAsync(user, token, newPassword);
-            if (result.Succeeded)
+            var res = await _userManager.ResetPasswordAsync(user, token, newPassword);
+            if (res.Succeeded)
             {
                 user.MustChangePassword = true;
                 await _userManager.UpdateAsync(user);
+                await _userManager.UpdateSecurityStampAsync(user);
             }
-            return result;
+            return res;
         }
 
         public async Task<IdentityResult> DeleteUserAsync(string userId)
@@ -105,9 +138,9 @@ namespace ProjectManagement.Services
             }
 
             // Prevent self-delete from the UI flow
-            var currentUser = _contextAccessor.HttpContext?.User?.Identity?.Name;
-            if (!string.IsNullOrEmpty(currentUser) &&
-                string.Equals(currentUser, user.UserName, StringComparison.OrdinalIgnoreCase))
+            var currentUserName = _http.HttpContext?.User?.Identity?.Name;
+            if (!string.IsNullOrEmpty(currentUserName) &&
+                string.Equals(currentUserName, user.UserName, StringComparison.OrdinalIgnoreCase))
             {
                 return IdentityResult.Failed(new IdentityError { Description = "You cannot delete your own account." });
             }


### PR DESCRIPTION
## Summary
- support assigning multiple roles when creating or editing a user
- refresh security stamps after role, activation, or password changes
- show all roles for each user in the admin list

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a33b38483299209606898b67b47