### PR TITLE
Remove unused notes feature from tasks

### DIFF
--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -28,8 +28,6 @@ namespace ProjectManagement.Models
         [Required, StringLength(160)]
         public string Title { get; set; } = string.Empty;
 
-        public string? Notes { get; set; }
-
         public DateTimeOffset? DueAtUtc { get; set; }
 
         [Required]

--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace ProjectManagement.Pages.Tasks
             _db = db; _todo = todo; _users = users;
         }
 
-        public record Row(Guid Id, string Title, string? Notes, TodoPriority Priority, bool IsPinned,
+        public record Row(Guid Id, string Title, TodoPriority Priority, bool IsPinned,
                           TodoStatus Status, DateTimeOffset? DueAtUtc, DateTimeOffset? CompletedUtc);
         public record Group(string Title, Row[] Items);
         public Group[] Groups { get; set; } = Array.Empty<Group>();
@@ -48,7 +48,7 @@ namespace ProjectManagement.Pages.Tasks
             if (!string.IsNullOrWhiteSpace(Q))
             {
                 var s = Q.Trim();
-                q = q.Where(x => EF.Functions.ILike(x.Title, $"%{s}%") || (x.Notes != null && EF.Functions.ILike(x.Notes, $"%{s}%")));
+                q = q.Where(x => EF.Functions.ILike(x.Title, $"%{s}%"));
             }
 
             var nowIst = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, Ist);
@@ -73,7 +73,7 @@ namespace ProjectManagement.Pages.Tasks
                 .ThenBy(x => x.DueAtUtc)
                 .ThenBy(x => x.OrderIndex)
                 .ThenBy(x => x.CreatedUtc)
-                .Select(x => new Row(x.Id, x.Title, x.Notes, x.Priority, x.IsPinned, x.Status, x.DueAtUtc, x.CompletedUtc))
+                .Select(x => new Row(x.Id, x.Title, x.Priority, x.IsPinned, x.Status, x.DueAtUtc, x.CompletedUtc))
                 .ToListAsync();
 
             // Group client-side (fast enough for a single user’s page)
@@ -163,7 +163,7 @@ namespace ProjectManagement.Pages.Tasks
             return Back();
         }
 
-        public async Task<IActionResult> OnPostEditAsync(Guid id, string? title, string? priority, DateTimeOffset? dueLocal, bool? pin, string? notes)
+        public async Task<IActionResult> OnPostEditAsync(Guid id, string? title, string? priority, DateTimeOffset? dueLocal, bool? pin)
         {
             var uid = _users.GetUserId(User);
             TodoPriority? prio = null;
@@ -172,7 +172,6 @@ namespace ProjectManagement.Pages.Tasks
             {
                 await _todo.EditAsync(uid!, id,
                     title: string.IsNullOrWhiteSpace(title) ? null : title.Trim(),
-                    notes: notes,
                     dueAtLocal: dueLocal,
                     priority: prio,
                     pinned: pin);

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -59,10 +59,6 @@
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="id" value="@t.Id" />
                             <input name="title" class="form-control form-control-sm border-0 ps-0 todo-title" value="@t.Title" maxlength="160" aria-label="Title" />
-                            <details class="mt-1">
-                                <summary class="small text-muted" role="button">Add notes…</summary>
-                                <textarea class="form-control form-control-sm" name="notes" rows="2" placeholder="Notes (optional)">@t.Notes</textarea>
-                            </details>
                         </form>
 
                         @if (!string.IsNullOrEmpty(chip))

--- a/ProjectManagement.Tests/TodoServiceTests.cs
+++ b/ProjectManagement.Tests/TodoServiceTests.cs
@@ -115,17 +115,6 @@ namespace ProjectManagement.Tests
         }
 
         [Fact]
-        public async Task NotesPersist()
-        {
-            using var context = CreateContext();
-            var audit = new FakeAudit();
-            var service = new TodoService(context, audit);
-            var item = await service.CreateAsync("alice", "Task", notes: "first\nsecond");
-            var stored = await context.TodoItems.FindAsync(item.Id);
-            Assert.Equal("first\nsecond", stored!.Notes);
-        }
-
-        [Fact]
         public async Task ReorderSkipsCompleted()
         {
             using var context = CreateContext();

--- a/Services/ITodoService.cs
+++ b/Services/ITodoService.cs
@@ -9,9 +9,9 @@ namespace ProjectManagement.Services
     {
         Task<TodoWidgetResult> GetWidgetAsync(string ownerId, int take = 20);
         Task<TodoItem> CreateAsync(string ownerId, string title, DateTimeOffset? dueAtLocal = null,
-                                   TodoPriority priority = TodoPriority.Normal, bool pinned = false, string? notes = null);
+                                   TodoPriority priority = TodoPriority.Normal, bool pinned = false);
         Task<bool> ToggleDoneAsync(string ownerId, Guid id, bool done);
-        Task<bool> EditAsync(string ownerId, Guid id, string? title = null, string? notes = null,
+        Task<bool> EditAsync(string ownerId, Guid id, string? title = null,
                               DateTimeOffset? dueAtLocal = null, TodoPriority? priority = null, bool? pinned = null);
         Task<bool> DeleteAsync(string ownerId, Guid id);
         Task<int> ClearCompletedAsync(string ownerId);

--- a/Services/TodoService.cs
+++ b/Services/TodoService.cs
@@ -68,7 +68,7 @@ namespace ProjectManagement.Services
         }
 
         public async Task<TodoItem> CreateAsync(string ownerId, string title, DateTimeOffset? dueAtLocal = null,
-                                   TodoPriority priority = TodoPriority.Normal, bool pinned = false, string? notes = null)
+                                   TodoPriority priority = TodoPriority.Normal, bool pinned = false)
         {
             var utcDue = ToUtc(dueAtLocal);
             var last = await _db.TodoItems.Where(x => x.OwnerId == ownerId && x.DeletedUtc == null).MaxAsync(x => (int?)x.OrderIndex) ?? -1;
@@ -77,7 +77,6 @@ namespace ProjectManagement.Services
                 Id = Guid.NewGuid(),
                 OwnerId = ownerId,
                 Title = title,
-                Notes = notes,
                 DueAtUtc = utcDue,
                 Priority = priority,
                 IsPinned = pinned,
@@ -120,13 +119,12 @@ namespace ProjectManagement.Services
             return true;
         }
 
-        public async Task<bool> EditAsync(string ownerId, Guid id, string? title = null, string? notes = null,
+        public async Task<bool> EditAsync(string ownerId, Guid id, string? title = null,
                               DateTimeOffset? dueAtLocal = null, TodoPriority? priority = null, bool? pinned = null)
         {
             var item = await _db.TodoItems.FirstOrDefaultAsync(x => x.Id == id && x.OwnerId == ownerId && x.DeletedUtc == null);
             if (item == null) return false;
             if (title != null) item.Title = title;
-            if (notes != null) item.Notes = notes;
             if (dueAtLocal.HasValue) item.DueAtUtc = ToUtc(dueAtLocal);
             if (priority.HasValue) item.Priority = priority.Value;
             if (pinned.HasValue && item.IsPinned != pinned.Value)

--- a/docs/data-domain.md
+++ b/docs/data-domain.md
@@ -19,4 +19,4 @@ Seeds initial roles (`Project Officer`, `HoD`, `Comdt`, `Admin`, `TA`, `MCO`, `P
 Extends `IdentityUser` with a `MustChangePassword` flag. New accounts are created with the flag set to `true`, forcing a password change on first login via `EnforcePasswordChangeFilter`.
 
 ### `Models/TodoItem.cs`
-Represents a personal task owned by a user. Each item records a title, optional notes, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates, completion and soft deletion. A `RowVersion` concurrency token is used to detect conflicting edits. Items marked completed are soft-deleted by setting `DeletedUtc`; a background worker purges entries older than the configured retention period.
+Represents a personal task owned by a user. Each item records a title, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates, completion and soft deletion. A `RowVersion` concurrency token is used to detect conflicting edits. Items marked completed are soft-deleted by setting `DeletedUtc`; a background worker purges entries older than the configured retention period.

--- a/docs/infrastructure-services.md
+++ b/docs/infrastructure-services.md
@@ -27,7 +27,7 @@ Concrete implementation backed by `UserManager<ApplicationUser>` and `RoleManage
 * `Services/SmtpEmailSender.cs` – sends HTML email via SMTP using configuration values (`Email:Smtp:Host`, `Port`, `Username`, `Password`, `Email:From`).
 
 ### `Services/ITodoService` and `TodoService`
-`ITodoService` abstracts operations on personal To-Do items such as creation, completion, pinning, snoozing, editing notes, reordering and bulk operations. `TodoService` implements the interface using `ApplicationDbContext` for persistence and `IAuditService` for logging. Time calculations are normalised to the `Asia/Kolkata` time zone to ensure consistent due date handling and `RowVersion` is used to detect concurrent edits.
+`ITodoService` abstracts operations on personal To-Do items such as creation, completion, pinning, snoozing, reordering and bulk operations. `TodoService` implements the interface using `ApplicationDbContext` for persistence and `IAuditService` for logging. Time calculations are normalised to the `Asia/Kolkata` time zone to ensure consistent due date handling and `RowVersion` is used to detect concurrent edits.
 
 ### `Services/TodoPurgeWorker`
 Background worker that permanently deletes soft-deleted to-do items after a retention period. The retention window is configured via `Todo:RetentionDays` in `appsettings.json` (defaults to 7 days) and the worker safely handles cancellation tokens.

--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -39,12 +39,6 @@
   opacity: .6;
 }
 
-.todo-notes {
-  font-size: .9rem;
-  color: #6c757d;
-  max-width: 60ch;
-}
-
 .todo-chip {
   font-size: .75rem;
   padding: .2rem .5rem;
@@ -58,10 +52,6 @@
 
 .row-actions .btn {
   font-size: .85rem;
-}
-
-@media (max-width: 576px) {
-  .todo-notes { max-width: 100%; }
 }
 
 


### PR DESCRIPTION
## Summary
- remove Add notes UI from task list
- drop notes support from todo service and models
- tidy docs and tests for removal

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c02895bcfc8329ad9396dcbb96df5e