### PR TITLE
Refine admin dashboard and help content

### DIFF
--- a/Areas/Admin/Pages/Help/Index.cshtml
+++ b/Areas/Admin/Pages/Help/Index.cshtml
@@ -9,16 +9,16 @@
     <li class="breadcrumb-item active" aria-current="page">Help</li>
   </ol>
 </nav>
-<div class="container py-3">
+<div class="py-3">
   <!-- Hero -->
   <div class="pb-3 mb-3 border-bottom">
     <h3 class="mb-1">Admin Help and Guidance</h3>
     <p class="text-muted mb-0">Essential how-tos for user lifecycle, security and audits. Short and practical.</p>
   </div>
 
-  <div class="row g-4">
+  <div class="row g-4" id="user-lifecycle">
     <!-- Main -->
-    <div class="col-lg-8">
+    <div class="col-md-8">
       <!-- Quick start -->
       <div class="row g-3">
         <div class="col-md-4">
@@ -53,7 +53,7 @@
         </div>
       </div>
 
-      <!-- Decision guide -->
+      @* Decision guide text that matches current capabilities *@
       <div id="disable-vs-delete" class="mt-4">
         <h5 class="mb-2">When to use what</h5>
         <div class="accordion" id="adminGuide">
@@ -65,7 +65,8 @@
             </h2>
             <div id="resetBody" class="accordion-collapse collapse" data-bs-parent="#adminGuide">
               <div class="accordion-body small">
-                Use for forgotten password or if the account may be compromised. Consider forcing password change at next sign-in.
+                Users cannot reset passwords themselves. If a user forgets the password, contact an administrator.
+                The administrator can set a temporary password and mark the account to require password change at next sign-in.
               </div>
             </div>
           </div>
@@ -77,7 +78,8 @@
             </h2>
             <div id="disableBody" class="accordion-collapse collapse show" data-bs-parent="#adminGuide">
               <div class="accordion-body small">
-                Temporary suspension. Preserves all associated data like projects, remarks and tasks. Reversible at any time.
+                Temporarily suspends sign-in while preserving all associated data such as projects, remarks and tasks.
+                Use when access must be paused. Re-enable to restore access.
               </div>
             </div>
           </div>
@@ -89,26 +91,27 @@
             </h2>
             <div id="deleteBody" class="accordion-collapse collapse" data-bs-parent="#adminGuide">
               <div class="accordion-body small">
-                Permanent removal after policy checks and retention periods. Irreversible. Use only when mandated.
+                Permanently removes the account after policy checks and retention periods.
+                This action cannot be undone.
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Security checklist -->
+      @* Security checklist — only what exists today *@
       <div id="security" class="mt-4">
         <h5 class="mb-2">Security checklist</h5>
         <ul class="small mb-0">
-          <li>Strong passwords and change on first sign-in for new users</li>
-          <li>Enable two-factor for admin accounts</li>
-          <li>Review audit logs weekly and purge per policy</li>
+          <li>Use strong passwords</li>
+          <li>Set “Require password change at next sign-in” for new or reset accounts</li>
+          <li>Review audit logs weekly and address any errors</li>
         </ul>
       </div>
     </div>
 
     <!-- Right rail -->
-    <div class="col-lg-4">
+    <div class="col-md-4">
       <div class="card shadow-sm sticky-top" style="top: 88px;">
         <div class="card-body">
           <h6 class="card-title">On this page</h6>

--- a/Areas/Admin/Pages/Index.cshtml
+++ b/Areas/Admin/Pages/Index.cshtml
@@ -1,5 +1,5 @@
 @page
-@model ProjectManagement.Areas.Admin.Pages.IndexModel
+@model ProjectManagement.Areas.Admin.Pages.AdminIndexModel
 @{
     ViewData["Title"] = "Admin dashboard";
 }
@@ -11,54 +11,119 @@
 </nav>
 <h3 class="mb-3">Admin dashboard</h3>
 
-<div class="row g-3">
-  <div class="col-sm-4">
-    <div class="card shadow-sm">
+@* Top metrics row: always visible without scrolling *@
+<div class="row g-3 mb-3">
+  <div class="col-md-4">
+    <div class="card shadow-sm h-100">
       <div class="card-body">
-        <div class="small text-muted">Total users</div>
-        <div class="fs-4 fw-semibold">@Model.Metrics.TotalUsers</div>
-      </div>
-    </div>
-  </div>
-  <div class="col-sm-4">
-    <div class="card shadow-sm">
-      <div class="card-body">
-        <div class="small text-muted">Disabled</div>
-        <div class="fs-4 fw-semibold">@Model.Metrics.DisabledUsers</div>
-      </div>
-    </div>
-  </div>
-  <div class="col-sm-4">
-    <div class="card shadow-sm">
-      <div class="card-body">
-        <div class="small text-muted">Must change password</div>
-        <div class="fs-4 fw-semibold">@Model.Metrics.MustChangePwd</div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="card shadow-sm mt-3">
-  <div class="card-header py-2"><strong>Recent admin actions</strong></div>
-  <div class="list-group list-group-flush">
-    @foreach (var a in Model.RecentAdminActions)
-    {
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <div class="small">
-          <span class="badge bg-secondary me-2">@a.Level</span>
-          @a.Message
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="small text-muted">Manage Users</div>
+          <a asp-area="Admin" asp-page="/Users/Index" class="small text-decoration-none">Open</a>
         </div>
-        <span class="text-muted small">@a.WhenLocal</span>
+        <div class="fs-4 fw-semibold">@Model.Metrics.TotalUsers</div>
+        <div class="small text-muted">Total users</div>
+
+        <div class="mt-3 small">
+          <div class="d-flex justify-content-between"><span>Disabled</span><span>@Model.Metrics.DisabledUsers</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.DisabledPct%"></div>
+          </div>
+          <div class="d-flex justify-content-between mt-2"><span>Must change password</span><span>@Model.Metrics.MustChangePwd</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.MustChangePwdPct%"></div>
+          </div>
+        </div>
       </div>
-    }
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="small text-muted">Analytics</div>
+          <a asp-area="Admin" asp-page="/Analytics/Index" class="small text-decoration-none">Open</a>
+        </div>
+        <div class="fs-4 fw-semibold">@Model.Metrics.LoginsLast7d</div>
+        <div class="small text-muted">Logins last 7 days</div>
+
+        <div class="mt-3 small">
+          <div class="d-flex justify-content-between"><span>Unique users</span><span>@Model.Metrics.UniqueLoginsLast7d</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.UniqueLoginPct%"></div>
+          </div>
+          <div class="d-flex justify-content-between mt-2"><span>Failed attempts</span><span>@Model.Metrics.FailedLoginsLast7d</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.FailedLoginPct%"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="small text-muted">Logs</div>
+          <a asp-area="Admin" asp-page="/Logs/Index" class="small text-decoration-none">Open</a>
+        </div>
+        <div class="fs-4 fw-semibold">@Model.Metrics.AuditEvents24h</div>
+        <div class="small text-muted">Audit events in last 24 hours</div>
+
+        <div class="mt-3 small">
+          <div class="d-flex justify-content-between"><span>Warnings</span><span>@Model.Metrics.WarningEvents24h</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.WarningPct%"></div>
+          </div>
+          <div class="d-flex justify-content-between mt-2"><span>Errors</span><span>@Model.Metrics.ErrorEvents24h</span></div>
+          <div class="progress" style="height:6px;">
+            <div class="progress-bar" role="progressbar" style="width:@Model.Metrics.ErrorPct%"></div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
-<div class="row row-cols-1 row-cols-md-3 g-4 mt-3">
-    @foreach (var card in Model.Cards)
-    {
-        <partial name="_AdminCard" model="card" />
-    }
+@* Attention band (only if something needs admin action) *@
+@if (Model.Attention.Items.Any())
+{
+  <div class="alert alert-warning d-flex align-items-center" role="alert">
+    <div class="me-2">Attention needed:</div>
+    <ul class="mb-0">
+      @foreach (var i in Model.Attention.Items)
+      {
+        <li class="mb-0">@i.Text @if (!string.IsNullOrEmpty(i.LinkText)) { <a class="ms-1" href="@i.Href">@i.LinkText</a> }</li>
+      }
+    </ul>
+  </div>
+}
+
+@* Two-column lower row: compact recent actions on the right *@
+<div class="row g-3">
+  <div class="col-lg-8">
+    @* Place any secondary content or keep empty for now *@
+  </div>
+  <div class="col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-header py-2"><strong>Recent admin actions</strong></div>
+      <div class="list-group list-group-flush" style="max-height: 320px; overflow:auto;">
+        @foreach (var a in Model.RecentAdminActions)
+        {
+          <div class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="small">
+              <span class="badge bg-secondary me-2">@a.Level</span>@a.Message
+            </div>
+            <span class="text-muted small">@a.WhenLocal</span>
+          </div>
+        }
+      </div>
+      <div class="card-footer text-end py-2">
+        <a asp-area="Admin" asp-page="/Logs/Index" class="small text-decoration-none">View all logs</a>
+      </div>
+    </div>
+  </div>
 </div>
 
 @section Styles {

--- a/Areas/Admin/Pages/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Index.cshtml.cs
@@ -1,48 +1,125 @@
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using ProjectManagement.Areas.Admin.Models;
-using ProjectManagement.Data;
-using ProjectManagement.Infrastructure;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Areas.Admin.Pages
 {
     [Authorize(Roles = "Admin")]
-    public class IndexModel : PageModel
+    public class AdminIndexModel : PageModel
     {
         private readonly ApplicationDbContext _db;
-        public IndexModel(ApplicationDbContext db) => _db = db;
 
-        public IList<AdminCard> Cards { get; } = new List<AdminCard>
+        public AdminIndexModel(ApplicationDbContext db) => _db = db;
+
+        public MetricsVM Metrics { get; set; } = new();
+        public List<ActionVM> RecentAdminActions { get; set; } = new();
+        public AttentionVM Attention { get; set; } = new();
+
+        public class MetricsVM
         {
-            new("Manage Users", "/Users/Index", "Create, edit and disable users", "users"),
-            new("Analytics", "/Analytics/Index", "Review platform analytics", "analytics"),
-            new("Logs", "/Logs/Index", "Inspect application logs", "logs")
-        };
+            public int TotalUsers { get; set; }
+            public int DisabledUsers { get; set; }
+            public int MustChangePwd { get; set; }
+            public int LoginsLast7d { get; set; }
+            public int UniqueLoginsLast7d { get; set; }
+            public int FailedLoginsLast7d { get; set; }
+            public int AuditEvents24h { get; set; }
+            public int WarningEvents24h { get; set; }
+            public int ErrorEvents24h { get; set; }
 
-        public MetricsDto Metrics { get; private set; } = new();
-        public IList<AdminActionDto> RecentAdminActions { get; private set; } = new List<AdminActionDto>();
-
-        public record MetricsDto(int TotalUsers, int DisabledUsers, int MustChangePwd)
-        {
-            public MetricsDto() : this(0, 0, 0) { }
+            public int DisabledPct => TotalUsers == 0 ? 0 : (int)Math.Round(100.0 * DisabledUsers / TotalUsers);
+            public int MustChangePwdPct => TotalUsers == 0 ? 0 : (int)Math.Round(100.0 * MustChangePwd / TotalUsers);
+            public int UniqueLoginPct => LoginsLast7d == 0 ? 0 : (int)Math.Round(100.0 * UniqueLoginsLast7d / LoginsLast7d);
+            public int FailedLoginPct => LoginsLast7d == 0 ? 0 : (int)Math.Round(100.0 * FailedLoginsLast7d / LoginsLast7d);
+            public int WarningPct => AuditEvents24h == 0 ? 0 : (int)Math.Round(100.0 * WarningEvents24h / AuditEvents24h);
+            public int ErrorPct => AuditEvents24h == 0 ? 0 : (int)Math.Round(100.0 * ErrorEvents24h / AuditEvents24h);
         }
 
-        public record AdminActionDto(string Level, string Message, string WhenLocal);
+        public class ActionVM
+        {
+            public string Level { get; set; } = string.Empty;
+            public string Message { get; set; } = string.Empty;
+            public string WhenLocal { get; set; } = string.Empty;
+        }
+
+        public class AttentionVM
+        {
+            public List<AttentionItem> Items { get; set; } = new();
+        }
+
+        public class AttentionItem
+        {
+            public string Text { get; set; } = string.Empty;
+            public string? LinkText { get; set; }
+            public string? Href { get; set; }
+        }
 
         public async Task OnGet()
         {
+            var nowUtc = DateTime.UtcNow;
+
             var users = await _db.Users.AsNoTracking().ToListAsync();
-            Metrics = new MetricsDto(users.Count, users.Count(u => u.IsDisabled), users.Count(u => u.MustChangePassword));
+            Metrics.TotalUsers = users.Count;
+            Metrics.DisabledUsers = users.Count(u => u.IsDisabled);
+            Metrics.MustChangePwd = users.Count(u => u.MustChangePassword);
+
+            var since7d = nowUtc.AddDays(-7);
+            var loginLogs = await _db.AuditLogs.AsNoTracking()
+                .Where(a => a.TimeUtc >= since7d)
+                .ToListAsync();
+            Metrics.LoginsLast7d = loginLogs.Count(a => a.Action == "LoginSuccess");
+            Metrics.UniqueLoginsLast7d = loginLogs.Where(a => a.Action == "LoginSuccess")
+                .Select(a => a.UserId).Where(id => id != null).Distinct().Count();
+            Metrics.FailedLoginsLast7d = loginLogs.Count(a => a.Action == "LoginFailed");
+
+            var since24h = nowUtc.AddDays(-1);
+            var recentEvents = await _db.AuditLogs.AsNoTracking()
+                .Where(a => a.TimeUtc >= since24h)
+                .ToListAsync();
+            Metrics.AuditEvents24h = recentEvents.Count;
+            Metrics.WarningEvents24h = recentEvents.Count(a => a.Level == "Warning");
+            Metrics.ErrorEvents24h = recentEvents.Count(a => a.Level == "Error");
+
+            if (Metrics.MustChangePwd > 0)
+                Attention.Items.Add(new AttentionItem
+                {
+                    Text = $"{Metrics.MustChangePwd} users must change password",
+                    LinkText = "View",
+                    Href = Url.Page("/Admin/Users/Index", new { status = "" })
+                });
+            if (Metrics.DisabledUsers > 0)
+                Attention.Items.Add(new AttentionItem
+                {
+                    Text = $"{Metrics.DisabledUsers} users are disabled",
+                    LinkText = "Manage",
+                    Href = Url.Page("/Admin/Users/Index", new { status = "disabled" })
+                });
+            if (Metrics.ErrorEvents24h > 0)
+                Attention.Items.Add(new AttentionItem
+                {
+                    Text = $"{Metrics.ErrorEvents24h} error logs in last 24 hours",
+                    LinkText = "Investigate",
+                    Href = Url.Page("/Admin/Logs/Index")
+                });
 
             RecentAdminActions = await _db.AuditLogs.AsNoTracking()
                 .OrderByDescending(a => a.TimeUtc)
                 .Take(10)
-                .Select(a => new AdminActionDto(a.Level, a.Message ?? a.Action, TimeFmt.ToIst(a.TimeUtc)))
+                .Select(a => new ActionVM
+                {
+                    Level = a.Level,
+                    Message = a.Message ?? a.Action,
+                    WhenLocal = TimeFmt.ToIst(a.TimeUtc)
+                })
                 .ToListAsync();
         }
     }
 }
+

--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -7,11 +7,17 @@
     ViewData["Title"] = "Logs";
 }
 
-<h3 class="mb-3">Logs
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Logs</li>
+  </ol>
+</nav>
+<h4 class="mb-2">Logs
   <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="logs" title="Help">
     <i class="bi bi-question-circle"></i>
   </a>
-</h3>
+</h4>
 
 <form method="get" class="row g-2 mb-3 align-items-end">
   <div class="col-sm-2">


### PR DESCRIPTION
## Summary
- Add anchor and layout fixes to Admin Help with updated guidance and right-rail behavior
- Rework Admin dashboard layout with metric cards, attention alerts, and compact recent actions
- Add breadcrumb navigation to Logs page

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf01c1e8b08329827a2cd5b88866a9