### PR TITLE
Use PostgreSQL xmin concurrency token for TodoItem

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 using ProjectManagement.Models;
 
 namespace ProjectManagement.Data
@@ -33,6 +34,7 @@ namespace ProjectManagement.Data
 
             builder.Entity<TodoItem>(e =>
             {
+                e.UseXminAsConcurrencyToken();
                 e.HasIndex(x => new { x.OwnerId, x.Status, x.IsPinned, x.DueAtUtc });
                 e.HasIndex(x => new { x.OwnerId, x.OrderIndex });
                 e.HasIndex(x => x.DeletedUtc);
@@ -41,9 +43,6 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Status).HasDefaultValue(TodoStatus.Open);
                 e.Property(x => x.IsPinned).HasDefaultValue(false);
                 e.Property(x => x.OrderIndex).HasDefaultValue(0);
-                e.Property(x => x.RowVersion)
-                    .IsRowVersion()
-                    .HasDefaultValue(new byte[0]);
             });
 
             builder.Entity<Celebration>(e =>

--- a/Migrations/20250909153316_UseXminForTodoItem.Designer.cs
+++ b/Migrations/20250909153316_UseXminForTodoItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250909153316_UseXminForTodoItem")]
+    partial class UseXminForTodoItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250909153316_UseXminForTodoItem.cs
+++ b/Migrations/20250909153316_UseXminForTodoItem.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class UseXminForTodoItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "TodoItems");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "TodoItems",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+    }
+}

--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ProjectManagement.Models
 {
@@ -51,9 +50,6 @@ namespace ProjectManagement.Models
         public DateTimeOffset? CompletedUtc { get; set; }
 
         public DateTimeOffset? DeletedUtc { get; set; }
-
-        [Timestamp]
-        public byte[] RowVersion { get; set; } = Array.Empty<byte>();
     }
 }
 

--- a/docs/data-domain.md
+++ b/docs/data-domain.md
@@ -19,7 +19,7 @@ Seeds initial roles (`Project Officer`, `HoD`, `Comdt`, `Admin`, `TA`, `MCO`, `P
 Extends `IdentityUser` with a `MustChangePassword` flag. New accounts are created with the flag set to `true`, forcing a password change on first login via `EnforcePasswordChangeFilter`.
 
 ### `Models/TodoItem.cs`
-Represents a personal task owned by a user. Each item records a title, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates, completion and soft deletion. A `RowVersion` concurrency token is used to detect conflicting edits. Items marked completed are soft-deleted by setting `DeletedUtc`; a background worker purges entries older than the configured retention period.
+Represents a personal task owned by a user. Each item records a title, due date (stored in UTC), priority, pin state, order index and timestamps for creation, updates, completion and soft deletion. PostgreSQL's `xmin` concurrency token is used to detect conflicting edits. Items marked completed are soft-deleted by setting `DeletedUtc`; a background worker purges entries older than the configured retention period.
 
 ### `Models/Celebration.cs`
 Stores birthdays and anniversaries with minimal fields for annual recurrence. Each row tracks the event type, name(s), day and month, optional year, creator metadata and soft-delete timestamp. Indexes on `(EventType, Month, Day)` enable fast upcoming lookups and a filtered index on `DeletedUtc` hides removed entries. Leap day events are rendered on 28 February in non-leap years.

--- a/docs/infrastructure-services.md
+++ b/docs/infrastructure-services.md
@@ -27,7 +27,7 @@ Concrete implementation backed by `UserManager<ApplicationUser>` and `RoleManage
 * `Services/SmtpEmailSender.cs` – sends HTML email via SMTP using configuration values (`Email:Smtp:Host`, `Port`, `Username`, `Password`, `Email:From`).
 
 ### `Services/ITodoService` and `TodoService`
-`ITodoService` abstracts operations on personal To-Do items such as creation, completion, pinning, snoozing, reordering and bulk operations. `TodoService` implements the interface using `ApplicationDbContext` for persistence and `IAuditService` for logging. Time calculations are normalised to the `Asia/Kolkata` time zone to ensure consistent due date handling; date-only inputs are coerced to 23:59:59 IST before conversion to UTC. `RowVersion` is used to detect concurrent edits.
+`ITodoService` abstracts operations on personal To-Do items such as creation, completion, pinning, snoozing, reordering and bulk operations. `TodoService` implements the interface using `ApplicationDbContext` for persistence and `IAuditService` for logging. Time calculations are normalised to the `Asia/Kolkata` time zone to ensure consistent due date handling; date-only inputs are coerced to 23:59:59 IST before conversion to UTC. PostgreSQL's `xmin` system column is used to detect concurrent edits.
 
 ### `Services/TodoPurgeWorker`
 Background worker that permanently deletes soft-deleted to-do items after a retention period. The retention window is configured via `Todo:RetentionDays` in `appsettings.json` (defaults to 7 days) and the worker safely handles cancellation tokens.


### PR DESCRIPTION
## Summary
- Use PostgreSQL xmin system column as concurrency token for TodoItem
- Drop obsolete RowVersion column and update EF model
- Document xmin-based concurrency handling

## Testing
- `dotnet ef database update` *(fails: Connection refused)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0482b60dc8329bca4715cbfbf0c88