### PR TITLE
fix(audit): correct client IP capture

### DIFF
--- a/Helpers/ClientIp.cs
+++ b/Helpers/ClientIp.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.AspNetCore.Http;
+
+namespace ProjectManagement.Helpers
+{
+    public static class ClientIp
+    {
+        public static string Get(HttpContext? ctx)
+        {
+            if (ctx?.Connection?.RemoteIpAddress is not IPAddress ip)
+                return string.Empty;
+
+            // Handle IPv6 and mapped IPv4 correctly
+            if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                if (ip.IsIPv4MappedToIPv6)
+                {
+                    ip = ip.MapToIPv4();               // ::ffff:192.168.1.50 -> 192.168.1.50
+                }
+                else if (IPAddress.IPv6Loopback.Equals(ip))
+                {
+                    return "127.0.0.1";                // ::1 -> 127.0.0.1 for clarity in logs
+                }
+            }
+
+            return ip.ToString();
+        }
+    }
+}

--- a/ProjectManagement.Tests/ClientIpTests.cs
+++ b/ProjectManagement.Tests/ClientIpTests.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using ProjectManagement.Helpers;
+
+namespace ProjectManagement.Tests
+{
+    public class ClientIpTests
+    {
+        [Fact]
+        public void IPv6Loopback_To_Localhost()
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Connection.RemoteIpAddress = IPAddress.IPv6Loopback;
+            Assert.Equal("127.0.0.1", ClientIp.Get(ctx));
+        }
+
+        [Fact]
+        public void IPv4MappedIPv6_To_IPv4()
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Connection.RemoteIpAddress = IPAddress.Parse("::ffff:10.0.0.5");
+            Assert.Equal("10.0.0.5", ClientIp.Get(ctx));
+        }
+
+        [Fact]
+        public void RealIPv6_RemainsIPv6()
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Connection.RemoteIpAddress = IPAddress.Parse("2001:db8::1");
+            Assert.Equal("2001:db8::1", ClientIp.Get(ctx));
+        }
+    }
+}

--- a/Services/AuditService.cs
+++ b/Services/AuditService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
-using System.Net;
+using ProjectManagement.Helpers;
 
 namespace ProjectManagement.Services
 {
@@ -42,7 +42,7 @@ namespace ProjectManagement.Services
                                    IDictionary<string, string?>? data = null, HttpContext? http = null)
         {
             http ??= _http.HttpContext;
-            var ip = http?.Connection?.RemoteIpAddress?.MapToIPv4().ToString();
+            var ip = ClientIp.Get(http);
             var ua = http?.Request?.Headers["User-Agent"].ToString();
 
             var clean = data is null ? null : Scrub(data);
@@ -54,7 +54,7 @@ namespace ProjectManagement.Services
                 Action = action,
                 UserId = userId,
                 UserName = userName,
-                Ip = ip,
+                Ip = string.IsNullOrWhiteSpace(ip) ? null : ip,
                 UserAgent = ua,
                 Message = message,
                 DataJson = clean is null ? null : JsonSerializer.Serialize(clean)


### PR DESCRIPTION
## Summary
- add ClientIp helper to unify IP address handling
- use helper in AuditService to avoid 0.0.0.1
- cover IPv6 loopback and IPv4-mapped IPv6 with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68be87cd77cc832995ebfc85f1913ad2