### PR TITLE
Fix scatter chart resizing and add navigation to login analytics

### DIFF
--- a/Areas/Admin/Pages/Analytics/Logins.cshtml
+++ b/Areas/Admin/Pages/Analytics/Logins.cshtml
@@ -36,7 +36,9 @@
     </div>
   </div>
   <div class="card-body">
-    <canvas id="loginsScatter" height="280"></canvas>
+    <div class="chart-container-320">
+      <canvas id="loginsScatter"></canvas>
+    </div>
     <div class="mt-3">
       <h6>Odd logins</h6>
       <div class="table-responsive">

--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -13,11 +13,17 @@
     <li class="breadcrumb-item active" aria-current="page">Logs</li>
   </ol>
 </nav>
-<h4 class="mb-2">Logs
-  <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="logs" title="Help">
-    <i class="bi bi-question-circle"></i>
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <h4 class="mb-0">Logs
+    <a class="ms-1 text-decoration-none" asp-area="Admin" asp-page="/Help/Index" asp-fragment="logs" title="Help">
+      <i class="bi bi-question-circle"></i>
+    </a>
+  </h4>
+  <a class="btn btn-sm btn-outline-primary"
+     asp-area="Admin" asp-page="/Analytics/Logins">
+    View login scatter
   </a>
-</h4>
+</div>
 
 <form method="get" class="row g-2 mb-3 align-items-end">
   <div class="col-sm-2">

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -37,6 +37,9 @@
                                 if ((ViewContext.RouteData.Values["area"]?.ToString() ?? "") == "Admin")
                                 {
                                     <li class="nav-item">
+                                        <a class="nav-link" asp-area="Admin" asp-page="/Analytics/Logins">Login scatter</a>
+                                    </li>
+                                    <li class="nav-item">
                                         <a class="nav-link" asp-area="Admin" asp-page="/Help/Index">Help</a>
                                     </li>
                                 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -158,6 +158,20 @@ body {
   .hero-art  { order: 2; max-width: clamp(220px, 50vw, 340px); }
 }
 
+/* Fixed-height wrapper for responsive Chart.js canvases */
+.chart-container-320 {
+  position: relative;
+  height: 320px;
+  width: 100%;
+}
+
+/* Ensure the canvas fills the wrapper, not the page */
+#loginsScatter {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+
 /* Help page micro-polish */
 .card h6 { font-weight: 600; }
 .accordion-button { font-weight: 600; }

--- a/wwwroot/js/analytics-logins.js
+++ b/wwwroot/js/analytics-logins.js
@@ -69,8 +69,9 @@ async function load() {
       ]
     },
     options: {
-      parsing: false,
+      responsive: true,
       maintainAspectRatio: false,
+      parsing: false,
       scales: {
         x: {
           type: 'linear',


### PR DESCRIPTION
## Summary
- wrap login scatter chart canvas with fixed-height container to prevent infinite vertical growth
- style login scatter canvas and container, ensure Chart.js responsive behavior
- link to login scatter analytics from logs page and admin top navigation

## Testing
- `dotnet test`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1382a6c148329bc33a7c623df3bcd