### PR TITLE
Include Bootstrap Icons stylesheet in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - ProjectManagement</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="icon" href="~/favicon.ico" />
     @await RenderSectionAsync("Styles", required: false)


### PR DESCRIPTION
## Summary
- reference Bootstrap Icons CSS in shared layout to enable icon usage

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb77537b483298342f6bb871718da