### PR TITLE
Fix FullCalendar plugin initialization

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -118,5 +118,5 @@
   <!-- Order matters: Bootstrap JS → FullCalendar bundle → our page script -->
   <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
   <script src="~/lib/fullcalendar/bundle/index.global.min.js"></script>
-  <script src="~/js/calendar.js" asp-append-version="true"></script>
+  <script type="module" src="~/js/calendar.js" asp-append-version="true"></script>
 }

--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -1,17 +1,13 @@
 (function () {
   // globals provided by index.global.min.js
-  const Calendar = window.FullCalendar && window.FullCalendar.Calendar;
+  const Calendar = window.FullCalendar?.Calendar;
   if (!Calendar) { console.error('FullCalendar global bundle missing'); return; }
-
-  const dayGridPlugin     = window.FullCalendar.dayGrid;
-  const timeGridPlugin    = window.FullCalendar.timeGrid;
-  const listPlugin        = window.FullCalendar.list;
-  const interactionPlugin = window.FullCalendar.interaction;
 
   const calendarEl = document.getElementById('calendar');
   if (!calendarEl) return;
 
   const canEdit = (calendarEl.dataset.canEdit || '').toLowerCase() === 'true';
+  let activeCategory = "";
 
   // helpers
   const pad = (n) => String(n).padStart(2,'0');
@@ -21,7 +17,6 @@
   };
 
   const calendar = new Calendar(calendarEl, {
-    plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
     initialView: 'dayGridMonth',
     headerToolbar: false,
     firstDay: 1,
@@ -66,7 +61,6 @@
 
   // category filter
   const catFilters = document.getElementById('categoryFilters');
-  let activeCategory = "";
   if (catFilters) {
     catFilters.querySelectorAll('button').forEach(btn => {
       btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove redundant plugin references when using FullCalendar bundle
- load page script as ES module after bundle

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c2597696a8832995bae1444445f897