### PR TITLE
Add user lifecycle with disable and timed hard delete

### DIFF
--- a/Areas/Admin/Pages/Users/Delete.cshtml
+++ b/Areas/Admin/Pages/Users/Delete.cshtml
@@ -1,11 +1,46 @@
 @page "{id}"
 @model ProjectManagement.Areas.Admin.Pages.Users.DeleteModel
-<h3>Delete user</h3>
+<h3>Delete account?</h3>
+@if (Model.UserEntity?.PendingDeletion ?? false)
+{
+    var due = Model.UserEntity.DeletionRequestedUtc!.Value.AddMinutes(Model.Options.UndoWindowMinutes);
+    <div class="alert alert-warning">
+        Account scheduled for deletion at @due.ToString("yyyy-MM-dd HH:mm").
+    </div>
+    @if (DateTime.UtcNow < due)
+    {
+        <form method="post" asp-page-handler="Undo">
+            <button class="btn btn-danger" type="submit">Undo</button>
+            <a asp-page="Index" class="btn btn-secondary">Back</a>
+        </form>
+    }
+    else
+    {
+        <a asp-page="Index" class="btn btn-secondary">Back</a>
+    }
+}
+else if (Model.UserEntity is not null)
+{
 <div class="pm-card pm-shadow p-4 p-md-5">
-  <p>Are you sure you want to delete @Model.UserName?</p>
+  <p>Deleting an account permanently removes the user’s sign-in and access. Business records previously created by this user will <strong>not</strong> be removed, but they may lose their owner/author link. Only delete accounts that were created by mistake. For all other cases, <strong>disable</strong> the account instead.</p>
+  <p>This action can be undone for the next <strong>@Model.Options.UndoWindowMinutes minutes</strong>, after which it is irreversible.</p>
   <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-    <button class="btn btn-danger" type="submit">Delete</button>
+    <input id="confirmUser" asp-for="ConfirmUser" class="form-control" placeholder="Type username to confirm" />
+    <div class="form-check mt-2">
+      <input class="form-check-input" asp-for="Ack" id="ack" />
+      <label class="form-check-label" for="ack">I understand this is permanent after the undo window.</label>
+    </div>
+    <button id="btnDelete" class="btn btn-danger" type="submit" disabled>Delete account</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
+<script>
+  const expected='@Model.UserEntity.UserName';
+  const input=document.getElementById('confirmUser');
+  const ack=document.getElementById('ack');
+  const btn=document.getElementById('btnDelete');
+  function update(){ btn.disabled = !(input.value===expected && ack.checked); }
+  input.addEventListener('input',update); ack.addEventListener('change',update);
+</script>
+}

--- a/Areas/Admin/Pages/Users/Delete.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Delete.cshtml.cs
@@ -1,45 +1,77 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Models;
 using ProjectManagement.Services;
-using System.Linq;
-using Microsoft.Extensions.Logging;
 
 namespace ProjectManagement.Areas.Admin.Pages.Users
 {
     [Authorize(Roles = "Admin")]
+    [ResponseCache(NoStore = true)]
     public class DeleteModel : PageModel
     {
-        private readonly IUserManagementService _userService;
-        private readonly ILogger<DeleteModel> _logger;
-        public DeleteModel(IUserManagementService userService, ILogger<DeleteModel> logger)
+        private readonly IUserLifecycleService _lifecycle;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly UserLifecycleOptions _opts;
+
+        public DeleteModel(IUserLifecycleService lifecycle, UserManager<ApplicationUser> userManager, IOptions<UserLifecycleOptions> opts)
         {
-            _userService = userService;
-            _logger = logger;
+            _lifecycle = lifecycle;
+            _userManager = userManager;
+            _opts = opts.Value;
         }
 
-        public string UserName { get; set; } = string.Empty;
+        public ApplicationUser? UserEntity { get; private set; }
+        public UserLifecycleOptions Options => _opts;
 
+        [BindProperty]
+        public string ConfirmUser { get; set; } = string.Empty;
+        [BindProperty]
+        public bool Ack { get; set; }
         public async Task<IActionResult> OnGetAsync(string id)
         {
-            var user = await _userService.GetUserByIdAsync(id);
-            if (user == null) return NotFound();
-            UserName = user.UserName ?? string.Empty;
+            UserEntity = await _userManager.FindByIdAsync(id);
+            if (UserEntity == null)
+                return NotFound();
             return Page();
         }
 
         public async Task<IActionResult> OnPostAsync(string id)
         {
-            var result = await _userService.DeleteUserAsync(id);
-            if (result.Succeeded)
+            UserEntity = await _userManager.FindByIdAsync(id);
+            if (UserEntity == null)
+                return NotFound();
+
+            if (ConfirmUser != (UserEntity.UserName ?? string.Empty) || !Ack)
             {
-                _logger.LogInformation("Admin {Admin} deleted user {UserId}", User.Identity?.Name, id);
-                TempData["ok"] = "User deleted.";
+                ModelState.AddModelError(string.Empty, "Confirmation required.");
+                return Page();
+            }
+
+            var actorId = _userManager.GetUserId(User) ?? string.Empty;
+            var res = await _lifecycle.RequestHardDeleteAsync(id, actorId);
+            if (!res.Allowed)
+            {
+                TempData["err"] = res.ReasonBlocked;
             }
             else
             {
-                TempData["err"] = string.Join(", ", result.Errors.Select(e => e.Description));
+                TempData["ok"] = "Deletion requested.";
             }
+            return RedirectToPage("Index");
+        }
+
+        public async Task<IActionResult> OnPostUndoAsync(string id)
+        {
+            var actorId = _userManager.GetUserId(User) ?? string.Empty;
+            var ok = await _lifecycle.UndoHardDeleteAsync(id, actorId);
+            TempData[ok ? "ok" : "err"] = ok ? "Deletion undone." : "Undo window expired.";
             return RedirectToPage("Index");
         }
     }

--- a/Areas/Admin/Pages/Users/Disable.cshtml
+++ b/Areas/Admin/Pages/Users/Disable.cshtml
@@ -1,0 +1,15 @@
+@page "{id}"
+@model ProjectManagement.Areas.Admin.Pages.Users.DisableModel
+<h3>Disable user</h3>
+<div class="pm-card pm-shadow p-4 p-md-5">
+  <p>Are you sure you want to disable @Model.UserEntity?.UserName?</p>
+  <form method="post">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+      <label asp-for="Reason" class="form-label">Reason (optional)</label>
+      <textarea asp-for="Reason" class="form-control"></textarea>
+    </div>
+    <button class="btn btn-warning" type="submit">Disable</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+  </form>
+</div>

--- a/Areas/Admin/Pages/Users/Disable.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Disable.cshtml.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Users
+{
+    [Authorize(Roles = "Admin")]
+    [ResponseCache(NoStore = true)]
+    public class DisableModel : PageModel
+    {
+        private readonly IUserLifecycleService _lifecycle;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public DisableModel(IUserLifecycleService lifecycle, UserManager<ApplicationUser> userManager)
+        {
+            _lifecycle = lifecycle;
+            _userManager = userManager;
+        }
+
+        public ApplicationUser? UserEntity { get; private set; }
+
+        [BindProperty]
+        public string Reason { get; set; } = string.Empty;
+
+        public async Task<IActionResult> OnGetAsync(string id)
+        {
+            UserEntity = await _userManager.FindByIdAsync(id);
+            if (UserEntity == null) return NotFound();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(string id)
+        {
+            UserEntity = await _userManager.FindByIdAsync(id);
+            if (UserEntity == null) return NotFound();
+            var actorId = _userManager.GetUserId(User) ?? string.Empty;
+            try
+            {
+                await _lifecycle.DisableAsync(id, actorId, Reason);
+                TempData["ok"] = "User disabled.";
+                return RedirectToPage("Index");
+            }
+            catch (System.Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+                return Page();
+            }
+        }
+    }
+}

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -32,15 +32,43 @@
       <td>@(row.LastLogin?.ToString("yyyy-MM-dd HH:mm") ?? "-")</td>
       <td>@row.LoginCount</td>
       <td>
-        <span class="badge @(row.IsActive ? "bg-success" : "bg-danger")">@(row.IsActive ? "Active" : "Disabled")</span>
+        @if (row.PendingDeletion && row.DeletionRequestedUtc.HasValue)
+        {
+            var due = row.DeletionRequestedUtc.Value.AddMinutes(Model.Options.UndoWindowMinutes);
+            <span class="badge bg-warning">Pending deletion</span>
+            <small class="text-muted">@due.ToString("yyyy-MM-dd HH:mm")</small>
+        }
+        else if (row.IsActive)
+        {
+            <span class="badge bg-success">Active</span>
+        }
+        else
+        {
+            <span class="badge bg-danger">Disabled</span>
+        }
       </td>
       <td class="text-end">
         <div class="d-flex justify-content-end gap-1">
           <a asp-page="Edit" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary" title="Edit user">Edit</a>
           <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary" title="Reset password">Reset</a>
-          <form method="post" asp-page="Delete" asp-route-id="@row.Id" class="d-inline">
-            <button type="submit" class="btn btn-sm btn-outline-danger delete-user-btn" data-username="@row.UserName" title="Delete user">Delete</button>
-          </form>
+          @if (!row.PendingDeletion)
+          {
+            <a asp-page="Disable" asp-route-id="@row.Id" class="btn btn-sm btn-outline-warning" title="Disable user">Disable</a>
+            if ((DateTime.UtcNow - row.CreatedUtc).TotalHours <= Model.Options.HardDeleteWindowHours)
+            {
+                <a asp-page="Delete" asp-route-id="@row.Id" class="btn btn-sm btn-outline-danger" title="Delete user">Delete</a>
+            }
+          }
+          else if (row.DeletionRequestedUtc.HasValue)
+          {
+            var due = row.DeletionRequestedUtc.Value.AddMinutes(Model.Options.UndoWindowMinutes);
+            if (DateTime.UtcNow < due)
+            {
+                <form method="post" asp-page="Delete" asp-page-handler="Undo" asp-route-id="@row.Id" class="d-inline">
+                  <button type="submit" class="btn btn-sm btn-outline-danger" title="Undo delete">Undo</button>
+                </form>
+            }
+          }
         </div>
       </td>
     </tr>

--- a/Migrations/20250908132651_UserLifecycle.Designer.cs
+++ b/Migrations/20250908132651_UserLifecycle.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250908132651_UserLifecycle")]
+    partial class UserLifecycle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250908132651_UserLifecycle.cs
+++ b/Migrations/20250908132651_UserLifecycle.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserLifecycle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedUtc",
+                table: "AspNetUsers",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeletionRequestedByUserId",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletionRequestedUtc",
+                table: "AspNetUsers",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DisabledByUserId",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DisabledUtc",
+                table: "AspNetUsers",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDisabled",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PendingDeletion",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedUtc",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DeletionRequestedByUserId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DeletionRequestedUtc",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DisabledByUserId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DisabledUtc",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "IsDisabled",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "PendingDeletion",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -11,6 +11,16 @@ namespace ProjectManagement.Models
 
         public DateTime? LastLoginUtc { get; set; }
         public int LoginCount { get; set; }
+
+        public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+        public bool IsDisabled { get; set; }
+        public DateTime? DisabledUtc { get; set; }
+        public string? DisabledByUserId { get; set; }
+
+        public bool PendingDeletion { get; set; }
+        public DateTime? DeletionRequestedUtc { get; set; }
+        public string? DeletionRequestedByUserId { get; set; }
     }
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -101,6 +101,10 @@ builder.Services.Configure<ForwardedHeadersOptions>(o =>
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IAuditService, AuditService>();
+builder.Services.Configure<UserLifecycleOptions>(
+    builder.Configuration.GetSection("UserLifecycle"));
+builder.Services.AddScoped<IUserLifecycleService, UserLifecycleService>();
+builder.Services.AddHostedService<UserPurgeWorker>();
 
 // Register email sender
 if (!string.IsNullOrWhiteSpace(builder.Configuration["Email:Smtp:Host"]))

--- a/ProjectManagement.Tests/UserLifecycleServiceTests.cs
+++ b/ProjectManagement.Tests/UserLifecycleServiceTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests
+{
+    public class UserLifecycleServiceTests
+    {
+        private static UserLifecycleService CreateService(UserLifecycleOptions? options,
+            out ApplicationDbContext context,
+            out UserManager<ApplicationUser> userManager,
+            out RoleManager<IdentityRole> roleManager)
+        {
+            var opts = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            context = new ApplicationDbContext(opts);
+
+            var services = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            userManager = new UserManager<ApplicationUser>(
+                new UserStore<ApplicationUser>(context),
+                Options.Create(new IdentityOptions()),
+                new PasswordHasher<ApplicationUser>(),
+                Array.Empty<IUserValidator<ApplicationUser>>(),
+                Array.Empty<IPasswordValidator<ApplicationUser>>(),
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                services,
+                new Logger<UserManager<ApplicationUser>>(new LoggerFactory()));
+
+            roleManager = new RoleManager<IdentityRole>(
+                new RoleStore<IdentityRole>(context),
+                new IRoleValidator<IdentityRole>[] { new RoleValidator<IdentityRole>() },
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                new Logger<RoleManager<IdentityRole>>(new LoggerFactory()));
+
+            var http = new HttpContextAccessor();
+            var audit = new AuditService(context, http);
+            return new UserLifecycleService(userManager, audit, Options.Create(options ?? new UserLifecycleOptions()));
+        }
+
+        [Fact]
+        public async Task CreationAgeGate()
+        {
+            var svc = CreateService(new UserLifecycleOptions { HardDeleteWindowHours = 72 }, out var ctx, out var um, out var rm);
+            var user1 = new ApplicationUser { UserName = "u1", CreatedUtc = DateTime.UtcNow.AddHours(-71) };
+            await um.CreateAsync(user1, "Passw0rd!");
+            var res1 = await svc.RequestHardDeleteAsync(user1.Id, "actor");
+            Assert.True(res1.Allowed);
+
+            var user2 = new ApplicationUser { UserName = "u2", CreatedUtc = DateTime.UtcNow.AddHours(-73) };
+            await um.CreateAsync(user2, "Passw0rd!");
+            var res2 = await svc.RequestHardDeleteAsync(user2.Id, "actor");
+            Assert.False(res2.Allowed);
+        }
+
+        [Fact]
+        public async Task UndoWindowHonored()
+        {
+            var svc = CreateService(null, out var ctx, out var um, out var rm);
+            var u = new ApplicationUser { UserName = "u", CreatedUtc = DateTime.UtcNow };
+            await um.CreateAsync(u, "Passw0rd!");
+            await svc.RequestHardDeleteAsync(u.Id, "actor");
+            u.DeletionRequestedUtc = DateTime.UtcNow.AddMinutes(-10);
+            ctx.Update(u);
+            await ctx.SaveChangesAsync();
+            var ok1 = await svc.UndoHardDeleteAsync(u.Id, "actor");
+            Assert.True(ok1);
+
+            await svc.RequestHardDeleteAsync(u.Id, "actor");
+            u = await um.FindByIdAsync(u.Id);
+            u!.DeletionRequestedUtc = DateTime.UtcNow.AddMinutes(-16);
+            ctx.Update(u);
+            await ctx.SaveChangesAsync();
+            var ok2 = await svc.UndoHardDeleteAsync(u.Id, "actor");
+            Assert.False(ok2);
+        }
+
+        [Fact]
+        public async Task SecurityStampChangesOnDisableAndDelete()
+        {
+            var svc = CreateService(null, out var ctx, out var um, out var rm);
+            var u = new ApplicationUser { UserName = "u", CreatedUtc = DateTime.UtcNow };
+            await um.CreateAsync(u, "Passw0rd!");
+            var stamp1 = u.SecurityStamp;
+            await svc.DisableAsync(u.Id, "actor", "reason");
+            var stamp2 = (await um.FindByIdAsync(u.Id))!.SecurityStamp;
+            Assert.NotEqual(stamp1, stamp2);
+
+            var stamp3 = stamp2;
+            await svc.RequestHardDeleteAsync(u.Id, "actor");
+            var stamp4 = (await um.FindByIdAsync(u.Id))!.SecurityStamp;
+            Assert.NotEqual(stamp3, stamp4);
+        }
+
+        [Fact]
+        public async Task LastAdminGuard()
+        {
+            var svc = CreateService(null, out var ctx, out var um, out var rm);
+            await rm.CreateAsync(new IdentityRole("Admin"));
+            var admin = new ApplicationUser { UserName = "admin", CreatedUtc = DateTime.UtcNow };
+            await um.CreateAsync(admin, "Passw0rd!");
+            await um.AddToRoleAsync(admin, "Admin");
+            await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DisableAsync(admin.Id, "actor", ""));
+            var res = await svc.RequestHardDeleteAsync(admin.Id, "actor");
+            Assert.False(res.Allowed);
+        }
+
+        [Fact]
+        public async Task PurgeRemovesUserOnly()
+        {
+            var svc = CreateService(new UserLifecycleOptions { UndoWindowMinutes = 15 }, out var ctx, out var um, out var rm);
+            var user = new ApplicationUser { UserName = "u", CreatedUtc = DateTime.UtcNow };
+            await um.CreateAsync(user, "Passw0rd!");
+            ctx.Projects.Add(new Project { Name = "P", CreatedAt = DateTime.UtcNow, Description = "" });
+            await ctx.SaveChangesAsync();
+            await svc.RequestHardDeleteAsync(user.Id, "actor");
+            user = await um.FindByIdAsync(user.Id);
+            user!.DeletionRequestedUtc = DateTime.UtcNow.AddMinutes(-20);
+            ctx.Update(user);
+            await ctx.SaveChangesAsync();
+            var purged = await svc.PurgeIfDueAsync(user.Id);
+            Assert.True(purged);
+            Assert.Null(await um.FindByIdAsync(user.Id));
+            Assert.Equal(1, await ctx.Projects.CountAsync());
+        }
+    }
+}

--- a/Services/IUserLifecycleService.cs
+++ b/Services/IUserLifecycleService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services
+{
+    public interface IUserLifecycleService
+    {
+        Task DisableAsync(string targetUserId, string actorUserId, string reason);
+        Task<(bool Allowed, string? ReasonBlocked, DateTime? ScheduledPurgeUtc)> RequestHardDeleteAsync(string targetUserId, string actorUserId);
+        Task<bool> UndoHardDeleteAsync(string targetUserId, string actorUserId);
+        Task<bool> PurgeIfDueAsync(string targetUserId);
+    }
+}

--- a/Services/UserLifecycleOptions.cs
+++ b/Services/UserLifecycleOptions.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ProjectManagement.Services
+{
+    public sealed class UserLifecycleOptions
+    {
+        public int HardDeleteWindowHours { get; set; } = 72;
+        public int UndoWindowMinutes { get; set; } = 15;
+    }
+}

--- a/Services/UserLifecycleService.cs
+++ b/Services/UserLifecycleService.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services
+{
+    public class UserLifecycleService : IUserLifecycleService
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IAuditService _audit;
+        private readonly UserLifecycleOptions _options;
+
+        public UserLifecycleService(UserManager<ApplicationUser> userManager,
+            IAuditService audit,
+            IOptions<UserLifecycleOptions> options)
+        {
+            _userManager = userManager;
+            _audit = audit;
+            _options = options.Value;
+        }
+
+        private async Task<bool> IsLastActiveAdminAsync(ApplicationUser target)
+        {
+            if (!await _userManager.IsInRoleAsync(target, "Admin"))
+                return false;
+            var admins = await _userManager.GetUsersInRoleAsync("Admin");
+            return admins.Count(a => !a.IsDisabled && !a.PendingDeletion && a.Id != target.Id) == 0;
+        }
+
+        public async Task DisableAsync(string targetUserId, string actorUserId, string reason)
+        {
+            if (targetUserId == actorUserId)
+                throw new InvalidOperationException("You cannot disable your own account.");
+
+            var user = await _userManager.FindByIdAsync(targetUserId) ??
+                throw new InvalidOperationException("User not found.");
+
+            if (await IsLastActiveAdminAsync(user))
+                throw new InvalidOperationException("Cannot disable the last active Admin.");
+
+            if (user.IsDisabled)
+                return;
+
+            user.IsDisabled = true;
+            user.DisabledUtc = DateTime.UtcNow;
+            user.DisabledByUserId = actorUserId;
+            user.LockoutEnabled = true;
+            user.LockoutEnd = DateTimeOffset.MaxValue;
+
+            await _userManager.UpdateAsync(user);
+            await _userManager.UpdateSecurityStampAsync(user);
+            await _audit.LogAsync("AdminUserDisabled", userId: user.Id, userName: user.UserName,
+                data: new Dictionary<string, string?> { ["Reason"] = reason, ["Actor"] = actorUserId });
+        }
+
+        public async Task<(bool Allowed, string? ReasonBlocked, DateTime? ScheduledPurgeUtc)> RequestHardDeleteAsync(string targetUserId, string actorUserId)
+        {
+            if (targetUserId == actorUserId)
+                return (false, "You cannot delete your own account.", null);
+
+            var user = await _userManager.FindByIdAsync(targetUserId);
+            if (user == null)
+                return (false, "User not found.", null);
+
+            if (await IsLastActiveAdminAsync(user))
+                return (false, "Cannot delete the last active Admin.", null);
+
+            var ageHours = (DateTime.UtcNow - user.CreatedUtc).TotalHours;
+            if (ageHours > _options.HardDeleteWindowHours)
+                return (false, $"Account older than {_options.HardDeleteWindowHours}h. Use Disable instead.", null);
+
+            user.PendingDeletion = true;
+            user.DeletionRequestedUtc = DateTime.UtcNow;
+            user.DeletionRequestedByUserId = actorUserId;
+            user.IsDisabled = true;
+            user.DisabledUtc ??= DateTime.UtcNow;
+            user.DisabledByUserId ??= actorUserId;
+            user.LockoutEnabled = true;
+            user.LockoutEnd = DateTimeOffset.MaxValue;
+
+            await _userManager.UpdateAsync(user);
+            await _userManager.UpdateSecurityStampAsync(user);
+            await _audit.LogAsync("AdminUserDeleteRequested", userId: user.Id, userName: user.UserName,
+                data: new Dictionary<string, string?> { ["Actor"] = actorUserId });
+
+            var scheduled = user.DeletionRequestedUtc.Value.AddMinutes(_options.UndoWindowMinutes);
+            return (true, null, scheduled);
+        }
+
+        public async Task<bool> UndoHardDeleteAsync(string targetUserId, string actorUserId)
+        {
+            var user = await _userManager.FindByIdAsync(targetUserId);
+            if (user == null || !user.PendingDeletion || user.DeletionRequestedUtc == null)
+                return false;
+
+            var due = user.DeletionRequestedUtc.Value.AddMinutes(_options.UndoWindowMinutes);
+            if (DateTime.UtcNow > due)
+                return false;
+
+            user.PendingDeletion = false;
+            user.DeletionRequestedUtc = null;
+            user.DeletionRequestedByUserId = null;
+            await _userManager.UpdateAsync(user);
+            await _userManager.UpdateSecurityStampAsync(user);
+            await _audit.LogAsync("AdminUserDeleteUndone", userId: user.Id, userName: user.UserName,
+                data: new Dictionary<string, string?> { ["Actor"] = actorUserId });
+            return true;
+        }
+
+        public async Task<bool> PurgeIfDueAsync(string targetUserId)
+        {
+            var user = await _userManager.FindByIdAsync(targetUserId);
+            if (user == null || !user.PendingDeletion || user.DeletionRequestedUtc == null)
+                return false;
+
+            var due = user.DeletionRequestedUtc.Value.AddMinutes(_options.UndoWindowMinutes);
+            if (DateTime.UtcNow < due)
+                return false;
+
+            var res = await _userManager.DeleteAsync(user);
+            if (res.Succeeded)
+            {
+                await _audit.LogAsync("AdminUserPurged", userId: user.Id, userName: user.UserName);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Services/UserPurgeWorker.cs
+++ b/Services/UserPurgeWorker.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Services
+{
+    public class UserPurgeWorker : BackgroundService
+    {
+        private readonly IServiceProvider _sp;
+        private readonly ILogger<UserPurgeWorker> _log;
+
+        public UserPurgeWorker(IServiceProvider sp, ILogger<UserPurgeWorker> log)
+        {
+            _sp = sp;
+            _log = log;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                using var scope = _sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var opts = scope.ServiceProvider.GetRequiredService<IOptions<UserLifecycleOptions>>().Value;
+                var due = await db.Users
+                    .Where(u => u.PendingDeletion && u.DeletionRequestedUtc != null &&
+                                DateTime.UtcNow >= u.DeletionRequestedUtc.Value.AddMinutes(opts.UndoWindowMinutes))
+                    .Select(u => u.Id)
+                    .ToListAsync(stoppingToken);
+
+                var svc = scope.ServiceProvider.GetRequiredService<IUserLifecycleService>();
+                foreach (var id in due)
+                {
+                    if (await svc.PurgeIfDueAsync(id))
+                        _log.LogInformation("Purged user {UserId}", id);
+                }
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,5 +17,9 @@
       "Username": "",
       "Password": ""
     }
+  },
+  "UserLifecycle": {
+    "HardDeleteWindowHours": 72,
+    "UndoWindowMinutes": 15
   }
 }

--- a/wwwroot/js/users/index.js
+++ b/wwwroot/js/users/index.js
@@ -11,13 +11,6 @@ function boot() {
     });
   }
 
-  // Ensure delete confirm is wired
-  document.querySelectorAll('.delete-user-btn').forEach(btn => {
-    btn.addEventListener('click', e => {
-      const username = btn.dataset.username || 'this user';
-      if (!confirm(`Delete ${username}?`)) e.preventDefault();
-    });
-  });
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- extend `ApplicationUser` with creation, disable, and deletion tracking
- add `UserLifecycleService` + options and background purge worker
- redesign admin user UI for disable-first flow and timed deletion with undo
- cover lifecycle rules with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bed8a387d0832982460ee2ddcb29c9