### PR TITLE
Ensure login scatter chart renders by importing Chart.js module

### DIFF
--- a/Areas/Admin/Pages/Analytics/Logins.cshtml
+++ b/Areas/Admin/Pages/Analytics/Logins.cshtml
@@ -50,6 +50,5 @@
 </div>
 
 @section Scripts {
-  <script src="~/lib/chart.js/chart.umd.js"></script>
   <script type="module" src="~/js/analytics-logins.js" asp-append-version="true"></script>
 }

--- a/wwwroot/js/analytics-logins.js
+++ b/wwwroot/js/analytics-logins.js
@@ -1,5 +1,6 @@
-// Chart is loaded globally via script tag
+import '../lib/chart.js/chart.umd.js';
 
+const Chart = window.Chart;
 const elCanvas = document.getElementById('loginsScatter');
 const elLookback = document.getElementById('lookback');
 const elWeekend = document.getElementById('weekendOdd');


### PR DESCRIPTION
## Summary
- import Chart.js via module in analytics logins script
- rely on module script on analytics page to render scatter chart

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c0dc4a1bc483299254ee2b9ba90f65