### PR TITLE
Fix RowVersion default on TodoItem

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -41,6 +41,9 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Status).HasDefaultValue(TodoStatus.Open);
                 e.Property(x => x.IsPinned).HasDefaultValue(false);
                 e.Property(x => x.OrderIndex).HasDefaultValue(0);
+                e.Property(x => x.RowVersion)
+                    .IsRowVersion()
+                    .HasDefaultValue(new byte[0]);
             });
 
             builder.Entity<Celebration>(e =>

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -427,7 +427,8 @@ namespace ProjectManagement.Migrations
                         .IsConcurrencyToken()
                         .IsRequired()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("bytea");
+                        .HasColumnType("bytea")
+                        .HasDefaultValue(new byte[0]);
 
                     b.Property<byte>("Status")
                         .ValueGeneratedOnAdd()


### PR DESCRIPTION
## Summary
- configure TodoItem.RowVersion as an EF Core row version with explicit default value

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c045b01bec8329813c656adaca97a5