### PR TITLE
Add sparklines and user login metrics

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml
@@ -6,9 +6,22 @@
 <h3 class="mb-3">Analytics</h3>
 
 <div class="row g-3 mb-4">
-  <div class="col-md-4"><div class="pm-card pm-shadow p-3"><div class="text-muted">Total users</div><div class="fs-3">@Model.TotalUsers</div></div></div>
-  <div class="col-md-4"><div class="pm-card pm-shadow p-3"><div class="text-muted">Active</div><div class="fs-3">@Model.ActiveUsers</div></div></div>
-  <div class="col-md-4"><div class="pm-card pm-shadow p-3"><div class="text-muted">Disabled</div><div class="fs-3">@Model.DisabledUsers</div></div></div>
+  <div class="col-md-3">
+    <div class="pm-card pm-shadow p-3">
+      <div class="text-muted">Logins today</div>
+      <div class="d-flex justify-content-between align-items-end">
+        <div class="fs-3">
+          @{ var loginsToday = Model.LoginsLast30Days[^1]; var loginsYesterday = Model.LoginsLast30Days.Length > 1 ? Model.LoginsLast30Days[^2] : 0; var diff = loginsToday - loginsYesterday; }
+          @loginsToday
+          <span class="fs-6 text-muted">@(diff >= 0 ? "▲" : "▼")@Math.Abs(diff)</span>
+        </div>
+        <div class="sparkline" data-points="@string.Join(',', Model.LoginsLast30Days.Skip(Math.Max(0, Model.LoginsLast30Days.Length-7)))"></div>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3"><div class="pm-card pm-shadow p-3"><div class="text-muted">Total users</div><div class="fs-3">@Model.TotalUsers</div></div></div>
+  <div class="col-md-3"><div class="pm-card pm-shadow p-3"><div class="text-muted">Active</div><div class="fs-3">@Model.ActiveUsers</div></div></div>
+  <div class="col-md-3"><div class="pm-card pm-shadow p-3"><div class="text-muted">Disabled</div><div class="fs-3">@Model.DisabledUsers</div></div></div>
 </div>
 
 <div class="pm-card pm-shadow p-3 mb-4">

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -4,27 +4,40 @@
 <p><a class="btn pm-btn-primary" asp-page="Create">Create user</a></p>
 <input id="userSearch" class="form-control mb-3" type="search" placeholder="Search by username or role" />
 <table class="table table-sm" id="usersTable">
-  <thead><tr><th>UserName</th><th>Roles</th><th>Status</th><th>Actions</th></tr></thead>
+  <thead>
+    <tr>
+      <th scope="col">UserName</th>
+      <th scope="col">Roles</th>
+      <th scope="col">Last login</th>
+      <th scope="col">Total logins</th>
+      <th scope="col">Status</th>
+      <th scope="col" class="text-end">Actions</th>
+    </tr>
+  </thead>
   <tbody>
   @foreach (var row in Model.Users)
   {
     <tr>
-      <td>@row.UserName</td>
-      <td>
+      <td class="text-start">@row.UserName</td>
+      <td class="text-start">
         @foreach (var r in row.Roles)
         {
           <span class="badge bg-secondary me-1">@r</span>
         }
       </td>
+      <td>@(row.LastLoginUtc?.ToString("yyyy-MM-dd HH:mm") ?? "-")</td>
+      <td>@row.LoginCount</td>
       <td>
         <span class="badge @(row.IsActive ? "bg-success" : "bg-danger")">@(row.IsActive ? "Active" : "Disabled")</span>
       </td>
-      <td class="text-nowrap">
-        <a asp-page="Edit" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
-        <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary me-1">Reset</a>
-        <form method="post" asp-page="Delete" asp-route-id="@row.Id" class="d-inline">
-          <button type="submit" class="btn btn-sm btn-outline-danger delete-user-btn" data-username="@row.UserName">Delete</button>
-        </form>
+      <td class="text-end">
+        <div class="d-flex justify-content-end gap-1">
+          <a asp-page="Edit" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary" title="Edit user">Edit</a>
+          <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary" title="Reset password">Reset</a>
+          <form method="post" asp-page="Delete" asp-route-id="@row.Id" class="d-inline">
+            <button type="submit" class="btn btn-sm btn-outline-danger delete-user-btn" data-username="@row.UserName" title="Delete user">Delete</button>
+          </form>
+        </div>
       </td>
     </tr>
   }

--- a/Areas/Admin/Pages/Users/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Index.cshtml.cs
@@ -21,6 +21,8 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             public string UserName { get; set; } = "";
             public IList<string> Roles { get; set; } = new List<string>();
             public bool IsActive { get; set; }
+            public DateTime? LastLoginUtc { get; set; }
+            public int LoginCount { get; set; }
         }
 
         public async Task OnGet()
@@ -35,7 +37,9 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                     Id = u.Id,
                     UserName = u.UserName ?? "",
                     Roles = roles.OrderBy(r => r).ToList(),
-                    IsActive = !u.LockoutEnd.HasValue || u.LockoutEnd <= DateTimeOffset.UtcNow
+                    IsActive = !u.LockoutEnd.HasValue || u.LockoutEnd <= DateTimeOffset.UtcNow,
+                    LastLoginUtc = u.LastLoginUtc,
+                    LoginCount = u.LoginCount
                 });
             }
             Users = rows;

--- a/wwwroot/js/charts/sparkline.js
+++ b/wwwroot/js/charts/sparkline.js
@@ -1,0 +1,30 @@
+export function initSparklines() {
+  document.querySelectorAll('.sparkline').forEach(el => {
+    const points = (el.dataset.points || '').split(',').map(s => parseFloat(s)).filter(n => !isNaN(n));
+    if (points.length === 0) return;
+    const width = el.clientWidth || 60;
+    const height = el.clientHeight || 20;
+    const max = Math.max(...points);
+    const min = Math.min(...points);
+    const len = points.length - 1;
+    const stepX = width / len;
+    const scaleY = max === min ? 0 : height / (max - min);
+    const path = points.map((p, i) => {
+      const x = i * stepX;
+      const y = height - (p - min) * scaleY;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', width);
+    svg.setAttribute('height', height);
+    const pathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    pathEl.setAttribute('d', path);
+    pathEl.setAttribute('fill', 'none');
+    pathEl.setAttribute('stroke', 'currentColor');
+    pathEl.setAttribute('stroke-width', '1');
+    svg.appendChild(pathEl);
+    el.innerHTML = '';
+    el.appendChild(svg);
+  });
+}

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,5 +1,7 @@
 import { initPasswordToggles } from './utils/password-toggle.js';
+import { initSparklines } from './charts/sparkline.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initPasswordToggles();
+  initSparklines();
 });


### PR DESCRIPTION
## Summary
- add lightweight SVG sparkline renderer and initialize globally
- surface login trends on analytics with new logins card
- enrich admin users table with last login, login counts, and aligned actions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b53dec483298731a13d35405d48