### PR TITLE
Fix log preset dates for local timezone

### DIFF
--- a/wwwroot/js/logs/index.js
+++ b/wwwroot/js/logs/index.js
@@ -7,11 +7,19 @@ function bindPresets() {
     btn.addEventListener('click', () => {
       const days = parseInt(btn.dataset.days, 10);
       const now = new Date();
-      const toStr = now.toISOString().slice(0, 10);
+
+      const formatDate = (d) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      };
+
+      const toStr = formatDate(now);
 
       let fromDate = new Date(now);
       if (days > 0) fromDate.setDate(now.getDate() - (days - 1));
-      const fromStr = fromDate.toISOString().slice(0, 10);
+      const fromStr = formatDate(fromDate);
 
       from.value = fromStr;
       to.value = toStr;


### PR DESCRIPTION
## Summary
- ensure quick-range date presets use local timezone formatting to avoid off-by-one day chart data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc80347788329bd6ccffde418516c