### PR TITLE
Improve seeding and draft validation

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -32,6 +32,9 @@
                             <li class="nav-item">
                                 <a class="nav-link" asp-page="/Process/Index">Process</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-page="/Projects/Index">Projects</a>
+                            </li>
                             if (User.IsInRole("Admin"))
                             {
                                 <li class="nav-item">


### PR DESCRIPTION
## Summary
- guard the stage flow seeder so it only skips when both templates and dependencies for SDD-1.0 already exist
- add per-stage date validation that enforces due ≥ start and flags incomplete date pairs when editing a draft
- expose a top navigation link to the projects list for quicker access

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4fad2d88c83299101f3152c03c2ca