### PR TITLE
Add project assignments and management pages

### DIFF
--- a/Migrations/20250911130000_AddProjectAssignments.Designer.cs
+++ b/Migrations/20250911130000_AddProjectAssignments.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250911130000_AddProjectAssignments")]
+    partial class AddProjectAssignments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250911130000_AddProjectAssignments.cs
+++ b/Migrations/20250911130000_AddProjectAssignments.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "HodUserId",
+                table: "Projects",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LeadPoUserId",
+                table: "Projects",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_HodUserId",
+                table: "Projects",
+                column: "HodUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_LeadPoUserId",
+                table: "Projects",
+                column: "LeadPoUserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_AspNetUsers_HodUserId",
+                table: "Projects",
+                column: "HodUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_AspNetUsers_LeadPoUserId",
+                table: "Projects",
+                column: "LeadPoUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_AspNetUsers_HodUserId",
+                table: "Projects");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_AspNetUsers_LeadPoUserId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_HodUserId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_LeadPoUserId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "HodUserId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "LeadPoUserId",
+                table: "Projects");
+        }
+    }
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -15,5 +15,12 @@ namespace ProjectManagement.Models
         public string? Description { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        // Assignments
+        public string? HodUserId { get; set; }
+        public ApplicationUser? HodUser { get; set; }
+
+        public string? LeadPoUserId { get; set; }
+        public ApplicationUser? LeadPoUser { get; set; }
     }
 }

--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -1,0 +1,42 @@
+@page
+@model ProjectManagement.Pages.Projects.CreateModel
+@{
+    ViewData["Title"] = "New Project";
+}
+<h2>New Project</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input asp-for="Input.Name" class="form-control" maxlength="100" required />
+    <span class="text-danger" asp-validation-for="Input.Name"></span>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea asp-for="Input.Description" class="form-control" rows="3" maxlength="1000"></textarea>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">HoD</label>
+      <select asp-for="Input.HodUserId" class="form-select">
+        <option value="">Unassigned</option>
+        @foreach (var u in Model.HodUsers)
+        { <option value="@u.Id">@u.Rank @u.FullName (@u.UserName)</option> }
+      </select>
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Lead Project Officer</label>
+      <select asp-for="Input.LeadPoUserId" class="form-select">
+        <option value="">Unassigned</option>
+        @foreach (var u in Model.PoUsers)
+        { <option value="@u.Id">@u.Rank @u.FullName (@u.UserName)</option> }
+      </select>
+    </div>
+  </div>
+
+  <div class="mt-3">
+    <button class="btn btn-primary" type="submit">Create</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>

--- a/Pages/Projects/Create.cshtml.cs
+++ b/Pages/Projects/Create.cshtml.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize(Roles = "Admin,HoD")]
+    public class CreateModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public CreateModel(ApplicationDbContext db, UserManager<ApplicationUser> um)
+        {
+            _db = db;
+            _userManager = um;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public List<ApplicationUser> HodUsers { get; set; } = new();
+        public List<ApplicationUser> PoUsers { get; set; } = new();
+
+        public class InputModel
+        {
+            public string Name { get; set; } = string.Empty;
+            public string? Description { get; set; }
+            public string? HodUserId { get; set; }
+            public string? LeadPoUserId { get; set; }
+        }
+
+        public async Task OnGetAsync()
+        {
+            HodUsers = (await _userManager.GetUsersInRoleAsync("HoD")).OrderBy(u => u.FullName).ToList();
+            PoUsers = (await _userManager.GetUsersInRoleAsync("Project Officer")).OrderBy(u => u.FullName).ToList();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                await OnGetAsync();
+                return Page();
+            }
+
+            var proj = new Project
+            {
+                Name = Input.Name.Trim(),
+                Description = string.IsNullOrWhiteSpace(Input.Description) ? null : Input.Description.Trim(),
+                HodUserId = Input.HodUserId,
+                LeadPoUserId = Input.LeadPoUserId
+            };
+
+            _db.Projects.Add(proj);
+            await _db.SaveChangesAsync();
+
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -1,0 +1,34 @@
+@page
+@model ProjectManagement.Pages.Projects.IndexModel
+@{
+    ViewData["Title"] = "Projects";
+}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">Projects</h2>
+  @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+  {
+    <a class="btn btn-primary" asp-page="Create">New Project</a>
+  }
+</div>
+
+<table class="table table-sm align-middle">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>HoD</th>
+      <th>Lead PO</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+  @foreach (var r in Model.Items)
+  {
+    <tr>
+      <td><a asp-page="View" asp-route-id="@r.Id">@r.Name</a></td>
+      <td>@r.Hod</td>
+      <td>@r.Po</td>
+      <td>@r.CreatedAt.ToLocalTime()</td>
+    </tr>
+  }
+  </tbody>
+</table>

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        public IndexModel(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public record Row(int Id, string Name, string? Hod, string? Po, DateTime CreatedAt);
+        public List<Row> Items { get; set; } = new();
+
+        public async Task OnGetAsync()
+        {
+            Items = await _db.Projects
+                .Include(p => p.HodUser)
+                .Include(p => p.LeadPoUser)
+                .OrderByDescending(p => p.CreatedAt)
+                .Select(p => new Row(
+                    p.Id,
+                    p.Name,
+                    p.HodUser == null ? null : $"{p.HodUser.Rank} {p.HodUser.FullName}",
+                    p.LeadPoUser == null ? null : $"{p.LeadPoUser.Rank} {p.LeadPoUser.FullName}",
+                    p.CreatedAt))
+                .ToListAsync();
+        }
+    }
+}

--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -1,0 +1,23 @@
+@page "{id:int}"
+@model ProjectManagement.Pages.Projects.ViewModel
+@{
+    ViewData["Title"] = Model.Item.Name;
+}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">@Model.Item.Name</h2>
+  <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+</div>
+
+<dl class="row">
+  <dt class="col-sm-3">Description</dt>
+  <dd class="col-sm-9">@Model.Item.Description</dd>
+
+  <dt class="col-sm-3">Head of Department</dt>
+  <dd class="col-sm-9">@Model.Item.Hod</dd>
+
+  <dt class="col-sm-3">Lead Project Officer</dt>
+  <dd class="col-sm-9">@Model.Item.Po</dd>
+
+  <dt class="col-sm-3">Created</dt>
+  <dd class="col-sm-9">@Model.Item.CreatedAt.ToLocalTime()</dd>
+</dl>

--- a/Pages/Projects/View.cshtml.cs
+++ b/Pages/Projects/View.cshtml.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize]
+    public class ViewModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        public ViewModel(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public record ItemModel(int Id, string Name, string? Description, string? Hod, string? Po, DateTime CreatedAt);
+
+        public ItemModel Item { get; private set; } = null!;
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            var item = await _db.Projects
+                .Include(p => p.HodUser)
+                .Include(p => p.LeadPoUser)
+                .Where(p => p.Id == id)
+                .Select(p => new ItemModel(
+                    p.Id,
+                    p.Name,
+                    p.Description,
+                    p.HodUser == null ? null : $"{p.HodUser.Rank} {p.HodUser.FullName}",
+                    p.LeadPoUser == null ? null : $"{p.LeadPoUser.Rank} {p.LeadPoUser.FullName}",
+                    p.CreatedAt))
+                .FirstOrDefaultAsync();
+
+            if (item == null)
+            {
+                return NotFound();
+            }
+
+            Item = item;
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Project entity with optional HoD and Lead PO assignments
- add a migration updating the database schema for the new assignment fields
- create Razor Pages to list, create, and view projects with appropriate role checks

## Testing
- dotnet ef migrations add AddProjectAssignments *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e8f0ecec8329bb3f5d2778e5fb11