### PR TITLE
Polish help page and user menu

### DIFF
--- a/Areas/Admin/Pages/Help/Index.cshtml
+++ b/Areas/Admin/Pages/Help/Index.cshtml
@@ -1,42 +1,120 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Help.IndexModel
 @{
-    ViewData["Title"] = "Admin Help & Guidance";
+    ViewData["Title"] = "Admin Help";
 }
-<h3 class="mb-3">Admin Help & Guidance</h3>
+<div class="container py-3">
+  <!-- Hero -->
+  <div class="pb-3 mb-3 border-bottom">
+    <h3 class="mb-1">Admin Help and Guidance</h3>
+    <p class="text-muted mb-0">Essential how-tos for user lifecycle, security and audits. Short and practical.</p>
+  </div>
 
-<section id="user-lifecycle" class="pm-card pm-shadow p-3 mb-3">
-  <h5>User lifecycle</h5>
-  <ol>
-    <li>Create user → assign roles → first login forces password change (configurable).</li>
-    <li>Disable user to suspend access (reversible); Delete only when policy requires.</li>
-  </ol>
-</section>
+  <div class="row g-4">
+    <!-- Main -->
+    <div class="col-lg-8">
+      <!-- Quick start -->
+      <div class="row g-3">
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h6 class="card-title mb-2">Create a user</h6>
+              <ol class="small mb-0 ps-3">
+                <li>Go to <strong>Admin → Users</strong></li>
+                <li>Click <strong>Add User</strong></li>
+                <li>Assign roles and save</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h6 class="card-title mb-2">Suspend access</h6>
+              <p class="small mb-2">Use <strong>Disable</strong> to suspend sign-in while keeping all data.</p>
+              <a class="small" href="#disable-vs-delete">Learn when to use what →</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h6 class="card-title mb-2">Reset password</h6>
+              <p class="small mb-0">For forgotten or suspected compromise. Sends a reset link or enforces change on next sign-in.</p>
+            </div>
+          </div>
+        </div>
+      </div>
 
-<section id="when-to-use-what" class="pm-card pm-shadow p-3 mb-3">
-  <h5>When to use what</h5>
-  <ul class="mb-0">
-    <li><strong>Reset password</strong>: Forgotten or suspected compromise.</li>
-    <li><strong>Disable</strong>: Temporary suspension; retains projects and remarks.</li>
-    <li><strong>Delete</strong>: Irreversible removal after retention checks.</li>
-  </ul>
-</section>
+      <!-- Decision guide -->
+      <div id="disable-vs-delete" class="mt-4">
+        <h5 class="mb-2">When to use what</h5>
+        <div class="accordion" id="adminGuide">
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="resetHead">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#resetBody">
+                Reset password
+              </button>
+            </h2>
+            <div id="resetBody" class="accordion-collapse collapse" data-bs-parent="#adminGuide">
+              <div class="accordion-body small">
+                Use for forgotten password or if the account may be compromised. Consider forcing password change at next sign-in.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="disableHead">
+              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#disableBody">
+                Disable
+              </button>
+            </h2>
+            <div id="disableBody" class="accordion-collapse collapse show" data-bs-parent="#adminGuide">
+              <div class="accordion-body small">
+                Temporary suspension. Preserves all associated data like projects, remarks and tasks. Reversible at any time.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="deleteHead">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#deleteBody">
+                Delete
+              </button>
+            </h2>
+            <div id="deleteBody" class="accordion-collapse collapse" data-bs-parent="#adminGuide">
+              <div class="accordion-body small">
+                Permanent removal after policy checks and retention periods. Irreversible. Use only when mandated.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-<section id="analytics" class="pm-card pm-shadow p-3 mb-3">
-  <h5>Analytics</h5>
-  <p class="mb-0">Charts help you track user activity. Use them to spot usage trends and unusual login spikes.</p>
-</section>
+      <!-- Security checklist -->
+      <div id="security" class="mt-4">
+        <h5 class="mb-2">Security checklist</h5>
+        <ul class="small mb-0">
+          <li>Strong passwords and change on first sign-in for new users</li>
+          <li>Enable two-factor for admin accounts</li>
+          <li>Review audit logs weekly and purge per policy</li>
+        </ul>
+      </div>
+    </div>
 
-<section id="logs" class="pm-card pm-shadow p-3 mb-3">
-  <h5>Audit logs</h5>
-  <p class="mb-0">Filter by level, action or user to investigate events. Logs older than retention are purged automatically.</p>
-</section>
+    <!-- Right rail -->
+    <div class="col-lg-4">
+      <div class="card shadow-sm sticky-top" style="top: 88px;">
+        <div class="card-body">
+          <h6 class="card-title">On this page</h6>
+          <div class="list-group list-group-flush">
+            <a class="list-group-item list-group-item-action py-2" href="#disable-vs-delete">When to use what</a>
+            <a class="list-group-item list-group-item-action py-2" href="#resetHead">Reset password</a>
+            <a class="list-group-item list-group-item-action py-2" href="#disableHead">Disable</a>
+            <a class="list-group-item list-group-item-action py-2" href="#deleteHead">Delete</a>
+            <a class="list-group-item list-group-item-action py-2" href="#security">Security checklist</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
-<section id="security" class="pm-card pm-shadow p-3">
-  <h5>Security checklist</h5>
-  <ul class="mb-0">
-    <li>Enforce strong passwords &amp; mandatory change on first login.</li>
-    <li>Enable MFA for admins.</li>
-    <li>Review Audit Logs weekly.</li>
-  </ul>
-</section>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -16,14 +16,14 @@
 </head>
 <body>
     <header class="pm-header border-bottom">
-        <nav class="navbar navbar-expand-sm navbar-light bg-white">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
             <div class="container">
                 <a class="navbar-brand fw-semibold" asp-area="" asp-page="/Index">ProjectManagement</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#pmNavbar">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div id="pmNavbar" class="collapse navbar-collapse">
-                    <ul class="navbar-nav me-auto mb-2 mb-sm-0">
+                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         @if (SignInManager.IsSignedIn(User))
                         {
                             <li class="nav-item">

--- a/Pages/Shared/_LoginPartial.cshtml
+++ b/Pages/Shared/_LoginPartial.cshtml
@@ -3,20 +3,37 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 
-<ul class="navbar-nav ms-auto align-items-center">
-    @if (SignInManager.IsSignedIn(User))
-    {
-        <li class="nav-item">
-            <span class="nav-link p-0">Hello @User.Identity?.Name!</span>
-        </li>
-        <li class="nav-item">
-            <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="/" method="post">
-                <button type="submit" class="btn btn-link nav-link p-0">Sign out</button>
-            </form>
-        </li>
-    }
-    else
-    {
-        <li class="nav-item"><a class="btn btn-primary ms-2" asp-area="Identity" asp-page="/Account/Login" asp-route-returnUrl="/Dashboard/Index">Sign in</a></li>
-    }
+<ul class="navbar-nav ms-auto">
+@if (SignInManager.IsSignedIn(User))
+{
+    var name = User.Identity?.Name ?? "User";
+    var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+    var initials = parts.Length >= 2 ? $"{parts[0][0]}{parts[^1][0]}" : $"{name[0]}";
+    <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="avatar me-2 text-uppercase">@initials</span>
+            <span class="d-none d-sm-inline">@name</span>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userMenu">
+            <li><a class="dropdown-item" asp-area="Identity" asp-page="/Account/Manage/Index">Profile</a></li>
+            @if (User.IsInRole("Admin"))
+            {
+                <li><a class="dropdown-item" asp-area="Admin" asp-page="/Index">Admin</a></li>
+            }
+            <li><hr class="dropdown-divider" /></li>
+            <li>
+                <form class="px-3 py-1" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="~/" method="post">
+                    <button type="submit" class="btn btn-sm btn-outline-secondary w-100">Sign out</button>
+                </form>
+            </li>
+        </ul>
+    </li>
+}
+else
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Login">Sign in</a>
+    </li>
+}
 </ul>
+

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -158,3 +158,22 @@ body {
   .hero-art  { order: 2; max-width: clamp(220px, 50vw, 340px); }
 }
 
+/* Help page micro-polish */
+.card h6 { font-weight: 600; }
+.accordion-button { font-weight: 600; }
+.list-group-item-action { font-size: .925rem; }
+
+/* Avatar */
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--bs-secondary-bg, #f1f3f5);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: .85rem;
+  border: 1px solid rgba(0,0,0,.06);
+}
+


### PR DESCRIPTION
## Summary
- Redesign admin help page with quick-start cards, decision accordion, and sticky right rail
- Replace plain login link with avatar dropdown and POST sign out
- Add subtle navbar shadow and micro CSS helpers for help page and avatar

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68beef2b7e588329a34731adbd531393