### PR TITLE
Fix logs events chart vertical growth

### DIFF
--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -100,9 +100,11 @@
 {
   <div class="pm-card pm-shadow p-3 mb-3">
     <h6 class="mb-2">Events per day</h6>
-    <canvas id="logsPerDay"
-            data-labels="@JsonSerializer.Serialize(Model.SeriesLabels)"
-            data-values="@JsonSerializer.Serialize(Model.SeriesCounts)"></canvas>
+    <div style="position:relative; height:240px;">
+      <canvas id="logsPerDay"
+              data-labels="@JsonSerializer.Serialize(Model.SeriesLabels)"
+              data-values="@JsonSerializer.Serialize(Model.SeriesCounts)"></canvas>
+    </div>
   </div>
 }
 


### PR DESCRIPTION
## Summary
- prevent logs events chart from expanding vertically by wrapping canvas in a fixed-height container

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcba0f9f08329bc57ca96e097e9fe