### PR TITLE
Fix build warnings and update dependencies

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -37,7 +37,7 @@ namespace ProjectManagement.Data
 
             builder.Entity<TodoItem>(e =>
             {
-                e.UseXminAsConcurrencyToken();
+                e.Property<uint>("xmin").IsRowVersion();
                 e.HasIndex(x => new { x.OwnerId, x.Status, x.IsPinned, x.DueAtUtc });
                 e.HasIndex(x => new { x.OwnerId, x.OrderIndex });
                 e.HasIndex(x => x.DeletedUtc);

--- a/Migrations/20250911125520_Calendar.Designer.cs
+++ b/Migrations/20250911125520_Calendar.Designer.cs
@@ -12,8 +12,8 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250911125520_calendar")]
-    partial class calendar
+    [Migration("20250911125520_Calendar")]
+    partial class Calendar
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/Migrations/20250911125520_Calendar.cs
+++ b/Migrations/20250911125520_Calendar.cs
@@ -7,7 +7,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ProjectManagement.Migrations
 {
     /// <inheritdoc />
-    public partial class calendar : Migration
+    public partial class Calendar : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/ProjectManagement.Tests/EventEndpointTests.cs
+++ b/ProjectManagement.Tests/EventEndpointTests.cs
@@ -128,8 +128,8 @@ namespace ProjectManagement.Tests
 
         private class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
         {
-            public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, System.Text.Encodings.Web.UrlEncoder encoder, ISystemClock clock)
-                : base(options, logger, encoder, clock) { }
+            public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, System.Text.Encodings.Web.UrlEncoder encoder)
+                : base(options, logger, encoder) { }
 
             protected override Task<AuthenticateResult> HandleAuthenticateAsync()
             {

--- a/ProjectManagement.csproj
+++ b/ProjectManagement.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="HtmlSanitizer" Version="8.0.795" />
-    <PackageReference Include="Ical.Net" Version="4.2.3" />
+    <PackageReference Include="Ical.Net" Version="4.3.0" />
     <PackageReference Include="TimeZoneConverter" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- replace obsolete xmin concurrency token call with standard `IsRowVersion`
- rename `calendar` migration class to `Calendar`
- update Ical.Net to 4.3.0 and remove obsolete test auth handler clock parameter

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b15b7a74832980108c9c059b0a15