### PR TITLE
Fix plan draft version query

### DIFF
--- a/Services/Plans/PlanDraftService.cs
+++ b/Services/Plans/PlanDraftService.cs
@@ -49,7 +49,7 @@ public class PlanDraftService
         var latestVersion = await _db.PlanVersions
             .Where(p => p.ProjectId == projectId)
             .Select(p => p.VersionNo)
-            .DefaultIfEmpty(0)
+            .DefaultIfEmpty()
             .MaxAsync(cancellationToken);
 
         var stageCodes = await _db.StageTemplates


### PR DESCRIPTION
## Summary
- stop providing a constant to `DefaultIfEmpty` when determining the latest plan version so EF Core can translate the query

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5389b30948329807e8392f9ef5933