### PR TITLE
Add day view switch to calendar

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -14,6 +14,7 @@
     <div class="btn-group btn-group-sm" role="group" aria-label="View">
       <button class="btn btn-outline-secondary" data-view="dayGridMonth">Month</button>
       <button class="btn btn-outline-secondary" data-view="timeGridWeek">Week</button>
+      <button class="btn btn-outline-secondary" data-view="timeGridDay">Day</button>
       <button class="btn btn-outline-secondary" data-view="listMonth">List</button>
       <button class="btn btn-outline-secondary" id="btnToday">Today</button>
     </div>


### PR DESCRIPTION
## Summary
- Add Day button to calendar toolbar wired to FullCalendar's day view

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3af743e5c8329aadb30e7f90e53bc