### PR TITLE
Seed additional user roles

### DIFF
--- a/Data/IdentitySeeder.cs
+++ b/Data/IdentitySeeder.cs
@@ -7,7 +7,17 @@ namespace ProjectManagement.Data
     {
         public static async Task SeedAsync(IServiceProvider services)
         {
-            var roles = new[] { "Admin", "HoD", "TeamLead", "User" };
+            var roles = new[]
+            {
+                "Project Officer",
+                "HoD",
+                "Comdt",
+                "Admin",
+                "TA",
+                "MCO",
+                "Project Office",
+                "Main Office"
+            };
             var roleMgr = services.GetRequiredService<RoleManager<IdentityRole>>();
             foreach (var r in roles)
                 if (!await roleMgr.RoleExistsAsync(r))

--- a/docs/data-domain.md
+++ b/docs/data-domain.md
@@ -11,7 +11,7 @@ Derives from `IdentityDbContext<ApplicationUser>` and exposes the `Projects` tab
 Provides a design-time factory so Entity Framework tooling can create the context when running migrations. It reads configuration from `appsettings.json`, `appsettings.Development.json`, or environment variables.
 
 ### `Data/IdentitySeeder.cs`
-Seeds initial roles (`Admin`, `HoD`, `TeamLead`, `User`) and creates a default `admin` account with the password `ChangeMe!123` if it does not already exist. The `admin` user has `MustChangePassword` set to `false` so it can log in immediately.
+Seeds initial roles (`Project Officer`, `HoD`, `Comdt`, `Admin`, `TA`, `MCO`, `Project Office`, `Main Office`) and creates a default `admin` account with the password `ChangeMe!123` if it does not already exist. The `admin` user has `MustChangePassword` set to `false` so it can log in immediately.
 
 ## Domain model
 


### PR DESCRIPTION
## Summary
- expand IdentitySeeder to create roles: Project Officer, HoD, Comdt, Admin, TA, MCO, Project Office and Main Office
- document new default roles in the data/domain docs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68be95bb55fc8329b1a64bd4b8909c1a