### PR TITLE
Refactor task actions to POST and quiet noisy logs

### DIFF
--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
+using ProjectManagement.Helpers;
 using System;
 using System.Threading.Tasks;
 
@@ -44,9 +45,11 @@ namespace ProjectManagement.Pages.Dashboard
             var uid = _users.GetUserId(User);
             if (uid == null) return Unauthorized();
 
+            TodoQuickParser.Parse(NewTitle, out var clean, out var dueLocal, out var prio);
+
             try
             {
-                await _todo.CreateAsync(uid, NewTitle.Trim());
+                await _todo.CreateAsync(uid, clean, dueLocal, prio);
             }
             catch (InvalidOperationException ex)
             {

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -67,7 +67,7 @@
     @await RenderSectionAsync("Scripts", required: false)
     <script>
     document.addEventListener('DOMContentLoaded', () => {
-      document.querySelectorAll('.todo-actions .dropdown-toggle').forEach(el => {
+      document.querySelectorAll('.btn-kebab.dropdown-toggle').forEach(el => {
         new bootstrap.Dropdown(el, { container: 'body', popperConfig: { strategy: 'fixed' }});
       });
     });

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -59,83 +59,78 @@
             }
           </div>
           <div class="dropdown">
-            <button class="btn btn-link text-muted btn-kebab" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-container="body" aria-expanded="false" title="More actions">
-              <i class="bi bi-three-dots-vertical"></i>
-            </button>
+            <button type="button" class="btn btn-outline-secondary btn-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" title="More actions">⋯</button>
             <ul class="dropdown-menu dropdown-menu-end">
               <li>
                 <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Pin" class="m-0 p-0">
                   @Html.AntiForgeryToken()
                   <input type="hidden" name="id" value="@t.Id" />
                   <input type="hidden" name="pin" value="@(!t.IsPinned)" />
-                  <button class="dropdown-item">@(t.IsPinned ? "Unpin" : "Pin")</button>
+                  <button type="submit" class="dropdown-item">@(t.IsPinned ? "Unpin" : "Pin")</button>
                 </form>
               </li>
-              <li class="dropstart">
-                <button class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside">Priority</button>
-                <ul class="dropdown-menu">
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="priority" value="High">High</button>
-                    </form>
-                  </li>
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="priority" value="Normal">Normal</button>
-                    </form>
-                  </li>
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="priority" value="Low">Low</button>
-                    </form>
-                  </li>
-                </ul>
+
+              <li><hr class="dropdown-divider" /></li>
+              <li class="dropdown-header small">Priority</li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="High">High</button>
+                </form>
               </li>
-              <li class="dropstart">
-                <button class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside">Snooze</button>
-                <ul class="dropdown-menu">
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="preset" value="today_pm">Today 6:00 PM</button>
-                    </form>
-                  </li>
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="preset" value="tom_am">Tomorrow 10:00 AM</button>
-                    </form>
-                  </li>
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="preset" value="next_mon">Next Monday 10:00 AM</button>
-                    </form>
-                  </li>
-                  <li>
-                    <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
-                      @Html.AntiForgeryToken()
-                      <input type="hidden" name="id" value="@t.Id" />
-                      <button class="dropdown-item" name="preset" value="clear">Clear due date</button>
-                    </form>
-                  </li>
-                </ul>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="Normal">Normal</button>
+                </form>
               </li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="Low">Low</button>
+                </form>
+              </li>
+
+              <li><hr class="dropdown-divider" /></li>
+              <li class="dropdown-header small">Snooze</li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="today_pm">Today 6:00 PM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="tom_am">Tomorrow 10:00 AM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="next_mon">Next Monday 10:00 AM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="clear">Clear due date</button>
+                </form>
+              </li>
+
               <li><hr class="dropdown-divider" /></li>
               <li>
                 <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Delete" class="m-0 p-0" onsubmit="return confirm('Delete this task?');">
                   @Html.AntiForgeryToken()
                   <input type="hidden" name="id" value="@t.Id" />
-                  <button class="dropdown-item text-danger">Delete</button>
+                  <button type="submit" class="dropdown-item text-danger">Delete</button>
                 </form>
               </li>
             </ul>

--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -127,11 +127,6 @@ document.querySelectorAll('li.todo-row').forEach(row => {
   });
 })();
 
-// bootstrap dropdowns inside scrollers -> render to body
-document.querySelectorAll('.btn-kebab.dropdown-toggle').forEach(el => {
-  new bootstrap.Dropdown(el, { container: 'body', popperConfig: { strategy: 'fixed' }});
-});
-
 // select mode toggle
 const selectToggle = document.getElementById('selectToggle');
 const batchForm = document.getElementById('batchForm');

--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -120,7 +120,7 @@ namespace ProjectManagement.Pages.Tasks
         // Actions
         public async Task<IActionResult> OnPostAddAsync(string title)
         {
-            if (string.IsNullOrWhiteSpace(title)) return RedirectToPage(new { Tab, Q });
+            if (string.IsNullOrWhiteSpace(title)) return Back();
             var uid = _users.GetUserId(User);
             TodoQuickParser.Parse(title, out var clean, out var dueLocal, out var prio);
             try
@@ -131,7 +131,7 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostToggleAsync(Guid id, bool done)
@@ -146,7 +146,7 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostUndoAsync(Guid id)
@@ -160,7 +160,7 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostEditAsync(Guid id, string? title, string? priority, DateTimeOffset? dueLocal, bool? pin, string? notes)
@@ -181,7 +181,7 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostSnoozeAsync(Guid id, string preset)
@@ -206,7 +206,7 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostReorderAsync([FromForm] Guid[] ids)
@@ -235,13 +235,13 @@ namespace ProjectManagement.Pages.Tasks
             {
                 TempData["Error"] = ex.Message;
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostBatchDoneAsync([FromForm] Guid[] ids)
         {
             var uid = _users.GetUserId(User);
-            if (uid == null || ids == null || ids.Length == 0) return RedirectToPage(new { Tab, Q, Page, PageSize });
+            if (uid == null || ids == null || ids.Length == 0) return Back();
             foreach (var id in ids)
             {
                 try
@@ -254,13 +254,13 @@ namespace ProjectManagement.Pages.Tasks
                     break;
                 }
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
 
         public async Task<IActionResult> OnPostBatchDeleteAsync([FromForm] Guid[] ids)
         {
             var uid = _users.GetUserId(User);
-            if (uid == null || ids == null || ids.Length == 0) return RedirectToPage(new { Tab, Q, Page, PageSize });
+            if (uid == null || ids == null || ids.Length == 0) return Back();
             foreach (var id in ids)
             {
                 try
@@ -273,8 +273,24 @@ namespace ProjectManagement.Pages.Tasks
                     break;
                 }
             }
-            return RedirectToPage(new { Tab, Q, Page, PageSize });
+            return Back();
         }
+
+        public async Task<IActionResult> OnPostPinAsync(Guid id, bool pin)
+        {
+            var uid = _users.GetUserId(User);
+            try
+            {
+                await _todo.EditAsync(uid!, id, pinned: pin);
+            }
+            catch (InvalidOperationException ex)
+            {
+                TempData["Error"] = ex.Message;
+            }
+            return Back();
+        }
+
+        private IActionResult Back() => RedirectToPage("Index", new { Tab, Q, Page, PageSize });
 
         private static DateTimeOffset NextOccurrenceTodayOrTomorrow(int h, int m)
         {

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -63,46 +63,86 @@
 
         <div class="d-flex align-items-center gap-3">
           <div class="row-actions d-none">
-            <button form="@formId" class="btn btn-link btn-sm p-0">Save</button>
+            <button form="@formId" type="submit" class="btn btn-link btn-sm p-0">Save</button>
             <button type="reset" form="@formId" class="btn btn-link btn-sm p-0 text-muted">Cancel</button>
           </div>
 
           <div class="dropdown">
-            <button class="btn btn-outline-secondary btn-kebab dropdown-toggle"
+            <button type="button" class="btn btn-outline-secondary btn-kebab dropdown-toggle"
                     data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" title="More actions" aria-label="More actions">⋯</button>
             <ul class="dropdown-menu dropdown-menu-end">
+              <li>
+                <form method="post" asp-page-handler="Pin" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <input type="hidden" name="pin" value="@(!t.IsPinned)" />
+                  <button type="submit" class="dropdown-item">@(t.IsPinned ? "Unpin" : "Pin")</button>
+                </form>
+              </li>
+
+              <li><hr class="dropdown-divider" /></li>
               <li class="dropdown-header small">Priority</li>
-              <li><button class="dropdown-item" form="@formId" name="priority" value="High">High</button></li>
-              <li><button class="dropdown-item" form="@formId" name="priority" value="Normal">Normal</button></li>
-              <li><button class="dropdown-item" form="@formId" name="priority" value="Low">Low</button></li>
+              <li>
+                <form method="post" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="High">High</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="Normal">Normal</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page-handler="Edit" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="priority" value="Low">Low</button>
+                </form>
+              </li>
+
               <li><hr class="dropdown-divider" /></li>
               <li class="dropdown-header small">Snooze</li>
-              <li><form method="post" asp-page-handler="Snooze" class="m-0 p-0">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" value="@t.Id" />
-                    <button class="dropdown-item" name="preset" value="today_pm">Today 6:00 PM</button>
-                  </form></li>
-              <li><form method="post" asp-page-handler="Snooze" class="m-0 p-0">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" value="@t.Id" />
-                    <button class="dropdown-item" name="preset" value="tom_am">Tomorrow 10:00 AM</button>
-                  </form></li>
-              <li><form method="post" asp-page-handler="Snooze" class="m-0 p-0">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" value="@t.Id" />
-                    <button class="dropdown-item" name="preset" value="next_mon">Next Monday 10:00 AM</button>
-                  </form></li>
-              <li><form method="post" asp-page-handler="Snooze" class="m-0 p-0">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" value="@t.Id" />
-                    <button class="dropdown-item" name="preset" value="clear">Clear due date</button>
-                  </form></li>
+              <li>
+                <form method="post" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="today_pm">Today 6:00 PM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="tom_am">Tomorrow 10:00 AM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="next_mon">Next Monday 10:00 AM</button>
+                </form>
+              </li>
+              <li>
+                <form method="post" asp-page-handler="Snooze" class="m-0 p-0">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item" name="preset" value="clear">Clear due date</button>
+                </form>
+              </li>
+
               <li><hr class="dropdown-divider" /></li>
-              <li><form method="post" asp-page-handler="Delete" class="m-0 p-0" onsubmit="return confirm('Delete this task?');">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" value="@t.Id" />
-                    <button class="dropdown-item text-danger">Delete</button>
-                  </form></li>
+              <li>
+                <form method="post" asp-page-handler="Delete" class="m-0 p-0" onsubmit="return confirm('Delete this task?');">
+                  @Html.AntiForgeryToken()
+                  <input type="hidden" name="id" value="@t.Id" />
+                  <button type="submit" class="dropdown-item text-danger">Delete</button>
+                </form>
+              </li>
             </ul>
           </div>
         </div>

--- a/Program.cs
+++ b/Program.cs
@@ -11,8 +11,14 @@ using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
 using ProjectManagement.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
+builder.Logging.AddFilter("Microsoft.EntityFrameworkCore.Model.Validation", LogLevel.Warning);
+builder.Logging.AddFilter("ProjectManagement.Services.TodoService", LogLevel.None);
+builder.Logging.AddFilter("ProjectManagement.Services.TodoPurgeWorker", LogLevel.Warning);
 
 var keysDir = Environment.GetEnvironmentVariable("DP_KEYS_DIR");
 if (string.IsNullOrWhiteSpace(keysDir))

--- a/Services/AuditService.cs
+++ b/Services/AuditService.cs
@@ -41,6 +41,11 @@ namespace ProjectManagement.Services
                                    string? userId = null, string? userName = null,
                                    IDictionary<string, string?>? data = null, HttpContext? http = null)
         {
+            if (action.StartsWith("Todo.", StringComparison.OrdinalIgnoreCase))
+            {
+                return; // Skip noisy Todo logs
+            }
+
             http ??= _http.HttpContext;
             var ip = ClientIp.Get(http);
             var ua = http?.Request?.Headers["User-Agent"].ToString();

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,7 +5,12 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "Microsoft.EntityFrameworkCore.Model.Validation": "Warning",
+      "ProjectManagement.Services.TodoService": "None",
+      "ProjectManagement.Services.TodoPurgeWorker": "Warning"
     }
   },
   "AllowedHosts": "*",

--- a/docs/infrastructure-services.md
+++ b/docs/infrastructure-services.md
@@ -31,3 +31,6 @@ Concrete implementation backed by `UserManager<ApplicationUser>` and `RoleManage
 
 ### `Services/TodoPurgeWorker`
 Background worker that permanently deletes soft-deleted to-do items after a retention period. The retention window is configured via `Todo:RetentionDays` in `appsettings.json` (defaults to 7 days) and the worker safely handles cancellation tokens.
+
+### Logging
+`appsettings.json` and `Program.cs` configure logging filters to keep output concise: verbose Entity Framework messages and routine To-Do service logs are suppressed, while the `TodoPurgeWorker` logs only warnings or higher. Additionally, `AuditService` skips writing `Todo.*` actions to the `AuditLogs` table.


### PR DESCRIPTION
## Summary
- use standalone POST forms for task row actions and add a dedicated pin handler
- standardize task redirects and quick-add parsing
- filter verbose EF Core and todo logs, skipping Todo.* audit entries

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa2dc3fcc8329990ce60cdc54d479