### PR TITLE
Move inline scripts to external files

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -52,22 +52,8 @@
       <a asp-page="Index" class="btn btn-secondary">Cancel</a>
     </div>
   </form>
-</div>
+  </div>
 
-<script>
-  function randomPwd() {
-    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let pwd = "";
-    for (let i = 0; i < 12; i++) pwd += chars[Math.floor(Math.random() * chars.length)];
-    return pwd;
-  }
-  document.getElementById('generatePwd').addEventListener('click', () => {
-    const input = document.getElementById('Input_Password');
-    input.value = randomPwd();
-  });
-  document.getElementById('copyPwd').addEventListener('click', () => {
-    const input = document.getElementById('Input_Password');
-    navigator.clipboard.writeText(input.value);
-  });
-</script>
-
+@section Scripts {
+    <script type="module" src="~/js/users/create.js" asp-append-version="true"></script>
+}

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -23,7 +23,7 @@
         <a asp-page="Edit" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
         <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Reset</a>
         <form method="post" asp-page="Delete" asp-route-id="@row.Id" class="d-inline">
-          <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete user @row.UserName?');">Delete</button>
+          <button type="submit" class="btn btn-sm btn-outline-danger delete-user-btn" data-username="@row.UserName">Delete</button>
         </form>
       </td>
     </tr>
@@ -31,12 +31,6 @@
   </tbody>
 </table>
 
-<script>
-  document.getElementById('userSearch').addEventListener('input', function () {
-    const term = this.value.toLowerCase();
-    document.querySelectorAll('#usersTable tbody tr').forEach(row => {
-      const text = row.textContent.toLowerCase();
-      row.style.display = text.includes(term) ? '' : 'none';
-    });
-  });
-</script>
+@section Scripts {
+    <script type="module" src="~/js/users/index.js" asp-append-version="true"></script>
+}

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -27,19 +27,6 @@
   </form>
 </div>
 
-<script>
-  function rndPwd(){
-    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let pwd = "";
-    for(let i=0;i<12;i++) pwd += chars[Math.floor(Math.random()*chars.length)];
-    return pwd;
-  }
-  document.getElementById('genPwd').addEventListener('click',()=>{
-    const inp=document.getElementById('NewPassword');
-    inp.value=rndPwd();
-  });
-  document.getElementById('cpyPwd').addEventListener('click',()=>{
-    const inp=document.getElementById('NewPassword');
-    navigator.clipboard.writeText(inp.value);
-  });
-</script>
+@section Scripts {
+    <script type="module" src="~/js/users/reset.js" asp-append-version="true"></script>
+}

--- a/wwwroot/js/users/create.js
+++ b/wwwroot/js/users/create.js
@@ -1,0 +1,11 @@
+import { generatePassword } from '../utils/password.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pwdInput = document.getElementById('Input_Password');
+  document.getElementById('generatePwd').addEventListener('click', () => {
+    pwdInput.value = generatePassword();
+  });
+  document.getElementById('copyPwd').addEventListener('click', () => {
+    navigator.clipboard.writeText(pwdInput.value);
+  });
+});

--- a/wwwroot/js/users/index.js
+++ b/wwwroot/js/users/index.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const searchInput = document.getElementById('userSearch');
+  searchInput.addEventListener('input', function () {
+    const term = this.value.toLowerCase();
+    document.querySelectorAll('#usersTable tbody tr').forEach(row => {
+      const text = row.textContent.toLowerCase();
+      row.style.display = text.includes(term) ? '' : 'none';
+    });
+  });
+
+  document.querySelectorAll('.delete-user-btn').forEach(btn => {
+    btn.addEventListener('click', e => {
+      const username = btn.dataset.username;
+      if (!confirm(`Delete user ${username}?`)) {
+        e.preventDefault();
+      }
+    });
+  });
+});

--- a/wwwroot/js/users/reset.js
+++ b/wwwroot/js/users/reset.js
@@ -1,0 +1,11 @@
+import { generatePassword } from '../utils/password.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pwdInput = document.getElementById('NewPassword');
+  document.getElementById('genPwd').addEventListener('click', () => {
+    pwdInput.value = generatePassword();
+  });
+  document.getElementById('cpyPwd').addEventListener('click', () => {
+    navigator.clipboard.writeText(pwdInput.value);
+  });
+});

--- a/wwwroot/js/utils/password.js
+++ b/wwwroot/js/utils/password.js
@@ -1,0 +1,8 @@
+export function generatePassword(length = 12) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let pwd = '';
+  for (let i = 0; i < length; i++) {
+    pwd += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return pwd;
+}


### PR DESCRIPTION
## Summary
- move user page inline scripts to dedicated ES modules
- centralize password generation in reusable utility
- wire up handlers for search, password actions and deletion via external scripts to keep CSP strict

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2407f1e08329b074e95557932d37