### PR TITLE
Enhance task UX with pagination, snooze fix, and soft delete

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -34,6 +34,7 @@ namespace ProjectManagement.Data
             {
                 e.HasIndex(x => new { x.OwnerId, x.Status, x.IsPinned, x.DueAtUtc });
                 e.HasIndex(x => new { x.OwnerId, x.OrderIndex });
+                e.HasIndex(x => x.DeletedUtc);
                 e.Property(x => x.Title).IsRequired().HasMaxLength(160);
                 e.Property(x => x.Priority).HasDefaultValue(TodoPriority.Normal);
                 e.Property(x => x.Status).HasDefaultValue(TodoStatus.Open);

--- a/Migrations/20250908000000_TodoSoftDelete.cs
+++ b/Migrations/20250908000000_TodoSoftDelete.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    public partial class TodoSoftDelete : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DeletedUtc",
+                table: "TodoItems",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TodoItems_DeletedUtc",
+                table: "TodoItems",
+                column: "DeletedUtc");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_TodoItems_DeletedUtc",
+                table: "TodoItems");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedUtc",
+                table: "TodoItems");
+        }
+    }
+}

--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -52,6 +52,8 @@ namespace ProjectManagement.Models
 
         public DateTimeOffset? CompletedUtc { get; set; }
 
+        public DateTimeOffset? DeletedUtc { get; set; }
+
         [Timestamp]
         public byte[] RowVersion { get; set; } = Array.Empty<byte>();
     }

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -3,8 +3,13 @@
 @attribute [Microsoft.AspNetCore.Authorization.Authorize]
 @using ProjectManagement.Services
 @using ProjectManagement.Models
-@{ 
+@{
     ViewData["Title"] = "Dashboard";
+}
+
+@if (TempData["Error"] is string err && !string.IsNullOrWhiteSpace(err))
+{
+  <div class="alert alert-warning py-2"><i class="bi bi-exclamation-triangle-fill me-2"></i>@err</div>
 }
 
 @if (Model.TodoWidget != null && (Model.TodoWidget.OverdueCount > 0 || Model.TodoWidget.TodayCount > 0))

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -2,6 +2,7 @@
 @using ProjectManagement.Models
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
+@inject ProjectManagement.Services.ITodoService TodoService
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -43,7 +44,32 @@
                             }
                         }
                     </ul>
-                    <partial name="_LoginPartial" />
+                    @if (SignInManager.IsSignedIn(User))
+                    {
+                        var widget = await TodoService.GetWidgetAsync(UserManager.GetUserId(User)!, take:20);
+                        var count = widget.OverdueCount + widget.TodayCount;
+                        <button class="btn btn-link position-relative me-2" data-bs-toggle="offcanvas" data-bs-target="#todoCanvas" aria-label="My Tasks">
+                            <i class="bi bi-bell"></i>
+                            @if (count > 0)
+                            {
+                                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">@count</span>
+                            }
+                        </button>
+                        <partial name="_LoginPartial" />
+                        <div class="offcanvas offcanvas-end" tabindex="-1" id="todoCanvas" aria-labelledby="todoCanvasLabel">
+                            <div class="offcanvas-header">
+                                <h5 class="offcanvas-title" id="todoCanvasLabel">My Tasks</h5>
+                                <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                            </div>
+                            <div class="offcanvas-body">
+                                @await Html.PartialAsync("_TodoWidget", widget)
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <partial name="_LoginPartial" />
+                    }
                 </div>
             </div>
         </nav>

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -75,6 +75,16 @@
                 </button>
               </form>
 
+              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@t.Id" />
+                <select class="form-select form-select-sm" name="priority" aria-label="Priority" onchange="this.form.submit()">
+                  <option value="Low" selected="@(t.Priority==TodoPriority.Low)">L</option>
+                  <option value="Normal" selected="@(t.Priority==TodoPriority.Normal)">N</option>
+                  <option value="High" selected="@(t.Priority==TodoPriority.High)">H</option>
+                </select>
+              </form>
+
               <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="id" value="@t.Id" />

--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -13,6 +13,11 @@
 
 <h4 class="mb-3">My Tasks</h4>
 
+@if (TempData["Error"] is string err && !string.IsNullOrWhiteSpace(err))
+{
+  <div class="alert alert-warning py-2"><i class="bi bi-exclamation-triangle-fill me-2"></i>@err</div>
+}
+
 <form method="get" class="row g-2 align-items-end mb-3">
   <div class="col-md-3">
     <label class="form-label small">View</label>
@@ -23,9 +28,17 @@
       <option value="completed" selected="@(Model.Tab=="completed")">Completed</option>
     </select>
   </div>
-  <div class="col-md-5">
+  <div class="col-md-3">
     <label class="form-label small">Search</label>
     <input class="form-control form-control-sm" name="q" value="@Model.Q" placeholder="Title or notes">
+  </div>
+  <div class="col-md-2">
+    <label class="form-label small">Page size</label>
+    <select class="form-select form-select-sm" name="PageSize">
+      <option value="10" selected="@(Model.PageSize==10)">10</option>
+      <option value="25" selected="@(Model.PageSize==25)">25</option>
+      <option value="50" selected="@(Model.PageSize==50)">50</option>
+    </select>
   </div>
   <div class="col-md-2 d-grid">
     <button class="btn btn-sm btn-primary">Apply</button>
@@ -49,11 +62,19 @@
 }
 else
 {
+  <form method="post" id="batchForm">
+    @Html.AntiForgeryToken()
+    <div class="mb-2">
+      <button class="btn btn-sm btn-outline-primary" formaction="?handler=BatchDone" aria-label="Mark selected done">Mark done</button>
+      <button class="btn btn-sm btn-outline-danger" formaction="?handler=BatchDelete" onclick="return confirm('Delete selected tasks?');" aria-label="Delete selected">Delete</button>
+    </div>
+  </form>
   <div class="table-responsive">
     <table class="table table-sm align-middle">
       <thead>
         <tr>
           <th style="width:24px;"></th>
+          <th style="width:24px;"><input type="checkbox" id="selectAll" form="batchForm" aria-label="Select all" /></th>
           <th style="width:40px;"></th>
           <th>Title / Notes</th>
           <th style="width:140px;">Due</th>
@@ -65,9 +86,10 @@ else
       <tbody>
       @foreach (var t in Model.Items)
       {
-        var formId = $"edit-{t.Id}";
+        var formId = $"f-{t.Id}";
         <tr draggable="@(Model.Tab=="completed" ? "false" : "true")" data-id="@t.Id" class="todo-row">
-          <td class="text-muted"><i class="bi bi-grip-vertical" title="Drag to reorder"></i></td>
+          <td class="text-muted"><i class="bi bi-grip-vertical" title="Drag to reorder (order is applied within the same due group)"></i></td>
+          <td><input class="form-check-input" type="checkbox" name="ids" value="@t.Id" form="batchForm" aria-label="Select task" /></td>
           <td>
             <form method="post" asp-page-handler="Toggle" class="m-0 p-0">
               @Html.AntiForgeryToken()
@@ -101,7 +123,7 @@ else
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="id" value="@t.Id" />
                 <button class="btn btn-sm btn-outline-primary">Save</button>
-                <a href="#" class="btn btn-sm btn-outline-secondary" onclick="event.preventDefault();">Cancel</a>
+                <button type="reset" form="@formId" class="btn btn-sm btn-outline-secondary">Cancel</button>
               </form>
               <form method="post" asp-page-handler="Delete" class="d-inline" onsubmit="return confirm('Delete this task?');">
                 @Html.AntiForgeryToken()
@@ -114,6 +136,19 @@ else
       </tbody>
     </table>
   </div>
+  @if (Model.TotalPages > 1)
+  {
+    <nav class="mt-2">
+      <ul class="pagination pagination-sm mb-0">
+        @for (var p = 1; p <= Model.TotalPages; p++)
+        {
+          <li class="page-item @(p==Model.Page ? "active" : "")">
+            <a class="page-link" href="@Url.Page(null, new { tab = Model.Tab, q = Model.Q, page = p, pageSize = Model.PageSize })">@p</a>
+          </li>
+        }
+      </ul>
+    </nav>
+  }
 }
 
 <script>
@@ -151,6 +186,12 @@ else
 
     await fetch("?handler=Reorder", { method: "POST", body: formData });
   });
+  const selectAll = document.getElementById("selectAll");
+  if (selectAll) {
+    selectAll.addEventListener("change", e => {
+      document.querySelectorAll("input[name='ids']").forEach(cb => cb.checked = selectAll.checked);
+    });
+  }
 })();
 </script>
 

--- a/Program.cs
+++ b/Program.cs
@@ -106,6 +106,7 @@ builder.Services.Configure<UserLifecycleOptions>(
 builder.Services.AddScoped<IUserLifecycleService, UserLifecycleService>();
 builder.Services.AddHostedService<UserPurgeWorker>();
 builder.Services.AddScoped<ITodoService, TodoService>();
+builder.Services.AddHostedService<TodoPurgeWorker>();
 
 // Register email sender
 if (!string.IsNullOrWhiteSpace(builder.Configuration["Email:Smtp:Host"]))

--- a/ProjectManagement.Tests/TodoServiceTests.cs
+++ b/ProjectManagement.Tests/TodoServiceTests.cs
@@ -162,6 +162,20 @@ namespace ProjectManagement.Tests
             Assert.Equal(nextMon.ToUniversalTime(), stored3!.DueAtUtc);
         }
 
+        [Fact]
+        public async Task DeleteSoftDeletesCompleted()
+        {
+            using var context = CreateContext();
+            var audit = new FakeAudit();
+            var service = new TodoService(context, audit);
+            var item = await service.CreateAsync("alice", "Task");
+            await service.ToggleDoneAsync("alice", item.Id, true);
+            await service.DeleteAsync("alice", item.Id);
+            var stored = await context.TodoItems.FirstOrDefaultAsync(x => x.Id == item.Id);
+            Assert.NotNull(stored);
+            Assert.NotNull(stored!.DeletedUtc);
+        }
+
         private static DateTimeOffset TodayAt(int h, int m)
         {
             var ist = TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");

--- a/Services/TodoPurgeWorker.cs
+++ b/Services/TodoPurgeWorker.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Services
+{
+    public class TodoPurgeWorker : BackgroundService
+    {
+        private readonly IServiceProvider _sp;
+        private readonly ILogger<TodoPurgeWorker> _log;
+        private const int RetentionDays = 7;
+
+        public TodoPurgeWorker(IServiceProvider sp, ILogger<TodoPurgeWorker> log)
+        {
+            _sp = sp;
+            _log = log;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                using var scope = _sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var cutoff = DateTimeOffset.UtcNow.AddDays(-RetentionDays);
+                var deleted = await db.TodoItems
+                    .Where(t => t.DeletedUtc != null && t.DeletedUtc < cutoff)
+                    .ExecuteDeleteAsync(stoppingToken);
+                if (deleted > 0)
+                    _log.LogInformation("Purged {Count} todo items", deleted);
+                await Task.Delay(TimeSpan.FromDays(7), stoppingToken);
+            }
+        }
+    }
+}

--- a/docs/data-domain.md
+++ b/docs/data-domain.md
@@ -19,4 +19,4 @@ Seeds initial roles (`Project Officer`, `HoD`, `Comdt`, `Admin`, `TA`, `MCO`, `P
 Extends `IdentityUser` with a `MustChangePassword` flag. New accounts are created with the flag set to `true`, forcing a password change on first login via `EnforcePasswordChangeFilter`.
 
 ### `Models/TodoItem.cs`
-Represents a personal task owned by a user. Each item records a title, optional notes, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates and completion. A `RowVersion` concurrency token is used to detect conflicting edits.
+Represents a personal task owned by a user. Each item records a title, optional notes, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates, completion and soft deletion. A `RowVersion` concurrency token is used to detect conflicting edits. Items marked completed are soft-deleted by setting `DeletedUtc`; a background worker purges entries older than a week.

--- a/docs/razor-pages.md
+++ b/docs/razor-pages.md
@@ -19,7 +19,7 @@ This module summarises the UI components exposed to end users.
 
 ## Dashboard
 * `Pages/Dashboard/Index.cshtml` – landing page after sign-in. It shows an attention band when tasks are overdue or due today and renders the **My Tasks** widget on the right column alongside placeholder content for future widgets.
-* `Pages/Shared/_TodoWidget.cshtml` – partial responsible for listing, adding, pinning, completing, snoozing and deleting tasks without requiring JavaScript, with priority dots and due badges.
+* `Pages/Shared/_TodoWidget.cshtml` – partial responsible for listing, adding, pinning, completing, snoozing, quick priority changes and deleting tasks without requiring JavaScript, with priority dots and due badges. It is also rendered inside a navbar off-canvas accessible from a bell icon showing the count of urgent tasks.
 
 ## Tasks
-* `Pages/Tasks/Index.cshtml` – full management interface with tabs, search, add, inline edits for title, notes, priority, due date, pinning, mark done, delete and drag-and-drop reordering of open tasks.
+* `Pages/Tasks/Index.cshtml` – full management interface with tabs, search, page size selection, pagination, batch mark-done/delete actions, add, inline edits for title, notes, priority, due date, pinning, mark done, delete and drag-and-drop reordering of open tasks.


### PR DESCRIPTION
## Summary
- prevent past-time snoozes by advancing "Today" presets when needed
- add paging, batch actions, and reset-friendly editing on the Tasks page
- support quick priority edits, navbar bell with off‑canvas widget, and soft delete with weekly purging

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1e84a5688329b0fcae4d2ffaaa03