### PR TITLE
Switch password eye icon to click-to-toggle

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -20,10 +20,15 @@
       <label asp-for="Input.Password" class="form-label"></label>
       <div class="password-container">
         <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -8,10 +8,15 @@
       <label class="form-label">New password</label>
       <div class="password-container">
         <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>

--- a/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Areas/Identity/Pages/Account/Login.cshtml
@@ -19,10 +19,15 @@
       <label asp-for="Input.Password" class="form-label"></label>
       <div class="password-container">
         <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>

--- a/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -14,10 +14,15 @@
       <label asp-for="Input.OldPassword" class="form-label"></label>
       <div class="password-container">
         <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>
@@ -27,10 +32,15 @@
       <label asp-for="Input.NewPassword" class="form-label"></label>
       <div class="password-container">
         <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>
@@ -40,10 +50,15 @@
       <label asp-for="Input.ConfirmPassword" class="form-label"></label>
       <div class="password-container">
         <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
-        <button type="button" class="password-toggle" aria-label="Show password">
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
             <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
           </svg>
         </button>
       </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -62,7 +62,7 @@
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script type="module" src="~/js/site.js" asp-append-version="true"></script>
 
     <partial name="_ValidationScriptsPartial" />
     @await RenderSectionAsync("Scripts", required: false)

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,20 +1,5 @@
-﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
-// for details on configuring this project to bundle and minify static web assets.
-
-// Write your JavaScript code.
+import { initPasswordToggles } from './utils/password-toggle.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.password-toggle').forEach(btn => {
-    const container = btn.closest('.password-container');
-    if (!container) return;
-    const input = container.querySelector('input');
-    if (!input) return;
-    const show = () => { input.type = 'text'; };
-    const hide = () => { input.type = 'password'; };
-    btn.addEventListener('mousedown', show);
-    btn.addEventListener('touchstart', show);
-    btn.addEventListener('mouseup', hide);
-    btn.addEventListener('mouseleave', hide);
-    btn.addEventListener('touchend', hide);
-  });
+  initPasswordToggles();
 });

--- a/wwwroot/js/utils/password-toggle.js
+++ b/wwwroot/js/utils/password-toggle.js
@@ -1,0 +1,24 @@
+export function initPasswordToggles() {
+  document.querySelectorAll('.password-toggle').forEach(btn => {
+    const container = btn.closest('.password-container');
+    if (!container) return;
+    const input = container.querySelector('input');
+    if (!input) return;
+    const showIcon = btn.querySelector('.eye-open');
+    const hideIcon = btn.querySelector('.eye-closed');
+    const setVisible = visible => {
+      input.type = visible ? 'text' : 'password';
+      btn.setAttribute('aria-pressed', visible);
+      btn.setAttribute('aria-label', visible ? 'Hide password' : 'Show password');
+      if (showIcon && hideIcon) {
+        showIcon.hidden = visible;
+        hideIcon.hidden = !visible;
+      }
+    };
+    btn.addEventListener('click', () => {
+      const visible = input.type === 'password';
+      setVisible(visible);
+    });
+    setVisible(false);
+  });
+}


### PR DESCRIPTION
## Summary
- Replace press-and-hold password reveal with click-to-toggle eye icon across login, password change, and user management forms
- Add reusable `initPasswordToggles` utility and load `site.js` as an ES module

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd32084e148329867172834c016a49