### PR TITLE
Add Dashboard To-Do widget and tasks page stub

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -1,8 +1,18 @@
-﻿@page
+@page
 @model ProjectManagement.Pages.Dashboard.IndexModel
 @attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@using ProjectManagement.Services
+@using ProjectManagement.Models
 @{
     ViewData["Title"] = "Dashboard";
 }
-<h1 class="h4 fw-bold mb-3">Your dashboard</h1>
-<p class="text-secondary">This is a placeholder. Add role-specific widgets here.</p>
+
+<div class="row g-3">
+  <div class="col-lg-8">
+    <h1 class="h4 fw-bold mb-3">Your dashboard</h1>
+    <p class="text-secondary">This is a placeholder. Add role-specific widgets here.</p>
+  </div>
+  <div class="col-lg-4">
+    <partial name="_TodoWidget" model="Model.TodoWidget" />
+  </div>
+</div>

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -1,11 +1,75 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using System;
+using System.Threading.Tasks;
 
 namespace ProjectManagement.Pages.Dashboard
 {
+    [Authorize]
     public class IndexModel : PageModel
     {
-        public void OnGet()
+        private readonly ITodoService _todo;
+        private readonly UserManager<ApplicationUser> _users;
+
+        public IndexModel(ITodoService todo, UserManager<ApplicationUser> users)
         {
+            _todo = todo;
+            _users = users;
+        }
+
+        public TodoWidgetResult? TodoWidget { get; set; }
+
+        [BindProperty]
+        public string? NewTitle { get; set; }
+
+        public async Task OnGetAsync()
+        {
+            var uid = _users.GetUserId(User);
+            if (uid != null)
+            {
+                TodoWidget = await _todo.GetWidgetAsync(uid, take: 20);
+            }
+        }
+
+        public async Task<IActionResult> OnPostAddAsync()
+        {
+            if (string.IsNullOrWhiteSpace(NewTitle))
+                return RedirectToPage();
+
+            var uid = _users.GetUserId(User);
+            if (uid == null) return Unauthorized();
+
+            await _todo.CreateAsync(uid, NewTitle.Trim());
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostToggleAsync(Guid id)
+        {
+            var uid = _users.GetUserId(User);
+            if (uid == null) return Unauthorized();
+            // Widget shows only Open items; toggling marks them done.
+            await _todo.ToggleDoneAsync(uid, id, done: true);
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(Guid id)
+        {
+            var uid = _users.GetUserId(User);
+            if (uid == null) return Unauthorized();
+            await _todo.DeleteAsync(uid, id);
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostPinAsync(Guid id, bool pin)
+        {
+            var uid = _users.GetUserId(User);
+            if (uid == null) return Unauthorized();
+            await _todo.EditAsync(uid, id, pinned: pin);
+            return RedirectToPage();
         }
     }
 }

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -1,0 +1,97 @@
+@using ProjectManagement.Services
+@using ProjectManagement.Models
+@model ProjectManagement.Services.TodoWidgetResult
+
+@if (Model is null)
+{
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="text-muted small">Loading tasks…</div>
+        </div>
+    </div>
+}
+else
+{
+    <div class="card shadow-sm">
+        <div class="card-header d-flex align-items-center justify-content-between py-2">
+            <strong>My Tasks</strong>
+            <div class="d-flex align-items-center gap-2 small">
+                @if (Model.OverdueCount > 0)
+                {
+                    <span class="badge bg-warning text-dark" title="Overdue">@Model.OverdueCount</span>
+                }
+                @if (Model.TodayCount > 0)
+                {
+                    <span class="badge bg-info text-dark" title="Due today">@Model.TodayCount</span>
+                }
+                <a asp-page="/Tasks/Index" class="text-decoration-none">View all</a>
+            </div>
+        </div>
+        <div class="card-body">
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Add" class="mb-2">
+                <div class="input-group input-group-sm">
+                    <input name="NewTitle" class="form-control" placeholder="Add a task…" />
+                    <button class="btn btn-primary">Add</button>
+                </div>
+                @Html.AntiForgeryToken()
+            </form>
+
+            @if (Model.Items.Count == 0)
+            {
+                <div class="text-muted small">No open tasks. You’re all caught up.</div>
+            }
+            else
+            {
+                <ul class="list-group list-group-flush" style="max-height: 320px; overflow:auto;">
+                @{
+                    var ist = TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");
+                    var todayIst = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, ist).Date;
+                }
+                @foreach (var t in Model.Items)
+                {
+                    var dueBadge = "";
+                    if (t.DueAtUtc.HasValue)
+                    {
+                        var dueDate = TimeZoneInfo.ConvertTime(t.DueAtUtc.Value, ist).Date;
+                        if (dueDate < todayIst) dueBadge = "Overdue";
+                        else if (dueDate == todayIst) dueBadge = "Today";
+                        else if (dueDate == todayIst.AddDays(1)) dueBadge = "Tomorrow";
+                    }
+
+                    <li class="list-group-item d-flex align-items-center justify-content-between py-2">
+                        <div class="d-flex align-items-center gap-2">
+                            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Toggle" class="m-0 p-0">
+                                <input type="hidden" name="id" value="@t.Id" />
+                                @Html.AntiForgeryToken()
+                                <input class="form-check-input" type="checkbox" title="Mark done" onchange="this.form.submit()" />
+                            </form>
+                            <span>@t.Title</span>
+                            @if (!string.IsNullOrEmpty(dueBadge))
+                            {
+                                <span class="badge rounded-pill bg-light text-dark border">@dueBadge</span>
+                            }
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Pin" class="m-0 p-0 d-inline">
+                                <input type="hidden" name="id" value="@t.Id" />
+                                <input type="hidden" name="pin" value="@(!t.IsPinned)" />
+                                @Html.AntiForgeryToken()
+                                <button class="btn btn-link btn-sm text-decoration-none" title="@(t.IsPinned ? "Unpin" : "Pin")">
+                                    <i class="bi @(t.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
+                                </button>
+                            </form>
+                            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Delete" class="m-0 p-0 d-inline" onsubmit="return confirm('Delete this task?');">
+                                <input type="hidden" name="id" value="@t.Id" />
+                                @Html.AntiForgeryToken()
+                                <button class="btn btn-link btn-sm text-danger text-decoration-none" title="Delete">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </form>
+                        </div>
+                    </li>
+                }
+                </ul>
+            }
+        </div>
+    </div>
+}

--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -1,0 +1,15 @@
+@page
+@model ProjectManagement.Pages.Tasks.IndexModel
+@attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@{
+    ViewData["Title"] = "My Tasks";
+}
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-page="/Dashboard/Index">Dashboard</a></li>
+    <li class="breadcrumb-item active" aria-current="page">My Tasks</li>
+  </ol>
+</nav>
+
+<h4 class="mb-2">My Tasks</h4>
+<p class="text-muted">Full management view can be added next. The dashboard widget is fully functional.</p>

--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Pages.Tasks
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        public void OnGet() { }
+    }
+}

--- a/docs/data-domain.md
+++ b/docs/data-domain.md
@@ -5,7 +5,7 @@ This module covers the persistence layer and core domain types.
 ## Data layer
 
 ### `Data/ApplicationDbContext.cs`
-Derives from `IdentityDbContext<ApplicationUser>` and exposes the `Projects` table. Identity tables (users, roles, claims, etc.) are provided by the base class.
+Derives from `IdentityDbContext<ApplicationUser>` and exposes the `Projects` and `TodoItems` tables. Indexes on `TodoItem` enforce fast lookups by owner and due date. Identity tables (users, roles, claims, etc.) are provided by the base class.
 
 ### `Data/DesignTimeDbContextFactory.cs`
 Provides a design-time factory so Entity Framework tooling can create the context when running migrations. It reads configuration from `appsettings.json`, `appsettings.Development.json`, or environment variables.
@@ -17,3 +17,6 @@ Seeds initial roles (`Project Officer`, `HoD`, `Comdt`, `Admin`, `TA`, `MCO`, `P
 
 ### `Models/ApplicationUser.cs`
 Extends `IdentityUser` with a `MustChangePassword` flag. New accounts are created with the flag set to `true`, forcing a password change on first login via `EnforcePasswordChangeFilter`.
+
+### `Models/TodoItem.cs`
+Represents a personal task owned by a user. Each item records a title, optional notes, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates and completion.

--- a/docs/infrastructure-services.md
+++ b/docs/infrastructure-services.md
@@ -25,3 +25,6 @@ Concrete implementation backed by `UserManager<ApplicationUser>` and `RoleManage
 ### Email senders
 * `Services/NoOpEmailSender.cs` – a dummy implementation used when SMTP settings are absent (common on private networks).
 * `Services/SmtpEmailSender.cs` – sends HTML email via SMTP using configuration values (`Email:Smtp:Host`, `Port`, `Username`, `Password`, `Email:From`).
+
+### `Services/ITodoService` and `TodoService`
+`ITodoService` abstracts operations on personal To-Do items such as creation, completion, pinning and deletion. `TodoService` implements the interface using `ApplicationDbContext` for persistence and `IAuditService` for logging. Time calculations are normalised to the `Asia/Kolkata` time zone to ensure consistent due date handling.

--- a/docs/razor-pages.md
+++ b/docs/razor-pages.md
@@ -16,3 +16,10 @@ This module summarises the UI components exposed to end users.
 ## Change Password
 * `Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml` – form for updating the current user's password.
 * `Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs` – validates the old password, updates it, clears the `MustChangePassword` flag and refreshes the sign-in cookie.
+
+## Dashboard
+* `Pages/Dashboard/Index.cshtml` – landing page after sign-in. It renders the **My Tasks** widget on the right column alongside placeholder content for future widgets.
+* `Pages/Shared/_TodoWidget.cshtml` – partial responsible for listing, adding, pinning, completing and deleting tasks without requiring JavaScript.
+
+## Tasks
+* `Pages/Tasks/Index.cshtml` – placeholder page linked from the dashboard widget's "View all" link. A full management interface can be built here later.


### PR DESCRIPTION
## Summary
- Render new My Tasks widget on the dashboard
- Handle add, toggle, pin and delete actions in Dashboard IndexModel
- Create reusable _TodoWidget partial and stub `/Tasks` page
- Document TodoItem domain, TodoService and new pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf11428ccc83298fae5594dce47f37