### PR TITLE
Enhance audit log console with advanced filtering and export

### DIFF
--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -1,63 +1,227 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Logs.IndexModel
+@using ProjectManagement.Infrastructure
+@using Microsoft.AspNetCore.Html
+@using System.Text.Json
 @{
-  ViewData["Title"] = "Logs";
+    ViewData["Title"] = "Logs";
 }
+
 <h3 class="mb-3">Logs</h3>
 
-<form method="get" class="row g-2 mb-3">
-  <div class="col-md-2"><input name="Level" value="@Model.Level" class="form-control" placeholder="Level (Info/Warning/Error)" /></div>
-  <div class="col-md-2"><input name="Action" value="@Model.Action" class="form-control" placeholder="Action (e.g., LoginSuccess)" /></div>
-  <div class="col-md-2"><input name="User"   value="@Model.User"   class="form-control" placeholder="User" /></div>
-  <div class="col-md-2"><input type="date" name="From" value="@(Model.From?.ToString("yyyy-MM-dd"))" class="form-control" /></div>
-  <div class="col-md-2"><input type="date" name="To" value="@(Model.To?.ToString("yyyy-MM-dd"))" class="form-control" /></div>
-  <div class="col-md-2 d-grid"><button class="btn btn-outline-secondary" type="submit">Filter</button></div>
+<form method="get" class="row g-2 mb-3 align-items-end">
+  <div class="col-sm-2">
+    <label class="form-label">Level</label>
+    <select name="Level" class="form-select">
+      <option value="" selected="@(string.IsNullOrEmpty(Model.Level) ? "selected" : null)">All</option>
+      <option value="Info" selected="@(Model.Level=="Info" ? "selected" : null)">Info</option>
+      <option value="Warning" selected="@(Model.Level=="Warning" ? "selected" : null)">Warning</option>
+      <option value="Error" selected="@(Model.Level=="Error" ? "selected" : null)">Error</option>
+    </select>
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">Action</label>
+    <input name="Action" class="form-control" list="action-list" value="@Model.Action" placeholder="e.g. LoginSuccess" />
+    <datalist id="action-list">
+      @foreach (var a in Model.ActionOptions) { <option value="@a"></option> }
+    </datalist>
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">User</label>
+    <input name="User" class="form-control" value="@Model.User" />
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">IP</label>
+    <input name="Ip" class="form-control" value="@Model.Ip" />
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">Contains</label>
+    <input name="Contains" class="form-control" value="@Model.Contains" placeholder="Message or JSON" />
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">From</label>
+    <input type="date" name="From" class="form-control" value="@(Model.From?.ToString("yyyy-MM-dd"))" />
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">To</label>
+    <input type="date" name="To" class="form-control" value="@(Model.To?.ToString("yyyy-MM-dd"))" />
+  </div>
+
+  <div class="col-sm-2">
+    <label class="form-label">Page size</label>
+    <select name="PageSize" class="form-select">
+      @foreach (var n in new[]{25,50,100,200})
+      {
+        <option value="@n" selected="@(Model.PageSize==n ? "selected" : null)">@n</option>
+      }
+    </select>
+  </div>
+
+  <div class="col-sm-2 d-grid">
+    <label class="form-label">&nbsp;</label>
+    <button class="btn btn-primary" type="submit">Filter</button>
+  </div>
+
+  <div class="col-sm-6">
+    <div class="btn-group btn-group-sm mt-2 mt-sm-0" role="group" aria-label="Quick ranges">
+      <button type="button" class="btn btn-outline-secondary log-preset" data-days="1">Last 24h</button>
+      <button type="button" class="btn btn-outline-secondary log-preset" data-days="7">7 days</button>
+      <button type="button" class="btn btn-outline-secondary log-preset" data-days="30">30 days</button>
+    </div>
+  </div>
 </form>
 
-<div class="mb-3">
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <div>
+    <strong>@Model.Total</strong> result(s)
+    @if (Model.Total > 0)
+    {
+      var start = (Model.PageNo - 1) * Model.PageSize + 1;
+      var end = Math.Min(Model.PageNo * Model.PageSize, Model.Total);
+      <span class="text-muted"> • showing @start–@end</span>
+    }
+  </div>
+
   <div class="btn-group btn-group-sm" role="group">
-    <button type="button" class="btn btn-outline-secondary log-preset" data-days="0">Today</button>
-    <button type="button" class="btn btn-outline-secondary log-preset" data-days="7">7d</button>
-    <button type="button" class="btn btn-outline-secondary log-preset" data-days="30">30d</button>
+    <a class="btn btn-outline-secondary"
+       href="@Url.Page(null, null, new { handler = "ExportCsv", Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains, From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd") }, null)">
+      <i class="bi bi-filetype-csv me-1"></i> Export CSV
+    </a>
   </div>
 </div>
 
-<div class="pm-card pm-shadow p-2">
-  <table class="table table-sm table-hover align-middle mb-0">
-    <thead class="table-light">
-      <tr><th>Time (IST)</th><th>Level</th><th>Action</th><th>User</th><th>IP</th><th>Message</th></tr>
+@if (Model.SeriesLabels.Count > 0)
+{
+  <div class="pm-card pm-shadow p-3 mb-3">
+    <h6 class="mb-2">Events per day</h6>
+    <canvas id="logsPerDay"
+            data-labels="@JsonSerializer.Serialize(Model.SeriesLabels)"
+            data-values="@JsonSerializer.Serialize(Model.SeriesCounts)"></canvas>
+  </div>
+}
+
+<div class="table-responsive">
+  <table class="table table-sm align-middle">
+    <thead>
+      <tr>
+        @* sortable headers *@
+        <th>@SortLink("Time", "Time", Model.Sort, Model.Dir)</th>
+        <th>@SortLink("Level", "Level", Model.Sort, Model.Dir)</th>
+        <th>@SortLink("Action", "Action", Model.Sort, Model.Dir)</th>
+        <th>@SortLink("User", "User", Model.Sort, Model.Dir)</th>
+        <th>@SortLink("IP", "Ip", Model.Sort, Model.Dir)</th>
+        <th>Message</th>
+        <th style="width: 1%"></th>
+      </tr>
     </thead>
     <tbody>
-      @foreach (var r in Model.Rows)
-      {
-        <tr>
-          <td>@r.Time.ToString("yyyy-MM-dd HH:mm:ss")</td>
-          <td><span class="pm-badge @(r.Level=="Error" ? "pm-badge-warn" : r.Level=="Warning" ? "pm-badge-warn" : "")">@r.Level</span></td>
-          <td>@r.Action</td>
-          <td>@r.UserName</td>
-          <td>@r.Ip</td>
-          <td>@r.Message</td>
-        </tr>
-      }
+    @foreach (var r in Model.Rows)
+    {
+      <tr>
+        <td class="text-nowrap">@IstClock.ToIst(r.TimeUtc).ToString("yyyy-MM-dd HH:mm")</td>
+        <td>
+          <span class="badge bg-@LevelColor(r.Level)">@r.Level</span>
+        </td>
+        <td class="text-nowrap">@r.Action</td>
+        <td class="text-nowrap">@r.UserName</td>
+        <td class="text-monospace">@r.Ip</td>
+        <td style="max-width: 420px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">@r.Message</td>
+        <td>
+          @if (!string.IsNullOrWhiteSpace(r.DataJson))
+          {
+            <button type="button" class="btn btn-outline-secondary btn-sm view-json"
+                    data-bs-toggle="modal" data-bs-target="#jsonModal"
+                    data-json="@r.DataJson">
+              Details
+            </button>
+          }
+        </td>
+      </tr>
+    }
     </tbody>
   </table>
 </div>
 
-<nav class="mt-2">
-  @{
-    var pages = (int)Math.Ceiling((double)Model.Total / Model.PageSize);
-    if (pages < 1) pages = 1;
+@{
+  var pages = (int)Math.Ceiling((double)Model.Total / Model.PageSize);
+  string qs(string sort = "", string dir = "") =>
+    Url.Page(null, null, new {
+      Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
+      From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
+      PageNo = Model.PageNo, PageSize = Model.PageSize,
+      Sort = string.IsNullOrEmpty(sort) ? Model.Sort : sort,
+      Dir = string.IsNullOrEmpty(dir) ? Model.Dir : dir
+    }, null) ?? "#";
+}
+
+@if (pages > 1)
+{
+  <nav aria-label="Pages">
+    <ul class="pagination pagination-sm">
+      @for (var i = 1; i <= pages; i++)
+      {
+        <li class="page-item @(i==Model.PageNo?"active":"")">
+          <a class="page-link" href="@Url.Page(null, null, new {
+               Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
+               From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
+               PageNo = i, PageSize = Model.PageSize, Sort = Model.Sort, Dir = Model.Dir }, null)">@i</a>
+        </li>
+      }
+    </ul>
+  </nav>
+}
+
+@functions {
+  string LevelColor(string level) => level switch
+  {
+    "Error" => "danger",
+    "Warning" => "warning",
+    _ => "secondary"
+  };
+
+  IHtmlContent SortLink(string text, string col, string curSort, string curDir)
+  {
+    var nextDir = (curSort == col && curDir == "asc") ? "desc" : "asc";
+    var url = Url.Page(null, null, new {
+      Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
+      From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
+      PageNo = 1, PageSize = Model.PageSize, Sort = col, Dir = nextDir
+    }, null) ?? "#";
+
+    var icon = curSort == col
+      ? (curDir == "asc" ? "bi-caret-up-fill" : "bi-caret-down-fill")
+      : "bi-caret-down";
+
+    return new HtmlString($@"<a class=""link-dark text-decoration-none"" href=""{url}"">{text} <i class=""bi {icon}""></i></a>");
   }
-  <ul class="pagination pagination-sm">
-    @for (var i=1; i<=pages; i++)
-    {
-      <li class="page-item @(i==Model.PageNo?"active":"")">
-        <a class="page-link" href="?Level=@Model.Level&Action=@Model.Action&User=@Model.User&From=@(Model.From?.ToString("yyyy-MM-dd"))&To=@(Model.To?.ToString("yyyy-MM-dd"))&PageNo=@i">@i</a>
-      </li>
-    }
-  </ul>
-</nav>
+}
+
+@* JSON details modal *@
+<div class="modal fade" id="jsonModal" tabindex="-1" aria-labelledby="jsonModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="jsonModalLabel">Log details</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <pre class="mb-0"><code id="jsonContent"></code></pre>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="copyJson"><i class="bi bi-clipboard"></i> Copy</button>
+        <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 @section Scripts {
-    <script type="module" src="~/js/logs/index.js" asp-append-version="true"></script>
+  <script src="~/lib/chart.js/chart.umd.js"></script>
+  <script type="module" src="~/js/logs/index.js" asp-append-version="true"></script>
 }

--- a/Areas/Admin/Pages/Logs/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Logs/Index.cshtml.cs
@@ -3,51 +3,189 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
+using ProjectManagement.Models;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using System.Text.Json;
 
 namespace ProjectManagement.Areas.Admin.Pages.Logs
 {
-    [Authorize(Roles="Admin")]
+    [Authorize(Roles = "Admin")]
     public class IndexModel : PageModel
     {
         private readonly ApplicationDbContext _db;
         public IndexModel(ApplicationDbContext db) => _db = db;
 
+        // ---------- Filters (GET-bound) ----------
         [BindProperty(SupportsGet = true)] public string? Level { get; set; }
         [BindProperty(SupportsGet = true)] public string? Action { get; set; }
-        [BindProperty(SupportsGet = true)] public new string? User { get; set; }
-        [BindProperty(SupportsGet = true)] public DateTime? From { get; set; }
-        [BindProperty(SupportsGet = true)] public DateTime? To { get; set; }
-        [BindProperty(SupportsGet = true)] public int PageNo { get; set; } = 1;
+        [BindProperty(SupportsGet = true)] public string? User { get; set; }
+        [BindProperty(SupportsGet = true)] public string? Ip { get; set; }
+        [BindProperty(SupportsGet = true)] public string? Contains { get; set; }
+        [BindProperty(SupportsGet = true)] [DataType(DataType.Date)] public DateTime? From { get; set; }
+        [BindProperty(SupportsGet = true)] [DataType(DataType.Date)] public DateTime? To { get; set; }
 
+        // ---------- Paging & sorting ----------
+        [BindProperty(SupportsGet = true)] public int PageNo { get; set; } = 1;
+        [BindProperty(SupportsGet = true)] public int PageSize { get; set; } = 25; // cap in OnGet
+        [BindProperty(SupportsGet = true)] public string Sort { get; set; } = "Time";
+        [BindProperty(SupportsGet = true)] public string Dir { get; set; } = "desc"; // asc|desc
+
+        // ---------- Results ----------
         public int Total { get; private set; }
-        public int PageSize { get; } = 50;
-        public List<LogRow> Rows { get; private set; } = new();
+        public IReadOnlyList<LogRow> Rows { get; private set; } = Array.Empty<LogRow>();
+
+        // For UI helpers
+        public IReadOnlyList<string> ActionOptions { get; private set; } = Array.Empty<string>();
+
+        // Daily counts for the filtered range
+        public IReadOnlyList<string> SeriesLabels { get; private set; } = Array.Empty<string>();
+        public IReadOnlyList<int> SeriesCounts { get; private set; } = Array.Empty<int>();
 
         public class LogRow
         {
-            public DateTime Time { get; set; }
-            public string Level { get; set; } = string.Empty;
-            public string Action { get; set; } = string.Empty;
+            public DateTime TimeUtc { get; set; }
+            public string Level { get; set; } = "";
+            public string Action { get; set; } = "";
             public string? UserName { get; set; }
             public string? Ip { get; set; }
             public string? Message { get; set; }
+            public string? DataJson { get; set; }
         }
 
-        public async Task OnGet()
+        public async Task<IActionResult> OnGetAsync()
         {
-            var q = _db.AuditLogs.AsNoTracking().OrderByDescending(x => x.TimeUtc).AsQueryable();
-            if (!string.IsNullOrWhiteSpace(Level)) q = q.Where(x => x.Level == Level);
-            if (!string.IsNullOrWhiteSpace(Action)) q = q.Where(x => x.Action == Action);
-            if (!string.IsNullOrWhiteSpace(User)) q = q.Where(x => x.UserName!.Contains(User));
-            if (From.HasValue) q = q.Where(x => x.TimeUtc >= From.Value);
-            if (To.HasValue)   q = q.Where(x => x.TimeUtc <= To.Value);
+            if (PageNo < 1) PageNo = 1;
+            if (PageSize <= 0 || PageSize > 200) PageSize = 25; // sensible cap
+
+            var q = ComposeQuery(_db.AuditLogs.AsNoTracking());
 
             Total = await q.CountAsync();
-            Rows = await q.Skip((PageNo-1)*PageSize).Take(PageSize)
-                .Select(x => new LogRow {
-                    Time = x.TimeUtc, Level = x.Level, Action = x.Action,
-                    UserName = x.UserName, Ip = x.Ip, Message = x.Message
-                }).ToListAsync();
+
+            q = ApplySort(q, Sort, Dir);
+
+            Rows = await q
+                .Skip((PageNo - 1) * PageSize)
+                .Take(PageSize)
+                .Select(x => new LogRow
+                {
+                    TimeUtc = x.TimeUtc,
+                    Level = x.Level,
+                    Action = x.Action,
+                    UserName = x.UserName,
+                    Ip = x.Ip,
+                    Message = x.Message,
+                    DataJson = x.DataJson
+                })
+                .ToListAsync();
+
+            // Populate Action datalist with a small distinct set
+            ActionOptions = await _db.AuditLogs.AsNoTracking()
+                .Select(a => a.Action).Distinct().OrderBy(a => a).Take(50).ToListAsync();
+
+            // Daily count series for the filtered range
+            var perDay = await ComposeQuery(_db.AuditLogs.AsNoTracking())
+                .GroupBy(x => x.TimeUtc.Date)
+                .Select(g => new { Day = g.Key, Count = g.Count() })
+                .OrderBy(x => x.Day)
+                .ToListAsync();
+
+            SeriesLabels = perDay.Select(d => d.Day.ToString("yyyy-MM-dd")).ToList();
+            SeriesCounts = perDay.Select(d => d.Count).ToList();
+
+            return Page();
+        }
+
+        // CSV export for current filter
+        public async Task<FileResult> OnGetExportCsvAsync()
+        {
+            var q = ApplySort(ComposeQuery(_db.AuditLogs.AsNoTracking()), "Time", "desc");
+
+            // Hard cap to avoid accidental huge dumps
+            var rows = await q.Take(100_000).ToListAsync();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("TimeIST,Level,Action,User,IP,Message,DataJson");
+
+            foreach (var x in rows)
+            {
+                var tIst = IstClock.ToIst(x.TimeUtc).ToString("yyyy-MM-dd HH:mm:ss");
+                sb.AppendLine(string.Join(",", new[]
+                {
+                    Csv(tIst), Csv(x.Level), Csv(x.Action), Csv(x.UserName), Csv(x.Ip),
+                    Csv(x.Message), Csv(x.DataJson)
+                }));
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+            var fileName = $"logs_{DateTime.UtcNow:yyyyMMdd_HHmmss}.csv";
+            return File(bytes, "text/csv; charset=utf-8", fileName);
+        }
+
+        // ---------- Helpers ----------
+
+        private IQueryable<AuditLog> ComposeQuery(IQueryable<AuditLog> q)
+        {
+            if (!string.IsNullOrWhiteSpace(Level)) q = q.Where(x => x.Level == Level);
+            if (!string.IsNullOrWhiteSpace(Action)) q = q.Where(x => x.Action == Action);
+            if (!string.IsNullOrWhiteSpace(User)) q = q.Where(x => x.UserName != null && x.UserName.Contains(User));
+            if (!string.IsNullOrWhiteSpace(Ip)) q = q.Where(x => x.Ip != null && x.Ip.Contains(Ip));
+
+            if (!string.IsNullOrWhiteSpace(Contains))
+            {
+                // Postgres: ILIKE for case-insensitive contains
+                // Falls back to Contains if provider does not support ILike
+                if (EF.Functions.GetType().GetMethod("ILike") != null)
+                {
+                    q = q.Where(x =>
+                        (x.Message != null && EF.Functions.ILike(x.Message, $"%{Contains}%")) ||
+                        (x.DataJson != null && EF.Functions.ILike(x.DataJson, $"%{Contains}%")));
+                }
+                else
+                {
+                    var needle = Contains.ToLowerInvariant();
+                    q = q.Where(x =>
+                        (x.Message != null && x.Message.ToLower().Contains(needle)) ||
+                        (x.DataJson != null && x.DataJson.ToLower().Contains(needle)));
+                }
+            }
+
+            if (From.HasValue) q = q.Where(x => x.TimeUtc >= From.Value);
+            if (To.HasValue) q = q.Where(x => x.TimeUtc <= To.Value.AddDays(1).AddTicks(-1)); // inclusive day
+
+            return q;
+        }
+
+        private static IQueryable<AuditLog> ApplySort(IQueryable<AuditLog> q, string sort, string dir)
+        {
+            bool asc = string.Equals(dir, "asc", StringComparison.OrdinalIgnoreCase);
+
+            return sort switch
+            {
+                "Level" => asc ? q.OrderBy(x => x.Level).ThenBy(x => x.TimeUtc)
+                               : q.OrderByDescending(x => x.Level).ThenByDescending(x => x.TimeUtc),
+
+                "Action" => asc ? q.OrderBy(x => x.Action).ThenBy(x => x.TimeUtc)
+                                : q.OrderByDescending(x => x.Action).ThenByDescending(x => x.TimeUtc),
+
+                "User" => asc ? q.OrderBy(x => x.UserName).ThenBy(x => x.TimeUtc)
+                              : q.OrderByDescending(x => x.UserName).ThenByDescending(x => x.TimeUtc),
+
+                "Ip" => asc ? q.OrderBy(x => x.Ip).ThenBy(x => x.TimeUtc)
+                            : q.OrderByDescending(x => x.Ip).ThenByDescending(x => x.TimeUtc),
+
+                _ => asc ? q.OrderBy(x => x.TimeUtc) : q.OrderByDescending(x => x.TimeUtc)
+            };
+        }
+
+        private static string Csv(string? s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            // Escape double quotes and wrap
+            var t = s.Replace("\"", "\"\"");
+            return $"\"{t}\"";
         }
     }
 }
+

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -21,6 +21,9 @@ namespace ProjectManagement.Data
                 e.HasIndex(x => x.TimeUtc);
                 e.HasIndex(x => x.Action);
                 e.HasIndex(x => x.UserId);
+                e.HasIndex(x => x.Level);
+                e.HasIndex(x => x.UserName);
+                e.HasIndex(x => x.Ip);
                 e.Property(x => x.Level).HasMaxLength(16);
                 e.Property(x => x.Action).HasMaxLength(64);
                 e.Property(x => x.Message).HasMaxLength(1024);

--- a/Migrations/20250907174955_AddAuditLogIndexes.Designer.cs
+++ b/Migrations/20250907174955_AddAuditLogIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250907174955_AddAuditLogIndexes")]
+    partial class AddAuditLogIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250907174955_AddAuditLogIndexes.cs
+++ b/Migrations/20250907174955_AddAuditLogIndexes.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLogIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_Ip",
+                table: "AuditLogs",
+                column: "Ip");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_Level",
+                table: "AuditLogs",
+                column: "Level");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_UserName",
+                table: "AuditLogs",
+                column: "UserName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_Ip",
+                table: "AuditLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_Level",
+                table: "AuditLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_UserName",
+                table: "AuditLogs");
+        }
+    }
+}

--- a/wwwroot/js/logs/index.js
+++ b/wwwroot/js/logs/index.js
@@ -1,4 +1,4 @@
-function boot() {
+function bindPresets() {
   const from = document.querySelector('input[name="From"]');
   const to = document.querySelector('input[name="To"]');
   if (!from || !to) return;
@@ -8,15 +8,81 @@ function boot() {
       const days = parseInt(btn.dataset.days, 10);
       const now = new Date();
       const toStr = now.toISOString().slice(0, 10);
+
       let fromDate = new Date(now);
-      if (days > 0) {
-        fromDate.setDate(now.getDate() - (days - 1));
-      }
+      if (days > 0) fromDate.setDate(now.getDate() - (days - 1));
       const fromStr = fromDate.toISOString().slice(0, 10);
+
       from.value = fromStr;
       to.value = toStr;
     });
   });
+}
+
+function bindJsonModal() {
+  const jsonModal = document.getElementById('jsonModal');
+  if (!jsonModal) return;
+
+  const content = document.getElementById('jsonContent');
+  const copyBtn = document.getElementById('copyJson');
+
+  jsonModal.addEventListener('show.bs.modal', (ev) => {
+    const trigger = ev.relatedTarget;
+    const raw = trigger?.getAttribute('data-json') || '';
+    try {
+      const obj = JSON.parse(raw);
+      content.textContent = JSON.stringify(obj, null, 2);
+    } catch {
+      content.textContent = raw;
+    }
+  });
+
+  copyBtn?.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(content.textContent || '');
+      copyBtn.innerText = 'Copied';
+      setTimeout(() => (copyBtn.innerHTML = '<i class="bi bi-clipboard"></i> Copy'), 1000);
+    } catch {}
+  });
+}
+
+function initChart() {
+  const el = document.getElementById('logsPerDay');
+  if (!el || !window.Chart) return;
+
+  let labels = [];
+  let values = [];
+  try {
+    labels = JSON.parse(el.dataset.labels || '[]');
+    values = JSON.parse(el.dataset.values || '[]');
+  } catch {}
+
+  if (labels.length === 0) return;
+  if (labels.length === 1) { labels = [labels[0], labels[0]]; values = [values[0], values[0]]; }
+
+  const ctx = el.getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{ label: 'Events', data: values, tension: 0.3, fill: false }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false } },
+        y: { beginAtZero: true, grid: { color: 'rgba(0,0,0,.06)' }, ticks: { precision: 0 } }
+      }
+    }
+  });
+}
+
+function boot() {
+  bindPresets();
+  bindJsonModal();
+  initChart();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Expand audit log filters and sorting, add CSV export and per-day chart
- Add JSON detail modal and preset helpers on logs page
- Index new audit log fields to speed up queries

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet ef database update` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc47e6648832991528186a7c6e35d