### PR TITLE
Fix login analytics to include current day

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml.cs
@@ -27,7 +27,8 @@ namespace ProjectManagement.Areas.Admin.Pages.Analytics
             ActiveUsers = await users.CountAsync(u => !u.LockoutEnd.HasValue || u.LockoutEnd <= now);
             DisabledUsers = TotalUsers - ActiveUsers;
 
-            var since = IstClock.Now.Date.AddDays(-30);
+            // Include today in the 30 day window by starting 29 days ago
+            var since = IstClock.Now.Date.AddDays(-29);
             var raw = await _db.AuditLogs.AsNoTracking()
                 .Where(a => a.Action == "LoginSuccess" && a.TimeUtc >= since)
                 .GroupBy(a => a.TimeUtc.Date)


### PR DESCRIPTION
## Summary
- include today's logins in analytics range

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd586d84fc832998292aed47e0dca9