### PR TITLE
Expose hidden project features in UI

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -11,6 +11,15 @@
   }
 </div>
 
+@{
+    var canDraftPlan = User.IsInRole("Project Officer") || User.IsInRole("HoD") || User.IsInRole("Admin");
+    var canReviewPlan = User.IsInRole("HoD") || User.IsInRole("Admin");
+    var canAccessStages = User.IsInRole("Project Officer") || User.IsInRole("HoD") || User.IsInRole("Admin") || User.IsInRole("MCO") || User.IsInRole("Comdt");
+    var planPermissionHint = "Requires Project Officer, HoD, or Admin rights.";
+    var reviewPermissionHint = "Requires HoD or Admin rights.";
+    var stagePermissionHint = "Requires Project Officer, HoD, Admin, MCO, or Comdt rights.";
+}
+
 <table class="table table-sm align-middle">
   <thead>
     <tr>
@@ -18,6 +27,7 @@
       <th>HoD</th>
       <th>Lead PO</th>
       <th>Created</th>
+      <th class="text-end">Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -28,6 +38,48 @@
       <td>@r.Hod</td>
       <td>@r.Po</td>
       <td>@r.CreatedAt.ToLocalTime()</td>
+      <td class="text-end">
+        <div class="d-flex flex-wrap justify-content-end gap-2">
+          <a class="btn btn-sm btn-outline-secondary" asp-page="View" asp-route-id="@r.Id" title="Open project">Open</a>
+
+          @if (!r.HasApprovedPlan)
+          {
+              if (canDraftPlan)
+              {
+                  <a class="btn btn-sm btn-outline-primary" asp-page="/Projects/Plan/Draft" asp-route-id="@r.Id" title="Draft or submit plan">Plan</a>
+              }
+              else
+              {
+                  <span class="btn btn-sm btn-outline-secondary disabled" role="button" aria-disabled="true" title="@planPermissionHint">Plan</span>
+              }
+
+              if (r.IsPlanPendingApproval)
+              {
+                  if (canReviewPlan)
+                  {
+                      <a class="btn btn-sm btn-primary" asp-page="/Projects/Plan/Review" asp-route-id="@r.Id" title="Review and approve">Review</a>
+                  }
+                  else
+                  {
+                      <span class="btn btn-sm btn-outline-secondary disabled" role="button" aria-disabled="true" title="@reviewPermissionHint">Review</span>
+                  }
+              }
+          }
+          else
+          {
+              if (canAccessStages)
+              {
+                  <a class="btn btn-sm btn-outline-success" asp-page="/Projects/Stages" asp-route-id="@r.Id" title="Execution stages">Stages</a>
+              }
+              else
+              {
+                  <span class="btn btn-sm btn-outline-secondary disabled" role="button" aria-disabled="true" title="@stagePermissionHint">Stages</span>
+              }
+          }
+
+          <a class="btn btn-sm btn-outline-dark" asp-page="/Projects/Activity" asp-route-id="@r.Id" title="Comments &amp; files">Activity</a>
+        </div>
+      </td>
     </tr>
   }
   </tbody>

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Models.Plans;
 
 namespace ProjectManagement.Pages.Projects
 {
@@ -18,22 +20,49 @@ namespace ProjectManagement.Pages.Projects
             _db = db;
         }
 
-        public record Row(int Id, string Name, string? Hod, string? Po, DateTime CreatedAt);
+        public record Row(int Id, string Name, string? Hod, string? Po, DateTime CreatedAt, bool HasApprovedPlan, bool IsPlanPendingApproval);
         public List<Row> Items { get; set; } = new();
 
         public async Task OnGetAsync()
         {
-            Items = await _db.Projects
+            var cancellationToken = HttpContext.RequestAborted;
+
+            var projects = await _db.Projects
                 .Include(p => p.HodUser)
                 .Include(p => p.LeadPoUser)
                 .OrderByDescending(p => p.CreatedAt)
+                .Select(p => new
+                {
+                    p.Id,
+                    p.Name,
+                    Hod = p.HodUser == null ? null : $"{p.HodUser.Rank} {p.HodUser.FullName}",
+                    Po = p.LeadPoUser == null ? null : $"{p.LeadPoUser.Rank} {p.LeadPoUser.FullName}",
+                    p.CreatedAt,
+                    HasApprovedPlan = p.ActivePlanVersionNo != null
+                })
+                .ToListAsync(cancellationToken);
+
+            var projectIds = projects.Select(p => p.Id).ToList();
+
+            var pendingApprovals = await _db.PlanVersions
+                .AsNoTracking()
+                .Where(v => projectIds.Contains(v.ProjectId) && v.Status == PlanVersionStatus.PendingApproval)
+                .GroupBy(v => v.ProjectId)
+                .Select(g => g.Key)
+                .ToListAsync(cancellationToken);
+
+            var pendingLookup = new HashSet<int>(pendingApprovals);
+
+            Items = projects
                 .Select(p => new Row(
                     p.Id,
                     p.Name,
-                    p.HodUser == null ? null : $"{p.HodUser.Rank} {p.HodUser.FullName}",
-                    p.LeadPoUser == null ? null : $"{p.LeadPoUser.Rank} {p.LeadPoUser.FullName}",
-                    p.CreatedAt))
-                .ToListAsync();
+                    p.Hod,
+                    p.Po,
+                    p.CreatedAt,
+                    p.HasApprovedPlan,
+                    pendingLookup.Contains(p.Id)))
+                .ToList();
         }
     }
 }

--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -12,10 +12,20 @@
         ProjectRagStatus.Amber => "badge bg-warning text-dark",
         _ => "badge bg-success"
     };
+    var canManage = Model.CanManageStages;
+    var manageTooltip = "Only Admin, HoD, or the assigned Lead PO can update stages.";
 }
 
-<h1 class="mb-3">Project Stages</h1>
-<p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-3">
+    <div>
+        <h1 class="h3 mb-1">Project stages</h1>
+        <p class="text-muted mb-0">Project: <strong>@Model.ProjectName</strong></p>
+    </div>
+    <div class="btn-group btn-group-sm" role="group" aria-label="Stage navigation">
+        <a class="btn btn-outline-secondary" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back to project</a>
+        <a class="btn btn-outline-dark" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId" title="Comments &amp; files">Activity</a>
+    </div>
+</div>
 
 @if (!string.IsNullOrEmpty(Model.StatusMessage))
 {
@@ -31,124 +41,157 @@
     </div>
 }
 
-<div class="border rounded p-3 mb-3">
-    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
-        <div>
-            <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+<div class="row g-4">
+    <div class="col-12 col-lg-8">
+        <div class="card shadow-sm mb-3">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+                    <div>
+                        <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+                    </div>
+                    <div class="flex-grow-1">
+                        <div class="fw-semibold mb-1">Slip (days)</div>
+                        <ul class="list-inline mb-0">
+                            @foreach (var slip in Model.StageSlips)
+                            {
+                                <li class="list-inline-item mb-1">
+                                    <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="flex-grow-1">
-            <div class="fw-semibold mb-1">Slip (days)</div>
-            <ul class="list-inline mb-0">
-                @foreach (var slip in Model.StageSlips)
-                {
-                    <li class="list-inline-item mb-1">
-                        <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
-                    </li>
-                }
-            </ul>
+
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col" style="width: 6rem;">Stage</th>
+                                <th scope="col">Description</th>
+                                <th scope="col" style="width: 12rem;">Planned Start</th>
+                                <th scope="col" style="width: 12rem;">Planned Due</th>
+                                <th scope="col" style="width: 10rem;">Status</th>
+                                <th scope="col" style="width: 8rem;">Slip (days)</th>
+                                <th scope="col" style="width: 12rem;">Actual Start</th>
+                                <th scope="col" style="width: 12rem;">Completed On</th>
+                                <th scope="col" class="text-end" style="width: 18rem;">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var stage in Model.Stages)
+                        {
+                            var prereqHint = Model.GetPrereqHint(stage.Code);
+                            var startAllowed = stage.StartGuard.Allowed && canManage;
+                            var completeAllowed = stage.CompleteGuard.Allowed && canManage;
+                            var skipAllowed = stage.SkipGuard.Allowed && canManage;
+                            var startTitle = !canManage
+                                ? manageTooltip
+                                : stage.StartGuard.Allowed ? "Start stage" : stage.StartGuard.Reason ?? "Stage cannot start yet";
+                            var completeTitle = !canManage
+                                ? manageTooltip
+                                : stage.CompleteGuard.Allowed ? "Mark complete" : stage.CompleteGuard.Reason ?? "Stage cannot complete yet";
+                            var skipTitle = !canManage
+                                ? manageTooltip
+                                : stage.SkipGuard.Allowed ? "Skip PNC with reason" : stage.SkipGuard.Reason ?? "PNC cannot be skipped.";
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">@stage.Code</div>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold d-flex align-items-center gap-2">
+                                        @stage.Name
+                                        @if (!string.IsNullOrEmpty(prereqHint))
+                                        {
+                                            <span class="text-muted" title="@prereqHint">
+                                                <i class="bi bi-lock" aria-hidden="true"></i>
+                                                <span class="visually-hidden">Blocked: @prereqHint</span>
+                                            </span>
+                                        }
+                                    </div>
+                                </td>
+                                <td>@stage.PlannedStart?.ToString("dd MMM yyyy")</td>
+                                <td>@stage.PlannedDue?.ToString("dd MMM yyyy")</td>
+                                <td>@stage.Status</td>
+                                <td>@stage.SlipDays</td>
+                                <td>@stage.ActualStart?.ToString("dd MMM yyyy")</td>
+                                <td>@stage.CompletedOn?.ToString("dd MMM yyyy")</td>
+                                <td class="text-end">
+                                    <div class="d-flex flex-wrap justify-content-end gap-2">
+                                        <form method="post" asp-page-handler="Start" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
+                                            <button type="submit" class="btn btn-outline-primary btn-sm" disabled="@(startAllowed ? null : "disabled")" title="@startTitle">Start</button>
+                                        </form>
+                                        <form method="post" asp-page-handler="Complete" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
+                                            <button type="submit" class="btn btn-outline-success btn-sm" disabled="@(completeAllowed ? null : "disabled")" title="@completeTitle">Complete</button>
+                                        </form>
+                                        @if (string.Equals(stage.Code, "PNC", System.StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-flex flex-wrap gap-2">
+                                                <input type="text" name="reason" class="form-control form-control-sm" placeholder="Reason" required minlength="3" maxlength="200" @(canManage ? null : "disabled") />
+                                                <button type="submit" class="btn btn-outline-secondary btn-sm" disabled="@(skipAllowed ? null : "disabled")" title="@skipTitle">Skip</button>
+                                            </form>
+                                        }
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 col-lg-4">
+        <div class="vstack gap-3">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h2 class="h5 mb-3">Stage remarks</h2>
+                    <form method="get" class="row gy-2 gx-2 align-items-end mb-3">
+                        <input type="hidden" name="id" value="@Model.ProjectId" />
+                        <div class="col-12">
+                            <label asp-for="CommentStageId" class="form-label">Stage</label>
+                            <select asp-for="CommentStageId" asp-items="Model.CommentStageOptions" class="form-select"></select>
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-primary">View</button>
+                        </div>
+                    </form>
+
+                    @{
+                        var routeValues = new Dictionary<string, object?>();
+                        if (Model.CommentStageId.HasValue)
+                        {
+                            routeValues["commentStageId"] = Model.CommentStageId;
+                        }
+
+                        var threadViewData = new ViewDataDictionary(ViewData)
+                        {
+                            ["CommentsPage"] = "/Projects/Stages",
+                            ["ProjectId"] = Model.ProjectId,
+                            ["ShowStage"] = false,
+                            ["RouteValues"] = routeValues,
+                            ["ReplyParam"] = "commentParentId",
+                            ["EditParam"] = "commentEditId",
+                            ["DeleteHandler"] = "DeleteComment",
+                            ["DownloadHandler"] = "DownloadAttachment"
+                        };
+                    }
+
+                    @await Html.PartialAsync("_CommentThread", Model.StageComments, threadViewData)
+
+                    <div class="mt-3 text-end">
+                        <a class="btn btn-sm btn-outline-secondary" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId">Open activity</a>
+                    </div>
+                </div>
+            </div>
+
+            @if (Model.CanComment && Model.CommentStageOptions.Any())
+            {
+                @await Html.PartialAsync("_CommentComposer", Model.CommentComposer)
+            }
         </div>
     </div>
 </div>
-
-<div class="table-responsive">
-    <table class="table table-sm align-middle">
-        <thead>
-            <tr>
-                <th scope="col" style="width: 6rem;">Stage</th>
-                <th scope="col">Description</th>
-                <th scope="col" style="width: 12rem;">Planned Start</th>
-                <th scope="col" style="width: 12rem;">Planned Due</th>
-                <th scope="col" style="width: 10rem;">Status</th>
-                <th scope="col" style="width: 8rem;">Slip (days)</th>
-                <th scope="col" style="width: 12rem;">Actual Start</th>
-                <th scope="col" style="width: 12rem;">Completed On</th>
-                @if (Model.CanManageStages)
-                {
-                    <th scope="col" style="width: 18rem;">Actions</th>
-                }
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var stage in Model.Stages)
-        {
-            <tr>
-                <td>
-                    <div class="fw-semibold">@stage.Code</div>
-                </td>
-                <td>
-                    <div class="fw-semibold">@stage.Name</div>
-                </td>
-                <td>@stage.PlannedStart?.ToString("dd MMM yyyy")</td>
-                <td>@stage.PlannedDue?.ToString("dd MMM yyyy")</td>
-                <td>@stage.Status</td>
-                <td>@stage.SlipDays</td>
-                <td>@stage.ActualStart?.ToString("dd MMM yyyy")</td>
-                <td>@stage.CompletedOn?.ToString("dd MMM yyyy")</td>
-                @if (Model.CanManageStages)
-                {
-                    <td>
-                        <div class="d-flex flex-wrap gap-2">
-                            <form method="post" asp-page-handler="Start" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
-                                <button type="submit" class="btn btn-outline-primary btn-sm" title="@stage.StartGuard.Reason" @(stage.StartGuard.Allowed ? null : "disabled")>Start</button>
-                            </form>
-                            <form method="post" asp-page-handler="Complete" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
-                                <button type="submit" class="btn btn-outline-success btn-sm" title="@stage.CompleteGuard.Reason" @(stage.CompleteGuard.Allowed ? null : "disabled")>Complete</button>
-                            </form>
-                            @if (string.Equals(stage.Code, "PNC", StringComparison.OrdinalIgnoreCase))
-                            {
-                                <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-flex flex-wrap gap-2">
-                                    <input type="text" name="reason" class="form-control form-control-sm" placeholder="Reason" required minlength="3" maxlength="200" />
-                                    <button type="submit" class="btn btn-outline-danger btn-sm" title="@stage.SkipGuard.Reason" @(stage.SkipGuard.Allowed ? null : "disabled")>Skip</button>
-                                </form>
-                            }
-                        </div>
-                    </td>
-                }
-            </tr>
-        }
-        </tbody>
-    </table>
-</div>
-
-<a class="btn btn-outline-secondary mt-3" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back to Project</a>
-
-<section class="mt-5">
-    <h2 class="h4 mb-3">Stage remarks</h2>
-    <form method="get" class="row gy-3 gx-3 align-items-end mb-3">
-        <input type="hidden" name="id" value="@Model.ProjectId" />
-        <div class="col-12 col-md-4">
-            <label asp-for="CommentStageId" class="form-label">Stage</label>
-            <select asp-for="CommentStageId" asp-items="Model.CommentStageOptions" class="form-select"></select>
-        </div>
-        <div class="col-12 col-md-2">
-            <button type="submit" class="btn btn-primary">View</button>
-        </div>
-    </form>
-
-    @if (Model.CanComment && Model.CommentStageOptions.Any())
-    {
-        <div class="mb-3">
-            @await Html.PartialAsync("_CommentComposer", Model.CommentComposer)
-        </div>
-    }
-
-    @{
-        var routeValues = new Dictionary<string, object?>();
-        if (Model.CommentStageId.HasValue)
-        {
-            routeValues["commentStageId"] = Model.CommentStageId;
-        }
-        var threadViewData = new ViewDataDictionary(ViewData)
-        {
-            ["CommentsPage"] = "/Projects/Stages",
-            ["ProjectId"] = Model.ProjectId,
-            ["ShowStage"] = false,
-            ["RouteValues"] = routeValues,
-            ["ReplyParam"] = "commentParentId",
-            ["EditParam"] = "commentEditId",
-            ["DeleteHandler"] = "DeleteComment",
-            ["DownloadHandler"] = "DownloadAttachment"
-        };
-    }
-    @await Html.PartialAsync("_CommentThread", Model.StageComments, threadViewData)
-</section>

--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -1,20 +1,21 @@
 @page "{id:int}"
 @model ProjectManagement.Pages.Projects.ViewModel
 @using ProjectManagement.Models.Execution
-@{
-    ViewData["Title"] = Model.Item.Name;
-    var ragClass = Model.ProjectRag switch
-    {
-        ProjectRagStatus.Red => "badge bg-danger",
-        ProjectRagStatus.Amber => "badge bg-warning text-dark",
-        _ => "badge bg-success"
-    };
-}
-<div class="d-flex justify-content-between align-items-center mb-3">
-  <h2 class="mb-0">@Model.Item.Name</h2>
-  <a asp-page="Index" class="btn btn-secondary">Back to List</a>
-</div>
-
+@{ 
+    ViewData["Title"] = Model.Item.Name; 
+    var ragClass = Model.ProjectRag switch 
+    { 
+        ProjectRagStatus.Red => "badge bg-danger", 
+        ProjectRagStatus.Amber => "badge bg-warning text-dark", 
+        _ => "badge bg-success" 
+    }; 
+    var canDraftPlan = User.IsInRole("Project Officer") || User.IsInRole("HoD") || User.IsInRole("Admin");
+    var canReviewPlan = User.IsInRole("HoD") || User.IsInRole("Admin");
+    var canAccessStages = User.IsInRole("Project Officer") || User.IsInRole("HoD") || User.IsInRole("Admin") || User.IsInRole("MCO") || User.IsInRole("Comdt");
+    var planPermissionHint = "Requires Project Officer, HoD, or Admin rights.";
+    var reviewPermissionHint = "Requires HoD or Admin rights.";
+    var stagePermissionHint = "Requires Project Officer, HoD, Admin, MCO, or Comdt rights.";
+} 
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
 {
   <div class="alert alert-success" role="alert">
@@ -22,35 +23,145 @@
   </div>
 }
 
-<div class="border rounded p-3 mb-3">
-  <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
-    <div>
-      <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+<div class="card shadow-sm mb-3">
+  <div class="card-body">
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-start gap-3">
+      <div>
+        <h2 class="mb-1">@Model.Item.Name</h2>
+        <div class="text-muted">Created @Model.Item.CreatedAt.ToLocalTime()</div>
+      </div>
+      <div class="btn-toolbar" role="toolbar" aria-label="Project actions">
+        <div class="btn-group btn-group-sm" role="group">
+          <a asp-page="Index" class="btn btn-outline-secondary" title="Back to projects">Back</a>
+          <a class="btn btn-outline-dark" asp-page="/Projects/Activity" asp-route-id="@Model.Item.Id" title="Comments &amp; files">Activity</a>
+        </div>
+        <div class="btn-group btn-group-sm ms-2" role="group">
+          @if (!Model.HasApprovedPlan)
+          {
+              if (canDraftPlan)
+              {
+                  <a class="btn btn-outline-primary" asp-page="/Projects/Plan/Draft" asp-route-id="@Model.Item.Id" title="Draft or submit baseline">Plan</a>
+              }
+              else
+              {
+                  <span class="btn btn-outline-secondary disabled" role="button" aria-disabled="true" title="@planPermissionHint">Plan</span>
+              }
+
+              if (Model.IsPlanPendingApproval)
+              {
+                  if (canReviewPlan)
+                  {
+                      <a class="btn btn-primary" asp-page="/Projects/Plan/Review" asp-route-id="@Model.Item.Id" title="Review and approve">Review</a>
+                  }
+                  else
+                  {
+                      <span class="btn btn-outline-secondary disabled" role="button" aria-disabled="true" title="@reviewPermissionHint">Review</span>
+                  }
+              }
+          }
+          else
+          {
+              if (canAccessStages)
+              {
+                  <a class="btn btn-outline-success" asp-page="/Projects/Stages" asp-route-id="@Model.Item.Id" title="Execution stages">Stages</a>
+              }
+              else
+              {
+                  <span class="btn btn-outline-secondary disabled" role="button" aria-disabled="true" title="@stagePermissionHint">Stages</span>
+              }
+          }
+        </div>
+      </div>
     </div>
-    <div class="flex-grow-1">
-      <div class="fw-semibold mb-1">Slip (days)</div>
-      <ul class="list-inline mb-0">
-        @foreach (var slip in Model.StageSlips)
-        {
-          <li class="list-inline-item mb-1">
-            <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
-          </li>
-        }
-      </ul>
+
+    @if (Model.HasApprovedPlan)
+    {
+      <div class="alert alert-success mt-3 mb-0" role="status">
+        <strong>Baseline v@Model.ActivePlanVersionNo approved.</strong>
+        <span class="ms-2">Next due: <span class="badge bg-secondary">@Model.NextDueText</span></span>
+      </div>
+    }
+    else if (Model.IsPlanPendingApproval)
+    {
+      <div class="alert alert-warning mt-3 mb-0" role="status">
+        <strong>Plan submitted.</strong> Awaiting HoD approval.
+      </div>
+    }
+    else
+    {
+      <div class="alert alert-info mt-3 mb-0" role="status">
+        No approved plan yet. Create a baseline to start execution.
+      </div>
+    }
+  </div>
+</div>
+
+<div class="card shadow-sm mb-3">
+  <div class="card-body">
+    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+      <div>
+        <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+      </div>
+      <div class="flex-grow-1">
+        <div class="fw-semibold mb-1">Slip (days)</div>
+        <ul class="list-inline mb-0">
+          @foreach (var slip in Model.StageSlips)
+          {
+            <li class="list-inline-item mb-1">
+              <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
+            </li>
+          }
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 
-<dl class="row">
-  <dt class="col-sm-3">Description</dt>
-  <dd class="col-sm-9">@Model.Item.Description</dd>
+<div class="card shadow-sm">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Description</dt>
+      <dd class="col-sm-9">@Model.Item.Description</dd>
 
-  <dt class="col-sm-3">Head of Department</dt>
-  <dd class="col-sm-9">@Model.Item.Hod</dd>
+      <dt class="col-sm-3">Head of Department</dt>
+      <dd class="col-sm-9">@Model.Item.Hod</dd>
 
-  <dt class="col-sm-3">Lead Project Officer</dt>
-  <dd class="col-sm-9">@Model.Item.Po</dd>
+      <dt class="col-sm-3">Lead Project Officer</dt>
+      <dd class="col-sm-9">@Model.Item.Po</dd>
+    </dl>
+  </div>
+</div>
 
-  <dt class="col-sm-3">Created</dt>
-  <dd class="col-sm-9">@Model.Item.CreatedAt.ToLocalTime()</dd>
-</dl>
+<section class="mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <h3 class="h5 mb-0">Recent activity</h3>
+    <a class="btn btn-sm btn-outline-secondary" asp-page="/Projects/Activity" asp-route-id="@Model.Item.Id" title="Open full activity">See all</a>
+  </div>
+  @if (Model.RecentActivity.Any())
+  {
+    <div class="list-group list-group-flush border rounded shadow-sm">
+      @foreach (var entry in Model.RecentActivity)
+      {
+        <div class="list-group-item">
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            <span class="badge bg-secondary">@entry.Type</span>
+            @if (!string.IsNullOrEmpty(entry.StageLabel))
+            {
+              <span class="badge bg-light text-dark border">@entry.StageLabel</span>
+            }
+            <span class="ms-auto text-muted small">@entry.CreatedOn.ToLocalTime().ToString("dd MMM yyyy HH:mm")</span>
+          </div>
+          <div class="fw-semibold mt-2">@entry.AuthorName</div>
+          <p class="mb-2 text-muted">@entry.BodyPreview</p>
+          <div class="d-flex justify-content-end">
+            <a class="btn btn-sm btn-outline-primary" asp-page="/Projects/Activity" asp-route-id="@Model.Item.Id" asp-route-StageId="@(entry.StageId)" title="View in activity">Open activity</a>
+          </div>
+        </div>
+      }
+    </div>
+  }
+  else
+  {
+    <p class="text-muted">No remarks yet.</p>
+  }
+</section>

--- a/Pages/Projects/View.cshtml.cs
+++ b/Pages/Projects/View.cshtml.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Services;
@@ -24,17 +27,26 @@ namespace ProjectManagement.Pages.Projects
             _clock = clock;
         }
 
-        public record ItemModel(int Id, string Name, string? Description, string? Hod, string? Po, DateTime CreatedAt);
+        public record ItemModel(int Id, string Name, string? Description, string? Hod, string? Po, DateTime CreatedAt, int? ActivePlanVersionNo);
+
+        public record ActivitySummary(int CommentId, int? StageId, string? StageLabel, string AuthorName, string BodyPreview, ProjectCommentType Type, DateTime CreatedOn);
 
         public ItemModel Item { get; private set; } = null!;
         public List<StageSlipSummary> StageSlips { get; private set; } = new();
         public ProjectRagStatus ProjectRag { get; private set; } = ProjectRagStatus.Green;
+        public bool HasApprovedPlan { get; private set; }
+        public bool IsPlanPendingApproval { get; private set; }
+        public int? ActivePlanVersionNo { get; private set; }
+        public string NextDueText { get; private set; } = string.Empty;
+        public List<ActivitySummary> RecentActivity { get; private set; } = new();
 
         [TempData]
         public string? StatusMessage { get; set; }
 
         public async Task<IActionResult> OnGetAsync(int id)
         {
+            var cancellationToken = HttpContext.RequestAborted;
+
             var item = await _db.Projects
                 .Include(p => p.HodUser)
                 .Include(p => p.LeadPoUser)
@@ -45,8 +57,9 @@ namespace ProjectManagement.Pages.Projects
                     p.Description,
                     p.HodUser == null ? null : $"{p.HodUser.Rank} {p.HodUser.FullName}",
                     p.LeadPoUser == null ? null : $"{p.LeadPoUser.Rank} {p.LeadPoUser.FullName}",
-                    p.CreatedAt))
-                .FirstOrDefaultAsync();
+                    p.CreatedAt,
+                    p.ActivePlanVersionNo))
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (item == null)
             {
@@ -54,8 +67,11 @@ namespace ProjectManagement.Pages.Projects
             }
 
             Item = item;
+            ActivePlanVersionNo = item.ActivePlanVersionNo;
+            HasApprovedPlan = item.ActivePlanVersionNo.HasValue;
 
             await LoadStageHealthAsync(id);
+            await LoadPlanInsightsAsync(id, cancellationToken);
             return Page();
         }
 
@@ -82,6 +98,157 @@ namespace ProjectManagement.Pages.Projects
                 .ToList();
 
             ProjectRag = health.Rag;
+        }
+
+        private async Task LoadPlanInsightsAsync(int projectId, CancellationToken cancellationToken)
+        {
+            IsPlanPendingApproval = await _db.PlanVersions
+                .AsNoTracking()
+                .AnyAsync(p => p.ProjectId == projectId && p.Status == PlanVersionStatus.PendingApproval, cancellationToken);
+
+            var stageNames = await _db.StageTemplates
+                .AsNoTracking()
+                .Where(t => t.Version == PlanConstants.StageTemplateVersion)
+                .ToDictionaryAsync(t => t.Code, t => t.Name, StringComparer.OrdinalIgnoreCase, cancellationToken);
+
+            if (!HasApprovedPlan || !ActivePlanVersionNo.HasValue)
+            {
+                NextDueText = "Baseline not approved.";
+                await LoadRecentActivityAsync(projectId, stageNames, cancellationToken);
+                return;
+            }
+
+            var plan = await _db.PlanVersions
+                .AsNoTracking()
+                .Include(p => p.StagePlans)
+                .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.VersionNo == ActivePlanVersionNo.Value, cancellationToken);
+
+            IReadOnlyCollection<StagePlan>? stagePlans = plan?.StagePlans;
+            IReadOnlyDictionary<string, ProjectStage>? stageStatus = null;
+
+            if (plan != null)
+            {
+                stageStatus = await _db.ProjectStages
+                    .AsNoTracking()
+                    .Where(ps => ps.ProjectId == projectId)
+                    .ToDictionaryAsync(ps => ps.StageCode, StringComparer.OrdinalIgnoreCase, cancellationToken);
+            }
+
+            NextDueText = BuildNextDueText(stagePlans, stageStatus, stageNames);
+
+            await LoadRecentActivityAsync(projectId, stageNames, cancellationToken);
+        }
+
+        private async Task LoadRecentActivityAsync(int projectId, IReadOnlyDictionary<string, string> stageNames, CancellationToken cancellationToken)
+        {
+            var comments = await _db.ProjectComments
+                .AsNoTracking()
+                .Where(c => c.ProjectId == projectId && !c.IsDeleted && c.ParentCommentId == null)
+                .OrderByDescending(c => c.Pinned)
+                .ThenByDescending(c => c.CreatedOn)
+                .ThenByDescending(c => c.Id)
+                .Take(3)
+                .Select(c => new
+                {
+                    c.Id,
+                    c.ProjectStageId,
+                    StageCode = c.ProjectStage != null ? c.ProjectStage.StageCode : null,
+                    c.Body,
+                    c.Type,
+                    c.CreatedOn,
+                    Author = c.CreatedByUser,
+                    c.CreatedByUserId
+                })
+                .ToListAsync(cancellationToken);
+
+            RecentActivity = comments
+                .Select(c => new ActivitySummary(
+                    c.Id,
+                    c.ProjectStageId,
+                    string.IsNullOrWhiteSpace(c.StageCode) ? null : BuildStageLabel(c.StageCode!, stageNames),
+                    BuildAuthorName(c.Author, c.CreatedByUserId),
+                    BuildPreview(c.Body),
+                    c.Type,
+                    c.CreatedOn))
+                .ToList();
+        }
+
+        private static string BuildNextDueText(IReadOnlyCollection<StagePlan>? stagePlans, IReadOnlyDictionary<string, ProjectStage>? stageStatus, IReadOnlyDictionary<string, string> stageNames)
+        {
+            if (stagePlans == null || stagePlans.Count == 0)
+            {
+                return "Schedule not configured.";
+            }
+
+            var ordered = stagePlans
+                .Where(sp => sp.PlannedDue.HasValue || sp.PlannedStart.HasValue)
+                .OrderBy(sp => sp.PlannedDue ?? sp.PlannedStart)
+                .ToList();
+
+            if (!ordered.Any())
+            {
+                return "No planned dates.";
+            }
+
+            foreach (var plan in ordered)
+            {
+                var status = stageStatus != null && stageStatus.TryGetValue(plan.StageCode, out var stage)
+                    ? stage.Status
+                    : StageStatus.NotStarted;
+
+                if (status is StageStatus.Completed or StageStatus.Skipped)
+                {
+                    continue;
+                }
+
+                var label = BuildStageLabel(plan.StageCode, stageNames);
+                var date = plan.PlannedDue ?? plan.PlannedStart;
+                return date.HasValue ? $"{label} — {date.Value:dd MMM yyyy}" : label;
+            }
+
+            return "All stages completed.";
+        }
+
+        private static string BuildStageLabel(string? stageCode, IReadOnlyDictionary<string, string> stageNames)
+        {
+            if (string.IsNullOrWhiteSpace(stageCode))
+            {
+                return "Project";
+            }
+
+            return stageNames.TryGetValue(stageCode, out var name) && !string.IsNullOrWhiteSpace(name)
+                ? $"{stageCode} — {name}"
+                : stageCode;
+        }
+
+        private static string BuildAuthorName(ApplicationUser? user, string? userId)
+        {
+            if (user == null)
+            {
+                return string.IsNullOrEmpty(userId) ? "Unknown" : "Former user";
+            }
+
+            var display = string.IsNullOrWhiteSpace(user.FullName) ? user.UserName : $"{user.Rank} {user.FullName}";
+            return string.IsNullOrWhiteSpace(display) ? user.UserName ?? "User" : display.Trim();
+        }
+
+        private static string BuildPreview(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return "(No details provided)";
+            }
+
+            var trimmed = body.Trim();
+            var normalized = trimmed.Replace("\r", " ").Replace("\n", " ");
+            const int maxLength = 140;
+            if (normalized.Length <= maxLength)
+            {
+                return normalized;
+            }
+
+            var shortened = normalized.Substring(0, Math.Min(normalized.Length, maxLength)).TrimEnd();
+            return shortened + "…";
         }
     }
 }

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -27,13 +27,13 @@
                         @if (SignInManager.IsSignedIn(User))
                         {
                             <li class="nav-item">
-                                <a class="nav-link" asp-page="/Dashboard/Index">Dashboard</a>
+                                <a class="nav-link" asp-page="/Projects/Index">Projects</a>
                             </li>
                             <li class="nav-item">
                                 <a class="nav-link" asp-page="/Process/Index">Process</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" asp-page="/Projects/Index">Projects</a>
+                                <a class="nav-link" asp-page="/Dashboard/Index">Dashboard</a>
                             </li>
                             if (User.IsInRole("Admin"))
                             {


### PR DESCRIPTION
## Summary
- promote Projects and Process in the main navigation and expand the projects list with role-aware action buttons
- surface plan status, entry points to planning, stages, and activity, plus recent remarks on the project overview
- redesign the stages page with prerequisite hints, discoverable actions, and an embedded stage remarks panel

## Testing
- `dotnet test` *(fails: dotnet command unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53280724c83298791a2c462cc0697