### PR TITLE
Fix dropdown overflow and unreliable checkbox submit

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -23,7 +23,7 @@
     }
     else
     {
-      <ul class="list-group list-group-flush todo-list" style="max-height: 340px; overflow:auto;">
+      <ul class="list-group list-group-flush todo-list pm-scroll">
         @{
           var ist = TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");
           var todayIst = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, ist).Date;
@@ -52,7 +52,7 @@
               <input type="hidden" name="done" value="false" />
               <input class="form-check-input" type="checkbox" name="done" value="true"
                      @(t.Status==TodoStatus.Done ? "checked" : "")
-                     title="Mark done" aria-label="Mark done" onchange="this.form.submit()" />
+                     title="Mark done" aria-label="Mark done" onchange="this.form.requestSubmit()" />
             </form>
             <span class="todo-dot @prioClass" title="@t.Priority"></span>
             <span class="todo-title">@t.Title</span>
@@ -62,7 +62,7 @@
             }
           </div>
           <div class="dropdown dropstart">
-            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="outside" aria-expanded="false" aria-label="More actions" data-bs-placement="left">
+            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" aria-label="More actions" data-bs-placement="left">
               <i class="bi bi-three-dots"></i>
             </button>
             <ul class="dropdown-menu">

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -43,7 +43,7 @@
             <input type="hidden" name="done" value="false" />
             <input class="form-check-input" type="checkbox" name="done" value="true"
                    @(t.Status == TodoStatus.Done ? "checked" : "")
-                   title="Mark done" aria-label="Mark done" onchange="this.form.submit()" />
+                   title="Mark done" aria-label="Mark done" onchange="this.form.requestSubmit()" />
           </form>
 
           <span class="todo-dot @(Dot(t.Priority))" title="@t.Priority"></span>
@@ -71,7 +71,7 @@
 
           <div class="dropdown">
             <button type="button" class="btn todo-kebab dropdown-toggle"
-                    data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="outside"
+                    data-bs-toggle="dropdown" data-bs-auto-close="outside"
                     aria-expanded="false" aria-label="More actions">
               <i class="bi bi-three-dots"></i>
             </button>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -199,6 +199,9 @@ h1, .h1 { font-size: 1.25rem; }
 .todo-list .list-group-item { padding: .35rem .6rem; }
 .todo-actions .btn { padding: 0; width: var(--pm-btn-icon); height: var(--pm-btn-icon); display: inline-flex; align-items: center; justify-content: center; }
 
+/* Scrollable area helper */
+.pm-scroll{ max-height:340px; overflow:auto; }
+
 /* Priority dots */
 .todo-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
 .todo-dot-low { background: #6c757d; }


### PR DESCRIPTION
## Summary
- Allow dropdown menus to flip by removing `data-bs-display="static"`
- Use `requestSubmit()` for checkbox toggles
- Add reusable `.pm-scroll` class for scrolling lists

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc99e4ba48329a7cf4298734f7cdc