### PR TITLE
Add project comment system with attachments

### DIFF
--- a/Migrations/20251015120000_AddProjectComments.Designer.cs
+++ b/Migrations/20251015120000_AddProjectComments.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,10 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251015120000_AddProjectComments")]
+    partial class AddProjectComments : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251015120000_AddProjectComments.cs
+++ b/Migrations/20251015120000_AddProjectComments.cs
@@ -1,0 +1,152 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectComments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProjectComments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    ProjectStageId = table.Column<int>(type: "integer", nullable: true),
+                    ParentCommentId = table.Column<int>(type: "integer", nullable: true),
+                    Body = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    Type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Pinned = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    CreatedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    EditedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    EditedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectComments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectComments_ProjectComments_ParentCommentId",
+                        column: x => x.ParentCommentId,
+                        principalTable: "ProjectComments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectComments_ProjectStages_ProjectStageId",
+                        column: x => x.ProjectStageId,
+                        principalTable: "ProjectStages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectComments_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectCommentAttachments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CommentId = table.Column<int>(type: "integer", nullable: false),
+                    FileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    SizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    StoragePath = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    UploadedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    UploadedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectCommentAttachments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectCommentAttachments_ProjectComments_CommentId",
+                        column: x => x.CommentId,
+                        principalTable: "ProjectComments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectCommentMentions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CommentId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectCommentMentions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectCommentMentions_ProjectComments_CommentId",
+                        column: x => x.CommentId,
+                        principalTable: "ProjectComments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectCommentMentions_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectCommentAttachments_CommentId",
+                table: "ProjectCommentAttachments",
+                column: "CommentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectCommentMentions_CommentId_UserId",
+                table: "ProjectCommentMentions",
+                columns: new[] { "CommentId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectCommentMentions_UserId",
+                table: "ProjectCommentMentions",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectComments_ParentCommentId",
+                table: "ProjectComments",
+                column: "ParentCommentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectComments_ProjectId_CreatedOn",
+                table: "ProjectComments",
+                columns: new[] { "ProjectId", "CreatedOn" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectComments_ProjectStageId",
+                table: "ProjectComments",
+                column: "ProjectStageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectCommentAttachments");
+
+            migrationBuilder.DropTable(
+                name: "ProjectCommentMentions");
+
+            migrationBuilder.DropTable(
+                name: "ProjectComments");
+        }
+    }
+}

--- a/Models/ProjectComment.cs
+++ b/Models/ProjectComment.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models
+{
+    public enum ProjectCommentType
+    {
+        Update = 0,
+        Risk = 1,
+        Blocker = 2,
+        Decision = 3,
+        Info = 4
+    }
+
+    public class ProjectComment
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int ProjectId { get; set; }
+
+        public int? ProjectStageId { get; set; }
+
+        public int? ParentCommentId { get; set; }
+
+        [Required]
+        [MaxLength(2000)]
+        [MinLength(4)]
+        public string Body { get; set; } = string.Empty;
+
+        [Required]
+        public ProjectCommentType Type { get; set; }
+
+        public bool Pinned { get; set; }
+
+        public bool IsDeleted { get; set; }
+
+        [Required]
+        [MaxLength(450)]
+        public string CreatedByUserId { get; set; } = string.Empty;
+
+        public ApplicationUser? CreatedByUser { get; set; }
+
+        public DateTime CreatedOn { get; set; }
+
+        [MaxLength(450)]
+        public string? EditedByUserId { get; set; }
+
+        public ApplicationUser? EditedByUser { get; set; }
+
+        public DateTime? EditedOn { get; set; }
+
+        public Project? Project { get; set; }
+
+        public ProjectStage? ProjectStage { get; set; }
+
+        public ProjectComment? ParentComment { get; set; }
+
+        public ICollection<ProjectComment> Replies { get; set; } = new List<ProjectComment>();
+
+        public ICollection<ProjectCommentAttachment> Attachments { get; set; } = new List<ProjectCommentAttachment>();
+
+        public ICollection<ProjectCommentMention> Mentions { get; set; } = new List<ProjectCommentMention>();
+    }
+
+    public class ProjectCommentAttachment
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int CommentId { get; set; }
+
+        public ProjectComment Comment { get; set; } = null!;
+
+        [Required]
+        [MaxLength(260)]
+        public string FileName { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(128)]
+        public string ContentType { get; set; } = string.Empty;
+
+        public long SizeBytes { get; set; }
+
+        [Required]
+        [MaxLength(512)]
+        public string StoragePath { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(450)]
+        public string UploadedByUserId { get; set; } = string.Empty;
+
+        public ApplicationUser? UploadedByUser { get; set; }
+
+        public DateTime UploadedOn { get; set; }
+    }
+
+    public class ProjectCommentMention
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int CommentId { get; set; }
+
+        public ProjectComment Comment { get; set; } = null!;
+
+        [Required]
+        [MaxLength(450)]
+        public string UserId { get; set; } = string.Empty;
+
+        public ApplicationUser? User { get; set; }
+    }
+}

--- a/Pages/Projects/Activity.cshtml
+++ b/Pages/Projects/Activity.cshtml
@@ -1,0 +1,123 @@
+@page
+@using System.Collections.Generic
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
+@model ProjectManagement.Pages.Projects.ActivityModel
+@{
+    ViewData["Title"] = "Project Activity";
+}
+
+<h1 class="mb-3">Project activity</h1>
+<p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
+
+<section class="mb-4">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <form method="get" class="row gy-3 gx-3 align-items-end">
+                <input type="hidden" name="id" value="@Model.ProjectId" />
+
+                <div class="col-12 col-md-3">
+                    <label asp-for="Type" class="form-label">Type</label>
+                    <select asp-for="Type" asp-items="Model.TypeOptions" class="form-select">
+                        <option value="">All types</option>
+                    </select>
+                </div>
+
+                <div class="col-12 col-md-3">
+                    <label asp-for="StageId" class="form-label">Stage</label>
+                    <select asp-for="StageId" asp-items="Model.StageOptions" class="form-select">
+                        <option value="">All stages</option>
+                    </select>
+                </div>
+
+                <div class="col-12 col-md-3">
+                    <label asp-for="AuthorId" class="form-label">Author</label>
+                    <select asp-for="AuthorId" asp-items="Model.AuthorOptions" class="form-select">
+                        <option value="">All authors</option>
+                    </select>
+                </div>
+
+                <div class="col-6 col-md-1">
+                    <label asp-for="From" class="form-label">From</label>
+                    <input asp-for="From" class="form-control" type="date" />
+                </div>
+
+                <div class="col-6 col-md-1">
+                    <label asp-for="To" class="form-label">To</label>
+                    <input asp-for="To" class="form-control" type="date" />
+                </div>
+
+                <div class="col-12 col-md-1 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary flex-grow-1">Filter</button>
+                    <a class="btn btn-outline-secondary" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId">Reset</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+
+@if (Model.CanComment)
+{
+    <section class="mb-4">
+        @await Html.PartialAsync("_CommentComposer", Model.Composer)
+    </section>
+}
+
+<section class="mb-4">
+    <h2 class="h4 mb-3">Remarks</h2>
+    @{
+        var routeValues = new Dictionary<string, object?>();
+        if (Model.Type.HasValue)
+        {
+            routeValues["Type"] = Model.Type;
+        }
+        if (!string.IsNullOrEmpty(Model.AuthorId))
+        {
+            routeValues["AuthorId"] = Model.AuthorId;
+        }
+        if (Model.StageId.HasValue)
+        {
+            routeValues["StageId"] = Model.StageId;
+        }
+        if (Model.From.HasValue)
+        {
+            routeValues["From"] = Model.From.Value.ToString("yyyy-MM-dd");
+        }
+        if (Model.To.HasValue)
+        {
+            routeValues["To"] = Model.To.Value.ToString("yyyy-MM-dd");
+        }
+        if (Model.CurrentPage > 1)
+        {
+            routeValues["Page"] = Model.CurrentPage;
+        }
+
+        var threadViewData = new ViewDataDictionary(ViewData)
+        {
+            ["CommentsPage"] = "/Projects/Activity",
+            ["ProjectId"] = Model.ProjectId,
+            ["ShowStage"] = true,
+            ["RouteValues"] = routeValues
+        };
+    }
+    @await Html.PartialAsync("_CommentThread", Model.Comments, threadViewData)
+</section>
+
+@if (Model.TotalPages > 1)
+{
+    <nav aria-label="Activity pagination">
+        <ul class="pagination">
+            <li class="page-item @(Model.CurrentPage == 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId" asp-route-Type="@Model.Type" asp-route-AuthorId="@Model.AuthorId" asp-route-StageId="@Model.StageId" asp-route-From="@Model.From" asp-route-To="@Model.To" asp-route-Page="@(Model.CurrentPage - 1)">Previous</a>
+            </li>
+            @for (var i = 1; i <= Model.TotalPages; i++)
+            {
+                <li class="page-item @(Model.CurrentPage == i ? "active" : string.Empty)">
+                    <a class="page-link" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId" asp-route-Type="@Model.Type" asp-route-AuthorId="@Model.AuthorId" asp-route-StageId="@Model.StageId" asp-route-From="@Model.From" asp-route-To="@Model.To" asp-route-Page="@i">@i</a>
+                </li>
+            }
+            <li class="page-item @(Model.CurrentPage == Model.TotalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId" asp-route-Type="@Model.Type" asp-route-AuthorId="@Model.AuthorId" asp-route-StageId="@Model.StageId" asp-route-From="@Model.From" asp-route-To="@Model.To" asp-route-Page="@(Model.CurrentPage + 1)">Next</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/Pages/Projects/Activity.cshtml.cs
+++ b/Pages/Projects/Activity.cshtml.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Pages.Projects;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize]
+    public class ActivityModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ProjectCommentService _commentService;
+
+        private const int PageSize = 20;
+
+        public ActivityModel(ApplicationDbContext db, UserManager<ApplicationUser> userManager, ProjectCommentService commentService)
+        {
+            _db = db;
+            _userManager = userManager;
+            _commentService = commentService;
+        }
+
+        public int ProjectId { get; private set; }
+        public string ProjectName { get; private set; } = string.Empty;
+        public List<CommentDisplayModel> Comments { get; private set; } = new();
+        public CommentComposerViewModel Composer { get; private set; } = new();
+        public List<SelectListItem> StageOptions { get; private set; } = new();
+        public List<SelectListItem> TypeOptions { get; private set; } = new();
+        public List<SelectListItem> AuthorOptions { get; private set; } = new();
+        public int CurrentPage { get; private set; } = 1;
+        public int TotalPages { get; private set; } = 1;
+        public bool CanComment { get; private set; }
+
+        [TempData]
+        public string? StatusMessage { get; set; }
+
+        [TempData]
+        public string? ErrorMessage { get; set; }
+
+        [BindProperty(Name = "Form")]
+        public CommentFormModel Input { get; set; } = new();
+
+        [BindProperty(SupportsGet = true)]
+        public ProjectCommentType? Type { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string? AuthorId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public int? StageId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public DateOnly? From { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public DateOnly? To { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public int Page { get; set; } = 1;
+
+        [BindProperty(SupportsGet = true, Name = "parentId")]
+        public int? ReplyTo { get; set; }
+
+        [BindProperty(SupportsGet = true, Name = "editId")]
+        public int? EditId { get; set; }
+
+        private static readonly string[] CommentRoles = new[] { "Admin", "HoD", "Project Officer", "MCO", "Comdt" };
+
+        public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+        {
+            var project = await _db.Projects
+                .AsNoTracking()
+                .Where(p => p.Id == id)
+                .Select(p => new { p.Id, p.Name })
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (project == null)
+            {
+                return NotFound();
+            }
+
+            ProjectId = project.Id;
+            ProjectName = project.Name;
+            CanComment = UserCanComment();
+
+            await LoadSelectListsAsync(id, cancellationToken);
+            await PrepareComposerAsync(cancellationToken);
+            await LoadCommentsAsync(id, cancellationToken);
+
+            return Page();
+        }
+
+        [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
+        public async Task<IActionResult> OnPostCommentAsync(int id, CancellationToken cancellationToken)
+        {
+            ProjectId = id;
+            CanComment = UserCanComment();
+            if (!CanComment)
+            {
+                return Forbid();
+            }
+
+            Input.ProjectId = id;
+
+            var project = await _db.Projects.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+            if (project == null)
+            {
+                return NotFound();
+            }
+
+            await LoadSelectListsAsync(id, cancellationToken);
+
+            if (!ModelState.IsValid)
+            {
+                await PrepareComposerAsync(cancellationToken);
+                await LoadCommentsAsync(id, cancellationToken);
+                return Page();
+            }
+
+            var userId = _userManager.GetUserId(User)!;
+
+            try
+            {
+                if (Input.EditingCommentId.HasValue)
+                {
+                    var updated = await _commentService.UpdateAsync(Input.EditingCommentId.Value, userId, Input.Body, Input.Type, Input.Pinned, Input.Files, cancellationToken);
+                    if (updated == null)
+                    {
+                        ErrorMessage = "Unable to edit the remark.";
+                    }
+                    else
+                    {
+                        StatusMessage = "Remark updated.";
+                    }
+                }
+                else
+                {
+                    await _commentService.CreateAsync(id, Input.StageId, Input.ParentCommentId, Input.Body, Input.Type, Input.Pinned, userId, Input.Files, cancellationToken);
+                    StatusMessage = "Remark added.";
+                }
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = ex.Message;
+            }
+
+            var redirect = Input.RedirectTo ?? Url.Page("/Projects/Activity", new
+            {
+                id,
+                Type,
+                AuthorId,
+                StageId,
+                From,
+                To,
+                Page
+            });
+
+            if (!string.IsNullOrEmpty(redirect))
+            {
+                return Redirect(redirect);
+            }
+
+            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page });
+        }
+
+        [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
+        public async Task<IActionResult> OnPostDeleteCommentAsync(int id, int commentId, CancellationToken cancellationToken)
+        {
+            var userId = _userManager.GetUserId(User);
+            if (userId == null)
+            {
+                return Forbid();
+            }
+
+            var ok = await _commentService.SoftDeleteAsync(commentId, userId, cancellationToken);
+            StatusMessage = ok ? "Remark deleted." : "Unable to delete remark.";
+
+            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page });
+        }
+
+        public async Task<IActionResult> OnGetDownloadAttachmentAsync(int id, int commentId, int attachmentId, CancellationToken cancellationToken)
+        {
+            var result = await _commentService.OpenAttachmentAsync(id, commentId, attachmentId, cancellationToken);
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            var (attachment, stream) = result.Value;
+            return File(stream, attachment.ContentType, attachment.FileName);
+        }
+        private async Task LoadSelectListsAsync(int projectId, CancellationToken cancellationToken)
+        {
+            var stages = await _db.ProjectStages
+                .AsNoTracking()
+                .Where(s => s.ProjectId == projectId)
+                .OrderBy(s => s.StageCode)
+                .Select(s => new { s.Id, s.StageCode })
+                .ToListAsync(cancellationToken);
+
+            StageOptions = stages
+                .Select(s => new SelectListItem($"{s.StageCode}", s.Id.ToString()))
+                .ToList();
+
+            TypeOptions = Enum.GetValues<ProjectCommentType>()
+                .Select(t => new SelectListItem(t.ToString(), t.ToString()))
+                .ToList();
+
+            var authorData = await _db.ProjectComments
+                .AsNoTracking()
+                .Where(c => c.ProjectId == projectId && !c.IsDeleted)
+                .Select(c => new
+                {
+                    c.CreatedByUserId,
+                    Rank = c.CreatedByUser != null ? c.CreatedByUser.Rank : null,
+                    FullName = c.CreatedByUser != null ? c.CreatedByUser.FullName : null,
+                    UserName = c.CreatedByUser != null ? c.CreatedByUser.UserName : null
+                })
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            AuthorOptions = authorData
+                .Where(a => !string.IsNullOrEmpty(a.CreatedByUserId))
+                .Select(a =>
+                {
+                    var display = string.IsNullOrWhiteSpace(a.FullName)
+                        ? a.UserName
+                        : $"{a.Rank} {a.FullName}";
+
+                    if (string.IsNullOrWhiteSpace(display))
+                    {
+                        display = "Former user";
+                    }
+                    else
+                    {
+                        display = display.Trim();
+                    }
+
+                    return new SelectListItem(display ?? "Former user", a.CreatedByUserId!);
+                })
+                .OrderBy(a => a.Text)
+                .ToList();
+        }
+
+        private async Task PrepareComposerAsync(CancellationToken cancellationToken)
+        {
+            var composerForm = new CommentFormModel
+            {
+                ProjectId = ProjectId,
+                StageId = StageId,
+                ParentCommentId = ReplyTo,
+                EditingCommentId = EditId,
+                Body = Input.Body,
+                Type = Input.Type,
+                Pinned = Input.Pinned,
+                RedirectTo = Url.Page("/Projects/Activity", new
+                {
+                    id = ProjectId,
+                    Type,
+                    AuthorId,
+                    StageId,
+                    From,
+                    To,
+                    Page
+                })
+            };
+
+            if (ReplyTo.HasValue)
+            {
+                var parent = await _db.ProjectComments
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(c => c.Id == ReplyTo.Value && c.ProjectId == ProjectId && !c.IsDeleted, cancellationToken);
+
+                if (parent != null)
+                {
+                    composerForm.StageId ??= parent.ProjectStageId;
+                }
+            }
+
+            if (EditId.HasValue)
+            {
+                var comment = await _db.ProjectComments
+                    .AsNoTracking()
+                    .Where(c => c.Id == EditId.Value && c.ProjectId == ProjectId && !c.IsDeleted)
+                    .Select(c => new { c.Body, c.Type, c.Pinned, c.ProjectStageId, c.CreatedByUserId })
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                var userId = _userManager.GetUserId(User);
+                if (comment != null && userId != null && string.Equals(comment.CreatedByUserId, userId, StringComparison.Ordinal))
+                {
+                    composerForm.Body = comment.Body;
+                    composerForm.Type = comment.Type;
+                    composerForm.Pinned = comment.Pinned;
+                    composerForm.StageId = comment.ProjectStageId;
+                }
+                else
+                {
+                    EditId = null;
+                    composerForm.EditingCommentId = null;
+                }
+            }
+
+            Composer = new CommentComposerViewModel
+            {
+                FormHandler = "Comment",
+                Form = composerForm,
+                StageOptions = StageOptions,
+                TypeOptions = TypeOptions,
+                SubmitButtonLabel = EditId.HasValue ? "Save" : ReplyTo.HasValue ? "Reply" : "Post",
+                Legend = EditId.HasValue ? "Edit remark" : ReplyTo.HasValue ? "Reply to remark" : "Add a remark",
+                ShowStagePicker = !ReplyTo.HasValue,
+                ShowPinnedToggle = true,
+                MaxFileSizeBytes = ProjectCommentService.MaxAttachmentSizeBytes,
+                StatusMessage = StatusMessage,
+                ErrorMessage = ErrorMessage
+            };
+        }
+
+        private async Task LoadCommentsAsync(int projectId, CancellationToken cancellationToken)
+        {
+            CurrentPage = Page < 1 ? 1 : Page;
+            var userId = _userManager.GetUserId(User);
+            var canComment = UserCanComment();
+
+            var baseQuery = _db.ProjectComments
+                .AsNoTracking()
+                .Where(c => c.ProjectId == projectId && !c.IsDeleted && c.ParentCommentId == null);
+
+            if (Type.HasValue)
+            {
+                baseQuery = baseQuery.Where(c => c.Type == Type.Value);
+            }
+
+            if (!string.IsNullOrEmpty(AuthorId))
+            {
+                baseQuery = baseQuery.Where(c => c.CreatedByUserId == AuthorId);
+            }
+
+            if (StageId.HasValue)
+            {
+                baseQuery = baseQuery.Where(c => c.ProjectStageId == StageId);
+            }
+
+            if (From.HasValue)
+            {
+                var fromDate = From.Value.ToDateTime(TimeOnly.MinValue);
+                baseQuery = baseQuery.Where(c => c.CreatedOn >= fromDate);
+            }
+
+            if (To.HasValue)
+            {
+                var toDate = To.Value.ToDateTime(TimeOnly.MaxValue);
+                baseQuery = baseQuery.Where(c => c.CreatedOn <= toDate);
+            }
+
+            var total = await baseQuery.CountAsync(cancellationToken);
+            TotalPages = Math.Max(1, (int)Math.Ceiling(total / (double)PageSize));
+            if (CurrentPage > TotalPages)
+            {
+                CurrentPage = TotalPages;
+            }
+
+            var skip = (CurrentPage - 1) * PageSize;
+
+            var topLevel = await baseQuery
+                .OrderByDescending(c => c.Pinned)
+                .ThenByDescending(c => c.CreatedOn)
+                .Skip(skip)
+                .Take(PageSize)
+                .Select(c => new
+                {
+                    Comment = c,
+                    Author = c.CreatedByUser,
+                    Stage = c.ProjectStage,
+                    Attachments = c.Attachments.OrderBy(a => a.FileName).Select(a => new { a.Id, a.FileName, a.SizeBytes }).ToList(),
+                    Replies = c.Replies
+                        .Where(r => !r.IsDeleted)
+                        .OrderBy(r => r.CreatedOn)
+                        .Select(r => new
+                        {
+                            Reply = r,
+                            Author = r.CreatedByUser,
+                            Attachments = r.Attachments.OrderBy(a => a.FileName).Select(a => new { a.Id, a.FileName, a.SizeBytes }).ToList()
+                        }).ToList()
+                })
+                .ToListAsync(cancellationToken);
+
+            Comments = topLevel.Select(c =>
+            {
+                var comment = c.Comment;
+                var authorName = BuildAuthorName(c.Author, comment.CreatedByUserId);
+                return new CommentDisplayModel
+                {
+                    Id = comment.Id,
+                    ProjectId = comment.ProjectId,
+                    Body = comment.Body,
+                    Type = comment.Type,
+                    Pinned = comment.Pinned,
+                    CreatedOn = comment.CreatedOn,
+                    EditedOn = comment.EditedOn,
+                    AuthorId = comment.CreatedByUserId,
+                    AuthorName = authorName,
+                    StageCode = c.Stage?.StageCode,
+                    StageName = c.Stage?.StageCode,
+                    Attachments = c.Attachments
+                        .Select(a => new CommentAttachmentViewModel(a.Id, a.FileName, a.SizeBytes))
+                        .ToList(),
+                    Replies = c.Replies.Select(r => new CommentReplyModel
+                    {
+                        Id = r.Reply.Id,
+                        ProjectId = r.Reply.ProjectId,
+                        Body = r.Reply.Body,
+                        Type = r.Reply.Type,
+                        CreatedOn = r.Reply.CreatedOn,
+                        EditedOn = r.Reply.EditedOn,
+                        AuthorId = r.Reply.CreatedByUserId,
+                        AuthorName = BuildAuthorName(r.Author, r.Reply.CreatedByUserId),
+                        Attachments = r.Attachments.Select(a => new CommentAttachmentViewModel(a.Id, a.FileName, a.SizeBytes)).ToList(),
+                        CanEdit = canComment && userId != null && string.Equals(r.Reply.CreatedByUserId, userId, StringComparison.Ordinal)
+                    }).ToList(),
+                    CanEdit = canComment && userId != null && string.Equals(comment.CreatedByUserId, userId, StringComparison.Ordinal),
+                    CanReply = canComment
+                };
+            }).ToList();
+        }
+
+        private static string BuildAuthorName(ApplicationUser? user, string userId)
+        {
+            if (user == null)
+            {
+                return string.IsNullOrEmpty(userId) ? "Unknown" : "Former user";
+            }
+
+            var display = string.IsNullOrWhiteSpace(user.FullName) ? user.UserName : $"{user.Rank} {user.FullName}";
+            return string.IsNullOrWhiteSpace(display) ? user.UserName ?? "User" : display.Trim();
+        }
+
+        private bool UserCanComment()
+        {
+            foreach (var role in CommentRoles)
+            {
+                if (User.IsInRole(role))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Pages/Projects/CommentViewModels.cs
+++ b/Pages/Projects/CommentViewModels.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Pages.Projects
+{
+    public class CommentFormModel
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        public int? StageId { get; set; }
+
+        public int? ParentCommentId { get; set; }
+
+        public int? EditingCommentId { get; set; }
+
+        [Required]
+        [StringLength(2000, MinimumLength = 4)]
+        public string Body { get; set; } = string.Empty;
+
+        [Required]
+        public ProjectCommentType Type { get; set; } = ProjectCommentType.Update;
+
+        public bool Pinned { get; set; }
+
+        public List<IFormFile> Files { get; set; } = new();
+
+        public string? RedirectTo { get; set; }
+    }
+
+    public class CommentComposerViewModel
+    {
+        public string FormHandler { get; init; } = "Comment";
+
+        public CommentFormModel Form { get; init; } = new();
+
+        public IEnumerable<SelectListItem> StageOptions { get; init; } = new List<SelectListItem>();
+
+        public IEnumerable<SelectListItem> TypeOptions { get; init; } = new List<SelectListItem>();
+
+        public string SubmitButtonLabel { get; init; } = "Post";
+
+        public string? Legend { get; init; }
+
+        public bool ShowStagePicker { get; init; } = true;
+
+        public bool ShowPinnedToggle { get; init; } = true;
+
+        public long MaxFileSizeBytes { get; init; }
+
+        public string? StatusMessage { get; init; }
+
+        public string? ErrorMessage { get; init; }
+    }
+
+    public record CommentAttachmentViewModel(int Id, string FileName, long SizeBytes);
+
+    public class CommentReplyModel
+    {
+        public int Id { get; init; }
+
+        public int ProjectId { get; init; }
+
+        public string Body { get; init; } = string.Empty;
+
+        public ProjectCommentType Type { get; init; }
+
+        public DateTime CreatedOn { get; init; }
+
+        public DateTime? EditedOn { get; init; }
+
+        public string AuthorName { get; init; } = string.Empty;
+
+        public string? AuthorId { get; init; }
+
+        public IReadOnlyList<CommentAttachmentViewModel> Attachments { get; init; } = new List<CommentAttachmentViewModel>();
+
+        public bool CanEdit { get; init; }
+    }
+
+    public class CommentDisplayModel
+    {
+        public int Id { get; init; }
+
+        public int ProjectId { get; init; }
+
+        public string Body { get; init; } = string.Empty;
+
+        public ProjectCommentType Type { get; init; }
+
+        public bool Pinned { get; init; }
+
+        public DateTime CreatedOn { get; init; }
+
+        public DateTime? EditedOn { get; init; }
+
+        public string AuthorName { get; init; } = string.Empty;
+
+        public string? AuthorId { get; init; }
+
+        public string? StageCode { get; init; }
+
+        public string? StageName { get; init; }
+
+        public IReadOnlyList<CommentAttachmentViewModel> Attachments { get; init; } = new List<CommentAttachmentViewModel>();
+
+        public IReadOnlyList<CommentReplyModel> Replies { get; init; } = new List<CommentReplyModel>();
+
+        public bool CanEdit { get; init; }
+
+        public bool CanReply { get; init; }
+    }
+}

--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -1,5 +1,8 @@
 @page
 @model ProjectManagement.Pages.Projects.StagesModel
+@using System.Collections.Generic
+@using System.Linq
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
 @using ProjectManagement.Models.Execution
 @{
     ViewData["Title"] = "Project Stages";
@@ -108,3 +111,44 @@
 </div>
 
 <a class="btn btn-outline-secondary mt-3" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back to Project</a>
+
+<section class="mt-5">
+    <h2 class="h4 mb-3">Stage remarks</h2>
+    <form method="get" class="row gy-3 gx-3 align-items-end mb-3">
+        <input type="hidden" name="id" value="@Model.ProjectId" />
+        <div class="col-12 col-md-4">
+            <label asp-for="CommentStageId" class="form-label">Stage</label>
+            <select asp-for="CommentStageId" asp-items="Model.CommentStageOptions" class="form-select"></select>
+        </div>
+        <div class="col-12 col-md-2">
+            <button type="submit" class="btn btn-primary">View</button>
+        </div>
+    </form>
+
+    @if (Model.CanComment && Model.CommentStageOptions.Any())
+    {
+        <div class="mb-3">
+            @await Html.PartialAsync("_CommentComposer", Model.CommentComposer)
+        </div>
+    }
+
+    @{
+        var routeValues = new Dictionary<string, object?>();
+        if (Model.CommentStageId.HasValue)
+        {
+            routeValues["commentStageId"] = Model.CommentStageId;
+        }
+        var threadViewData = new ViewDataDictionary(ViewData)
+        {
+            ["CommentsPage"] = "/Projects/Stages",
+            ["ProjectId"] = Model.ProjectId,
+            ["ShowStage"] = false,
+            ["RouteValues"] = routeValues,
+            ["ReplyParam"] = "commentParentId",
+            ["EditParam"] = "commentEditId",
+            ["DeleteHandler"] = "DeleteComment",
+            ["DownloadHandler"] = "DownloadAttachment"
+        };
+    }
+    @await Html.PartialAsync("_CommentThread", Model.StageComments, threadViewData)
+</section>

--- a/Pages/Shared/_CommentComposer.cshtml
+++ b/Pages/Shared/_CommentComposer.cshtml
@@ -1,0 +1,69 @@
+@model ProjectManagement.Pages.Projects.CommentComposerViewModel
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        @if (!string.IsNullOrEmpty(Model.Legend))
+        {
+            <h5 class="card-title">@Model.Legend</h5>
+        }
+        @if (!string.IsNullOrEmpty(Model.StatusMessage))
+        {
+            <div class="alert alert-success" role="alert">@Model.StatusMessage</div>
+        }
+        @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+        {
+            <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+        }
+        <form method="post" asp-page-handler="@Model.FormHandler" enctype="multipart/form-data" class="vstack gap-3">
+            <input type="hidden" asp-for="Form.ProjectId" />
+            @if (!Model.ShowStagePicker)
+            {
+                <input type="hidden" asp-for="Form.StageId" />
+            }
+            <input type="hidden" asp-for="Form.ParentCommentId" />
+            <input type="hidden" asp-for="Form.EditingCommentId" />
+            <input type="hidden" asp-for="Form.RedirectTo" />
+
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+            @if (Model.ShowStagePicker)
+            {
+                <div>
+                    <label asp-for="Form.StageId" class="form-label">Stage</label>
+                    <select asp-for="Form.StageId" asp-items="Model.StageOptions" class="form-select">
+                        <option value="">All stages</option>
+                    </select>
+                </div>
+            }
+
+            <div>
+                <label asp-for="Form.Type" class="form-label">Type</label>
+                <select asp-for="Form.Type" asp-items="Model.TypeOptions" class="form-select"></select>
+            </div>
+
+            <div>
+                <label asp-for="Form.Body" class="form-label">Remarks</label>
+                <textarea asp-for="Form.Body" class="form-control" rows="4" maxlength="2000" minlength="4"></textarea>
+                <span asp-validation-for="Form.Body" class="text-danger"></span>
+            </div>
+
+            @if (Model.ShowPinnedToggle)
+            {
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="Form.Pinned" />
+                    <label class="form-check-label" asp-for="Form.Pinned">Pin this remark</label>
+                </div>
+            }
+
+            <div>
+                <label class="form-label" asp-for="Form.Files">Attachments</label>
+                <input asp-for="Form.Files" class="form-control" type="file" multiple data-max-size="@Model.MaxFileSizeBytes" />
+                <div class="form-text">Maximum size @((Model.MaxFileSizeBytes / 1024 / 1024).ToString("0")) MB per file.</div>
+            </div>
+
+            <div class="d-flex justify-content-end gap-2">
+                <button type="submit" class="btn btn-primary">@Model.SubmitButtonLabel</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/Pages/Shared/_CommentThread.cshtml
+++ b/Pages/Shared/_CommentThread.cshtml
@@ -1,0 +1,142 @@
+@using System.Collections.Generic
+@using System.Linq
+@using Microsoft.AspNetCore.Routing
+@model IEnumerable<ProjectManagement.Pages.Projects.CommentDisplayModel>
+@{
+    var showStage = (bool?)(ViewData["ShowStage"] ?? false) ?? false;
+    var pageName = ViewData["CommentsPage"]?.ToString() ?? string.Empty;
+    var projectId = (int?)(ViewData["ProjectId"] ?? 0) ?? 0;
+    var routeValues = ViewData["RouteValues"] as IDictionary<string, object?> ?? new Dictionary<string, object?>();
+    var replyParam = ViewData["ReplyParam"]?.ToString() ?? "parentId";
+    var editParam = ViewData["EditParam"]?.ToString() ?? "editId";
+    var deleteHandler = ViewData["DeleteHandler"]?.ToString() ?? "DeleteComment";
+    var downloadHandler = ViewData["DownloadHandler"]?.ToString() ?? "DownloadAttachment";
+    var baseRoute = new RouteValueDictionary(routeValues)
+    {
+        ["id"] = projectId
+    };
+    Func<string?, object?, RouteValueDictionary> withRoute = (key, value) =>
+    {
+        var dict = new RouteValueDictionary(baseRoute);
+        if (!string.IsNullOrEmpty(key))
+        {
+            dict[key!] = value;
+        }
+        return dict;
+    };
+}
+
+@if (!Model.Any())
+{
+    <p class="text-muted">No remarks yet.</p>
+}
+else
+{
+    <div class="vstack gap-3">
+        @foreach (var comment in Model)
+        {
+            <article class="border rounded p-3 bg-white">
+                <div class="d-flex justify-content-between align-items-start gap-2">
+                    <div>
+                        <div class="d-flex align-items-center gap-2">
+                            <span class="badge bg-secondary">@comment.Type</span>
+                            @if (comment.Pinned)
+                            {
+                                <span class="badge bg-warning text-dark"><i class="bi bi-pin-angle"></i> Pinned</span>
+                            }
+                            <span class="text-muted small">@comment.CreatedOn.ToString("dd MMM yyyy HH:mm")</span>
+                        </div>
+                        <div class="fw-semibold">@comment.AuthorName</div>
+                        @if (showStage && !string.IsNullOrEmpty(comment.StageCode))
+                        {
+                            <div class="text-muted small">Stage: @comment.StageCode (@comment.StageName)</div>
+                        }
+                        <p class="mt-2 mb-0">@comment.Body</p>
+                        @if (comment.EditedOn.HasValue)
+                        {
+                            <div class="text-muted small">Edited @comment.EditedOn.Value.ToString("dd MMM yyyy HH:mm")</div>
+                        }
+                        @if (comment.Attachments.Any())
+                        {
+                            <ul class="list-unstyled mt-2 mb-0 small">
+                                @foreach (var attachment in comment.Attachments)
+                                {
+                                    @{ var downloadRoute = withRoute(null, null); downloadRoute["commentId"] = comment.Id; downloadRoute["attachmentId"] = attachment.Id; }
+                                    <li>
+                                        <a asp-page="@pageName" asp-page-handler="@downloadHandler" asp-all-route-data="@(downloadRoute)">
+                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@(System.Math.Max(1, attachment.SizeBytes / 1024)) KB)
+                                        </a>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </div>
+                    <div class="d-flex flex-column align-items-end gap-2">
+                        @if (comment.CanReply)
+                        {
+                            @{ var replyRoute = withRoute(replyParam, comment.Id); }
+                            <a class="btn btn-sm btn-outline-primary" asp-page="@pageName" asp-all-route-data="@(replyRoute)">Reply</a>
+                        }
+                        @if (comment.CanEdit)
+                        {
+                            @{ var editRoute = withRoute(editParam, comment.Id); var deleteRoute = withRoute(null, null); deleteRoute["commentId"] = comment.Id; }
+                            <a class="btn btn-sm btn-outline-secondary" asp-page="@pageName" asp-all-route-data="@(editRoute)">Edit</a>
+                            <form method="post" asp-page="@pageName" asp-page-handler="@deleteHandler" asp-all-route-data="@(deleteRoute)" data-confirm="Delete this remark?">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                            </form>
+                        }
+                    </div>
+                </div>
+
+                @if (comment.Replies.Any())
+                {
+                    <div class="mt-3 ms-3 ps-3 border-start border-2">
+                        @foreach (var reply in comment.Replies)
+                        {
+                            @{ var replyEditRoute = withRoute(editParam, reply.Id); var replyDeleteRoute = withRoute(null, null); replyDeleteRoute["commentId"] = reply.Id; }
+                            <div class="mb-3">
+                                <div class="d-flex justify-content-between align-items-start gap-2">
+                                    <div>
+                                        <div class="d-flex align-items-center gap-2">
+                                            <span class="badge bg-light text-dark border">@reply.Type</span>
+                                            <span class="text-muted small">@reply.CreatedOn.ToString("dd MMM yyyy HH:mm")</span>
+                                        </div>
+                                        <div class="fw-semibold">@reply.AuthorName</div>
+                                        <p class="mt-2 mb-0">@reply.Body</p>
+                                        @if (reply.EditedOn.HasValue)
+                                        {
+                                            <div class="text-muted small">Edited @reply.EditedOn.Value.ToString("dd MMM yyyy HH:mm")</div>
+                                        }
+                                        @if (reply.Attachments.Any())
+                                        {
+                                            <ul class="list-unstyled mt-2 mb-0 small">
+                                                @foreach (var attachment in reply.Attachments)
+                                                {
+                                                    @{ var replyDownloadRoute = withRoute(null, null); replyDownloadRoute["commentId"] = reply.Id; replyDownloadRoute["attachmentId"] = attachment.Id; }
+                                                    <li>
+                                                        <a asp-page="@pageName" asp-page-handler="@downloadHandler" asp-all-route-data="@(replyDownloadRoute)">
+                                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@(System.Math.Max(1, attachment.SizeBytes / 1024)) KB)
+                                                        </a>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
+                                    </div>
+                                    @if (reply.CanEdit)
+                                    {
+                                        <div class="d-flex flex-column gap-2">
+                                            <a class="btn btn-sm btn-outline-secondary" asp-page="@pageName" asp-all-route-data="@(replyEditRoute)">Edit</a>
+                                            <form method="post" asp-page="@pageName" asp-page-handler="@deleteHandler" asp-all-route-data="@(replyDeleteRoute)" data-confirm="Delete this remark?">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                            </form>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </article>
+        }
+    </div>
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -86,6 +86,7 @@
 
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/comments.js" asp-append-version="true" defer></script>
     @await RenderSectionAsync("Scripts", required: false)
     <script src="~/js/init.js" data-todo-src="@Url.Content("~/js/todo.js")" data-cele-src="@Url.Content("~/js/celebrations.js")" asp-append-version="true" defer></script>
 </body>

--- a/Program.cs
+++ b/Program.cs
@@ -137,6 +137,7 @@ builder.Services.AddHostedService<TodoPurgeWorker>();
 builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
+builder.Services.AddScoped<ProjectCommentService>();
 
 builder.Services.ConfigureHttpJsonOptions(o =>
 {

--- a/Services/ProjectCommentService.cs
+++ b/Services/ProjectCommentService.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services
+{
+    public class ProjectCommentService
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly IClock _clock;
+        private readonly IAuditService _audit;
+        private readonly ILogger<ProjectCommentService> _logger;
+        private readonly string _basePath;
+
+        public const long MaxAttachmentSizeBytes = 10 * 1024 * 1024; // 10 MB per file
+
+        public ProjectCommentService(ApplicationDbContext db, IClock clock, IAuditService audit, ILogger<ProjectCommentService> logger)
+        {
+            _db = db;
+            _clock = clock;
+            _audit = audit;
+            _logger = logger;
+            _basePath = Environment.GetEnvironmentVariable("PM_UPLOAD_ROOT") ?? "/var/pm/uploads";
+        }
+
+        public async Task<ProjectComment> CreateAsync(int projectId,
+                                                      int? projectStageId,
+                                                      int? parentCommentId,
+                                                      string body,
+                                                      ProjectCommentType type,
+                                                      bool pinned,
+                                                      string userId,
+                                                      IEnumerable<IFormFile> attachments,
+                                                      CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                throw new ArgumentException("Comment body is required.", nameof(body));
+            }
+
+            await EnsureStageBelongsToProject(projectId, projectStageId, cancellationToken);
+            var parent = await GetParentCommentForProjectAsync(projectId, parentCommentId, cancellationToken);
+
+            if (parent != null)
+            {
+                if (parent.ProjectStageId.HasValue)
+                {
+                    if (projectStageId.HasValue && parent.ProjectStageId.Value != projectStageId.Value)
+                    {
+                        throw new InvalidOperationException("Replies must stay within the same stage.");
+                    }
+
+                    projectStageId = parent.ProjectStageId;
+                }
+                else if (projectStageId.HasValue)
+                {
+                    throw new InvalidOperationException("Project-level remarks cannot target a stage.");
+                }
+            }
+
+            var now = _clock.UtcNow.UtcDateTime;
+
+            using var tx = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+            var comment = new ProjectComment
+            {
+                ProjectId = projectId,
+                ProjectStageId = projectStageId,
+                ParentCommentId = parentCommentId,
+                Body = body.Trim(),
+                Type = type,
+                Pinned = pinned,
+                IsDeleted = false,
+                CreatedByUserId = userId,
+                CreatedOn = now
+            };
+
+            _db.ProjectComments.Add(comment);
+            await _db.SaveChangesAsync(cancellationToken);
+
+            var saved = await SaveAttachmentsAsync(projectId, comment, attachments, userId, now, cancellationToken);
+            if (saved.Count > 0)
+            {
+                await _db.ProjectCommentAttachments.AddRangeAsync(saved, cancellationToken);
+                await _db.SaveChangesAsync(cancellationToken);
+            }
+
+            await tx.CommitAsync(cancellationToken);
+
+            comment.Attachments = saved;
+
+            await _audit.LogAsync("Comments.CommentAdded",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(),
+                    ["CommentId"] = comment.Id.ToString(),
+                    ["StageId"] = projectStageId?.ToString(),
+                    ["ParentCommentId"] = parentCommentId?.ToString(),
+                    ["AttachmentCount"] = saved.Count.ToString()
+                });
+
+            return comment;
+        }
+
+        public async Task<ProjectComment?> UpdateAsync(int commentId,
+                                                       string userId,
+                                                       string body,
+                                                       ProjectCommentType type,
+                                                       bool pinned,
+                                                       IEnumerable<IFormFile> newAttachments,
+                                                       CancellationToken cancellationToken)
+        {
+            var comment = await _db.ProjectComments
+                .Include(c => c.Attachments)
+                .FirstOrDefaultAsync(c => c.Id == commentId, cancellationToken);
+
+            if (comment == null || comment.IsDeleted)
+            {
+                return null;
+            }
+
+            if (!string.Equals(comment.CreatedByUserId, userId, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                throw new ArgumentException("Comment body is required.", nameof(body));
+            }
+
+            var now = _clock.UtcNow.UtcDateTime;
+
+            comment.Body = body.Trim();
+            comment.Type = type;
+            comment.Pinned = pinned;
+            comment.EditedByUserId = userId;
+            comment.EditedOn = now;
+
+            var saved = await SaveAttachmentsAsync(comment.ProjectId, comment, newAttachments, userId, now, cancellationToken);
+            if (saved.Count > 0)
+            {
+                await _db.ProjectCommentAttachments.AddRangeAsync(saved, cancellationToken);
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+
+            if (saved.Count > 0)
+            {
+                comment.Attachments = comment.Attachments.Concat(saved).ToList();
+            }
+
+            await _audit.LogAsync("Comments.CommentEdited",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["CommentId"] = comment.Id.ToString(),
+                    ["ProjectId"] = comment.ProjectId.ToString(),
+                    ["AttachmentCount"] = saved.Count > 0 ? saved.Count.ToString() : "0"
+                });
+
+            return comment;
+        }
+
+        public async Task<bool> SoftDeleteAsync(int commentId, string userId, CancellationToken cancellationToken)
+        {
+            var comment = await _db.ProjectComments.FirstOrDefaultAsync(c => c.Id == commentId, cancellationToken);
+            if (comment == null || comment.IsDeleted)
+            {
+                return false;
+            }
+
+            if (!string.Equals(comment.CreatedByUserId, userId, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            comment.IsDeleted = true;
+            comment.EditedByUserId = userId;
+            comment.EditedOn = _clock.UtcNow.UtcDateTime;
+
+            await _db.SaveChangesAsync(cancellationToken);
+
+            await _audit.LogAsync("Comments.CommentDeleted",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["CommentId"] = comment.Id.ToString(),
+                    ["ProjectId"] = comment.ProjectId.ToString()
+                });
+
+            return true;
+        }
+
+        public async Task<(ProjectCommentAttachment attachment, Stream stream)?> OpenAttachmentAsync(int projectId, int commentId, int attachmentId, CancellationToken cancellationToken)
+        {
+            var attachment = await _db.ProjectCommentAttachments
+                .Include(a => a.Comment)
+                .FirstOrDefaultAsync(a => a.Id == attachmentId && a.CommentId == commentId, cancellationToken);
+
+            if (attachment == null || attachment.Comment.IsDeleted || attachment.Comment.ProjectId != projectId)
+            {
+                return null;
+            }
+
+            if (!File.Exists(attachment.StoragePath))
+            {
+                _logger.LogWarning("Attachment file missing at path {Path} for attachment {AttachmentId}", attachment.StoragePath, attachmentId);
+                return null;
+            }
+
+            var stream = new FileStream(attachment.StoragePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return (attachment, stream);
+        }
+
+        private async Task EnsureStageBelongsToProject(int projectId, int? stageId, CancellationToken cancellationToken)
+        {
+            if (stageId == null)
+            {
+                return;
+            }
+
+            var exists = await _db.ProjectStages
+                .AsNoTracking()
+                .AnyAsync(s => s.Id == stageId.Value && s.ProjectId == projectId, cancellationToken);
+
+            if (!exists)
+            {
+                throw new InvalidOperationException("Stage not found for project.");
+            }
+        }
+
+        private async Task<ProjectComment?> GetParentCommentForProjectAsync(int projectId, int? parentId, CancellationToken cancellationToken)
+        {
+            if (parentId == null)
+            {
+                return null;
+            }
+
+            var parent = await _db.ProjectComments
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == parentId.Value && c.ProjectId == projectId && !c.IsDeleted, cancellationToken);
+
+            if (parent == null)
+            {
+                throw new InvalidOperationException("Parent comment not found.");
+            }
+
+            return parent;
+        }
+
+        private async Task<List<ProjectCommentAttachment>> SaveAttachmentsAsync(int projectId,
+                                                                                ProjectComment comment,
+                                                                                IEnumerable<IFormFile> files,
+                                                                                string userId,
+                                                                                DateTime timestamp,
+                                                                                CancellationToken cancellationToken)
+        {
+            var list = new List<ProjectCommentAttachment>();
+            if (files == null)
+            {
+                return list;
+            }
+
+            foreach (var file in files)
+            {
+                if (file == null || file.Length <= 0)
+                {
+                    continue;
+                }
+
+                if (file.Length > MaxAttachmentSizeBytes)
+                {
+                    throw new InvalidOperationException($"Attachment '{file.FileName}' exceeds the maximum size of {MaxAttachmentSizeBytes / (1024 * 1024)} MB.");
+                }
+
+                var contentType = string.IsNullOrWhiteSpace(file.ContentType)
+                    ? "application/octet-stream"
+                    : file.ContentType;
+
+                if (contentType.Length > 128)
+                {
+                    contentType = contentType[..128];
+                }
+
+                var safeFileName = SanitizeFileName(file.FileName);
+                var uniqueName = $"{Guid.NewGuid():n}{Path.GetExtension(safeFileName)}";
+                var directory = BuildCommentDirectory(projectId, comment.Id);
+                Directory.CreateDirectory(directory);
+                var fullPath = Path.Combine(directory, uniqueName);
+
+                await using (var target = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await file.CopyToAsync(target, cancellationToken);
+                }
+
+                list.Add(new ProjectCommentAttachment
+                {
+                    CommentId = comment.Id,
+                    FileName = safeFileName,
+                    ContentType = contentType,
+                    SizeBytes = file.Length,
+                    StoragePath = fullPath,
+                    UploadedByUserId = userId,
+                    UploadedOn = timestamp
+                });
+            }
+
+            return list;
+        }
+
+        private string BuildCommentDirectory(int projectId, int commentId)
+        {
+            return Path.Combine(_basePath, "projects", projectId.ToString(), "comments", commentId.ToString());
+        }
+
+        private static string SanitizeFileName(string? fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return "attachment";
+            }
+
+            var safe = Path.GetFileName(fileName);
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                safe = safe.Replace(c, '_');
+            }
+
+            return safe.Length > 200 ? safe[..200] : safe;
+        }
+    }
+}

--- a/wwwroot/js/comments.js
+++ b/wwwroot/js/comments.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const fileInputs = document.querySelectorAll('input[type="file"][data-max-size]');
+  fileInputs.forEach(input => {
+    input.addEventListener('change', () => {
+      const maxSize = Number.parseInt(input.getAttribute('data-max-size') ?? '0', 10);
+      if (!Number.isFinite(maxSize) || maxSize <= 0) {
+        return;
+      }
+
+      const files = Array.from(input.files ?? []);
+      const tooLarge = files.find(file => file.size > maxSize);
+      if (tooLarge) {
+        const sizeMb = (maxSize / (1024 * 1024)).toFixed(0);
+        window.alert(`File "${tooLarge.name}" exceeds the limit of ${sizeMb} MB.`);
+        input.value = '';
+      }
+    });
+  });
+
+  const confirmForms = document.querySelectorAll('form[data-confirm]');
+  confirmForms.forEach(form => {
+    form.addEventListener('submit', event => {
+      const message = form.getAttribute('data-confirm');
+      if (message && !window.confirm(message)) {
+        event.preventDefault();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add comment entities, EF configuration, and migration for project/stage remark threads
- implement a comment service that enforces ownership, manages attachments, and records audit events
- surface project activity and stage remark UIs with shared composer/thread partials plus client-side helpers
- register the comment service and load the new script bundle in the shared layout

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5181be3a08329b05f2591851e3818