### PR TITLE
Improve reset page script and button contrast

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -23,15 +23,15 @@ body {
 
 :root{
   --pm-bg:#f9fbfd; --pm-card:#fff; --pm-text:#333;
-  --pm-accent:#a3cfff; --pm-border:#e3e6ea; --pm-muted:#7f8c8d; --pm-radius:14px;
+  --pm-accent:#1a73e8; --pm-border:#e3e6ea; --pm-muted:#7f8c8d; --pm-radius:14px;
 }
 body{background:var(--pm-bg);color:var(--pm-text)}
 .pm-card{background:var(--pm-card);border:1px solid var(--pm-border);border-radius:var(--pm-radius)}
 .pm-shadow{box-shadow:0 10px 24px rgba(0,0,0,.08)}
-.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent);color:#333}
+.pm-btn-primary{background:var(--pm-accent);border-color:var(--pm-accent);color:#fff}
 .pm-btn-primary:hover,
-.pm-btn-primary:focus{filter:brightness(.95);color:#333}
-.pm-btn-primary:disabled{opacity:.65;color:#333}
+.pm-btn-primary:focus,
+.pm-btn-primary:disabled{color:#fff;filter:brightness(.95)}
 .pm-field-hint{color:var(--pm-muted);font-size:.85rem}
 
 .password-container{position:relative}

--- a/wwwroot/js/users/reset.js
+++ b/wwwroot/js/users/reset.js
@@ -1,11 +1,36 @@
 import { generatePassword } from '../utils/password.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+function boot() {
   const pwdInput = document.getElementById('NewPassword');
-  document.getElementById('genPwd').addEventListener('click', () => {
+  const genBtn = document.getElementById('genPwd');
+  const copyBtn = document.getElementById('cpyPwd');
+  if (!pwdInput || !genBtn || !copyBtn) return;
+
+  genBtn.addEventListener('click', () => {
     pwdInput.value = generatePassword();
+    pwdInput.dispatchEvent(new Event('input', { bubbles: true })); // keep client validation synced
   });
-  document.getElementById('cpyPwd').addEventListener('click', () => {
-    navigator.clipboard.writeText(pwdInput.value);
+
+  copyBtn.addEventListener('click', async () => {
+    const text = pwdInput.value || '';
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const ta = document.createElement('textarea');
+        ta.value = text; ta.style.position = 'fixed'; ta.style.left = '-9999px';
+        document.body.appendChild(ta); ta.select(); document.execCommand('copy'); ta.remove();
+      }
+      copyBtn.textContent = 'Copied';
+    } catch {
+      copyBtn.textContent = 'Copy failed';
+    }
+    setTimeout(() => (copyBtn.textContent = 'Copy'), 1000);
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true });
+} else {
+  boot();
+}


### PR DESCRIPTION
## Summary
- Prevent reset page JS from silently failing and add clipboard fallback
- Strengthen primary button accent color and enforce white text for accessibility

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4a91107883298f8fbc32e0125d70