### PR TITLE
Ensure Lead PO dropdown includes Project Offr role

### DIFF
--- a/Pages/Projects/Create.cshtml.cs
+++ b/Pages/Projects/Create.cshtml.cs
@@ -39,7 +39,18 @@ namespace ProjectManagement.Pages.Projects
         public async Task OnGetAsync()
         {
             HodUsers = (await _userManager.GetUsersInRoleAsync("HoD")).OrderBy(u => u.FullName).ToList();
-            PoUsers = (await _userManager.GetUsersInRoleAsync("Project Officer")).OrderBy(u => u.FullName).ToList();
+
+            var poRoleNames = new[] { "Project Officer", "Project Offr" };
+            var poUsers = new Dictionary<string, ApplicationUser>();
+
+            foreach (var role in poRoleNames)
+            {
+                var usersInRole = await _userManager.GetUsersInRoleAsync(role);
+                foreach (var user in usersInRole)
+                    poUsers[user.Id] = user;
+            }
+
+            PoUsers = poUsers.Values.OrderBy(u => u.FullName).ToList();
         }
 
         public async Task<IActionResult> OnPostAsync()


### PR DESCRIPTION
## Summary
- update the project creation page model to gather Lead Project Officer candidates from both the "Project Officer" and "Project Offr" roles
- deduplicate the combined results so the dropdown contains every eligible user exactly once

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d503c294f88329a4de0d926afcc24a