### PR TITLE
Fix task dropdown alignment and menu stacking

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -66,11 +66,11 @@
                             }
                         </div>
 
-                        <div class="dropdown dropstart">
+                        <div class="dropdown">
                             <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport" aria-expanded="false" aria-label="More actions">
                                 <i class="bi bi-three-dots"></i>
                             </button>
-                            <ul class="dropdown-menu todo-menu">
+                            <ul class="dropdown-menu todo-menu dropdown-menu-end">
                                 <li>
                                     <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Pin" class="m-0 p-0">
                                         @Html.AntiForgeryToken()

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -69,7 +69,7 @@
                                     aria-expanded="false" aria-label="More actions">
                                 <i class="bi bi-three-dots"></i>
                             </button>
-                            <ul class="dropdown-menu todo-menu">
+                            <ul class="dropdown-menu todo-menu dropdown-menu-end">
                                 <li>
                                     <form method="post" asp-page-handler="Pin" class="m-0 p-0">
                                         @Html.AntiForgeryToken()

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -235,9 +235,9 @@ h1, .h1 { font-size: 1.25rem; }
   z-index: 1046; /* > fixed(1030)/sticky(1020)/offcanvas(1045), < modal-backdrop(1050)/modal(1055) */
 }
 
-/* Kebab menus moved to <body> need their own elevation */
+/* Menus we move to <body> must sit above dashboard cards */
 .dropdown-menu.todo-menu {
-  z-index: 1046;
+  z-index: 1051; /* > card/overlays (<=1045), < modal/backdrop (1055/1050) */
 }
 
 /* If any card/section had overflow clipping, turn it off at the outer wrapper */

--- a/wwwroot/js/todo.js
+++ b/wwwroot/js/todo.js
@@ -13,20 +13,11 @@
         popperConfig: {
           strategy: 'fixed',
           modifiers: [
+            { name: 'flip', options: { fallbackPlacements: ['bottom-end','top-end','top-start','bottom-start'] } },
             { name: 'preventOverflow', options: { boundary: 'viewport' } },
             { name: 'offset', options: { offset: [0, 6] } }
           ]
         }
-      });
-
-      // If there's not enough room to the right, open to the left (dropstart)
-      btn.addEventListener('show.bs.dropdown', () => {
-        const dd = btn.closest('.dropdown');
-        if (!dd) return;
-        const r = btn.getBoundingClientRect();
-        const roomRight = (window.innerWidth - r.right) > 320; // ~menu width
-        // Only toggle for widgets tight to the right; OK on My Tasks too
-        dd.classList.toggle('dropstart', !roomRight);
       });
     });
   }


### PR DESCRIPTION
## Summary
- keep task dropdown menus aligned to the right using `dropdown-menu-end`
- raise todo dropdown z-index to sit above dashboard cards
- configure dropdown Popper with flip modifier and remove custom dropstart logic

## Testing
- `~/.dotnet/dotnet test`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bf4857148329bc47eaa3638bbd39