### PR TITLE
Add enable workflow and user disable/delete confirmations

### DIFF
--- a/Areas/Admin/Pages/Users/Delete.cshtml
+++ b/Areas/Admin/Pages/Users/Delete.cshtml
@@ -22,11 +22,11 @@
 else if (Model.UserEntity is not null)
 {
 <div class="pm-card pm-shadow p-4 p-md-5">
-  <p>Deleting an account permanently removes the user’s sign-in and access. Business records previously created by this user will <strong>not</strong> be removed, but they may lose their owner/author link. Only delete accounts that were created by mistake. For all other cases, <strong>disable</strong> the account instead.</p>
+  <p>Deleting an account permanently removes the user’s sign-in and access. Project records previously created by this user will <strong>not</strong> be removed, but they may lose their owner/author link and any remarks or comments may lose their association. Only delete accounts that were created by mistake. For all other cases, <strong>disable</strong> the account instead.</p>
   <p>This action can be undone for the next <strong>@Model.Options.UndoWindowMinutes minutes</strong>, after which it is irreversible.</p>
   <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-    <input id="confirmUser" asp-for="ConfirmUser" class="form-control" placeholder="Type username to confirm" />
+    <input id="confirmUser" asp-for="ConfirmUser" class="form-control" placeholder="Type username to confirm" data-expected="@Model.UserEntity.UserName" data-button="btnDelete" />
     <div class="form-check mt-2">
       <input class="form-check-input" asp-for="Ack" id="ack" />
       <label class="form-check-label" for="ack">I understand this is permanent after the undo window.</label>
@@ -35,12 +35,7 @@ else if (Model.UserEntity is not null)
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
-<script>
-  const expected='@Model.UserEntity.UserName';
-  const input=document.getElementById('confirmUser');
-  const ack=document.getElementById('ack');
-  const btn=document.getElementById('btnDelete');
-  function update(){ btn.disabled = !(input.value===expected && ack.checked); }
-  input.addEventListener('input',update); ack.addEventListener('change',update);
-</script>
+@section Scripts {
+  <script type="module" src="~/js/users/confirm-user.js" asp-append-version="true"></script>
+}
 }

--- a/Areas/Admin/Pages/Users/Disable.cshtml
+++ b/Areas/Admin/Pages/Users/Disable.cshtml
@@ -2,14 +2,22 @@
 @model ProjectManagement.Areas.Admin.Pages.Users.DisableModel
 <h3>Disable user</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
-  <p>Are you sure you want to disable @Model.UserEntity?.UserName?</p>
+  <p>Disabling an account prevents the user from signing in. Project records previously created by this user will not be removed, but they may lose their owner/author link while the account is disabled. Use this when a member leaves or is temporarily away. You can enable the account later.</p>
   <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <div class="mb-3">
       <label asp-for="Reason" class="form-label">Reason (optional)</label>
       <textarea asp-for="Reason" class="form-control"></textarea>
     </div>
-    <button class="btn btn-warning" type="submit">Disable</button>
+    <input id="confirmUser" asp-for="ConfirmUser" class="form-control" placeholder="Type username to confirm" data-expected="@Model.UserEntity?.UserName" data-button="btnDisable" />
+    <div class="form-check mt-2">
+      <input class="form-check-input" asp-for="Ack" id="ack" />
+      <label class="form-check-label" for="ack">I understand this will prevent the user from signing in.</label>
+    </div>
+    <button id="btnDisable" class="btn btn-warning" type="submit" disabled>Disable</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
   </form>
 </div>
+@section Scripts {
+  <script type="module" src="~/js/users/confirm-user.js" asp-append-version="true"></script>
+}

--- a/Areas/Admin/Pages/Users/Enable.cshtml
+++ b/Areas/Admin/Pages/Users/Enable.cshtml
@@ -1,0 +1,19 @@
+@page "{id}"
+@model ProjectManagement.Areas.Admin.Pages.Users.EnableModel
+<h3>Enable user</h3>
+<div class="pm-card pm-shadow p-4 p-md-5">
+  <p>Enabling an account restores the user's access to the system.</p>
+  <form method="post">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <input id="confirmUser" asp-for="ConfirmUser" class="form-control" placeholder="Type username to confirm" data-expected="@Model.UserEntity?.UserName" data-button="btnEnable" />
+    <div class="form-check mt-2">
+      <input class="form-check-input" asp-for="Ack" id="ack" />
+      <label class="form-check-label" for="ack">I understand this will restore access to this user.</label>
+    </div>
+    <button id="btnEnable" class="btn btn-success" type="submit" disabled>Enable user</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+  </form>
+</div>
+@section Scripts {
+  <script type="module" src="~/js/users/confirm-user.js" asp-append-version="true"></script>
+}

--- a/Areas/Admin/Pages/Users/Enable.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Enable.cshtml.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -11,21 +10,18 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
 {
     [Authorize(Roles = "Admin")]
     [ResponseCache(NoStore = true)]
-    public class DisableModel : PageModel
+    public class EnableModel : PageModel
     {
         private readonly IUserLifecycleService _lifecycle;
         private readonly UserManager<ApplicationUser> _userManager;
 
-        public DisableModel(IUserLifecycleService lifecycle, UserManager<ApplicationUser> userManager)
+        public EnableModel(IUserLifecycleService lifecycle, UserManager<ApplicationUser> userManager)
         {
             _lifecycle = lifecycle;
             _userManager = userManager;
         }
 
         public ApplicationUser? UserEntity { get; private set; }
-
-        [BindProperty]
-        public string Reason { get; set; } = string.Empty;
 
         [BindProperty]
         public string ConfirmUser { get; set; } = string.Empty;
@@ -37,9 +33,9 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
         {
             UserEntity = await _userManager.FindByIdAsync(id);
             if (UserEntity == null) return NotFound();
-            if (UserEntity.IsDisabled)
+            if (!UserEntity.IsDisabled)
             {
-                TempData["ok"] = "User already disabled.";
+                TempData["ok"] = "User already active.";
                 return RedirectToPage("Index");
             }
             return Page();
@@ -49,7 +45,6 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
         {
             UserEntity = await _userManager.FindByIdAsync(id);
             if (UserEntity == null) return NotFound();
-
             if (ConfirmUser != UserEntity.UserName)
             {
                 ModelState.AddModelError("ConfirmUser", "Username mismatch.");
@@ -62,12 +57,11 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             {
                 return Page();
             }
-
             var actorId = _userManager.GetUserId(User) ?? string.Empty;
             try
             {
-                await _lifecycle.DisableAsync(id, actorId, Reason);
-                TempData["ok"] = "User disabled.";
+                await _lifecycle.EnableAsync(id, actorId);
+                TempData["ok"] = "User enabled.";
                 return RedirectToPage("Index");
             }
             catch (System.Exception ex)

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -53,7 +53,14 @@
           <a asp-page="Reset" asp-route-id="@row.Id" class="btn btn-sm btn-outline-secondary" title="Reset password">Reset</a>
           @if (!row.PendingDeletion)
           {
-            <a asp-page="Disable" asp-route-id="@row.Id" class="btn btn-sm btn-outline-warning" title="Disable user">Disable</a>
+            if (row.IsActive)
+            {
+                <a asp-page="Disable" asp-route-id="@row.Id" class="btn btn-sm btn-outline-warning" title="Disable user">Disable</a>
+            }
+            else
+            {
+                <a asp-page="Enable" asp-route-id="@row.Id" class="btn btn-sm btn-outline-success" title="Enable user">Enable</a>
+            }
             if ((DateTime.UtcNow - row.CreatedUtc).TotalHours <= Model.Options.HardDeleteWindowHours)
             {
                 <a asp-page="Delete" asp-route-id="@row.Id" class="btn btn-sm btn-outline-danger" title="Delete user">Delete</a>

--- a/Services/IUserLifecycleService.cs
+++ b/Services/IUserLifecycleService.cs
@@ -6,6 +6,7 @@ namespace ProjectManagement.Services
     public interface IUserLifecycleService
     {
         Task DisableAsync(string targetUserId, string actorUserId, string reason);
+        Task EnableAsync(string targetUserId, string actorUserId);
         Task<(bool Allowed, string? ReasonBlocked, DateTime? ScheduledPurgeUtc)> RequestHardDeleteAsync(string targetUserId, string actorUserId);
         Task<bool> UndoHardDeleteAsync(string targetUserId, string actorUserId);
         Task<bool> PurgeIfDueAsync(string targetUserId);

--- a/wwwroot/js/users/confirm-user.js
+++ b/wwwroot/js/users/confirm-user.js
@@ -1,0 +1,16 @@
+export default function init(){
+  const input=document.getElementById('confirmUser');
+  if(!input) return;
+  const expected=input.dataset.expected;
+  const buttonId=input.dataset.button;
+  const button=document.getElementById(buttonId);
+  const ack=document.getElementById('ack');
+  function update(){
+    button.disabled=!(input.value===expected && ack.checked);
+  }
+  input.addEventListener('input',update);
+  ack.addEventListener('change',update);
+  update();
+}
+
+document.addEventListener('DOMContentLoaded',init);


### PR DESCRIPTION
## Summary
- Require username confirmation and acknowledgment for disabling users
- Add enable user page and service API to re-activate disabled accounts
- Fix delete confirmation button activation and update wording to project records

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bedcc07c2c8329897fa47fab2010f2