### PR TITLE
Use bootstrap icons for password toggles

### DIFF
--- a/Areas/Admin/Pages/Users/Create.cshtml
+++ b/Areas/Admin/Pages/Users/Create.cshtml
@@ -21,15 +21,8 @@
       <div class="password-container">
         <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <div class="mt-2 d-flex gap-2">

--- a/Areas/Admin/Pages/Users/Reset.cshtml
+++ b/Areas/Admin/Pages/Users/Reset.cshtml
@@ -9,15 +9,8 @@
       <div class="password-container">
         <input asp-for="NewPassword" class="form-control" autocomplete="new-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <div class="mt-2 d-flex gap-2">

--- a/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Areas/Identity/Pages/Account/Login.cshtml
@@ -20,15 +20,8 @@
       <div class="password-container">
         <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <span asp-validation-for="Input.Password" class="text-danger"></span>

--- a/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml
@@ -15,15 +15,8 @@
       <div class="password-container">
         <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
@@ -33,15 +26,8 @@
       <div class="password-container">
         <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
@@ -51,15 +37,8 @@
       <div class="password-container">
         <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
         <button type="button" class="password-toggle" aria-label="Show password" aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>

--- a/Pages/Shared/_LoginCard.cshtml
+++ b/Pages/Shared/_LoginCard.cshtml
@@ -30,15 +30,8 @@
                 class="password-toggle"
                 aria-label="Show password"
                 aria-pressed="false">
-          <svg class="eye-open" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-          </svg>
-          <svg class="eye-closed" viewBox="0 0 16 16" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" hidden>
-            <path d="M1 8s3-5 7-5 7 5 7 5-3 5-7 5-7-5-7-5z"/>
-            <circle cx="8" cy="8" r="3"/>
-            <path d="M1 1l14 14"/>
-          </svg>
+          <i class="eye-open bi bi-eye"></i>
+          <i class="eye-closed bi bi-eye-slash" hidden></i>
         </button>
       </div>
       <div class="invalid-feedback">Password is required.</div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -120,6 +120,30 @@ body {
         border-color: var(--pm-primary-hover);
     }
 
+/* ---------- Password visibility toggle ---------- */
+.password-container {
+    position: relative;
+}
+
+.password-container input {
+    padding-right: 2.5rem;
+}
+
+.password-toggle {
+    position: absolute;
+    top: 50%;
+    right: .75rem;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    padding: 0;
+    color: var(--pm-text-secondary);
+}
+
+.password-toggle .bi {
+    font-size: 1rem;
+}
+
 /* Responsive behaviour */
 @media (max-width: 992px) {
   .hero {


### PR DESCRIPTION
## Summary
- replace inline SVGs with Bootstrap eye/eye-slash icons for password visibility
- style password toggle button for consistent positioning

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9c7c480832991325c019b825dc2