### PR TITLE
Add client-side validation for stage due date order

### DIFF
--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -104,3 +104,36 @@
         <a class="btn btn-outline-secondary" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back</a>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script>
+        (() => {
+            const starts = document.querySelectorAll('input[name$=".PlannedStart"]');
+            for (const start of starts) {
+                const dueName = start.name.replace('.PlannedStart', '.PlannedDue');
+                const due = document.querySelector(`input[name="${dueName}"]`);
+                if (!due) {
+                    continue;
+                }
+
+                const validate = () => {
+                    start.setCustomValidity('');
+                    due.setCustomValidity('');
+
+                    const startValue = start.value;
+                    const dueValue = due.value;
+
+                    if (startValue && dueValue && dueValue < startValue) {
+                        due.setCustomValidity('Planned due must be on or after the planned start date.');
+                    }
+                };
+
+                start.addEventListener('input', validate);
+                due.addEventListener('input', validate);
+
+                validate();
+            }
+        })();
+    </script>
+}


### PR DESCRIPTION
## Summary
- add client-side validation on the plan draft page to require each planned due date to be on or after its matching start date
- include the shared validation scripts partial so unobtrusive validation remains available

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d50c450cd88329be233fc60971480f