### PR TITLE
Fix unclosed checkbox inputs in task views

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -49,9 +49,9 @@
             <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Toggle" class="m-0 p-0">
               @Html.AntiForgeryToken()
               <input type="hidden" name="id" value="@t.Id" />
-              
-              <input class="form-check-input js-done-checkbox" type="checkbox" name="done" value="true"
+
               <input type="hidden" name="done" value="false" />
+              <input class="form-check-input js-done-checkbox" type="checkbox" name="done" value="true"
                      @(t.Status==TodoStatus.Done ? "checked" : "")
                      title="Mark done" aria-label="Mark done" />
             </form>

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -40,8 +40,8 @@
           <form method="post" asp-page-handler="Toggle" class="m-0 p-0">
             @Html.AntiForgeryToken()
             <input type="hidden" name="id" value="@t.Id" />
-            <input class="form-check-input js-done-checkbox" type="checkbox" name="done" value="true"
             <input type="hidden" name="done" value="false" />
+            <input class="form-check-input js-done-checkbox" type="checkbox" name="done" value="true"
                    @(t.Status == TodoStatus.Done ? "checked" : "")
                    title="Mark done" aria-label="Mark done" />
           </form>


### PR DESCRIPTION
## Summary
- close malformed checkbox inputs in todo widget and task list
- ensure hidden fields precede checkboxes to avoid Razor parse errors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c01160ceb883299819f98b25357839