### PR TITLE
Add press-and-hold password reveal to password fields

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -18,7 +18,15 @@
 
     <div class="mb-3">
       <label asp-for="Input.Password" class="form-label"></label>
-      <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+      <div class="password-container">
+        <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <div class="mt-2 d-flex gap-2">
         <button type="button" id="generatePwd" class="btn btn-sm btn-outline-secondary">Generate</button>
         <button type="button" id="copyPwd" class="btn btn-sm btn-outline-secondary">Copy</button>

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -6,7 +6,15 @@
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <div class="mb-3">
       <label class="form-label">New password</label>
-      <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
+      <div class="password-container">
+        <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <div class="mt-2 d-flex gap-2">
         <button type="button" id="genPwd" class="btn btn-sm btn-outline-secondary">Generate</button>
         <button type="button" id="cpyPwd" class="btn btn-sm btn-outline-secondary">Copy</button>

--- a/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Areas/Identity/Pages/Account/Login.cshtml
@@ -17,7 +17,15 @@
     </div>
     <div class="mb-3">
       <label asp-for="Input.Password" class="form-label"></label>
-      <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
+      <div class="password-container">
+        <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <span asp-validation-for="Input.Password" class="text-danger"></span>
     </div>
     <div class="mb-3 form-check">

--- a/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -12,17 +12,41 @@
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <div class="mb-3">
       <label asp-for="Input.OldPassword" class="form-label"></label>
-      <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
+      <div class="password-container">
+        <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
     </div>
     <div class="mb-3">
       <label asp-for="Input.NewPassword" class="form-label"></label>
-      <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
+      <div class="password-container">
+        <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
     </div>
     <div class="mb-3">
       <label asp-for="Input.ConfirmPassword" class="form-label"></label>
-      <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+      <div class="password-container">
+        <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+        <button type="button" class="password-toggle" aria-label="Show password">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+        </button>
+      </div>
       <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
     </div>
     <button type="submit" class="btn pm-btn-primary">Change password</button>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -34,3 +34,8 @@ body{background:var(--pm-bg);color:var(--pm-text)}
 .pm-btn-primary:disabled{opacity:.65;color:#fff}
 .pm-field-hint{color:var(--pm-muted);font-size:.85rem}
 
+.password-container{position:relative}
+.password-toggle{background:none;border:none;position:absolute;top:50%;right:.75rem;transform:translateY(-50%);color:var(--pm-muted);padding:0;line-height:0}
+.password-toggle:focus{outline:none}
+.password-toggle svg{width:1.25rem;height:1.25rem}
+

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -2,3 +2,19 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.password-toggle').forEach(btn => {
+    const container = btn.closest('.password-container');
+    if (!container) return;
+    const input = container.querySelector('input');
+    if (!input) return;
+    const show = () => { input.type = 'text'; };
+    const hide = () => { input.type = 'password'; };
+    btn.addEventListener('mousedown', show);
+    btn.addEventListener('touchstart', show);
+    btn.addEventListener('mouseup', hide);
+    btn.addEventListener('mouseleave', hide);
+    btn.addEventListener('touchend', hide);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable press-and-hold password reveal control and style
- enable password reveal on login, user creation, password reset, and password change pages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd178777248329b151061eb1ac58e0