### PR TITLE
Fix draft stage date inputs

### DIFF
--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -53,11 +53,25 @@
                     </td>
                     <td>
                         <input type="hidden" asp-for="Stages[i].StageCode" />
-                        <input asp-for="Stages[i].PlannedStart" type="date" class="form-control form-control-sm" @(Model.AllowEdit ? null : "disabled") />
+                        @if (Model.AllowEdit)
+                        {
+                            <input asp-for="Stages[i].PlannedStart" type="date" class="form-control form-control-sm" />
+                        }
+                        else
+                        {
+                            <input asp-for="Stages[i].PlannedStart" type="date" class="form-control form-control-sm" disabled />
+                        }
                         <span asp-validation-for="Stages[i].PlannedStart" class="text-danger small"></span>
                     </td>
                     <td>
-                        <input asp-for="Stages[i].PlannedDue" type="date" class="form-control form-control-sm" @(Model.AllowEdit ? null : "disabled") />
+                        @if (Model.AllowEdit)
+                        {
+                            <input asp-for="Stages[i].PlannedDue" type="date" class="form-control form-control-sm" />
+                        }
+                        else
+                        {
+                            <input asp-for="Stages[i].PlannedDue" type="date" class="form-control form-control-sm" disabled />
+                        }
                         <span asp-validation-for="Stages[i].PlannedDue" class="text-danger small"></span>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- render separate editable and disabled date inputs to avoid invalid attributes when editing is not allowed

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d4f990d0bc83298c32f0790b5579a9