### PR TITLE
Fix calendar styling and time handling

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -85,6 +85,13 @@
     </div>
 </div>
 
+@section Styles {
+  <link rel="stylesheet" href="~/lib/fullcalendar/daygrid/index.css" asp-append-version="true" />
+  <link rel="stylesheet" href="~/lib/fullcalendar/timegrid/index.css" asp-append-version="true" />
+  <link rel="stylesheet" href="~/lib/fullcalendar/list/index.css" asp-append-version="true" />
+  <link rel="stylesheet" href="~/css/calendar.css" asp-append-version="true" />
+}
+
 @section Scripts {
     <script type="module" src="~/js/calendar.js"></script>
 }

--- a/Pages/Calendar/Index.cshtml.cs
+++ b/Pages/Calendar/Index.cshtml.cs
@@ -10,7 +10,7 @@ namespace ProjectManagement.Pages.Calendar
 
         public void OnGet()
         {
-            CanEdit = User.IsInRole("Admin") || User.IsInRole("TA") || User.IsInRole("HOD");
+            CanEdit = User.IsInRole("Admin") || User.IsInRole("TA") || User.IsInRole("HoD");
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -265,7 +265,7 @@ eventsApi.MapPost("", async (EventDto dto, ApplicationDbContext db, IClock clock
     db.Events.Add(ev);
     await db.SaveChangesAsync();
     return Results.Ok(new { id = ev.Id });
-}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HOD" });
+}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HoD" });
 
 eventsApi.MapPut("/{id:guid}", async (Guid id, EventDto dto, ApplicationDbContext db, IClock clock, UserManager<ApplicationUser> users, ClaimsPrincipal user) =>
 {
@@ -274,7 +274,8 @@ eventsApi.MapPut("/{id:guid}", async (Guid id, EventDto dto, ApplicationDbContex
     if (ev == null) return Results.NotFound();
     var userId = users.GetUserId(user);
     ev.Title = dto.Title;
-    ev.Description = dto.Description;
+    if (dto.Description is not null)
+        ev.Description = dto.Description;
     ev.Category = dto.Category;
     ev.Location = dto.Location;
     ev.StartUtc = dto.StartUtc;
@@ -284,7 +285,7 @@ eventsApi.MapPut("/{id:guid}", async (Guid id, EventDto dto, ApplicationDbContex
     ev.UpdatedAt = clock.UtcNow;
     await db.SaveChangesAsync();
     return Results.Ok();
-}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HOD" });
+}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HoD" });
 
 eventsApi.MapDelete("/{id:guid}", async (Guid id, ApplicationDbContext db, IClock clock, UserManager<ApplicationUser> users, ClaimsPrincipal user) =>
 {
@@ -295,7 +296,7 @@ eventsApi.MapDelete("/{id:guid}", async (Guid id, ApplicationDbContext db, ICloc
     ev.UpdatedById = users.GetUserId(user);
     await db.SaveChangesAsync();
     return Results.Ok();
-}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HOD" });
+}).RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,TA,HoD" });
 
 eventsApi.MapPost("/{id:guid}/task", async (Guid id, ApplicationDbContext db, ITodoService todos, UserManager<ApplicationUser> users, ClaimsPrincipal user) =>
 {

--- a/wwwroot/css/calendar.css
+++ b/wwwroot/css/calendar.css
@@ -1,0 +1,6 @@
+/* left-color accents */
+.fc .fc-event.pm-cat-training  { border-left: 4px solid #22c55e; }
+.fc .fc-event.pm-cat-holiday   { border-left: 4px solid #ef4444; }
+.fc .fc-event.pm-cat-townhall  { border-left: 4px solid #0ea5e9; }
+.fc .fc-event.pm-cat-hiring    { border-left: 4px solid #8b5cf6; }
+.fc .fc-event.pm-cat-other     { border-left: 4px solid #64748b; }

--- a/wwwroot/lib/fullcalendar/daygrid/index.css
+++ b/wwwroot/lib/fullcalendar/daygrid/index.css
@@ -1,0 +1,6 @@
+
+@import '../../core/src/styles/mixins';
+@import './styles/vars';
+
+@import './styles/daygrid';
+@import './styles/daygrid-event';

--- a/wwwroot/lib/fullcalendar/list/index.css
+++ b/wwwroot/lib/fullcalendar/list/index.css
@@ -1,0 +1,7 @@
+
+@import '../../core/src/styles/mixins';
+@import './styles/vars';
+
+@import './styles/list';
+@import './styles/list-table';
+@import './styles/list-event';

--- a/wwwroot/lib/fullcalendar/timegrid/index.css
+++ b/wwwroot/lib/fullcalendar/timegrid/index.css
@@ -1,0 +1,10 @@
+
+@import '../../core/src/styles/mixins';
+@import './styles/constants';
+
+@import './styles/v-event';
+@import './styles/timegrid';
+@import './styles/timegrid-slots';
+@import './styles/timegrid-cols';
+@import './styles/timegrid-event';
+@import './styles/timegrid-now-indicator';


### PR DESCRIPTION
## Summary
- Fix role casing to grant HoD edit permissions
- Switch FullCalendar to ESM imports and add plugin CSS
- Convert form times to UTC and preserve descriptions on drag/resize

## Testing
- `dotnet test`
- `libman restore` *(fails: "@fullcalendar/daygrid@6.1.15" does not contain index.css)*

------
https://chatgpt.com/codex/tasks/task_e_68c222da29648329ad3ee7b3915f17dc