### PR TITLE
Wrap calendar script in IIFE to fix module parse error

### DIFF
--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -1,5 +1,6 @@
 // No imports; FullCalendar globals are already on window from the script tags
 
+(() => {
 const el = document.getElementById('orgCalendar');
 if (!el) return;
 
@@ -264,3 +265,4 @@ eventForm?.addEventListener('submit', async e => {
     console.error(err);
   }
 });
+})();


### PR DESCRIPTION
## Summary
- Wrap calendar module in an IIFE to avoid illegal top-level `return` and allow calendar initialization to run.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c1716932bc8329a40fdcdc4ab2b0a1