### PR TITLE
Enforce planned due date ordering on plan draft

### DIFF
--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -27,7 +27,7 @@
 
 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-<form method="post" asp-route-id="@Model.ProjectId">
+<form id="plan-draft-form" method="post" asp-route-id="@Model.ProjectId">
     <div class="table-responsive mb-4">
         <table class="table table-sm align-middle">
             <thead>
@@ -104,3 +104,8 @@
         <a class="btn btn-outline-secondary" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back</a>
     </div>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/projects/plan-draft.js" defer></script>
+}

--- a/wwwroot/js/projects/plan-draft.js
+++ b/wwwroot/js/projects/plan-draft.js
@@ -1,0 +1,49 @@
+(() => {
+  const form = document.getElementById('plan-draft-form');
+  if (!form) {
+    return;
+  }
+
+  const rows = form.querySelectorAll('tbody tr');
+  rows.forEach((row) => {
+    const startInput = row.querySelector('input[name$=".PlannedStart"]');
+    const dueInput = row.querySelector('input[name$=".PlannedDue"]');
+
+    if (!startInput || !dueInput || startInput.disabled || dueInput.disabled) {
+      return;
+    }
+
+    const syncMin = () => {
+      if (startInput.value) {
+        dueInput.setAttribute('min', startInput.value);
+      } else {
+        dueInput.removeAttribute('min');
+      }
+    };
+
+    const validate = () => {
+      if (startInput.value && dueInput.value && dueInput.value < startInput.value) {
+        dueInput.setCustomValidity('Planned due must be on or after the planned start date.');
+      } else {
+        dueInput.setCustomValidity('');
+      }
+    };
+
+    const handleStartChange = () => {
+      syncMin();
+      validate();
+    };
+
+    const handleDueChange = () => {
+      validate();
+    };
+
+    startInput.addEventListener('input', handleStartChange);
+    startInput.addEventListener('change', handleStartChange);
+    dueInput.addEventListener('input', handleDueChange);
+    dueInput.addEventListener('change', handleDueChange);
+
+    syncMin();
+    validate();
+  });
+})();


### PR DESCRIPTION
## Summary
- tag the plan draft form so client scripts can find stage date inputs
- add a dedicated plan draft script that synchronises due date minimums and custom validity messages when due precedes start
- register the new script on the draft page to surface client-side feedback without introducing inline scripts

## Testing
- `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50d704a3c83298e8e1e34c96aeed6