### PR TITLE
Rename PartnerName to SpouseName with optional label

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -49,7 +49,7 @@ namespace ProjectManagement.Data
                 e.HasIndex(x => new { x.EventType, x.Month, x.Day });
                 e.Property(x => x.EventType).ValueGeneratedNever();
                 e.Property(x => x.Name).IsRequired().HasMaxLength(120);
-                e.Property(x => x.PartnerName).HasMaxLength(120);
+                e.Property(x => x.SpouseName).HasMaxLength(120);
             });
         }
     }

--- a/Helpers/CelebrationHelpers.cs
+++ b/Helpers/CelebrationHelpers.cs
@@ -38,8 +38,8 @@ namespace ProjectManagement.Helpers
         }
 
         public static string DisplayName(Celebration c) =>
-            c.EventType == CelebrationType.Anniversary && !string.IsNullOrWhiteSpace(c.PartnerName)
-                ? $"{c.Name} & {c.PartnerName}"
+            c.EventType == CelebrationType.Anniversary && !string.IsNullOrWhiteSpace(c.SpouseName)
+                ? $"{c.Name} & {c.SpouseName}"
                 : c.Name;
     }
 }

--- a/Migrations/20250909140550_AddCelebrations.Designer.cs
+++ b/Migrations/20250909140550_AddCelebrations.Designer.cs
@@ -346,7 +346,7 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
 
-                    b.Property<string>("PartnerName")
+                    b.Property<string>("SpouseName")
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
 

--- a/Migrations/20250909140550_AddCelebrations.cs
+++ b/Migrations/20250909140550_AddCelebrations.cs
@@ -18,7 +18,7 @@ namespace ProjectManagement.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     EventType = table.Column<byte>(type: "smallint", nullable: false),
                     Name = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
-                    PartnerName = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                    SpouseName = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
                     Day = table.Column<byte>(type: "smallint", nullable: false),
                     Month = table.Column<byte>(type: "smallint", nullable: false),
                     Year = table.Column<short>(type: "smallint", nullable: true),

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -343,7 +343,7 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
 
-                    b.Property<string>("PartnerName")
+                    b.Property<string>("SpouseName")
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
 

--- a/Models/Celebration.cs
+++ b/Models/Celebration.cs
@@ -21,7 +21,8 @@ namespace ProjectManagement.Models
         public string Name { get; set; } = string.Empty;
 
         [StringLength(120)]
-        public string? PartnerName { get; set; }
+        [Display(Name = "Spouse Name (Optional)")]
+        public string? SpouseName { get; set; }
 
         [Range(1,31)]
         public byte Day { get; set; }

--- a/Pages/Celebrations/Edit.cshtml
+++ b/Pages/Celebrations/Edit.cshtml
@@ -21,8 +21,8 @@
         <span asp-validation-for="Input.Name" class="text-danger small"></span>
     </div>
     <div class="mb-2">
-        <label asp-for="Input.PartnerName" class="form-label"></label>
-        <input asp-for="Input.PartnerName" class="form-control" />
+        <label asp-for="Input.SpouseName" class="form-label"></label>
+        <input asp-for="Input.SpouseName" class="form-control" />
     </div>
     <div class="row mb-2">
         <div class="col">

--- a/Pages/Celebrations/Edit.cshtml.cs
+++ b/Pages/Celebrations/Edit.cshtml.cs
@@ -33,7 +33,8 @@ namespace ProjectManagement.Pages.Celebrations
             [Required, StringLength(120)]
             public string Name { get; set; } = string.Empty;
             [StringLength(120)]
-            public string? PartnerName { get; set; }
+            [Display(Name = "Spouse Name (Optional)")]
+            public string? SpouseName { get; set; }
             [Range(1,31)]
             public byte Day { get; set; }
             [Range(1,12)]
@@ -52,7 +53,7 @@ namespace ProjectManagement.Pages.Celebrations
                     Id = c.Id,
                     EventType = c.EventType,
                     Name = c.Name,
-                    PartnerName = c.PartnerName,
+                    SpouseName = c.SpouseName,
                     Day = c.Day,
                     Month = c.Month,
                     Year = c.Year
@@ -89,7 +90,7 @@ namespace ProjectManagement.Pages.Celebrations
 
             entity.EventType = Input.EventType;
             entity.Name = Input.Name.Trim();
-            entity.PartnerName = string.IsNullOrWhiteSpace(Input.PartnerName) ? null : Input.PartnerName.Trim();
+            entity.SpouseName = string.IsNullOrWhiteSpace(Input.SpouseName) ? null : Input.SpouseName.Trim();
             entity.Day = Input.Day;
             entity.Month = Input.Month;
             entity.Year = Input.Year;

--- a/Pages/Celebrations/Index.cshtml.cs
+++ b/Pages/Celebrations/Index.cshtml.cs
@@ -40,7 +40,7 @@ namespace ProjectManagement.Pages.Celebrations
             if (!string.IsNullOrWhiteSpace(Q))
             {
                 var s = Q.Trim();
-                q = q.Where(x => EF.Functions.ILike(x.Name, $"%{s}%") || (x.PartnerName != null && EF.Functions.ILike(x.PartnerName, $"%{s}%")));
+                q = q.Where(x => EF.Functions.ILike(x.Name, $"%{s}%") || (x.SpouseName != null && EF.Functions.ILike(x.SpouseName, $"%{s}%")));
             }
 
             var nowLocal = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, Ist);


### PR DESCRIPTION
## Summary
- rename celebration field from PartnerName to SpouseName
- mark spouse name as optional and update edit form label
- adjust helper, queries, and migrations for new field name

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c03e9b7344832997d12e5d0424438f