### PR TITLE
Fix password visibility toggle and add icons

### DIFF
--- a/Pages/Shared/_LoginCard.cshtml
+++ b/Pages/Shared/_LoginCard.cshtml
@@ -28,8 +28,17 @@
                required />
         <button type="button"
                 class="password-toggle"
-                aria-label="Show or hide password">
-          <!-- eye icons expected -->
+                aria-label="Show password"
+                aria-pressed="false">
+          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+          </svg>
+          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
+            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
+            <circle cx="8" cy="8" r="3"/>
+            <path d="M1 1l14 14"/>
+          </svg>
         </button>
       </div>
       <div class="invalid-feedback">Password is required.</div>

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,8 +1,6 @@
-import { initPasswordToggles } from './utils/password-toggle.js';
 import { initSparklines } from './charts/sparkline.js';
 
 function boot() {
-  initPasswordToggles();
   initSparklines();
 }
 

--- a/wwwroot/js/utils/password-toggle.js
+++ b/wwwroot/js/utils/password-toggle.js
@@ -1,14 +1,13 @@
 export function initPasswordToggles() {
-  document.querySelectorAll('.password-toggle').forEach(btn => {
-    const container = btn.closest('.password-container');
-    if (!container) return;
+  document.querySelectorAll('.password-container').forEach(container => {
     const input = container.querySelector('input');
-    if (!input) return;
+    const btn = container.querySelector('.password-toggle');
+    if (!input || !btn) return;
     const showIcon = btn.querySelector('.eye-open');
     const hideIcon = btn.querySelector('.eye-closed');
     const setVisible = visible => {
       input.type = visible ? 'text' : 'password';
-      btn.setAttribute('aria-pressed', visible);
+      btn.setAttribute('aria-pressed', String(visible));
       btn.setAttribute('aria-label', visible ? 'Hide password' : 'Show password');
       if (showIcon && hideIcon) {
         showIcon.hidden = visible;
@@ -23,5 +22,8 @@ export function initPasswordToggles() {
   });
 }
 
-// initialize toggles on load
-initPasswordToggles();
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPasswordToggles, { once: true });
+} else {
+  initPasswordToggles();
+}


### PR DESCRIPTION
## Summary
- add missing eye icons to shared login card
- initialize password toggles after DOM ready and target container elements
- drop redundant password toggle call from site script

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd9bcf2a0c83298bf60b4acf7bbb8e