### PR TITLE
Fix FullCalendar plugin registration in calendar view

### DIFF
--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -28,12 +28,12 @@ const calendar = new window.FullCalendar.Calendar(el, {
   expandRows: true,
   weekends: true,
 
-  // plugins come from global builds under the FullCalendar namespace
+  // plugins are globally registered by the FullCalendar script files
   plugins: [
-    window.FullCalendar.DayGrid,
-    window.FullCalendar.TimeGrid,
-    window.FullCalendar.List,
-    window.FullCalendar.Interaction
+    'dayGrid',
+    'timeGrid',
+    'list',
+    'interaction'
   ],
 
   editable: canEdit,


### PR DESCRIPTION
## Summary
- use plugin IDs instead of global objects for FullCalendar config
- ensure calendar renders without initialization crash

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c18547e4a0832994792b9aa036f8bf