### PR TITLE
Fix login and styling inconsistencies

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -53,12 +53,13 @@
     </fieldset>
 
     <div class="d-flex gap-2">
-      <button class="btn pm-btn-primary" type="submit">Create</button>
+      <button class="btn btn-primary" type="submit">Create</button>
       <a asp-page="Index" class="btn btn-secondary">Cancel</a>
     </div>
   </form>
   </div>
 
 @section Scripts {
+    <script type="module" src="~/js/utils/password-toggle.js"></script>
     <script type="module" src="~/js/users/create.js" asp-append-version="true"></script>
 }

--- a/Areas/Admin/Pages/Users/Edit.cshtml
+++ b/Areas/Admin/Pages/Users/Edit.cshtml
@@ -28,7 +28,7 @@
     </div>
 
     <div class="d-flex gap-2">
-      <button class="btn pm-btn-primary" type="submit">Save</button>
+      <button class="btn btn-primary" type="submit">Save</button>
       <a asp-page="Index" class="btn btn-secondary">Cancel</a>
     </div>
   </form>

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -1,7 +1,7 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Users.IndexModel
 <h3>Users</h3>
-<p><a class="btn pm-btn-primary" asp-page="Create">Create user</a></p>
+<p><a class="btn btn-primary" asp-page="Create">Create user</a></p>
 <input id="userSearch" class="form-control mb-3" type="search" placeholder="Search by username or role" />
 <table class="table table-sm" id="usersTable">
   <thead>
@@ -22,13 +22,13 @@
       <td class="text-start">
         @foreach (var r in row.Roles)
         {
-          <span class="badge badge-role me-1">@r</span>
+          <span class="badge bg-secondary me-1">@r</span>
         }
       </td>
       <td>@(row.LastLogin?.ToString("yyyy-MM-dd HH:mm") ?? "-")</td>
       <td>@row.LoginCount</td>
       <td>
-        <span class="badge @(row.IsActive ? "badge-ok" : "badge-bad")">@(row.IsActive ? "Active" : "Disabled")</span>
+        <span class="badge @(row.IsActive ? "bg-success" : "bg-danger")">@(row.IsActive ? "Active" : "Disabled")</span>
       </td>
       <td class="text-end">
         <div class="d-flex justify-content-end gap-1">

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -33,5 +33,6 @@
 </div>
 
 @section Scripts {
+    <script type="module" src="~/js/utils/password-toggle.js"></script>
     <script type="module" src="~/js/users/reset.js" asp-append-version="true"></script>
 }

--- a/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Areas/Identity/Pages/Account/Login.cshtml
@@ -37,6 +37,10 @@
       <input asp-for="Input.RememberMe" class="form-check-input" />
       <label asp-for="Input.RememberMe" class="form-check-label"></label>
     </div>
-    <button type="submit" class="btn pm-btn-primary">Log in</button>
+    <button type="submit" class="btn btn-primary">Log in</button>
   </form>
 </div>
+
+@section Scripts {
+    <script type="module" src="~/js/utils/password-toggle.js"></script>
+}

--- a/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -64,6 +64,10 @@
       </div>
       <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
     </div>
-    <button type="submit" class="btn pm-btn-primary">Change password</button>
+    <button type="submit" class="btn btn-primary">Change password</button>
   </form>
 </div>
+
+@section Scripts {
+    <script type="module" src="~/js/utils/password-toggle.js"></script>
+}

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -67,3 +67,8 @@
 <section id="security" class="py-5 border-top">
     <partial name="_SecurityStrip" />
 </section>
+
+@section Scripts {
+    <script type="module" src="~/js/utils/password-toggle.js"></script>
+    <script type="module" src="~/js/utils/login-card.js"></script>
+}

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace ProjectManagement.Pages
 {
+    [AllowAnonymous]
     public class IndexModel : PageModel
     {
         public void OnGet()

--- a/Pages/Privacy.cshtml.cs
+++ b/Pages/Privacy.cshtml.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace ProjectManagement.Pages
 {
+    [AllowAnonymous]
     public class PrivacyModel : PageModel
     {
         private readonly ILogger<PrivacyModel> _logger;
@@ -16,5 +18,4 @@ namespace ProjectManagement.Pages
         {
         }
     }
-
 }

--- a/Pages/Shared/_LoginCard.cshtml
+++ b/Pages/Shared/_LoginCard.cshtml
@@ -1,56 +1,52 @@
-﻿@using Microsoft.AspNetCore.Antiforgery  
-@inject IAntiforgery Antiforgery  
+@using Microsoft.AspNetCore.Antiforgery
+@inject IAntiforgery Antiforgery
 
-<div class="pm-login-card shadow-sm bg-white rounded-4 p-4">  
-    <h3 class="h5 fw-bold mb-3 text-center">Sign in</h3>  
-    <form method="post"  
-          asp-area="Identity"  
-          asp-page="/Account/Login"  
-          asp-route-returnUrl="/Dashboard/Index"  
-          class="needs-validation" novalidate>  
+<div class="pm-login-card shadow-sm bg-white rounded-4 p-4">
+  <h3 class="h5 fw-bold mb-3 text-center">Sign in</h3>
 
-        <input name="__RequestVerificationToken"
-               type="hidden"
-               value="@Antiforgery.GetTokens(Context).RequestToken" />
-        <div class="mb-3">  
-            <label for="lpEmail" class="form-label">Email</label>  
-            <input id="lpEmail" name="Input.Email" type="email" class="form-control" autocomplete="username" required />  
-            <div class="invalid-feedback">Please enter a valid email.</div>  
-        </div>  
+  <form method="post"
+        asp-area="Identity"
+        asp-page="/Account/Login"
+        asp-route-returnUrl="/Dashboard/Index"
+        class="needs-validation" novalidate>
 
-        <div class="mb-3">  
-            <label for="lpPassword" class="form-label">Password</label>  
-            <input id="lpPassword" name="Input.Password" type="password" class="form-control" autocomplete="current-password" required />  
-            <div class="invalid-feedback">Password is required.</div>  
-        </div>  
-        <div class="d-flex justify-content-between align-items-center mb-3">  
-            <div class="form-check">  
-                <input class="form-check-input" type="checkbox" value="true" id="rememberMe" name="Input.RememberMe" />  
-                <label class="form-check-label" for="rememberMe">Remember me</label>  
-            </div>  
-            <a class="small" asp-area="Identity" asp-page="/Account/ForgotPassword">Forgot password</a>  
-        </div>  
-        <button type="submit" class="btn btn-primary w-100">Sign in</button>
-        <div class="text-center mt-3 small">
-            Contact your administrator for access.
-        </div>
-    </form>
+    <input name="__RequestVerificationToken"
+           type="hidden"
+           value="@Antiforgery.GetTokens(Context).RequestToken" />
+
+    <div class="mb-3">
+      <label for="lpUserName" class="form-label">Username</label>
+      <input id="lpUserName"
+             name="Input.UserName"
+             class="form-control"
+             autocomplete="username"
+             required />
+      <div class="invalid-feedback">Username is required.</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="lpPassword" class="form-label">Password</label>
+      <div class="password-container">
+        <input id="lpPassword"
+               name="Input.Password"
+               type="password"
+               class="form-control"
+               autocomplete="current-password"
+               required />
+        <button type="button"
+                class="password-toggle"
+                aria-label="Show or hide password">
+          <!-- eye icons expected -->
+        </button>
+      </div>
+      <div class="invalid-feedback">Password is required.</div>
+    </div>
+
+    <div class="mb-3 form-check">
+      <input id="lpRemember" name="Input.RememberMe" type="checkbox" class="form-check-input" value="true" />
+      <label for="lpRemember" class="form-check-label">Remember me</label>
+    </div>
+
+    <button type="submit" class="btn btn-primary w-100">Log in</button>
+  </form>
 </div>
-
-@section Scripts {  
-    <script>  
-        // Simple client-side validation hinting  
-        (() => {  
-          'use strict';  
-          const forms = document.querySelectorAll('.needs-validation');  
-          Array.from(forms).forEach(form => {  
-            form.addEventListener('submit', event => {  
-              if (!form.checkValidity()) {  
-                event.preventDefault(); event.stopPropagation();  
-              }  
-              form.classList.add('was-validated');  
-            }, false);  
-          });  
-        })();  
-    </script>  
-}

--- a/Program.cs
+++ b/Program.cs
@@ -71,7 +71,10 @@ builder.Services.AddScoped<EnforcePasswordChangeFilter>();
 builder.Services.AddRazorPages(options =>
 {
     options.Conventions.AuthorizeFolder("/");
+    options.Conventions.AuthorizeAreaFolder("Admin", "/");
     options.Conventions.AllowAnonymousToPage("/Index");
+    options.Conventions.AllowAnonymousToPage("/Privacy");
+    options.Conventions.AllowAnonymousToAreaPage("Identity", "/Account/Login");
 })
     .AddViewOptions(options =>
     {

--- a/wwwroot/js/utils/login-card.js
+++ b/wwwroot/js/utils/login-card.js
@@ -1,0 +1,14 @@
+// Client-side bootstrap validation
+(() => {
+  'use strict';
+  const forms = document.querySelectorAll('.needs-validation');
+  Array.from(forms).forEach(form => {
+    form.addEventListener('submit', evt => {
+      if (!form.checkValidity()) {
+        evt.preventDefault();
+        evt.stopPropagation();
+      }
+      form.classList.add('was-validated');
+    }, false);
+  });
+})();

--- a/wwwroot/js/utils/password-toggle.js
+++ b/wwwroot/js/utils/password-toggle.js
@@ -22,3 +22,6 @@ export function initPasswordToggles() {
     setVisible(false);
   });
 }
+
+// initialize toggles on load
+initPasswordToggles();


### PR DESCRIPTION
## Summary
- Align landing-page login card with Identity by posting `Input.UserName` and moving scripts to external modules
- Allow anonymous access to Index, Privacy, and login pages; lock down Admin area
- Replace custom `pm-btn-primary` and badge classes with Bootstrap equivalents and auto-init password toggles

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd8925d1f483299a9fac8f6ba57ed1