### PR TITLE
Fix Razor Page authorize handler warnings

### DIFF
--- a/Pages/Projects/Activity.cshtml.cs
+++ b/Pages/Projects/Activity.cshtml.cs
@@ -102,7 +102,6 @@ namespace ProjectManagement.Pages.Projects
             return Page();
         }
 
-        [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
         public async Task<IActionResult> OnPostCommentAsync(int id, CancellationToken cancellationToken)
         {
             ProjectId = id;
@@ -175,11 +174,10 @@ namespace ProjectManagement.Pages.Projects
             return RedirectToPage(new { id, Type, AuthorId, StageId, From, To, Page = PageIndex });
         }
 
-        [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
         public async Task<IActionResult> OnPostDeleteCommentAsync(int id, int commentId, CancellationToken cancellationToken)
         {
             var userId = _userManager.GetUserId(User);
-            if (userId == null)
+            if (userId == null || !UserCanComment())
             {
                 return Forbid();
             }

--- a/Pages/Projects/Stages.cshtml.cs
+++ b/Pages/Projects/Stages.cshtml.cs
@@ -232,7 +232,6 @@ public class StagesModel : PageModel
         return RedirectToPage(new { id = projectId });
     }
 
-    [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
     public async Task<IActionResult> OnPostStageCommentAsync(int projectId, CancellationToken cancellationToken)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -298,11 +297,10 @@ public class StagesModel : PageModel
         });
     }
 
-    [Authorize(Roles = "Admin,HoD,Project Officer,MCO,Comdt")]
     public async Task<IActionResult> OnPostDeleteCommentAsync(int projectId, int commentId, CancellationToken cancellationToken)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null)
+        if (userId == null || !UserCanComment())
         {
             return Forbid();
         }


### PR DESCRIPTION
## Summary
- remove unsupported method-level `[Authorize]` attributes from project activity and stages Razor Page handlers
- rely on existing role checks within the handlers to return `Forbid` when users lack comment permissions, matching Option B guidance

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52c8365ac8329acac690dbe512522