### PR TITLE
Adjust hero image scaling and hide login card for authenticated users

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -32,9 +32,12 @@
 
   <aside class="hero-right">
     <img class="hero-art" src="~/img/sdd.webp" alt="Gold archer symbolising decisive delivery" />
-    <div class="hero-card">
-      <partial name="_LoginCard" />
-    </div>
+    @if (!SignInManager.IsSignedIn(User))
+    {
+      <div class="hero-card">
+        <partial name="_LoginCard" />
+      </div>
+    }
   </aside>
 </section>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -43,7 +43,7 @@ body {
 }
 
 .hero-art {
-  max-width: clamp(280px, 34vw, 460px);
+  max-width: clamp(240px, 30vw, 360px);
   height: auto;
   /* keep it visible; never behind the card */
 }
@@ -131,6 +131,6 @@ body {
   }
   /* Show card first, art below on tablets/phones */
   .hero-card { order: 1; width: 100%; }
-  .hero-art  { order: 2; max-width: clamp(260px, 60vw, 420px); }
+  .hero-art  { order: 2; max-width: clamp(220px, 50vw, 340px); }
 }
 


### PR DESCRIPTION
## Summary
- Reduce hero image max-width for better balance
- Hide login card on the landing page when the user is already signed in

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bda6b3015883299a00034b44c49a21