### PR TITLE
Use IST timezone, fix IP logging, and adopt pastel theme

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Areas.Admin.Pages.Analytics
 {
@@ -22,11 +23,11 @@ namespace ProjectManagement.Areas.Admin.Pages.Analytics
         {
             var users = _db.Users.AsNoTracking();
             TotalUsers = await users.CountAsync();
-            var now = DateTimeOffset.UtcNow;
+            var now = IstClock.NowOffset;
             ActiveUsers = await users.CountAsync(u => !u.LockoutEnd.HasValue || u.LockoutEnd <= now);
             DisabledUsers = TotalUsers - ActiveUsers;
 
-            var since = DateTime.UtcNow.Date.AddDays(-30);
+            var since = IstClock.Now.Date.AddDays(-30);
             var raw = await _db.AuditLogs.AsNoTracking()
                 .Where(a => a.Action == "LoginSuccess" && a.TimeUtc >= since)
                 .GroupBy(a => a.TimeUtc.Date)

--- a/Areas/Admin/Pages/Users/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Edit.cshtml.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Services;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
 {
@@ -50,7 +51,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             {
                 Id = id,
                 Roles = userRoles.ToList(),
-                IsActive = !user.LockoutEnd.HasValue || user.LockoutEnd <= DateTimeOffset.UtcNow
+                IsActive = !user.LockoutEnd.HasValue || user.LockoutEnd <= IstClock.NowOffset
             };
             UserName = user.UserName;
             return Page();

--- a/Areas/Admin/Pages/Users/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Index.cshtml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Services;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
 {
@@ -37,7 +38,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                     Id = u.Id,
                     UserName = u.UserName ?? "",
                     Roles = roles.OrderBy(r => r).ToList(),
-                    IsActive = !u.LockoutEnd.HasValue || u.LockoutEnd <= DateTimeOffset.UtcNow,
+                    IsActive = !u.LockoutEnd.HasValue || u.LockoutEnd <= IstClock.NowOffset,
                     LastLoginUtc = u.LastLoginUtc,
                     LoginCount = u.LoginCount
                 });

--- a/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Areas.Identity.Pages.Account
 {
@@ -57,7 +58,7 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
                 ModelState.AddModelError(string.Empty, "Invalid username or password.");
                 return Page();
             }
-            if (user.LockoutEnd.HasValue && user.LockoutEnd.Value > DateTimeOffset.UtcNow)
+            if (user.LockoutEnd.HasValue && user.LockoutEnd.Value > IstClock.NowOffset)
             {
                 _logger.LogWarning("Login attempt for disabled user {UserName}", Input.UserName);
                 ModelState.AddModelError(string.Empty, "Account is disabled.");
@@ -68,7 +69,7 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
             if (result.Succeeded)
             {
                 await _signInManager.SignInAsync(user, Input.RememberMe);
-                user.LastLoginUtc = DateTime.UtcNow;
+                user.LastLoginUtc = IstClock.Now;
                 user.LoginCount = user.LoginCount + 1;
                 await _signInManager.UserManager.UpdateAsync(user);
                 await HttpContext.RequestServices.GetRequiredService<IAuditService>()

--- a/Infrastructure/IstClock.cs
+++ b/Infrastructure/IstClock.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ProjectManagement.Infrastructure
+{
+    public static class IstClock
+    {
+        private static readonly TimeZoneInfo _ist = TimeZoneInfo.FindSystemTimeZoneById(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "India Standard Time" : "Asia/Kolkata");
+
+        public static DateTime Now => TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, _ist);
+
+        public static DateTimeOffset NowOffset => TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, _ist);
+    }
+}

--- a/Models/AuditLog.cs
+++ b/Models/AuditLog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Models
 {
@@ -8,7 +9,7 @@ namespace ProjectManagement.Models
         public long Id { get; set; }
 
         [Required]
-        public DateTime TimeUtc { get; set; } = DateTime.UtcNow;
+        public DateTime TimeUtc { get; set; } = IstClock.Now;
 
         [Required, StringLength(16)]
         public string Level { get; set; } = "Info"; // Info, Warning, Error

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Models
 {
@@ -14,6 +15,6 @@ namespace ProjectManagement.Models
         [MaxLength(1000)]
         public string? Description { get; set; }
 
-        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime CreatedAt { get; set; } = IstClock.Now;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -118,7 +118,7 @@ using (var scope = app.Services.CreateScope())
 {
     await ProjectManagement.Data.IdentitySeeder.SeedAsync(scope.ServiceProvider);
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-    var cutoff = DateTime.UtcNow.AddDays(-90);
+    var cutoff = IstClock.Now.AddDays(-90);
     db.AuditLogs.Where(a => a.TimeUtc < cutoff).ExecuteDelete();
 }
 

--- a/Services/AuditService.cs
+++ b/Services/AuditService.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Infrastructure;
+using System.Net;
 
 namespace ProjectManagement.Services
 {
@@ -23,12 +25,12 @@ namespace ProjectManagement.Services
                                    object? data = null, HttpContext? http = null)
         {
             http ??= _http.HttpContext;
-            var ip = http?.Connection?.RemoteIpAddress?.ToString();
+            var ip = http?.Connection?.RemoteIpAddress?.MapToIPv4().ToString();
             var ua = http?.Request?.Headers["User-Agent"].ToString();
 
             var log = new AuditLog
             {
-                TimeUtc = DateTime.UtcNow,
+                TimeUtc = IstClock.Now,
                 Level = level,
                 Action = action,
                 UserId = userId,

--- a/Services/UserManagementService.cs
+++ b/Services/UserManagementService.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Models;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Services
 {
@@ -28,7 +29,7 @@ namespace ProjectManagement.Services
         }
 
         private static bool IsActive(ApplicationUser user) =>
-            !user.LockoutEnd.HasValue || user.LockoutEnd <= DateTimeOffset.UtcNow;
+            !user.LockoutEnd.HasValue || user.LockoutEnd <= IstClock.NowOffset;
 
         private async Task<int> CountActiveAdminsAsync()
         {

--- a/wwwroot/css/admin.css
+++ b/wwwroot/css/admin.css
@@ -1,19 +1,19 @@
 .admin-card {
-    color: #fff;
+    color: #333;
     min-height: 8rem;
     transition: transform 0.2s ease-in-out;
 }
 
 .admin-card.users {
-    background-color: #0078d7;
+    background-color: #a3d5ff;
 }
 
 .admin-card.analytics {
-    background-color: #2d7d9a;
+    background-color: #a5e9e1;
 }
 
 .admin-card.logs {
-    background-color: #e81123;
+    background-color: #ffcdd2;
 }
 
 .admin-card:hover {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -22,16 +22,16 @@ body {
 }
 
 :root{
-  --pm-bg:#fafafa; --pm-card:#fff; --pm-text:#202124;
-  --pm-accent:#1a73e8; --pm-border:#e6e6e6; --pm-muted:#5f6368; --pm-radius:14px;
+  --pm-bg:#f9fbfd; --pm-card:#fff; --pm-text:#333;
+  --pm-accent:#a3cfff; --pm-border:#e3e6ea; --pm-muted:#7f8c8d; --pm-radius:14px;
 }
 body{background:var(--pm-bg);color:var(--pm-text)}
 .pm-card{background:var(--pm-card);border:1px solid var(--pm-border);border-radius:var(--pm-radius)}
 .pm-shadow{box-shadow:0 10px 24px rgba(0,0,0,.08)}
-.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent);color:#fff}
+.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent);color:#333}
 .pm-btn-primary:hover,
-.pm-btn-primary:focus{filter:brightness(.95);color:#fff}
-.pm-btn-primary:disabled{opacity:.65;color:#fff}
+.pm-btn-primary:focus{filter:brightness(.95);color:#333}
+.pm-btn-primary:disabled{opacity:.65;color:#333}
 .pm-field-hint{color:var(--pm-muted);font-size:.85rem}
 
 .password-container{position:relative}
@@ -46,7 +46,7 @@ body{background:var(--pm-bg);color:var(--pm-text)}
   color: var(--pm-text);
 }
 
-.badge-role { background: rgba(26,115,232,.10); color:#1a73e8; border:1px solid rgba(26,115,232,.35); }
-.badge-ok   { background: rgba(25,135,84,.10);  color:#198754; border:1px solid rgba(25,135,84,.35); }
-.badge-bad  { background: rgba(220,53,69,.10);  color:#dc3545; border:1px solid rgba(220,53,69,.35); }
+.badge-role { background: #e0f0ff; color:#4a76a8; border:1px solid #b3d7ff; }
+.badge-ok   { background: #e7f9ed;  color:#2d7a36; border:1px solid #b1e5c4; }
+.badge-bad  { background: #fdecea;  color:#b32d2e; border:1px solid #f5c6c7; }
 


### PR DESCRIPTION
## Summary
- Add `IstClock` helper and replace UTC timestamps with Indian Standard Time across models and services
- Convert logged IP addresses to IPv4 for cleaner audit logs
- Refresh site and admin styles with pastel color palette for a lighter UI

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd44a1bd1483298534653e3e282caf