### PR TITLE
Refine user status controls and add admin help hub

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml
@@ -4,7 +4,11 @@
 @{
   ViewData["Title"] = "Analytics";
 }
-<h3 class="mb-3">Analytics</h3>
+<h3 class="mb-3">Analytics
+  <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="analytics" title="Help">
+    <i class="bi bi-question-circle"></i>
+  </a>
+</h3>
 
 <div class="row g-3 mb-4">
   <div class="col-md-3">

--- a/Areas/Admin/Pages/Help/Index.cshtml
+++ b/Areas/Admin/Pages/Help/Index.cshtml
@@ -1,0 +1,42 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Help.IndexModel
+@{
+    ViewData["Title"] = "Admin Help & Guidance";
+}
+<h3 class="mb-3">Admin Help & Guidance</h3>
+
+<section id="user-lifecycle" class="pm-card pm-shadow p-3 mb-3">
+  <h5>User lifecycle</h5>
+  <ol>
+    <li>Create user → assign roles → first login forces password change (configurable).</li>
+    <li>Disable user to suspend access (reversible); Delete only when policy requires.</li>
+  </ol>
+</section>
+
+<section id="when-to-use-what" class="pm-card pm-shadow p-3 mb-3">
+  <h5>When to use what</h5>
+  <ul class="mb-0">
+    <li><strong>Reset password</strong>: Forgotten or suspected compromise.</li>
+    <li><strong>Disable</strong>: Temporary suspension; retains projects and remarks.</li>
+    <li><strong>Delete</strong>: Irreversible removal after retention checks.</li>
+  </ul>
+</section>
+
+<section id="analytics" class="pm-card pm-shadow p-3 mb-3">
+  <h5>Analytics</h5>
+  <p class="mb-0">Charts help you track user activity. Use them to spot usage trends and unusual login spikes.</p>
+</section>
+
+<section id="logs" class="pm-card pm-shadow p-3 mb-3">
+  <h5>Audit logs</h5>
+  <p class="mb-0">Filter by level, action or user to investigate events. Logs older than retention are purged automatically.</p>
+</section>
+
+<section id="security" class="pm-card pm-shadow p-3">
+  <h5>Security checklist</h5>
+  <ul class="mb-0">
+    <li>Enforce strong passwords &amp; mandatory change on first login.</li>
+    <li>Enable MFA for admins.</li>
+    <li>Review Audit Logs weekly.</li>
+  </ul>
+</section>

--- a/Areas/Admin/Pages/Help/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Help/Index.cshtml.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Areas.Admin.Pages.Help
+{
+    [Authorize(Roles = "Admin")]
+    public class IndexModel : PageModel
+    {
+        public void OnGet() { }
+    }
+}

--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -7,7 +7,11 @@
     ViewData["Title"] = "Logs";
 }
 
-<h3 class="mb-3">Logs</h3>
+<h3 class="mb-3">Logs
+  <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="logs" title="Help">
+    <i class="bi bi-question-circle"></i>
+  </a>
+</h3>
 
 <form method="get" class="row g-2 mb-3 align-items-end">
   <div class="col-sm-2">

--- a/Areas/Admin/Pages/Users/Disable.cshtml
+++ b/Areas/Admin/Pages/Users/Disable.cshtml
@@ -2,7 +2,7 @@
 @model ProjectManagement.Areas.Admin.Pages.Users.DisableModel
 <h3>Disable user</h3>
 <div class="pm-card pm-shadow p-4 p-md-5">
-  <p>Disabling an account prevents the user from signing in. Project records previously created by this user will not be removed, but they may lose their owner/author link while the account is disabled. Use this when a member leaves or is temporarily away. You can enable the account later.</p>
+  <p>Disabling an account prevents the user from signing in. All associated data such as projects, remarks and tasks is preserved. Use this when a member leaves or is temporarily away. Use Delete only when policy requires permanent removal.</p>
   <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
     <div class="mb-3">

--- a/Areas/Admin/Pages/Users/Edit.cshtml
+++ b/Areas/Admin/Pages/Users/Edit.cshtml
@@ -34,9 +34,20 @@
       <span asp-validation-for="Input.Roles" class="text-danger"></span>
     </fieldset>
 
-    <div class="form-check mb-3">
-      <input class="form-check-input" type="checkbox" asp-for="Input.IsActive" id="isActiveChk" />
-      <label class="form-check-label" for="isActiveChk">Active</label>
+    <div class="mb-3">
+      <label class="form-label">Status</label>
+      <div>
+        @if (Model.Input.IsDisabled)
+        {
+          <span class="badge bg-danger">Disabled</span>
+          <a class="btn btn-sm btn-outline-success ms-2" asp-page="Enable" asp-route-id="@Model.Input.Id">Change…</a>
+        }
+        else
+        {
+          <span class="badge bg-success">Active</span>
+          <a class="btn btn-sm btn-outline-warning ms-2" asp-page="Disable" asp-route-id="@Model.Input.Id">Change…</a>
+        }
+      </div>
     </div>
 
     <div class="d-flex gap-2">

--- a/Areas/Admin/Pages/Users/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Users/Edit.cshtml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Services;
 
@@ -42,8 +41,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
             [Required, Display(Name = "Roles")]
             public List<string> Roles { get; set; } = new();
 
-            [Display(Name = "Active")]
-            public bool IsActive { get; set; }
+            public bool IsDisabled { get; set; }
         }
 
         public async Task<IActionResult> OnGetAsync(string id)
@@ -60,7 +58,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                 FullName = user.FullName,
                 Rank = user.Rank,
                 Roles = userRoles.ToList(),
-                IsActive = !user.LockoutEnd.HasValue || user.LockoutEnd <= DateTimeOffset.UtcNow
+                IsDisabled = user.IsDisabled
             };
             UserName = user.UserName;
             return Page();
@@ -85,15 +83,8 @@ namespace ProjectManagement.Areas.Admin.Pages.Users
                 return Page();
             }
 
-            var activeRes = await _users.ToggleUserActivationAsync(Input.Id, Input.IsActive);
-            if (!activeRes.Succeeded)
-            {
-                foreach (var e in activeRes.Errors) ModelState.AddModelError(string.Empty, e.Description);
-                return Page();
-            }
-
-            _logger.LogInformation("Admin {Admin} updated user {UserId}: name {FullName}; rank {Rank}; roles {Roles}; active {Active}",
-                User.Identity?.Name, Input.Id, Input.FullName, Input.Rank, string.Join(',', Input.Roles), Input.IsActive);
+            _logger.LogInformation("Admin {Admin} updated user {UserId}: name {FullName}; rank {Rank}; roles {Roles}",
+                User.Identity?.Name, Input.Id, Input.FullName, Input.Rank, string.Join(',', Input.Roles));
 
             TempData["ok"] = "User updated.";
             return RedirectToPage("Index");

--- a/Areas/Admin/Pages/Users/Index.cshtml
+++ b/Areas/Admin/Pages/Users/Index.cshtml
@@ -1,6 +1,10 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Users.IndexModel
-<h3>Users</h3>
+<h3>Users
+  <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="user-lifecycle" title="Help">
+    <i class="bi bi-question-circle"></i>
+  </a>
+</h3>
 <p><a class="btn btn-primary" asp-page="Create">Create user</a></p>
 <input id="userSearch" class="form-control mb-3" type="search" placeholder="Search by username or role" />
 <table class="table table-sm" id="usersTable">

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -34,6 +34,12 @@
                                 <li class="nav-item">
                                     <a class="nav-link" asp-area="Admin" asp-page="/Index">Admin Panel</a>
                                 </li>
+                                if ((ViewContext.RouteData.Values["area"]?.ToString() ?? "") == "Admin")
+                                {
+                                    <li class="nav-item">
+                                        <a class="nav-link" asp-area="Admin" asp-page="/Help/Index">Help</a>
+                                    </li>
+                                }
                             }
                         }
                     </ul>

--- a/ProjectManagement.Tests/UserLifecycleServiceTests.cs
+++ b/ProjectManagement.Tests/UserLifecycleServiceTests.cs
@@ -138,5 +138,14 @@ namespace ProjectManagement.Tests
             Assert.Null(await um.FindByIdAsync(user.Id));
             Assert.Equal(1, await ctx.Projects.CountAsync());
         }
+
+        [Fact]
+        public async Task CannotDisableOwnAccount()
+        {
+            var svc = CreateService(null, out var ctx, out var um, out var rm);
+            var user = new ApplicationUser { UserName = "u", CreatedUtc = DateTime.UtcNow };
+            await um.CreateAsync(user, "Passw0rd!");
+            await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DisableAsync(user.Id, user.Id, "reason"));
+        }
     }
 }

--- a/ProjectManagement.Tests/UserManagementServiceTests.cs
+++ b/ProjectManagement.Tests/UserManagementServiceTests.cs
@@ -58,34 +58,6 @@ namespace ProjectManagement.Tests
         }
 
         [Fact]
-        public async Task CannotDisableOwnAccount()
-        {
-            var service = CreateService("admin", out var context, out var userManager, out var roleManager);
-            await roleManager.CreateAsync(new IdentityRole("Admin"));
-            var admin = new ApplicationUser { UserName = "admin" };
-            await userManager.CreateAsync(admin, "Passw0rd!");
-            await userManager.AddToRoleAsync(admin, "Admin");
-
-            var result = await service.ToggleUserActivationAsync(admin.Id, false);
-
-            Assert.False(result.Succeeded);
-        }
-
-        [Fact]
-        public async Task CannotDisableLastActiveAdmin()
-        {
-            var service = CreateService("other", out var context, out var userManager, out var roleManager);
-            await roleManager.CreateAsync(new IdentityRole("Admin"));
-            var admin = new ApplicationUser { UserName = "admin" };
-            await userManager.CreateAsync(admin, "Passw0rd!");
-            await userManager.AddToRoleAsync(admin, "Admin");
-
-            var result = await service.ToggleUserActivationAsync(admin.Id, false);
-
-            Assert.False(result.Succeeded);
-        }
-
-        [Fact]
         public async Task CannotRemoveAdminRoleFromLastActiveAdmin()
         {
             var service = CreateService("admin", out var context, out var userManager, out var roleManager);

--- a/Services/IUserManagementService.cs
+++ b/Services/IUserManagementService.cs
@@ -14,7 +14,6 @@ namespace ProjectManagement.Services
         Task<IdentityResult> CreateUserAsync(string userName, string password, string fullName, string rank, IEnumerable<string> roles);
         Task<IdentityResult> UpdateUserRolesAsync(string userId, IEnumerable<string> roles);
         Task<IdentityResult> UpdateUserDetailsAsync(string userId, string fullName, string rank);
-        Task<IdentityResult> ToggleUserActivationAsync(string userId, bool isActive);
         Task<IdentityResult> ResetPasswordAsync(string userId, string newPassword);
         Task<IdentityResult> DeleteUserAsync(string userId);
     }


### PR DESCRIPTION
## Summary
- replace IsActive checkbox with read-only status and disable/enable links
- drop ToggleUserActivationAsync from user management service
- add admin help page with contextual links and navbar entry
- document disable behaviour and guard against self-disable in tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bee759de608329b0ddb6bed094b50b