### PR TITLE
Fix Razor route data and page binding issues

### DIFF
--- a/Pages/Projects/Activity.cshtml.cs
+++ b/Pages/Projects/Activity.cshtml.cs
@@ -67,8 +67,8 @@ namespace ProjectManagement.Pages.Projects
         [BindProperty(SupportsGet = true)]
         public DateOnly? To { get; set; }
 
-        [BindProperty(SupportsGet = true)]
-        public int Page { get; set; } = 1;
+        [BindProperty(SupportsGet = true, Name = "Page")]
+        public int PageIndex { get; set; } = 1;
 
         [BindProperty(SupportsGet = true, Name = "parentId")]
         public int? ReplyTo { get; set; }
@@ -164,7 +164,7 @@ namespace ProjectManagement.Pages.Projects
                 StageId,
                 From,
                 To,
-                Page
+                Page = PageIndex
             });
 
             if (!string.IsNullOrEmpty(redirect))
@@ -172,7 +172,7 @@ namespace ProjectManagement.Pages.Projects
                 return Redirect(redirect);
             }
 
-            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page });
+            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page = PageIndex });
         }
 
         [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
@@ -187,7 +187,7 @@ namespace ProjectManagement.Pages.Projects
             var ok = await _commentService.SoftDeleteAsync(commentId, userId, cancellationToken);
             StatusMessage = ok ? "Remark deleted." : "Unable to delete remark.";
 
-            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page });
+            return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page = PageIndex });
         }
 
         public async Task<IActionResult> OnGetDownloadAttachmentAsync(int id, int commentId, int attachmentId, CancellationToken cancellationToken)
@@ -273,7 +273,7 @@ namespace ProjectManagement.Pages.Projects
                     StageId,
                     From,
                     To,
-                    Page
+                    Page = PageIndex
                 })
             };
 
@@ -330,7 +330,7 @@ namespace ProjectManagement.Pages.Projects
 
         private async Task LoadCommentsAsync(int projectId, CancellationToken cancellationToken)
         {
-            CurrentPage = Page < 1 ? 1 : Page;
+            CurrentPage = PageIndex < 1 ? 1 : PageIndex;
             var userId = _userManager.GetUserId(User);
             var canComment = UserCanComment();
 

--- a/Pages/Shared/_CommentThread.cshtml
+++ b/Pages/Shared/_CommentThread.cshtml
@@ -1,8 +1,7 @@
 @using System.Collections.Generic
 @using System.Linq
-@using Microsoft.AspNetCore.Routing
 @model IEnumerable<ProjectManagement.Pages.Projects.CommentDisplayModel>
-@{
+@{ 
     var showStage = (bool?)(ViewData["ShowStage"] ?? false) ?? false;
     var pageName = ViewData["CommentsPage"]?.ToString() ?? string.Empty;
     var projectId = (int?)(ViewData["ProjectId"] ?? 0) ?? 0;
@@ -11,16 +10,20 @@
     var editParam = ViewData["EditParam"]?.ToString() ?? "editId";
     var deleteHandler = ViewData["DeleteHandler"]?.ToString() ?? "DeleteComment";
     var downloadHandler = ViewData["DownloadHandler"]?.ToString() ?? "DownloadAttachment";
-    var baseRoute = new RouteValueDictionary(routeValues)
+    var baseRoute = new Dictionary<string, string?>(System.StringComparer.OrdinalIgnoreCase);
+    foreach (var pair in routeValues)
     {
-        ["id"] = projectId
-    };
-    Func<string?, object?, RouteValueDictionary> withRoute = (key, value) =>
+        baseRoute[pair.Key] = pair.Value?.ToString();
+    }
+
+    baseRoute["id"] = projectId.ToString();
+
+    Func<string?, object?, Dictionary<string, string?>> withRoute = (key, value) =>
     {
-        var dict = new RouteValueDictionary(baseRoute);
+        var dict = new Dictionary<string, string?>(baseRoute, System.StringComparer.OrdinalIgnoreCase);
         if (!string.IsNullOrEmpty(key))
         {
-            dict[key!] = value;
+            dict[key!] = value?.ToString();
         }
         return dict;
     };
@@ -61,10 +64,11 @@ else
                             <ul class="list-unstyled mt-2 mb-0 small">
                                 @foreach (var attachment in comment.Attachments)
                                 {
-                                    @{ var downloadRoute = withRoute(null, null); downloadRoute["commentId"] = comment.Id; downloadRoute["attachmentId"] = attachment.Id; }
+                                    var downloadRoute = withRoute("commentId", comment.Id);
+                                    downloadRoute["attachmentId"] = attachment.Id.ToString();
                                     <li>
                                         <a asp-page="@pageName" asp-page-handler="@downloadHandler" asp-all-route-data="@(downloadRoute)">
-                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@(System.Math.Max(1, attachment.SizeBytes / 1024)) KB)
+                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@Math.Max(1, attachment.SizeBytes / 1024) KB)
                                         </a>
                                     </li>
                                 }
@@ -74,12 +78,13 @@ else
                     <div class="d-flex flex-column align-items-end gap-2">
                         @if (comment.CanReply)
                         {
-                            @{ var replyRoute = withRoute(replyParam, comment.Id); }
+                            var replyRoute = withRoute(replyParam, comment.Id);
                             <a class="btn btn-sm btn-outline-primary" asp-page="@pageName" asp-all-route-data="@(replyRoute)">Reply</a>
                         }
                         @if (comment.CanEdit)
                         {
-                            @{ var editRoute = withRoute(editParam, comment.Id); var deleteRoute = withRoute(null, null); deleteRoute["commentId"] = comment.Id; }
+                            var editRoute = withRoute(editParam, comment.Id);
+                            var deleteRoute = withRoute("commentId", comment.Id);
                             <a class="btn btn-sm btn-outline-secondary" asp-page="@pageName" asp-all-route-data="@(editRoute)">Edit</a>
                             <form method="post" asp-page="@pageName" asp-page-handler="@deleteHandler" asp-all-route-data="@(deleteRoute)" data-confirm="Delete this remark?">
                                 <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
@@ -93,7 +98,8 @@ else
                     <div class="mt-3 ms-3 ps-3 border-start border-2">
                         @foreach (var reply in comment.Replies)
                         {
-                            @{ var replyEditRoute = withRoute(editParam, reply.Id); var replyDeleteRoute = withRoute(null, null); replyDeleteRoute["commentId"] = reply.Id; }
+                            var replyEditRoute = withRoute(editParam, reply.Id);
+                            var replyDeleteRoute = withRoute("commentId", reply.Id);
                             <div class="mb-3">
                                 <div class="d-flex justify-content-between align-items-start gap-2">
                                     <div>
@@ -112,10 +118,11 @@ else
                                             <ul class="list-unstyled mt-2 mb-0 small">
                                                 @foreach (var attachment in reply.Attachments)
                                                 {
-                                                    @{ var replyDownloadRoute = withRoute(null, null); replyDownloadRoute["commentId"] = reply.Id; replyDownloadRoute["attachmentId"] = attachment.Id; }
+                                                    var replyDownloadRoute = withRoute("commentId", reply.Id);
+                                                    replyDownloadRoute["attachmentId"] = attachment.Id.ToString();
                                                     <li>
                                                         <a asp-page="@pageName" asp-page-handler="@downloadHandler" asp-all-route-data="@(replyDownloadRoute)">
-                                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@(System.Math.Max(1, attachment.SizeBytes / 1024)) KB)
+                                                            <i class="bi bi-paperclip"></i> @attachment.FileName (@Math.Max(1, attachment.SizeBytes / 1024) KB)
                                                         </a>
                                                     </li>
                                                 }


### PR DESCRIPTION
## Summary
- replace nested Razor code blocks and RouteValueDictionary usage in `_CommentThread` with string-based route dictionaries compatible with `asp-all-route-data`
- ensure attachment, reply, edit, and delete links set route values without triggering RZ1010
- rename the Activity page bindable property to `PageIndex` to avoid hiding the `Page()` member

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d529d582248329a1716bd29746bdca