### PR TITLE
Add plan approval submission and review flow

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -23,6 +23,7 @@ namespace ProjectManagement.Data
         public DbSet<StageDependencyTemplate> StageDependencyTemplates => Set<StageDependencyTemplate>();
         public DbSet<PlanVersion> PlanVersions => Set<PlanVersion>();
         public DbSet<StagePlan> StagePlans => Set<StagePlan>();
+        public DbSet<PlanApprovalLog> PlanApprovalLogs => Set<PlanApprovalLog>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -104,12 +105,40 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Title).HasMaxLength(64);
                 e.Property(x => x.Status).HasConversion<string>().HasMaxLength(32);
                 e.Property(x => x.CreatedByUserId).HasMaxLength(450);
+                e.Property(x => x.SubmittedByUserId).HasMaxLength(450);
+                e.Property(x => x.ApprovedByUserId).HasMaxLength(450);
+                e.Property(x => x.Reason).HasMaxLength(512);
+                e.HasOne(x => x.SubmittedByUser)
+                    .WithMany()
+                    .HasForeignKey(x => x.SubmittedByUserId)
+                    .OnDelete(DeleteBehavior.SetNull);
+                e.HasOne(x => x.ApprovedByUser)
+                    .WithMany()
+                    .HasForeignKey(x => x.ApprovedByUserId)
+                    .OnDelete(DeleteBehavior.SetNull);
             });
 
             builder.Entity<StagePlan>(e =>
             {
                 e.HasIndex(x => new { x.PlanVersionId, x.StageCode }).IsUnique();
                 e.Property(x => x.StageCode).HasMaxLength(16);
+            });
+
+            builder.Entity<PlanApprovalLog>(e =>
+            {
+                e.HasIndex(x => x.PlanVersionId);
+                e.HasIndex(x => x.PerformedByUserId);
+                e.Property(x => x.Action).HasMaxLength(64);
+                e.Property(x => x.Note).HasMaxLength(1024);
+                e.Property(x => x.PerformedByUserId).HasMaxLength(450);
+                e.HasOne(x => x.PlanVersion)
+                    .WithMany(p => p.ApprovalLogs)
+                    .HasForeignKey(x => x.PlanVersionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+                e.HasOne(x => x.PerformedByUser)
+                    .WithMany()
+                    .HasForeignKey(x => x.PerformedByUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
             });
         }
     }

--- a/Migrations/20251001093000_AddPlanApproval.Designer.cs
+++ b/Migrations/20251001093000_AddPlanApproval.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001093000_AddPlanApproval")]
+    partial class AddPlanApproval
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251001093000_AddPlanApproval.cs
+++ b/Migrations/20251001093000_AddPlanApproval.cs
@@ -1,0 +1,157 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlanApproval : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApprovedByUserId",
+                table: "PlanVersions",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ApprovedOn",
+                table: "PlanVersions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "PlanVersions",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SubmittedByUserId",
+                table: "PlanVersions",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SubmittedOn",
+                table: "PlanVersions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PlanApprovalLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PlanVersionId = table.Column<int>(type: "integer", nullable: false),
+                    Action = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Note = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    PerformedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    PerformedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlanApprovalLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlanApprovalLogs_AspNetUsers_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PlanApprovalLogs_PlanVersions_PlanVersionId",
+                        column: x => x.PlanVersionId,
+                        principalTable: "PlanVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlanVersions_ApprovedByUserId",
+                table: "PlanVersions",
+                column: "ApprovedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlanVersions_SubmittedByUserId",
+                table: "PlanVersions",
+                column: "SubmittedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlanApprovalLogs_PerformedByUserId",
+                table: "PlanApprovalLogs",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlanApprovalLogs_PlanVersionId",
+                table: "PlanApprovalLogs",
+                column: "PlanVersionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PlanVersions_AspNetUsers_ApprovedByUserId",
+                table: "PlanVersions",
+                column: "ApprovedByUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PlanVersions_AspNetUsers_SubmittedByUserId",
+                table: "PlanVersions",
+                column: "SubmittedByUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PlanVersions_AspNetUsers_ApprovedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PlanVersions_AspNetUsers_SubmittedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropTable(
+                name: "PlanApprovalLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlanVersions_ApprovedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlanVersions_SubmittedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovedOn",
+                table: "PlanVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "PlanVersions");
+
+            migrationBuilder.DropColumn(
+                name: "SubmittedByUserId",
+                table: "PlanVersions");
+
+            migrationBuilder.DropColumn(
+                name: "SubmittedOn",
+                table: "PlanVersions");
+        }
+    }
+}

--- a/Models/Plans/PlanApprovalLog.cs
+++ b/Models/Plans/PlanApprovalLog.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Models.Plans;
+
+public class PlanApprovalLog
+{
+    public int Id { get; set; }
+
+    public int PlanVersionId { get; set; }
+    public PlanVersion? PlanVersion { get; set; }
+
+    [MaxLength(64)]
+    public string Action { get; set; } = string.Empty;
+
+    [MaxLength(1024)]
+    public string? Note { get; set; }
+
+    [MaxLength(450)]
+    public string PerformedByUserId { get; set; } = string.Empty;
+    public ApplicationUser? PerformedByUser { get; set; }
+
+    public DateTimeOffset PerformedOn { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Models/Plans/PlanConstants.cs
+++ b/Models/Plans/PlanConstants.cs
@@ -1,0 +1,6 @@
+namespace ProjectManagement.Models.Plans;
+
+public static class PlanConstants
+{
+    public const string StageTemplateVersion = "SDD-1.0";
+}

--- a/Models/Plans/PlanVersion.cs
+++ b/Models/Plans/PlanVersion.cs
@@ -25,7 +25,24 @@ public class PlanVersion
 
     public DateTimeOffset CreatedOn { get; set; } = DateTimeOffset.UtcNow;
 
+    [MaxLength(450)]
+    public string? SubmittedByUserId { get; set; }
+    public ApplicationUser? SubmittedByUser { get; set; }
+
+    public DateTimeOffset? SubmittedOn { get; set; }
+
+    [MaxLength(450)]
+    public string? ApprovedByUserId { get; set; }
+    public ApplicationUser? ApprovedByUser { get; set; }
+
+    public DateTimeOffset? ApprovedOn { get; set; }
+
+    [MaxLength(512)]
+    public string? Reason { get; set; }
+
     public List<StagePlan> StagePlans { get; set; } = new();
+
+    public List<PlanApprovalLog> ApprovalLogs { get; set; } = new();
 }
 
 public enum PlanVersionStatus

--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -11,6 +11,13 @@
     <p class="text-muted">Version @Model.Draft.VersionNo (@Model.Draft.Status)</p>
 }
 
+@if (Model.Draft is not null && Model.Draft.Status != ProjectManagement.Models.Plans.PlanVersionStatus.Draft)
+{
+    <div class="alert alert-info" role="alert">
+        Editing is locked while the plan is @Model.Draft.Status.
+    </div>
+}
+
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
 {
     <div class="alert alert-success" role="alert">
@@ -80,7 +87,7 @@
         </table>
     </div>
 
-    <div class="d-flex gap-2">
+    <div class="d-flex flex-wrap gap-2">
         @if (Model.AllowEdit)
         {
             <button type="submit" class="btn btn-primary" asp-page-handler="Save">Save Draft</button>
@@ -89,6 +96,10 @@
         else if (Model.IsPreview)
         {
             <a class="btn btn-primary" asp-page="./Draft" asp-route-id="@Model.ProjectId">Edit Draft</a>
+        }
+        @if (Model.CanSubmit)
+        {
+            <button type="submit" class="btn btn-success" asp-page-handler="Submit">Submit for approval</button>
         }
         <a class="btn btn-outline-secondary" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back</a>
     </div>

--- a/Pages/Projects/Plan/Review.cshtml
+++ b/Pages/Projects/Plan/Review.cshtml
@@ -1,0 +1,98 @@
+@page
+@model ProjectManagement.Pages.Projects.Plan.ReviewModel
+@{
+    ViewData["Title"] = "Baseline Plan Review";
+}
+
+<h1 class="mb-3">Baseline Plan Review</h1>
+<p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
+@if (Model.Plan is not null)
+{
+    <dl class="row">
+        <dt class="col-sm-3">Version</dt>
+        <dd class="col-sm-9">@Model.Plan.VersionNo (@Model.Plan.Status)</dd>
+
+        <dt class="col-sm-3">Submitted On</dt>
+        <dd class="col-sm-9">
+            @if (Model.Plan.SubmittedOn.HasValue)
+            {
+                @Model.Plan.SubmittedOn.Value.ToLocalTime().ToString("dd MMM yyyy HH:mm")
+            }
+            else
+            {
+                <span class="text-muted">Not available</span>
+            }
+        </dd>
+
+        <dt class="col-sm-3">Submitted By</dt>
+        <dd class="col-sm-9">
+            @if (Model.Plan.SubmittedByUser is not null)
+            {
+                @($"{Model.Plan.SubmittedByUser.Rank} {Model.Plan.SubmittedByUser.FullName}")
+            }
+            else
+            {
+                @Model.Plan.SubmittedByUserId
+            }
+        </dd>
+    </dl>
+}
+
+<div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+<div class="table-responsive mb-4">
+    <table class="table table-sm align-middle">
+        <thead>
+            <tr>
+                <th scope="col" style="width: 6rem;">Stage</th>
+                <th scope="col">Description</th>
+                <th scope="col" style="width: 12rem;">Planned Start</th>
+                <th scope="col" style="width: 12rem;">Planned Due</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var stage in Model.Stages)
+        {
+            <tr>
+                <td>
+                    <div class="fw-semibold">@stage.Code</div>
+                </td>
+                <td>
+                    <div class="fw-semibold">@stage.Name</div>
+                </td>
+                <td>@stage.PlannedStart?.ToString("dd MMM yyyy")</td>
+                <td>@stage.PlannedDue?.ToString("dd MMM yyyy")</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>
+
+@if (Model.CanAct)
+{
+    <div class="d-flex flex-column flex-md-row gap-3">
+        <form method="post" asp-page-handler="Approve" asp-route-id="@Model.ProjectId" class="d-flex align-items-end gap-2">
+            <button type="submit" class="btn btn-success">Approve</button>
+        </form>
+        <form method="post" asp-page-handler="Reject" asp-route-id="@Model.ProjectId" class="flex-fill">
+            <div class="mb-2">
+                <label asp-for="Note" class="form-label">Rejection Note</label>
+                <textarea asp-for="Note" class="form-control" rows="3"></textarea>
+                <span asp-validation-for="Note" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-danger">Reject</button>
+        </form>
+    </div>
+}
+else
+{
+    <div class="alert alert-info" role="alert">
+        This plan is no longer pending approval.
+    </div>
+}
+
+<a class="btn btn-outline-secondary mt-3" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back to Project</a>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Plan/Review.cshtml.cs
+++ b/Pages/Projects/Plan/Review.cshtml.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services.Plans;
+
+namespace ProjectManagement.Pages.Projects.Plan;
+
+[Authorize(Roles = "HoD,Admin")]
+public class ReviewModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly PlanApprovalService _approvals;
+    private readonly UserManager<ApplicationUser> _users;
+
+    public ReviewModel(ApplicationDbContext db, PlanApprovalService approvals, UserManager<ApplicationUser> users)
+    {
+        _db = db;
+        _approvals = approvals;
+        _users = users;
+    }
+
+    public record StageRow(string Code, string Name, DateOnly? PlannedStart, DateOnly? PlannedDue);
+
+    public PlanVersion? Plan { get; private set; }
+    public List<StageRow> Stages { get; private set; } = new();
+    public string ProjectName { get; private set; } = string.Empty;
+    public int ProjectId { get; private set; }
+    public bool CanAct { get; private set; }
+
+    [BindProperty]
+    public string? Note { get; set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ProjectId = id;
+        var loadResult = await LoadAsync(id, cancellationToken);
+        if (loadResult != null)
+        {
+            return loadResult;
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostApproveAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ProjectId = id;
+        var userId = _users.GetUserId(User);
+        if (userId == null)
+        {
+            return Challenge();
+        }
+
+        try
+        {
+            await _approvals.ApproveAsync(id, userId, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            var loadResult = await LoadAsync(id, cancellationToken);
+            return loadResult ?? Page();
+        }
+
+        StatusMessage = "Baseline plan approved.";
+        return RedirectToPage("/Projects/View", new { id });
+    }
+
+    public async Task<IActionResult> OnPostRejectAsync(int id, CancellationToken cancellationToken = default)
+    {
+        ProjectId = id;
+        var trimmedNote = Note?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedNote))
+        {
+            ModelState.AddModelError(nameof(Note), "A note is required to reject the plan.");
+            var loadResult = await LoadAsync(id, cancellationToken);
+            return loadResult ?? Page();
+        }
+
+        Note = trimmedNote;
+
+        var userId = _users.GetUserId(User);
+        if (userId == null)
+        {
+            return Challenge();
+        }
+
+        try
+        {
+            await _approvals.RejectAsync(id, userId, trimmedNote!, cancellationToken);
+        }
+        catch (PlanApprovalValidationException ex)
+        {
+            foreach (var error in ex.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error);
+            }
+            var loadResult = await LoadAsync(id, cancellationToken);
+            return loadResult ?? Page();
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            var loadResult = await LoadAsync(id, cancellationToken);
+            return loadResult ?? Page();
+        }
+
+        StatusMessage = "Baseline plan rejected and returned to draft.";
+        return RedirectToPage("/Projects/View", new { id });
+    }
+
+    private async Task<IActionResult?> LoadAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var project = await _db.Projects
+            .AsNoTracking()
+            .Where(p => p.Id == projectId)
+            .Select(p => new { p.Name })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (project == null)
+        {
+            return NotFound();
+        }
+
+        ProjectName = project.Name;
+
+        Plan = await _db.PlanVersions
+            .Include(p => p.StagePlans)
+            .Include(p => p.SubmittedByUser)
+            .Where(p => p.ProjectId == projectId && p.Status == PlanVersionStatus.PendingApproval)
+            .OrderByDescending(p => p.VersionNo)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (Plan == null)
+        {
+            return NotFound();
+        }
+
+        var templates = await _db.StageTemplates
+            .AsNoTracking()
+            .Where(t => t.Version == PlanConstants.StageTemplateVersion)
+            .OrderBy(t => t.Sequence)
+            .ToListAsync(cancellationToken);
+
+        var planStages = Plan.StagePlans.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
+        Stages = templates
+            .Select(t =>
+            {
+                planStages.TryGetValue(t.Code, out var stage);
+                return new StageRow(t.Code, t.Name, stage?.PlannedStart, stage?.PlannedDue);
+            })
+            .ToList();
+
+        CanAct = Plan.Status == PlanVersionStatus.PendingApproval;
+        Note ??= string.Empty;
+        return null;
+    }
+}

--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -8,6 +8,13 @@
   <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </div>
 
+@if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+{
+  <div class="alert alert-success" role="alert">
+    @Model.StatusMessage
+  </div>
+}
+
 <dl class="row">
   <dt class="col-sm-3">Description</dt>
   <dd class="col-sm-9">@Model.Item.Description</dd>

--- a/Pages/Projects/View.cshtml.cs
+++ b/Pages/Projects/View.cshtml.cs
@@ -22,6 +22,9 @@ namespace ProjectManagement.Pages.Projects
 
         public ItemModel Item { get; private set; } = null!;
 
+        [TempData]
+        public string? StatusMessage { get; set; }
+
         public async Task<IActionResult> OnGetAsync(int id)
         {
             var item = await _db.Projects

--- a/Program.cs
+++ b/Program.cs
@@ -135,6 +135,7 @@ builder.Services.AddScoped<ILoginAnalyticsService, LoginAnalyticsService>();
 builder.Services.AddHostedService<LoginAggregationWorker>();
 builder.Services.AddHostedService<TodoPurgeWorker>();
 builder.Services.AddScoped<PlanDraftService>();
+builder.Services.AddScoped<PlanApprovalService>();
 
 builder.Services.ConfigureHttpJsonOptions(o =>
 {

--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Plans;
+
+public class PlanApprovalService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+    private readonly ILogger<PlanApprovalService> _logger;
+
+    public PlanApprovalService(ApplicationDbContext db, IClock clock, ILogger<PlanApprovalService> logger)
+    {
+        _db = db;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task SubmitAsync(int projectId, string userId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new ArgumentException("A valid user identifier is required to submit a plan for approval.", nameof(userId));
+        }
+
+        var plan = await _db.PlanVersions
+            .Include(p => p.StagePlans)
+            .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.Status == PlanVersionStatus.Draft, cancellationToken);
+
+        if (plan == null)
+        {
+            throw new InvalidOperationException("No draft plan was found to submit for approval.");
+        }
+
+        var errors = await ValidateStagePlansAsync(plan, cancellationToken);
+        if (errors.Count > 0)
+        {
+            throw new PlanApprovalValidationException(errors);
+        }
+
+        plan.Status = PlanVersionStatus.PendingApproval;
+        plan.SubmittedByUserId = userId;
+        plan.SubmittedOn = _clock.UtcNow;
+        plan.ApprovedByUserId = null;
+        plan.ApprovedOn = null;
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Plan version {PlanVersionId} for project {ProjectId} submitted for approval by {UserId}.", plan.Id, projectId, userId);
+    }
+
+    public async Task ApproveAsync(int projectId, string approverUserId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(approverUserId))
+        {
+            throw new ArgumentException("A valid approver identifier is required.", nameof(approverUserId));
+        }
+
+        var plan = await _db.PlanVersions
+            .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.Status == PlanVersionStatus.PendingApproval, cancellationToken);
+
+        if (plan == null)
+        {
+            throw new InvalidOperationException("No plan is currently pending approval for this project.");
+        }
+
+        plan.Status = PlanVersionStatus.Approved;
+        plan.ApprovedByUserId = approverUserId;
+        plan.ApprovedOn = _clock.UtcNow;
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Plan version {PlanVersionId} for project {ProjectId} approved by {UserId}.", plan.Id, projectId, approverUserId);
+    }
+
+    public async Task RejectAsync(int projectId, string approverUserId, string note, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(approverUserId))
+        {
+            throw new ArgumentException("A valid approver identifier is required.", nameof(approverUserId));
+        }
+
+        var trimmedNote = note?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedNote))
+        {
+            throw new PlanApprovalValidationException(new[] { "A rejection note is required." });
+        }
+
+        var plan = await _db.PlanVersions
+            .Include(p => p.ApprovalLogs)
+            .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.Status == PlanVersionStatus.PendingApproval, cancellationToken);
+
+        if (plan == null)
+        {
+            throw new InvalidOperationException("No plan is currently pending approval for this project.");
+        }
+
+        plan.Status = PlanVersionStatus.Draft;
+        plan.SubmittedByUserId = null;
+        plan.SubmittedOn = null;
+        plan.ApprovedByUserId = null;
+        plan.ApprovedOn = null;
+
+        plan.ApprovalLogs.Add(new PlanApprovalLog
+        {
+            PlanVersionId = plan.Id,
+            Action = "Rejected",
+            Note = trimmedNote,
+            PerformedByUserId = approverUserId,
+            PerformedOn = _clock.UtcNow
+        });
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Plan version {PlanVersionId} for project {ProjectId} was rejected by {UserId}.", plan.Id, projectId, approverUserId);
+    }
+
+    private async Task<List<string>> ValidateStagePlansAsync(PlanVersion plan, CancellationToken cancellationToken)
+    {
+        var errors = new List<string>();
+
+        var templates = await _db.StageTemplates
+            .AsNoTracking()
+            .Where(t => t.Version == PlanConstants.StageTemplateVersion)
+            .OrderBy(t => t.Sequence)
+            .ToListAsync(cancellationToken);
+
+        var templateNames = templates.ToDictionary(t => t.Code, t => t.Name, StringComparer.OrdinalIgnoreCase);
+
+        var dependencies = await _db.StageDependencyTemplates
+            .AsNoTracking()
+            .Where(d => d.Version == PlanConstants.StageTemplateVersion)
+            .ToListAsync(cancellationToken);
+
+        var dependenciesByStage = dependencies
+            .GroupBy(d => d.FromStageCode, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var stagePlans = plan.StagePlans.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var template in templates)
+        {
+            if (!stagePlans.TryGetValue(template.Code, out var stage))
+            {
+                errors.Add($"Stage {template.Name} ({template.Code}) is missing from the plan.");
+                continue;
+            }
+
+            if (stage.PlannedStart is not DateOnly start || stage.PlannedDue is not DateOnly due)
+            {
+                errors.Add($"Stage {template.Name} must have both a planned start and due date.");
+                continue;
+            }
+
+            if (due < start)
+            {
+                errors.Add($"Stage {template.Name} must end on or after its planned start date.");
+            }
+
+            if (!dependenciesByStage.TryGetValue(template.Code, out var stageDependencies))
+            {
+                continue;
+            }
+
+            foreach (var dependency in stageDependencies)
+            {
+                var dependencyCode = dependency.DependsOnStageCode;
+                var dependencyName = templateNames.TryGetValue(dependencyCode, out var friendlyName)
+                    ? friendlyName
+                    : dependencyCode;
+
+                if (!stagePlans.TryGetValue(dependencyCode, out var prerequisite) || prerequisite.PlannedDue is not DateOnly prerequisiteDue)
+                {
+                    errors.Add($"Stage {template.Name} requires {dependencyName} to have a planned due date before submission.");
+                    continue;
+                }
+
+                if (start < prerequisiteDue)
+                {
+                    errors.Add($"Stage {template.Name} must start on or after {dependencyName}'s planned due date ({prerequisiteDue:dd MMM yyyy}).");
+                }
+            }
+        }
+
+        return errors;
+    }
+}
+
+public class PlanApprovalValidationException : Exception
+{
+    public PlanApprovalValidationException(IEnumerable<string> errors)
+        : base("The plan is not ready for approval.")
+    {
+        Errors = errors?.Where(e => !string.IsNullOrWhiteSpace(e)).Select(e => e.Trim()).Distinct().ToArray() ?? Array.Empty<string>();
+    }
+
+    public IReadOnlyList<string> Errors { get; }
+}

--- a/Services/Plans/PlanDraftService.cs
+++ b/Services/Plans/PlanDraftService.cs
@@ -13,8 +13,6 @@ namespace ProjectManagement.Services.Plans;
 
 public class PlanDraftService
 {
-    private const string StageTemplateVersion = "SDD-1.0";
-
     private readonly ApplicationDbContext _db;
     private readonly IClock _clock;
     private readonly ILogger<PlanDraftService> _logger;
@@ -56,14 +54,15 @@ public class PlanDraftService
 
         var stageCodes = await _db.StageTemplates
             .AsNoTracking()
-            .Where(t => t.Version == StageTemplateVersion)
+            .Where(t => t.Version == PlanConstants.StageTemplateVersion)
             .OrderBy(t => t.Sequence)
             .Select(t => t.Code)
             .ToListAsync(cancellationToken);
 
         if (stageCodes.Count == 0)
         {
-            _logger.LogWarning("No stage templates found for version {Version}. Creating an empty draft for project {ProjectId}.", StageTemplateVersion, projectId);
+            _logger.LogWarning("No stage templates found for version {Version}. Creating an empty draft for project {ProjectId}.",
+                PlanConstants.StageTemplateVersion, projectId);
         }
 
         var plan = new PlanVersion


### PR DESCRIPTION
## Summary
- extend plan version metadata with submission/approval tracking, a plan approval log entity, and the corresponding migration
- introduce a plan approval service, update the draft workflow to handle submission validation and read-only states, and register the service for DI
- add a HoD/Admin review page with approve/reject actions and surface approval status messages on the project view

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fd3bdf1083299485944a00db823d