### PR TITLE
Fix calendar event type filter empty state

### DIFF
--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -309,6 +309,7 @@
         el.style.display = (!activeCategory || key === activeCategory) ? '' : 'none';
       });
       updateCounts();
+      updateEmptyState();
     });
   }
 


### PR DESCRIPTION
## Summary
- refresh empty-state message when calendar events are filtered by type

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c2cdd4646c832984f6b093d3cdc7bc