### PR TITLE
Fix blank calendar by including core FullCalendar styles

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -105,6 +105,7 @@
 <div class="toast-container position-fixed bottom-0 end-0 p-3" id="toastContainer"></div>
 
 @section Styles {
+  <link rel="stylesheet" href="~/lib/fullcalendar/core/index.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/lib/fullcalendar/daygrid/index.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/lib/fullcalendar/timegrid/index.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/lib/fullcalendar/list/index.css" asp-append-version="true" />


### PR DESCRIPTION
## Summary
- include missing core FullCalendar stylesheet so calendar renders

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c235dc57a0832988514ae9c246449d