### PR TITLE
Polish user management UI and add audit logging

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -19,17 +19,25 @@
     <div class="mb-3">
       <label asp-for="Input.Password" class="form-label"></label>
       <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+      <div class="mt-2 d-flex gap-2">
+        <button type="button" id="generatePwd" class="btn btn-sm btn-outline-secondary">Generate</button>
+        <button type="button" id="copyPwd" class="btn btn-sm btn-outline-secondary">Copy</button>
+      </div>
       <span class="form-text pm-field-hint">Minimum 8 characters. The user will be forced to change it at first login.</span>
       <span asp-validation-for="Input.Password" class="text-danger"></span>
     </div>
 
-    <div class="mb-3">
-      <label asp-for="Input.Roles" class="form-label"></label>
-      <select asp-for="Input.Roles"
-              asp-items="new MultiSelectList(Model.Roles)"
-              class="form-select" multiple size="4"></select>
+    <fieldset class="mb-3">
+      <legend class="form-label">Roles</legend>
+      @foreach (var role in Model.Roles)
+      {
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="Input.Roles" value="@role" id="create-role-@role" @(Model.Input.Roles.Contains(role) ? "checked" : null) />
+          <label class="form-check-label" for="create-role-@role">@role</label>
+        </div>
+      }
       <span asp-validation-for="Input.Roles" class="text-danger"></span>
-    </div>
+    </fieldset>
 
     <div class="d-flex gap-2">
       <button class="btn pm-btn-primary" type="submit">Create</button>
@@ -37,4 +45,21 @@
     </div>
   </form>
 </div>
+
+<script>
+  function randomPwd() {
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let pwd = "";
+    for (let i = 0; i < 12; i++) pwd += chars[Math.floor(Math.random() * chars.length)];
+    return pwd;
+  }
+  document.getElementById('generatePwd').addEventListener('click', () => {
+    const input = document.getElementById('Input_Password');
+    input.value = randomPwd();
+  });
+  document.getElementById('copyPwd').addEventListener('click', () => {
+    const input = document.getElementById('Input_Password');
+    navigator.clipboard.writeText(input.value);
+  });
+</script>
 

--- a/Areas/Admin/Pages/Users/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Create.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Logging;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
@@ -12,8 +13,13 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     public class CreateModel : PageModel
     {
         private readonly IUserManagementService _users;
+        private readonly ILogger<CreateModel> _logger;
 
-        public CreateModel(IUserManagementService users) => _users = users;
+        public CreateModel(IUserManagementService users, ILogger<CreateModel> logger)
+        {
+            _users = users;
+            _logger = logger;
+        }
 
         [BindProperty] public InputModel Input { get; set; } = new();
         public IList<string> Roles { get; private set; } = new List<string>();
@@ -43,6 +49,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             var res = await _users.CreateUserAsync(Input.UserName, Input.Password, Input.Roles);
             if (res.Succeeded)
             {
+                _logger.LogInformation("Admin {Admin} created user {User} with roles {Roles}", User.Identity?.Name, Input.UserName, string.Join(',', Input.Roles));
                 TempData["ok"] = "User created.";
                 return RedirectToPage("Index");
             }

--- a/Areas/Admin/Pages/Users/Delete.cshtml
+++ b/Areas/Admin/Pages/Users/Delete.cshtml
@@ -4,6 +4,7 @@
 <div class="pm-card pm-shadow p-4 p-md-5">
   <p>Are you sure you want to delete @Model.UserName?</p>
   <form method="post">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <button class="btn btn-danger" type="submit">Delete</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>

--- a/Areas/Admin/Pages/Users/Delete.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Delete.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Services;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
 {
@@ -10,7 +11,12 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     public class DeleteModel : PageModel
     {
         private readonly IUserManagementService _userService;
-        public DeleteModel(IUserManagementService userService) => _userService = userService;
+        private readonly ILogger<DeleteModel> _logger;
+        public DeleteModel(IUserManagementService userService, ILogger<DeleteModel> logger)
+        {
+            _userService = userService;
+            _logger = logger;
+        }
 
         public string UserName { get; set; } = string.Empty;
 
@@ -27,6 +33,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             var result = await _userService.DeleteUserAsync(id);
             if (result.Succeeded)
             {
+                _logger.LogInformation("Admin {Admin} deleted user {UserId}", User.Identity?.Name, id);
                 TempData["ok"] = "User deleted.";
             }
             else

--- a/Areas/Admin/Pages/Users/Edit.cshtml
+++ b/Areas/Admin/Pages/Users/Edit.cshtml
@@ -10,13 +10,17 @@
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <input type="hidden" asp-for="Input.Id" />
 
-    <div class="mb-3">
-      <label asp-for="Input.Roles" class="form-label"></label>
-      <select asp-for="Input.Roles"
-              asp-items="new MultiSelectList(Model.Roles, Model.Input.Roles)"
-              class="form-select" multiple size="4"></select>
+    <fieldset class="mb-3">
+      <legend class="form-label">Roles</legend>
+      @foreach (var role in Model.Roles)
+      {
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="Input.Roles" value="@role" id="edit-role-@role" @(Model.Input.Roles.Contains(role) ? "checked" : null) />
+          <label class="form-check-label" for="edit-role-@role">@role</label>
+        </div>
+      }
       <span asp-validation-for="Input.Roles" class="text-danger"></span>
-    </div>
+    </fieldset>
 
     <div class="form-check mb-3">
       <input class="form-check-input" type="checkbox" asp-for="Input.IsActive" id="isActiveChk" />

--- a/Areas/Admin/Pages/Users/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Edit.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Logging;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
@@ -14,8 +15,13 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     public class EditModel : PageModel
     {
         private readonly IUserManagementService _users;
+        private readonly ILogger<EditModel> _logger;
 
-        public EditModel(IUserManagementService users) => _users = users;
+        public EditModel(IUserManagementService users, ILogger<EditModel> logger)
+        {
+            _users = users;
+            _logger = logger;
+        }
 
         [BindProperty] public InputModel Input { get; set; } = new();
         public IList<string> Roles { get; private set; } = new List<string>();
@@ -63,6 +69,8 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             }
 
             await _users.ToggleUserActivationAsync(Input.Id, Input.IsActive);
+
+            _logger.LogInformation("Admin {Admin} updated user {UserId}: roles {Roles}; active {Active}", User.Identity?.Name, Input.Id, string.Join(',', Input.Roles), Input.IsActive);
 
             TempData["ok"] = "User updated.";
             return RedirectToPage("Index");

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -1,22 +1,42 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Users.IndexModel
 <h3>Users</h3>
-<p><a class="btn btn-success" asp-page="Create">Create user</a></p>
-<table class="table table-sm">
+<p><a class="btn pm-btn-primary" asp-page="Create">Create user</a></p>
+<input id="userSearch" class="form-control mb-3" type="search" placeholder="Search by username or role" />
+<table class="table table-sm" id="usersTable">
   <thead><tr><th>UserName</th><th>Roles</th><th>Status</th><th>Actions</th></tr></thead>
   <tbody>
   @foreach (var row in Model.Users)
   {
     <tr>
       <td>@row.UserName</td>
-      <td>@row.Roles</td>
-      <td>@(row.IsActive ? "Active" : "Disabled")</td>
       <td>
-        <a asp-page="Edit" asp-route-id="@row.Id">Edit</a> |
-        <a asp-page="Reset" asp-route-id="@row.Id">Reset password</a> |
-        <a asp-page="Delete" asp-route-id="@row.Id">Delete</a>
+        @foreach (var r in row.Roles)
+        {
+          <span class="badge bg-secondary me-1">@r</span>
+        }
+      </td>
+      <td>
+        <span class="badge @(row.IsActive ? "bg-success" : "bg-danger")">@(row.IsActive ? "Active" : "Disabled")</span>
+      </td>
+      <td class="text-nowrap">
+        <a asp-page="Edit" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
+        <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Reset</a>
+        <form method="post" asp-page="Delete" asp-route-id="@row.Id" class="d-inline">
+          <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete user @row.UserName?');">Delete</button>
+        </form>
       </td>
     </tr>
   }
   </tbody>
 </table>
+
+<script>
+  document.getElementById('userSearch').addEventListener('input', function () {
+    const term = this.value.toLowerCase();
+    document.querySelectorAll('#usersTable tbody tr').forEach(row => {
+      const text = row.textContent.toLowerCase();
+      row.style.display = text.includes(term) ? '' : 'none';
+    });
+  });
+</script>

--- a/Areas/Admin/Pages/Users/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Index.cshtml.cs
@@ -19,7 +19,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
         {
             public string Id { get; set; } = "";
             public string UserName { get; set; } = "";
-            public string Roles { get; set; } = "";
+            public IList<string> Roles { get; set; } = new List<string>();
             public bool IsActive { get; set; }
         }
 
@@ -34,7 +34,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                 {
                     Id = u.Id,
                     UserName = u.UserName ?? "",
-                    Roles = string.Join(", ", roles.OrderBy(r => r)),
+                    Roles = roles.OrderBy(r => r).ToList(),
                     IsActive = !u.LockoutEnd.HasValue || u.LockoutEnd <= DateTimeOffset.UtcNow
                 });
             }

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -3,13 +3,14 @@
 <h3>Reset password</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
   <form method="post">
-    <div class="visually-hidden" aria-live="polite">
-      <span asp-validation-summary="ModelOnly"></span>
-    </div>
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <div class="mb-3">
       <label class="form-label">New password</label>
       <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
+      <div class="mt-2 d-flex gap-2">
+        <button type="button" id="genPwd" class="btn btn-sm btn-outline-secondary">Generate</button>
+        <button type="button" id="cpyPwd" class="btn btn-sm btn-outline-secondary">Copy</button>
+      </div>
       <span class="form-text pm-field-hint">Minimum 8 characters. No special rules enforced.</span>
       <span asp-validation-for="NewPassword" class="text-danger"></span>
     </div>
@@ -17,3 +18,20 @@
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
+
+<script>
+  function rndPwd(){
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let pwd = "";
+    for(let i=0;i<12;i++) pwd += chars[Math.floor(Math.random()*chars.length)];
+    return pwd;
+  }
+  document.getElementById('genPwd').addEventListener('click',()=>{
+    const inp=document.getElementById('NewPassword');
+    inp.value=rndPwd();
+  });
+  document.getElementById('cpyPwd').addEventListener('click',()=>{
+    const inp=document.getElementById('NewPassword');
+    navigator.clipboard.writeText(inp.value);
+  });
+</script>

--- a/Areas/Admin/Pages/Users/Reset.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Reset.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
@@ -10,7 +11,12 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
     public class ResetModel : PageModel
     {
         private readonly IUserManagementService _userService;
-        public ResetModel(IUserManagementService userService) => _userService = userService;
+        private readonly ILogger<ResetModel> _logger;
+        public ResetModel(IUserManagementService userService, ILogger<ResetModel> logger)
+        {
+            _userService = userService;
+            _logger = logger;
+        }
 
         [BindProperty, Required, StringLength(100, MinimumLength = 8)]
         [DataType(DataType.Password)]
@@ -21,6 +27,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             var result = await _userService.ResetPasswordAsync(id, NewPassword);
             if (result.Succeeded)
             {
+                _logger.LogInformation("Admin {Admin} reset password for user {UserId}", User.Identity?.Name, id);
                 TempData["ok"] = "Password reset.";
                 return RedirectToPage("Index");
             }


### PR DESCRIPTION
## Summary
- Replace role multi-selects with accessible checkbox groups and add password generation/copy helpers
- Revamp users list with role/status badges, search box, and safer action buttons
- Log admin create/update/reset/delete actions for audit traceability

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd13c1fc908329ac3dbd8b2fbdef74