### PR TITLE
Fix FullCalendar plugin references

### DIFF
--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -17,7 +17,8 @@ const formCanvas = formCanvasEl && window.bootstrap
   : null;
 const eventForm = document.getElementById('eventForm');
 let editingId = null;
-const calendar = new window.FullCalendar.Calendar(el, {
+const FC = window.FullCalendar; // convenience
+const calendar = new FC.Calendar(el, {
   timeZone: 'Asia/Kolkata',
   initialView: 'dayGridMonth',
   headerToolbar: false,     // we use our own header
@@ -28,12 +29,12 @@ const calendar = new window.FullCalendar.Calendar(el, {
   expandRows: true,
   weekends: true,
 
-  // plugins are globally registered by the FullCalendar script files
+  // plugins are exposed on the FullCalendar global
   plugins: [
-    'dayGrid',
-    'timeGrid',
-    'list',
-    'interaction'
+    FC.DayGrid,
+    FC.TimeGrid,
+    FC.List,
+    FC.Interaction
   ],
 
   editable: canEdit,


### PR DESCRIPTION
## Summary
- fix FullCalendar plugin references to use global namespace

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c19210c6e883298ea0a9514cf09743