### PR TITLE
Streamline My Tasks widget rendering and layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -2,7 +2,6 @@
 @using ProjectManagement.Models
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
-@inject ProjectManagement.Services.ITodoService TodoService
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -44,32 +43,7 @@
                             }
                         }
                     </ul>
-                    @if (SignInManager.IsSignedIn(User))
-                    {
-                        var widget = await TodoService.GetWidgetAsync(UserManager.GetUserId(User)!, take:20);
-                        var count = widget.OverdueCount + widget.TodayCount;
-                        <button class="btn btn-link position-relative me-2" data-bs-toggle="offcanvas" data-bs-target="#todoCanvas" aria-label="My Tasks">
-                            <i class="bi bi-bell"></i>
-                            @if (count > 0)
-                            {
-                                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">@count</span>
-                            }
-                        </button>
-                        <partial name="_LoginPartial" />
-                        <div class="offcanvas offcanvas-end" tabindex="-1" id="todoCanvas" aria-labelledby="todoCanvasLabel">
-                            <div class="offcanvas-header">
-                                <h5 class="offcanvas-title" id="todoCanvasLabel">My Tasks</h5>
-                                <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-                            </div>
-                            <div class="offcanvas-body">
-                                @await Html.PartialAsync("_TodoWidget", widget)
-                            </div>
-                        </div>
-                    }
-                    else
-                    {
-                        <partial name="_LoginPartial" />
-                    }
+                    <partial name="_LoginPartial" />
                 </div>
             </div>
         </nav>

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -1,4 +1,3 @@
-@using ProjectManagement.Services
 @using ProjectManagement.Models
 @model ProjectManagement.Services.TodoWidgetResult
 
@@ -16,7 +15,7 @@
     <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Add" class="mb-2">
       @Html.AntiForgeryToken()
       <div class="input-group input-group-sm">
-        <input name="NewTitle" class="form-control" placeholder="Add a task…" maxlength="160" required aria-label="Task title" />
+        <input name="NewTitle" class="form-control" placeholder="Add a task…" maxlength="160" required aria-label="Task title">
         <button class="btn btn-primary">Add</button>
       </div>
     </form>
@@ -27,7 +26,7 @@
     }
     else
     {
-      <ul class="list-group list-group-flush" style="max-height: 340px; overflow:auto;">
+      <ul class="list-group list-group-flush todo-list" style="max-height: 340px; overflow:auto;">
         @{
           var ist = TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");
           var todayIst = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, ist).Date;
@@ -42,77 +41,78 @@
             else if (dueDate == todayIst) badge = "Today";
             else if (dueDate == todayIst.AddDays(1)) badge = "Tomorrow";
           }
-
           string prioClass = t.Priority switch
           {
             TodoPriority.Low    => "todo-dot-low",
             TodoPriority.High   => "todo-dot-high",
             _                   => "todo-dot-normal"
           };
+        <li class="list-group-item d-flex align-items-center justify-content-between py-1">
+          <div class="d-flex align-items-center gap-2">
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Toggle" class="m-0 p-0">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <input class="form-check-input" type="checkbox" title="Mark done" aria-label="Mark done" onchange="this.form.submit()" />
+            </form>
+            <span class="todo-dot @prioClass" title="@t.Priority"></span>
+            <span class="text-truncate" style="max-width: 240px;">@t.Title</span>
+            @if (!string.IsNullOrEmpty(badge))
+            {
+              <span class="badge rounded-pill bg-light text-dark border">@badge</span>
+            }
+          </div>
+          <div class="btn-group btn-group-sm todo-actions" role="group" aria-label="Task actions">
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Pin" class="m-0 p-0">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <input type="hidden" name="pin" value="@(!t.IsPinned)" />
+              <button class="btn btn-outline-secondary" title="@(t.IsPinned ? "Unpin" : "Pin")">
+                <i class="bi @(t.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
+              </button>
+            </form>
 
-          <li class="list-group-item d-flex align-items-center justify-content-between py-2">
-            <div class="d-flex align-items-center gap-2">
-              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Toggle" class="m-0 p-0">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <input class="form-check-input" type="checkbox" title="Mark done" aria-label="Mark done" onchange="this.form.submit()" />
-              </form>
-              <span class="todo-dot @prioClass" title="@t.Priority"></span>
-              <span>@t.Title</span>
-              @if (!string.IsNullOrEmpty(badge))
-              {
-                <span class="badge rounded-pill bg-light text-dark border">@badge</span>
-              }
-            </div>
-
-            <div class="btn-group btn-group-sm" role="group" aria-label="Task actions">
-              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Pin" class="m-0 p-0">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <input type="hidden" name="pin" value="@(!t.IsPinned)" />
-                <button class="btn btn-outline-secondary" title="@(t.IsPinned ? "Unpin" : "Pin")">
-                  <i class="bi @(t.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="Priority">
+                  @(t.Priority == TodoPriority.High ? "H" : t.Priority == TodoPriority.Low ? "L" : "N")
                 </button>
-              </form>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <li><button class="dropdown-item" name="priority" value="Low">Low</button></li>
+                  <li><button class="dropdown-item" name="priority" value="Normal">Normal</button></li>
+                  <li><button class="dropdown-item" name="priority" value="High">High</button></li>
+                </ul>
+              </div>
+            </form>
 
-              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <select class="form-select form-select-sm" name="priority" aria-label="Priority" onchange="this.form.submit()">
-                  <option value="Low" selected="@(t.Priority==TodoPriority.Low)">L</option>
-                  <option value="Normal" selected="@(t.Priority==TodoPriority.Normal)">N</option>
-                  <option value="High" selected="@(t.Priority==TodoPriority.High)">H</option>
-                </select>
-              </form>
-
-              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <div class="dropdown">
-                  <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="Snooze">
-                    <i class="bi bi-alarm"></i>
-                  </button>
-                  <ul class="dropdown-menu dropdown-menu-end">
-                    <li><button class="dropdown-item" name="preset" value="today_pm" formaction="?handler=Snooze">Today 6:00 PM</button></li>
-                    <li><button class="dropdown-item" name="preset" value="tom_am" formaction="?handler=Snooze">Tomorrow 10:00 AM</button></li>
-                    <li><button class="dropdown-item" name="preset" value="next_mon" formaction="?handler=Snooze">Next Monday 10:00 AM</button></li>
-                    <li><button class="dropdown-item" name="preset" value="clear" formaction="?handler=Snooze">Clear due date</button></li>
-                  </ul>
-                </div>
-              </form>
-
-              <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Delete" class="m-0 p-0" onsubmit="return confirm('Delete this task?');">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <button class="btn btn-outline-danger" title="Delete">
-                  <i class="bi bi-trash"></i>
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="Snooze">
+                  <i class="bi bi-alarm"></i>
                 </button>
-              </form>
-            </div>
-          </li>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <li><button class="dropdown-item" name="preset" value="today_pm">Today 6:00 PM</button></li>
+                  <li><button class="dropdown-item" name="preset" value="tom_am">Tomorrow 10:00 AM</button></li>
+                  <li><button class="dropdown-item" name="preset" value="next_mon">Next Monday 10:00 AM</button></li>
+                  <li><button class="dropdown-item" name="preset" value="clear">Clear due date</button></li>
+                </ul>
+              </div>
+            </form>
+
+            <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Delete" class="m-0 p-0" onsubmit="return confirm('Delete this task?');">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <button class="btn btn-outline-danger" title="Delete">
+                <i class="bi bi-trash"></i>
+              </button>
+            </form>
+          </div>
+        </li>
         }
       </ul>
     }
   </div>
 </div>
-

--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -88,9 +88,9 @@ else
       {
         var formId = $"f-{t.Id}";
         <tr draggable="@(Model.Tab=="completed" ? "false" : "true")" data-id="@t.Id" class="todo-row">
-          <td class="text-muted"><i class="bi bi-grip-vertical" title="Drag to reorder (order is applied within the same due group)"></i></td>
-          <td><input class="form-check-input" type="checkbox" name="ids" value="@t.Id" form="batchForm" aria-label="Select task" /></td>
-          <td>
+          <td class="text-muted align-middle"><i class="bi bi-grip-vertical" title="Drag to reorder (order is applied within the same due group)"></i></td>
+          <td class="align-middle"><input class="form-check-input" type="checkbox" name="ids" value="@t.Id" form="batchForm" aria-label="Select task" /></td>
+          <td class="align-middle">
             <form method="post" asp-page-handler="Toggle" class="m-0 p-0">
               @Html.AntiForgeryToken()
               <input type="hidden" name="id" value="@t.Id" />
@@ -98,33 +98,37 @@ else
               <input class="form-check-input" type="checkbox" title="Mark done" aria-label="Mark done" onchange="this.form.submit()" @(t.Status == ProjectManagement.Models.TodoStatus.Done ? "checked" : "") />
             </form>
           </td>
-          <td>
-              <input class="form-control form-control-sm mb-1" name="title" value="@t.Title" maxlength="160" form="@formId" aria-label="Title" />
-              <textarea class="form-control form-control-sm" name="notes" rows="2" placeholder="Notes (optional)" form="@formId" aria-label="Notes">@t.Notes</textarea>
+          <td class="align-middle">
+            <form id="@formId" method="post" asp-page-handler="Edit" class="row g-2 m-0 p-0">
+              @Html.AntiForgeryToken()
+              <input type="hidden" name="id" value="@t.Id" />
+              <div class="col-12">
+                <input class="form-control form-control-sm" name="title" value="@t.Title" maxlength="160" aria-label="Title">
+              </div>
+              <div class="col-12">
+                <textarea class="form-control form-control-sm" name="notes" rows="2" placeholder="Notes (optional)" aria-label="Notes">@t.Notes</textarea>
+              </div>
+            </form>
           </td>
-          <td>
+          <td class="align-middle">
               <input class="form-control form-control-sm" type="date"
-                     name="dueLocal"
                      form="@formId"
+                     name="dueLocal"
                      value="@(t.DueAtUtc.HasValue ? TimeZoneInfo.ConvertTime(t.DueAtUtc.Value, TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata")).ToString("yyyy-MM-dd") : "")" />
           </td>
-          <td>
-              <select class="form-select form-select-sm" name="priority" form="@formId">
+          <td class="align-middle">
+              <select class="form-select form-select-sm" form="@formId" name="priority">
                 <option value="Low" selected="@(t.Priority==ProjectManagement.Models.TodoPriority.Low)">Low</option>
                 <option value="Normal" selected="@(t.Priority==ProjectManagement.Models.TodoPriority.Normal)">Normal</option>
                 <option value="High" selected="@(t.Priority==ProjectManagement.Models.TodoPriority.High)">High</option>
               </select>
           </td>
-          <td class="text-center">
-              <input class="form-check-input" type="checkbox" name="pin" value="true" @(t.IsPinned ? "checked" : "") form="@formId" />
+          <td class="align-middle text-center">
+              <input class="form-check-input" form="@formId" type="checkbox" name="pin" value="true" @(t.IsPinned ? "checked" : "") />
           </td>
-          <td class="text-end">
-              <form id="@formId" method="post" asp-page-handler="Edit" class="d-inline">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="id" value="@t.Id" />
-                <button class="btn btn-sm btn-outline-primary">Save</button>
-                <button type="reset" form="@formId" class="btn btn-sm btn-outline-secondary">Cancel</button>
-              </form>
+          <td class="align-middle text-end">
+              <button form="@formId" class="btn btn-sm btn-outline-primary">Save</button>
+              <button type="reset" form="@formId" class="btn btn-sm btn-outline-secondary">Cancel</button>
               <form method="post" asp-page-handler="Delete" class="d-inline" onsubmit="return confirm('Delete this task?');">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="id" value="@t.Id" />

--- a/docs/razor-pages.md
+++ b/docs/razor-pages.md
@@ -19,7 +19,7 @@ This module summarises the UI components exposed to end users.
 
 ## Dashboard
 * `Pages/Dashboard/Index.cshtml` – landing page after sign-in. It shows an attention band when tasks are overdue or due today and renders the **My Tasks** widget on the right column alongside placeholder content for future widgets.
-* `Pages/Shared/_TodoWidget.cshtml` – partial responsible for listing, adding, pinning, completing, snoozing, quick priority changes and deleting tasks without requiring JavaScript, with priority dots and due badges. It is also rendered inside a navbar off-canvas accessible from a bell icon showing the count of urgent tasks.
+* `Pages/Shared/_TodoWidget.cshtml` – partial responsible for listing, adding, pinning, completing, snoozing, quick priority changes and deleting tasks without requiring JavaScript, with priority dots and due badges. The widget is rendered only on the dashboard's right column.
 
 ## Tasks
-* `Pages/Tasks/Index.cshtml` – full management interface with tabs, search, page size selection, pagination, batch mark-done/delete actions, add, inline edits for title, notes, priority, due date, pinning, mark done, delete and drag-and-drop reordering of open tasks.
+* `Pages/Tasks/Index.cshtml` – full management interface with tabs, search, page size selection, pagination, batch mark-done/delete actions, add, compact inline edits for title, notes, priority, due date, pinning, mark done, delete and drag-and-drop reordering of open tasks.

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -181,7 +181,9 @@ body {
 .table-sm td, .table-sm th { vertical-align: middle; }
 .badge { letter-spacing: .2px; }
 
-/* Todo priority dots */
+/* Widget compactness */
+.todo-list .list-group-item { padding-top: .35rem; padding-bottom: .35rem; }
+.todo-actions .btn { padding: .15rem .4rem; line-height: 1; }
 .todo-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
 .todo-dot-low { background: #6c757d; }
 .todo-dot-normal { background: #0d6efd; }


### PR DESCRIPTION
## Summary
- remove globally rendered My Tasks widget from shared layout
- compact My Tasks widget markup and tighten CSS spacing
- align /Tasks page editing form for clearer Save/Cancel controls
- update documentation for revised widget placement and tasks page layout

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bf291ba20883298e8e710c0589d3ed