### PR TITLE
Simplify login flow and remove self-registration

### DIFF
--- a/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -44,7 +44,7 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
 
         public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
         {
-            returnUrl ??= Url.Content("~/");
+            returnUrl ??= Url.Content("~/Dashboard/Index");
 
             if (!ModelState.IsValid)
             {

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -29,9 +29,6 @@
                        asp-area="Identity"
                        asp-page="/Account/Login"
                        asp-route-returnUrl="/Dashboard/Index">Sign in</a>
-                    <a class="btn btn-outline-primary btn-lg"
-                       asp-area="Identity"
-                       asp-page="/Account/Register">Create account</a>
                     <a class="btn btn-link btn-lg" href="#features">Explore features</a>
                 </div>
             }

--- a/Pages/Shared/_LoginCard.cshtml
+++ b/Pages/Shared/_LoginCard.cshtml
@@ -9,14 +9,14 @@
           asp-page="/Account/Login"  
           asp-route-returnUrl="/Dashboard/Index"  
           class="needs-validation" novalidate>  
-        <input name="__RequestVerificationToken"
-               type="hidden"
-               value="@Antiforgery.GetTokens(HttpContextAccessor.HttpContext).RequestToken" />  
-        <div class="mb-3">  
-            <label for="lpEmail" class="form-label">Email</label>  
-            <input id="lpEmail" name="Input.Email" type="email" class="form-control" autocomplete="username" required />  
-            <div class="invalid-feedback">Please enter a valid email.</div>  
-        </div>  
+          <input name="__RequestVerificationToken"
+                 type="hidden"
+                 value="@Antiforgery.GetTokens(HttpContextAccessor.HttpContext!).RequestToken" />
+        <div class="mb-3">
+            <label for="lpUserName" class="form-label">Username</label>
+            <input id="lpUserName" name="Input.UserName" type="text" class="form-control" autocomplete="username" required />
+            <div class="invalid-feedback">Username is required.</div>
+        </div>
         <div class="mb-3">  
             <label for="lpPassword" class="form-label">Password</label>  
             <input id="lpPassword" name="Input.Password" type="password" class="form-control" autocomplete="current-password" required />  
@@ -29,13 +29,12 @@
             </div>  
             <a class="small" asp-area="Identity" asp-page="/Account/ForgotPassword">Forgot password</a>  
         </div>  
-        <button type="submit" class="btn btn-primary w-100">Sign in</button>  
-        <div class="text-center mt-3 small">  
-            New here  
-            <a asp-area="Identity" asp-page="/Account/Register">Create account</a>  
-        </div>  
-    </form>  
-</div>  
+        <button type="submit" class="btn btn-primary w-100">Sign in</button>
+        <div class="text-center mt-3 small">
+            Contact your administrator for access.
+        </div>
+    </form>
+</div>
 
 @section Scripts {  
     <script>  

--- a/Pages/Shared/_LoginPartial.cshtml
+++ b/Pages/Shared/_LoginPartial.cshtml
@@ -17,7 +17,6 @@
     }
     else
     {
-        <li class="nav-item"><a class="nav-link" asp-area="Identity" asp-page="/Account/Register">Register</a></li>
         <li class="nav-item"><a class="btn btn-primary ms-2" asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="/Dashboard/Index">Sign in</a></li>
     }
 </ul>

--- a/Program.cs
+++ b/Program.cs
@@ -71,6 +71,7 @@ builder.Services.AddScoped<EnforcePasswordChangeFilter>();
 builder.Services.AddRazorPages(options =>
 {
     options.Conventions.AuthorizeFolder("/");
+    options.Conventions.AllowAnonymousToPage("/Index");
 })
     .AddViewOptions(options =>
     {


### PR DESCRIPTION
## Summary
- Allow anonymous access to landing page while keeping rest of site protected
- Redirect successful logins to dashboard and align login form with username auth
- Remove all self-registration links and prompts from UI

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd80c843708329968af070f2edb379