### PR TITLE
Add stage guard service and execution controls

### DIFF
--- a/Models/Execution/StageHealthCalculator.cs
+++ b/Models/Execution/StageHealthCalculator.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectManagement.Models.Execution;
+
+public enum ProjectRagStatus
+{
+    Green,
+    Amber,
+    Red
+}
+
+public record ProjectStageHealth(IReadOnlyDictionary<string, int> SlipByStage, ProjectRagStatus Rag)
+{
+    public static ProjectStageHealth Empty { get; } = new(new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase), ProjectRagStatus.Green);
+}
+
+public static class StageHealthCalculator
+{
+    public static ProjectStageHealth Compute(IEnumerable<ProjectStage> stages, DateOnly today)
+    {
+        if (stages == null)
+        {
+            throw new ArgumentNullException(nameof(stages));
+        }
+
+        var slipByStage = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var rag = ProjectRagStatus.Green;
+
+        foreach (var stage in stages)
+        {
+            var slip = CalculateSlip(stage, today);
+            slipByStage[stage.StageCode] = slip;
+
+            if (slip >= 7)
+            {
+                rag = ProjectRagStatus.Red;
+            }
+            else if (slip >= 1 && rag != ProjectRagStatus.Red)
+            {
+                rag = ProjectRagStatus.Amber;
+            }
+
+            if (rag == ProjectRagStatus.Red)
+            {
+                continue;
+            }
+
+            if (stage.Status is StageStatus.Completed or StageStatus.Skipped)
+            {
+                continue;
+            }
+
+            if (stage.PlannedDue.HasValue)
+            {
+                var daysToDue = stage.PlannedDue.Value.DayNumber - today.DayNumber;
+                if (daysToDue >= 0 && daysToDue <= 2 && rag == ProjectRagStatus.Green)
+                {
+                    rag = ProjectRagStatus.Amber;
+                }
+            }
+        }
+
+        return new ProjectStageHealth(slipByStage, rag);
+    }
+
+    private static int CalculateSlip(ProjectStage stage, DateOnly today)
+    {
+        if (stage.Status == StageStatus.Completed)
+        {
+            if (stage.CompletedOn.HasValue && stage.PlannedDue.HasValue)
+            {
+                var diff = stage.CompletedOn.Value.DayNumber - stage.PlannedDue.Value.DayNumber;
+                return Math.Max(0, diff);
+            }
+
+            return 0;
+        }
+
+        if (stage.Status == StageStatus.Skipped)
+        {
+            return 0;
+        }
+
+        if (!stage.PlannedDue.HasValue)
+        {
+            return 0;
+        }
+
+        var overdue = today.DayNumber - stage.PlannedDue.Value.DayNumber;
+        return Math.Max(0, overdue);
+    }
+}

--- a/Models/Execution/StageSlipSummary.cs
+++ b/Models/Execution/StageSlipSummary.cs
@@ -1,0 +1,3 @@
+namespace ProjectManagement.Models.Execution;
+
+public record StageSlipSummary(string Code, int SlipDays);

--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -1,11 +1,51 @@
 @page
 @model ProjectManagement.Pages.Projects.StagesModel
+@using ProjectManagement.Models.Execution
 @{
     ViewData["Title"] = "Project Stages";
+    var ragClass = Model.ProjectRag switch
+    {
+        ProjectRagStatus.Red => "badge bg-danger",
+        ProjectRagStatus.Amber => "badge bg-warning text-dark",
+        _ => "badge bg-success"
+    };
 }
 
 <h1 class="mb-3">Project Stages</h1>
 <p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="alert alert-success" role="alert">
+        @Model.StatusMessage
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @Model.ErrorMessage
+    </div>
+}
+
+<div class="border rounded p-3 mb-3">
+    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+        <div>
+            <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+        </div>
+        <div class="flex-grow-1">
+            <div class="fw-semibold mb-1">Slip (days)</div>
+            <ul class="list-inline mb-0">
+                @foreach (var slip in Model.StageSlips)
+                {
+                    <li class="list-inline-item mb-1">
+                        <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
+                    </li>
+                }
+            </ul>
+        </div>
+    </div>
+</div>
 
 <div class="table-responsive">
     <table class="table table-sm align-middle">
@@ -16,8 +56,13 @@
                 <th scope="col" style="width: 12rem;">Planned Start</th>
                 <th scope="col" style="width: 12rem;">Planned Due</th>
                 <th scope="col" style="width: 10rem;">Status</th>
+                <th scope="col" style="width: 8rem;">Slip (days)</th>
                 <th scope="col" style="width: 12rem;">Actual Start</th>
                 <th scope="col" style="width: 12rem;">Completed On</th>
+                @if (Model.CanManageStages)
+                {
+                    <th scope="col" style="width: 18rem;">Actions</th>
+                }
             </tr>
         </thead>
         <tbody>
@@ -33,8 +78,29 @@
                 <td>@stage.PlannedStart?.ToString("dd MMM yyyy")</td>
                 <td>@stage.PlannedDue?.ToString("dd MMM yyyy")</td>
                 <td>@stage.Status</td>
+                <td>@stage.SlipDays</td>
                 <td>@stage.ActualStart?.ToString("dd MMM yyyy")</td>
                 <td>@stage.CompletedOn?.ToString("dd MMM yyyy")</td>
+                @if (Model.CanManageStages)
+                {
+                    <td>
+                        <div class="d-flex flex-wrap gap-2">
+                            <form method="post" asp-page-handler="Start" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
+                                <button type="submit" class="btn btn-outline-primary btn-sm" title="@stage.StartGuard.Reason" @(stage.StartGuard.Allowed ? null : "disabled")>Start</button>
+                            </form>
+                            <form method="post" asp-page-handler="Complete" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
+                                <button type="submit" class="btn btn-outline-success btn-sm" title="@stage.CompleteGuard.Reason" @(stage.CompleteGuard.Allowed ? null : "disabled")>Complete</button>
+                            </form>
+                            @if (string.Equals(stage.Code, "PNC", StringComparison.OrdinalIgnoreCase))
+                            {
+                                <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-flex flex-wrap gap-2">
+                                    <input type="text" name="reason" class="form-control form-control-sm" placeholder="Reason" required minlength="3" maxlength="200" />
+                                    <button type="submit" class="btn btn-outline-danger btn-sm" title="@stage.SkipGuard.Reason" @(stage.SkipGuard.Allowed ? null : "disabled")>Skip</button>
+                                </form>
+                            }
+                        </div>
+                    </td>
+                }
             </tr>
         }
         </tbody>

--- a/Pages/Projects/Stages.cshtml.cs
+++ b/Pages/Projects/Stages.cshtml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,17 +11,22 @@ using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
+using ProjectManagement.Services;
 
 namespace ProjectManagement.Pages.Projects;
 
-[Authorize]
+[Authorize(Roles = "Project Officer,HoD,Admin")]
 public class StagesModel : PageModel
 {
     private readonly ApplicationDbContext _db;
+    private readonly StageRulesService _rules;
+    private readonly IClock _clock;
 
-    public StagesModel(ApplicationDbContext db)
+    public StagesModel(ApplicationDbContext db, StageRulesService rules, IClock clock)
     {
         _db = db;
+        _rules = rules;
+        _clock = clock;
     }
 
     public record StageRow(
@@ -29,19 +36,185 @@ public class StagesModel : PageModel
         DateOnly? PlannedDue,
         StageStatus Status,
         DateOnly? ActualStart,
-        DateOnly? CompletedOn);
+        DateOnly? CompletedOn,
+        int SlipDays,
+        StageGuardResult StartGuard,
+        StageGuardResult CompleteGuard,
+        StageGuardResult SkipGuard);
 
     public int ProjectId { get; private set; }
     public string ProjectName { get; private set; } = string.Empty;
     public List<StageRow> Stages { get; private set; } = new();
+    public List<StageSlipSummary> StageSlips { get; private set; } = new();
+    public ProjectRagStatus ProjectRag { get; private set; } = ProjectRagStatus.Green;
+    public bool CanManageStages { get; private set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    [TempData]
+    public string? ErrorMessage { get; set; }
 
     public async Task<IActionResult> OnGetAsync(int id)
     {
         var cancellationToken = HttpContext.RequestAborted;
+        return await LoadAsync(id, cancellationToken);
+    }
+
+    public async Task<IActionResult> OnPostStartAsync(int projectId, string stage, CancellationToken cancellationToken)
+    {
+        var stageCode = NormalizeStageCode(stage);
+        if (stageCode == null)
+        {
+            ErrorMessage = "Stage code is required.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var (result, ctx) = await LoadForMutationAsync(projectId, cancellationToken);
+        if (result != null)
+        {
+            return result;
+        }
+
+        if (ctx is null)
+        {
+            ErrorMessage = "Unable to load stage data.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var stageEntity = ctx.Stages.FirstOrDefault(s => s.StageCode.Equals(stageCode, StringComparison.OrdinalIgnoreCase));
+        if (stageEntity == null)
+        {
+            return NotFound();
+        }
+
+        var context = await _rules.BuildContextAsync(ctx.Stages, cancellationToken);
+        var guard = _rules.CanStart(context, stageCode);
+        if (!guard.Allowed)
+        {
+            ErrorMessage = guard.Reason ?? $"Stage {stageCode} cannot be started.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var today = Today();
+        stageEntity.ActualStart ??= today;
+        stageEntity.Status = StageStatus.InProgress;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        StatusMessage = $"Stage {stageCode} started.";
+        return RedirectToPage(new { id = projectId });
+    }
+
+    public async Task<IActionResult> OnPostCompleteAsync(int projectId, string stage, CancellationToken cancellationToken)
+    {
+        var stageCode = NormalizeStageCode(stage);
+        if (stageCode == null)
+        {
+            ErrorMessage = "Stage code is required.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var (result, ctx) = await LoadForMutationAsync(projectId, cancellationToken);
+        if (result != null)
+        {
+            return result;
+        }
+
+        if (ctx is null)
+        {
+            ErrorMessage = "Unable to load stage data.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var stageEntity = ctx.Stages.FirstOrDefault(s => s.StageCode.Equals(stageCode, StringComparison.OrdinalIgnoreCase));
+        if (stageEntity == null)
+        {
+            return NotFound();
+        }
+
+        var context = await _rules.BuildContextAsync(ctx.Stages, cancellationToken);
+        var guard = _rules.CanComplete(context, stageCode);
+        if (!guard.Allowed)
+        {
+            ErrorMessage = guard.Reason ?? $"Stage {stageCode} cannot be completed.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var today = Today();
+        stageEntity.CompletedOn = today;
+        stageEntity.ActualStart ??= today;
+        stageEntity.Status = StageStatus.Completed;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        StatusMessage = $"Stage {stageCode} completed.";
+        return RedirectToPage(new { id = projectId });
+    }
+
+    public async Task<IActionResult> OnPostSkipAsync(int projectId, string stage, string? reason, CancellationToken cancellationToken)
+    {
+        var stageCode = NormalizeStageCode(stage);
+        if (stageCode == null)
+        {
+            ErrorMessage = "Stage code is required.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        reason = reason?.Trim();
+        if (string.IsNullOrWhiteSpace(reason) || reason.Length is < 3 or > 200)
+        {
+            ErrorMessage = "Provide a reason between 3 and 200 characters to skip PNC.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var (result, ctx) = await LoadForMutationAsync(projectId, cancellationToken);
+        if (result != null)
+        {
+            return result;
+        }
+
+        if (ctx is null)
+        {
+            ErrorMessage = "Unable to load stage data.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        var stageEntity = ctx.Stages.FirstOrDefault(s => s.StageCode.Equals(stageCode, StringComparison.OrdinalIgnoreCase));
+        if (stageEntity == null)
+        {
+            return NotFound();
+        }
+
+        var context = await _rules.BuildContextAsync(ctx.Stages, cancellationToken);
+        var guard = _rules.CanSkip(context, stageCode);
+        if (!guard.Allowed)
+        {
+            ErrorMessage = guard.Reason ?? $"Stage {stageCode} cannot be skipped.";
+            return RedirectToPage(new { id = projectId });
+        }
+
+        stageEntity.Status = StageStatus.Skipped;
+        stageEntity.ActualStart = null;
+        stageEntity.CompletedOn = null;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        StatusMessage = $"Stage {stageCode} skipped.";
+        return RedirectToPage(new { id = projectId });
+    }
+
+    private async Task<IActionResult> LoadAsync(int id, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null)
+        {
+            return Challenge();
+        }
 
         var project = await _db.Projects
             .Where(p => p.Id == id)
-            .Select(p => new { p.Id, p.Name })
+            .Select(p => new { p.Id, p.Name, p.LeadPoUserId })
             .FirstOrDefaultAsync(cancellationToken);
 
         if (project is null)
@@ -51,6 +224,14 @@ public class StagesModel : PageModel
 
         ProjectId = project.Id;
         ProjectName = project.Name;
+
+        var canManage = UserCanManage(project.LeadPoUserId, userId);
+        if (!canManage && User.IsInRole("Project Officer"))
+        {
+            return Forbid();
+        }
+
+        CanManageStages = canManage;
 
         var templates = await _db.StageTemplates
             .AsNoTracking()
@@ -67,6 +248,17 @@ public class StagesModel : PageModel
         var stageLookup = projectStages
             .ToDictionary(ps => ps.StageCode, ps => ps, StringComparer.OrdinalIgnoreCase);
 
+        var context = await _rules.BuildContextAsync(projectStages, cancellationToken);
+        var today = Today();
+        var health = StageHealthCalculator.Compute(projectStages, today);
+
+        StageSlips = templates
+            .Select(t => new StageSlipSummary(
+                t.Code,
+                health.SlipByStage.TryGetValue(t.Code, out var slip) ? slip : 0))
+            .ToList();
+        ProjectRag = health.Rag;
+
         Stages = templates
             .Select(template =>
             {
@@ -81,10 +273,73 @@ public class StagesModel : PageModel
                     projectStage?.PlannedDue,
                     status,
                     projectStage?.ActualStart,
-                    projectStage?.CompletedOn);
+                    projectStage?.CompletedOn,
+                    health.SlipByStage.TryGetValue(template.Code, out var slip) ? slip : 0,
+                    _rules.CanStart(context, template.Code),
+                    _rules.CanComplete(context, template.Code),
+                    _rules.CanSkip(context, template.Code));
             })
             .ToList();
 
         return Page();
     }
+
+    private async Task<(IActionResult? Result, MutationContext? Context)> LoadForMutationAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null)
+        {
+            return (Challenge(), null);
+        }
+
+        var project = await _db.Projects
+            .Where(p => p.Id == projectId)
+            .Select(p => new { p.Id, p.LeadPoUserId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (project == null)
+        {
+            return (NotFound(), null);
+        }
+
+        if (!UserCanManage(project.LeadPoUserId, userId))
+        {
+            return (Forbid(), null);
+        }
+
+        var stages = await _db.ProjectStages
+            .Where(ps => ps.ProjectId == projectId)
+            .ToListAsync(cancellationToken);
+
+        return (null, new MutationContext(stages));
+    }
+
+    private static string? NormalizeStageCode(string? stage)
+    {
+        if (string.IsNullOrWhiteSpace(stage))
+        {
+            return null;
+        }
+
+        return stage.Trim().ToUpperInvariant();
+    }
+
+    private DateOnly Today() => DateOnly.FromDateTime(_clock.UtcNow.DateTime);
+
+    private bool UserCanManage(string? leadPoUserId, string? currentUserId)
+    {
+        if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(currentUserId) && string.Equals(leadPoUserId, currentUserId, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed record MutationContext(List<ProjectStage> Stages);
 }

--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -1,7 +1,14 @@
 @page "{id:int}"
 @model ProjectManagement.Pages.Projects.ViewModel
+@using ProjectManagement.Models.Execution
 @{
     ViewData["Title"] = Model.Item.Name;
+    var ragClass = Model.ProjectRag switch
+    {
+        ProjectRagStatus.Red => "badge bg-danger",
+        ProjectRagStatus.Amber => "badge bg-warning text-dark",
+        _ => "badge bg-success"
+    };
 }
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h2 class="mb-0">@Model.Item.Name</h2>
@@ -14,6 +21,25 @@
     @Model.StatusMessage
   </div>
 }
+
+<div class="border rounded p-3 mb-3">
+  <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+    <div>
+      <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+    </div>
+    <div class="flex-grow-1">
+      <div class="fw-semibold mb-1">Slip (days)</div>
+      <ul class="list-inline mb-0">
+        @foreach (var slip in Model.StageSlips)
+        {
+          <li class="list-inline-item mb-1">
+            <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
+          </li>
+        }
+      </ul>
+    </div>
+  </div>
+</div>
 
 <dl class="row">
   <dt class="col-sm-3">Description</dt>

--- a/Program.cs
+++ b/Program.cs
@@ -136,6 +136,7 @@ builder.Services.AddHostedService<LoginAggregationWorker>();
 builder.Services.AddHostedService<TodoPurgeWorker>();
 builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
+builder.Services.AddScoped<StageRulesService>();
 
 builder.Services.ConfigureHttpJsonOptions(o =>
 {

--- a/Services/StageRulesService.cs
+++ b/Services/StageRulesService.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Services;
+
+public class StageRulesService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly SemaphoreSlim _dependencyLock = new(1, 1);
+    private IReadOnlyDictionary<string, IReadOnlyList<string>>? _dependencyCache;
+
+    public StageRulesService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<StageRulesContext> GetContextAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var stages = await _db.ProjectStages
+            .AsNoTracking()
+            .Where(ps => ps.ProjectId == projectId)
+            .ToListAsync(cancellationToken);
+
+        return await BuildContextAsync(stages, cancellationToken);
+    }
+
+    public async Task<StageRulesContext> BuildContextAsync(IEnumerable<ProjectStage> stages, CancellationToken cancellationToken)
+    {
+        if (stages == null)
+        {
+            throw new ArgumentNullException(nameof(stages));
+        }
+
+        var stageSnapshots = stages
+            .Select(ps => new StageSnapshot(ps.StageCode, ps.Status, ps.ActualStart, ps.CompletedOn))
+            .ToList();
+
+        var dependencies = await GetDependencyMapAsync(cancellationToken);
+        return new StageRulesContext(stageSnapshots, dependencies);
+    }
+
+    public StageGuardResult CanStart(StageRulesContext context, string stageCode)
+    {
+        if (!context.TryGetStage(stageCode, out var stage))
+        {
+            return StageGuardResult.Deny($"Stage {stageCode} is not configured for this project.");
+        }
+
+        if (stage.Status == StageStatus.Completed)
+        {
+            return StageGuardResult.Deny($"Stage {stage.Code} is already completed.");
+        }
+
+        if (stage.Status == StageStatus.InProgress)
+        {
+            return StageGuardResult.Deny($"Stage {stage.Code} has already started.");
+        }
+
+        if (stage.Status == StageStatus.Skipped)
+        {
+            return StageGuardResult.Deny($"Stage {stage.Code} was skipped.");
+        }
+
+        foreach (var dependencyCode in context.GetDependencies(stageCode))
+        {
+            if (!context.TryGetStage(dependencyCode, out var dependency))
+            {
+                return StageGuardResult.Deny($"Dependency {dependencyCode} is missing for stage {stage.Code}.");
+            }
+
+            if (dependency.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            {
+                return StageGuardResult.Deny($"Complete or skip {dependency.Code} before starting {stage.Code}.");
+            }
+        }
+
+        if (string.Equals(stage.Code, "EAS", StringComparison.OrdinalIgnoreCase))
+        {
+            if (context.TryGetStage("PNC", out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            {
+                return StageGuardResult.Deny("EAS cannot start until PNC is completed or skipped.");
+            }
+        }
+
+        return StageGuardResult.Allow();
+    }
+
+    public StageGuardResult CanComplete(StageRulesContext context, string stageCode)
+    {
+        if (!context.TryGetStage(stageCode, out var stage))
+        {
+            return StageGuardResult.Deny($"Stage {stageCode} is not configured for this project.");
+        }
+
+        if (stage.Status == StageStatus.Completed)
+        {
+            return StageGuardResult.Deny($"Stage {stage.Code} is already completed.");
+        }
+
+        if (stage.Status == StageStatus.Skipped)
+        {
+            return StageGuardResult.Deny($"Stage {stage.Code} was skipped.");
+        }
+
+        if (stage.Status != StageStatus.InProgress)
+        {
+            return StageGuardResult.Deny($"Start {stage.Code} before completing it.");
+        }
+
+        if (string.Equals(stage.Code, "COB", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!context.TryGetStage("TEC", out var tec) || tec.Status != StageStatus.Completed)
+            {
+                return StageGuardResult.Deny("COB cannot complete until TEC is completed.");
+            }
+
+            if (!context.TryGetStage("BENCH", out var bench) || bench.Status != StageStatus.Completed)
+            {
+                return StageGuardResult.Deny("COB cannot complete until BENCH is completed.");
+            }
+        }
+
+        if (string.Equals(stage.Code, "EAS", StringComparison.OrdinalIgnoreCase))
+        {
+            if (context.TryGetStage("PNC", out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            {
+                return StageGuardResult.Deny("EAS cannot complete until PNC is completed or skipped.");
+            }
+        }
+
+        return StageGuardResult.Allow();
+    }
+
+    public StageGuardResult CanSkip(StageRulesContext context, string stageCode)
+    {
+        if (!string.Equals(stageCode, "PNC", StringComparison.OrdinalIgnoreCase))
+        {
+            return StageGuardResult.Deny("Only PNC can be skipped.");
+        }
+
+        if (!context.TryGetStage(stageCode, out var stage))
+        {
+            return StageGuardResult.Deny("PNC stage is not configured for this project.");
+        }
+
+        if (stage.Status == StageStatus.Completed)
+        {
+            return StageGuardResult.Deny("PNC is already completed.");
+        }
+
+        if (stage.Status == StageStatus.Skipped)
+        {
+            return StageGuardResult.Deny("PNC has already been skipped.");
+        }
+
+        return StageGuardResult.Allow();
+    }
+
+    private async Task<IReadOnlyDictionary<string, IReadOnlyList<string>>> GetDependencyMapAsync(CancellationToken cancellationToken)
+    {
+        if (_dependencyCache != null)
+        {
+            return _dependencyCache;
+        }
+
+        await _dependencyLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_dependencyCache == null)
+            {
+                var dependencies = await _db.StageDependencyTemplates
+                    .AsNoTracking()
+                    .Where(d => d.Version == PlanConstants.StageTemplateVersion)
+                    .ToListAsync(cancellationToken);
+
+                _dependencyCache = dependencies
+                    .GroupBy(d => d.FromStageCode, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => (IReadOnlyList<string>)g.Select(x => x.DependsOnStageCode).ToList(),
+                        StringComparer.OrdinalIgnoreCase);
+            }
+        }
+        finally
+        {
+            _dependencyLock.Release();
+        }
+
+        return _dependencyCache;
+    }
+}
+
+public sealed class StageRulesContext
+{
+    private readonly Dictionary<string, StageSnapshot> _stages;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _dependencies;
+
+    public StageRulesContext(IEnumerable<StageSnapshot> stages, IReadOnlyDictionary<string, IReadOnlyList<string>> dependencies)
+    {
+        _stages = stages.ToDictionary(s => s.Code, StringComparer.OrdinalIgnoreCase);
+        _dependencies = dependencies;
+    }
+
+    public bool TryGetStage(string stageCode, out StageSnapshot stage)
+        => _stages.TryGetValue(stageCode, out stage!);
+
+    public IReadOnlyList<string> GetDependencies(string stageCode)
+        => _dependencies.TryGetValue(stageCode, out var deps) ? deps : Array.Empty<string>();
+}
+
+public record StageSnapshot(string Code, StageStatus Status, DateOnly? ActualStart, DateOnly? CompletedOn);
+
+public record StageGuardResult(bool Allowed, string? Reason)
+{
+    public static StageGuardResult Allow() => new(true, null);
+    public static StageGuardResult Deny(string reason) => new(false, reason);
+}


### PR DESCRIPTION
## Summary
- add a StageRulesService to centralize start/complete/skip guard logic and enforce COB/PNC rules
- compute slip days and project RAG via a new stage health calculator and surface them on project pages
- add Razor Page handlers and UI controls so authorised users can start, complete, or skip stages with server-side validation

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d5100ade148329a0b986c702cc4480