### PR TITLE
Add account management page

### DIFF
--- a/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -1,0 +1,11 @@
+@page
+@model ProjectManagement.Areas.Identity.Pages.Account.Manage.IndexModel
+@{
+    ViewData["Title"] = "Account settings";
+}
+<h3>@ViewData["Title"]</h3>
+<div class="pm-card pm-shadow p-4 p-md-5">
+  <ul class="list-unstyled mb-0">
+    <li><a asp-page="./ChangePassword">Change password</a></li>
+  </ul>
+</div>

--- a/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Areas.Identity.Pages.Account.Manage
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/docs/login-user-management.md
+++ b/docs/login-user-management.md
@@ -77,6 +77,9 @@ Concrete implementation backed by `UserManager<ApplicationUser>` and `RoleManage
 * `Areas/Identity/Pages/Account/Logout.cshtml` – simple confirmation page after logout.
 * `Areas/Identity/Pages/Account/Logout.cshtml.cs` – signs the user out and clears the session.
 
+### Account management
+* `Areas/Identity/Pages/Account/Manage/Index.cshtml` – entry point for signed-in users to manage their account, including password changes.
+
 ### Change Password
 * `Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml` – form for updating the current user's password.
 * `Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs` – validates the old password, updates it, clears the `MustChangePassword` flag and refreshes the sign‑in cookie.


### PR DESCRIPTION
## Summary
- Add Account/Manage index Razor Page to expose password change option for signed-in users
- Document new account management page and link to change password

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd0d956dc88329a9b2b5500491eb22