### PR TITLE
Enforce last-active admin safeguards in user management

### DIFF
--- a/Areas/Admin/Pages/Users/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Edit.cshtml.cs
@@ -68,7 +68,12 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                 return Page();
             }
 
-            await _users.ToggleUserActivationAsync(Input.Id, Input.IsActive);
+            var activeRes = await _users.ToggleUserActivationAsync(Input.Id, Input.IsActive);
+            if (!activeRes.Succeeded)
+            {
+                foreach (var e in activeRes.Errors) ModelState.AddModelError(string.Empty, e.Description);
+                return Page();
+            }
 
             _logger.LogInformation("Admin {Admin} updated user {UserId}: roles {Roles}; active {Active}", User.Identity?.Name, Input.Id, string.Join(',', Input.Roles), Input.IsActive);
 

--- a/ProjectManagement.Tests/UserManagementServiceTests.cs
+++ b/ProjectManagement.Tests/UserManagementServiceTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests
+{
+    public class UserManagementServiceTests
+    {
+        private static UserManagementService CreateService(string currentUserName, out ApplicationDbContext context, out UserManager<ApplicationUser> userManager, out RoleManager<IdentityRole> roleManager)
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            context = new ApplicationDbContext(options);
+
+            var services = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            userManager = new UserManager<ApplicationUser>(
+                new UserStore<ApplicationUser>(context),
+                Options.Create(new IdentityOptions()),
+                new PasswordHasher<ApplicationUser>(),
+                Array.Empty<IUserValidator<ApplicationUser>>(),
+                Array.Empty<IPasswordValidator<ApplicationUser>>(),
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                services,
+                new Logger<UserManager<ApplicationUser>>(new LoggerFactory()));
+
+            roleManager = new RoleManager<IdentityRole>(
+                new RoleStore<IdentityRole>(context),
+                new IRoleValidator<IdentityRole>[] { new RoleValidator<IdentityRole>() },
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                new Logger<RoleManager<IdentityRole>>(new LoggerFactory()));
+
+            var httpContext = new DefaultHttpContext();
+            if (!string.IsNullOrEmpty(currentUserName))
+            {
+                httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, currentUserName) }, "test"));
+            }
+            var accessor = new HttpContextAccessor { HttpContext = httpContext };
+
+            return new UserManagementService(userManager, roleManager, accessor);
+        }
+
+        [Fact]
+        public async Task CannotDisableOwnAccount()
+        {
+            var service = CreateService("admin", out var context, out var userManager, out var roleManager);
+            await roleManager.CreateAsync(new IdentityRole("Admin"));
+            var admin = new ApplicationUser { UserName = "admin" };
+            await userManager.CreateAsync(admin, "Passw0rd!");
+            await userManager.AddToRoleAsync(admin, "Admin");
+
+            var result = await service.ToggleUserActivationAsync(admin.Id, false);
+
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task CannotDisableLastActiveAdmin()
+        {
+            var service = CreateService("other", out var context, out var userManager, out var roleManager);
+            await roleManager.CreateAsync(new IdentityRole("Admin"));
+            var admin = new ApplicationUser { UserName = "admin" };
+            await userManager.CreateAsync(admin, "Passw0rd!");
+            await userManager.AddToRoleAsync(admin, "Admin");
+
+            var result = await service.ToggleUserActivationAsync(admin.Id, false);
+
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task CannotRemoveAdminRoleFromLastActiveAdmin()
+        {
+            var service = CreateService("admin", out var context, out var userManager, out var roleManager);
+            await roleManager.CreateAsync(new IdentityRole("Admin"));
+            var admin = new ApplicationUser { UserName = "admin" };
+            await userManager.CreateAsync(admin, "Passw0rd!");
+            await userManager.AddToRoleAsync(admin, "Admin");
+
+            var result = await service.UpdateUserRolesAsync(admin.Id, Array.Empty<string>());
+
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task CannotDeleteLastActiveAdmin()
+        {
+            var service = CreateService("other", out var context, out var userManager, out var roleManager);
+            await roleManager.CreateAsync(new IdentityRole("Admin"));
+            var admin = new ApplicationUser { UserName = "admin" };
+            await userManager.CreateAsync(admin, "Passw0rd!");
+            await userManager.AddToRoleAsync(admin, "Admin");
+
+            var result = await service.DeleteUserAsync(admin.Id);
+
+            Assert.False(result.Succeeded);
+        }
+    }
+}

--- a/Services/IUserManagementService.cs
+++ b/Services/IUserManagementService.cs
@@ -13,7 +13,7 @@ namespace ProjectManagement.Services
         // Multi-role support
         Task<IdentityResult> CreateUserAsync(string userName, string password, IEnumerable<string> roles);
         Task<IdentityResult> UpdateUserRolesAsync(string userId, IEnumerable<string> roles);
-        Task ToggleUserActivationAsync(string userId, bool isActive);
+        Task<IdentityResult> ToggleUserActivationAsync(string userId, bool isActive);
         Task<IdentityResult> ResetPasswordAsync(string userId, string newPassword);
         Task<IdentityResult> DeleteUserAsync(string userId);
     }

--- a/docs/login-user-management.md
+++ b/docs/login-user-management.md
@@ -57,6 +57,7 @@ Defines an abstraction for managing users and roles:
 * Create users with an initial role
 * Update a user's role
 * Toggle activation/lockout
+* Enforce that at least one administrator remains active. Operations that would disable, delete or remove the Admin role from the last active admin are rejected, and users cannot disable their own account.
 * Reset passwords (marking the user for a forced change)
 * Delete users
 


### PR DESCRIPTION
## Summary
- Prevent disabling your own account and ensure at least one administrator stays active
- Block removing admin role or deleting a user when it would leave no active admins
- Add unit tests covering self-disable, last admin removal, and deletion safeguards

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd212760d88329b51c369247f4d4b4