### PR TITLE
Fix warnings in Admin Logs page

### DIFF
--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -30,7 +30,7 @@
 
   <div class="col-sm-2">
     <label class="form-label">User</label>
-    <input name="User" class="form-control" value="@Model.User" />
+    <input name="User" class="form-control" value="@Model.UserName" />
   </div>
 
   <div class="col-sm-2">
@@ -90,7 +90,7 @@
 
   <div class="btn-group btn-group-sm" role="group">
     <a class="btn btn-outline-secondary"
-       href="@Url.Page(null, null, new { handler = "ExportCsv", Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains, From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd") }, null)">
+       href="@Url.Page(null, null, new { handler = "ExportCsv", Level = Model.Level, Action = Model.Action, User = Model.UserName, Ip = Model.Ip, Contains = Model.Contains, From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd") }, null)">
       <i class="bi bi-filetype-csv me-1"></i> Export CSV
     </a>
   </div>
@@ -152,14 +152,6 @@
 
 @{
   var pages = (int)Math.Ceiling((double)Model.Total / Model.PageSize);
-  string qs(string sort = "", string dir = "") =>
-    Url.Page(null, null, new {
-      Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
-      From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
-      PageNo = Model.PageNo, PageSize = Model.PageSize,
-      Sort = string.IsNullOrEmpty(sort) ? Model.Sort : sort,
-      Dir = string.IsNullOrEmpty(dir) ? Model.Dir : dir
-    }, null) ?? "#";
 }
 
 @if (pages > 1)
@@ -170,7 +162,7 @@
       {
         <li class="page-item @(i==Model.PageNo?"active":"")">
           <a class="page-link" href="@Url.Page(null, null, new {
-               Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
+               Level = Model.Level, Action = Model.Action, User = Model.UserName, Ip = Model.Ip, Contains = Model.Contains,
                From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
                PageNo = i, PageSize = Model.PageSize, Sort = Model.Sort, Dir = Model.Dir }, null)">@i</a>
         </li>
@@ -191,7 +183,7 @@
   {
     var nextDir = (curSort == col && curDir == "asc") ? "desc" : "asc";
     var url = Url.Page(null, null, new {
-      Level = Model.Level, Action = Model.Action, User = Model.User, Ip = Model.Ip, Contains = Model.Contains,
+      Level = Model.Level, Action = Model.Action, User = Model.UserName, Ip = Model.Ip, Contains = Model.Contains,
       From = Model.From?.ToString("yyyy-MM-dd"), To = Model.To?.ToString("yyyy-MM-dd"),
       PageNo = 1, PageSize = Model.PageSize, Sort = col, Dir = nextDir
     }, null) ?? "#";

--- a/Areas/Admin/Pages/Logs/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Logs/Index.cshtml.cs
@@ -20,7 +20,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Logs
         // ---------- Filters (GET-bound) ----------
         [BindProperty(SupportsGet = true)] public string? Level { get; set; }
         [BindProperty(SupportsGet = true)] public string? Action { get; set; }
-        [BindProperty(SupportsGet = true)] public string? User { get; set; }
+        [BindProperty(SupportsGet = true, Name = "User")] public string? UserName { get; set; }
         [BindProperty(SupportsGet = true)] public string? Ip { get; set; }
         [BindProperty(SupportsGet = true)] public string? Contains { get; set; }
         [BindProperty(SupportsGet = true)] [DataType(DataType.Date)] public DateTime? From { get; set; }
@@ -129,7 +129,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Logs
         {
             if (!string.IsNullOrWhiteSpace(Level)) q = q.Where(x => x.Level == Level);
             if (!string.IsNullOrWhiteSpace(Action)) q = q.Where(x => x.Action == Action);
-            if (!string.IsNullOrWhiteSpace(User)) q = q.Where(x => x.UserName != null && x.UserName.Contains(User));
+            if (!string.IsNullOrWhiteSpace(UserName)) q = q.Where(x => x.UserName != null && x.UserName.Contains(UserName));
             if (!string.IsNullOrWhiteSpace(Ip)) q = q.Where(x => x.Ip != null && x.Ip.Contains(Ip));
 
             if (!string.IsNullOrWhiteSpace(Contains))


### PR DESCRIPTION
## Summary
- remove unused local function from logs page
- rename filter property to avoid hiding `PageModel.User`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcfe49c208329bb0b1030554717b2