### PR TITLE
Fix task dropdown layering and autoclose

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -35,7 +35,7 @@
   </div>
 }
 
-<div class="row g-3">
+<div class="row g-3 dashboard">
   <div class="col-lg-8">
     <h2 class="h5 fw-semibold mb-2">Dashboard</h2>
     <p class="text-secondary">This is a placeholder. Add role-specific widgets here.</p>

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -2,7 +2,7 @@
 @using ProjectManagement.Helpers
 @model ProjectManagement.Services.TodoWidgetResult
 
-<div class="card shadow-sm">
+<div class="card shadow-sm todo-widget">
     <div class="card-header d-flex align-items-center justify-content-between py-2">
         <span class="fw-semibold">My Tasks</span>
         <div class="d-flex align-items-center gap-2 small">
@@ -67,7 +67,7 @@
                         </div>
 
                         <div class="dropdown dropstart">
-                            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" aria-label="More actions">
+                            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport" aria-expanded="false" aria-label="More actions">
                                 <i class="bi bi-three-dots"></i>
                             </button>
                             <ul class="dropdown-menu">

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -65,7 +65,7 @@
 
                         <div class="dropdown">
                             <button type="button" class="btn todo-kebab dropdown-toggle"
-                                    data-bs-toggle="dropdown" data-bs-auto-close="outside"
+                                    data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport"
                                     aria-expanded="false" aria-label="More actions">
                                 <i class="bi bi-three-dots"></i>
                             </button>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -229,9 +229,20 @@ h1, .h1 { font-size: 1.25rem; }
 .todo-kebab.dropdown-toggle::after,
 .dropstart .todo-kebab.dropdown-toggle::before{ display:none !important }
 
-/* Menus above everything; prevent accidental clipping */
-.dropdown-menu{ z-index:1080; font-size:.875rem }
-.card, .card-body, .list-group-item{ overflow:visible }
+/* Keep dropdowns above any cards/sections on the dashboard */
+.dashboard .dropdown-menu,
+.todo-widget .dropdown-menu {
+  z-index: 1046; /* > fixed(1030)/sticky(1020)/offcanvas(1045), < modal-backdrop(1050)/modal(1055) */
+}
+
+/* If any card/section had overflow clipping, turn it off at the outer wrapper */
+.dashboard .card,
+.dashboard .card > .card-body {
+  overflow: visible;
+}
+
+/* Base menu tweaks */
+.dropdown-menu{ font-size:.875rem }
 
 .todo-row.done .todo-title { text-decoration: line-through; color: #6c757d; }
 .todo-row.done { opacity: .85; }

--- a/wwwroot/js/todo.js
+++ b/wwwroot/js/todo.js
@@ -32,6 +32,17 @@
     });
   }
 
+  // Close any other open dropdown when a new one opens
+  document.addEventListener('show.bs.dropdown', (e) => {
+    document.querySelectorAll('.dropdown-menu.show').forEach(m => {
+      const toggle = m.previousElementSibling;
+      if (!toggle || toggle !== e.target) {
+        const inst = toggle ? bootstrap.Dropdown.getInstance(toggle) : null;
+        inst && inst.hide();
+      }
+    });
+  });
+
   // ---------- Shared confirm modal ----------
   const modalEl = document.getElementById('appConfirmModal');
   const confirmTextEl = document.getElementById('appConfirmText');


### PR DESCRIPTION
## Summary
- raise task dropdown z-index and disable overflow so menus stay above dashboard cards
- allow Popper to flip menus dynamically and scope dashboard via new classes
- close any previously open dropdown when another menu opens

## Testing
- `dotnet test`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a664a8188329a8d3322461644d6f