### PR TITLE
Fix PlanVersion column migration references

### DIFF
--- a/Migrations/20251021000000_EnsurePlanAnchorColumnsExist.cs
+++ b/Migrations/20251021000000_EnsurePlanAnchorColumnsExist.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Models.Plans;
 
 #nullable disable
 
@@ -10,21 +11,21 @@ namespace ProjectManagement.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"AnchorDate\" date;");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"AnchorStageCode\" character varying(16);");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"SkipWeekends\" boolean NOT NULL DEFAULT true;");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"TransitionRule\" character varying(32) NOT NULL DEFAULT 'NextWorkingDay';");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"PncApplicable\" boolean NOT NULL DEFAULT true;");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"{nameof(PlanVersion.AnchorDate)}\" date;");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"{nameof(PlanVersion.AnchorStageCode)}\" character varying(16);");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"{nameof(PlanVersion.SkipWeekends)}\" boolean NOT NULL DEFAULT true;");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"{nameof(PlanVersion.TransitionRule)}\" character varying(32) NOT NULL DEFAULT 'NextWorkingDay';");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" ADD COLUMN IF NOT EXISTS \"{nameof(PlanVersion.PncApplicable)}\" boolean NOT NULL DEFAULT true;");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"AnchorDate\";");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"AnchorStageCode\";");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"SkipWeekends\";");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"TransitionRule\";");
-            migrationBuilder.Sql(@"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"PncApplicable\";");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"{nameof(PlanVersion.AnchorDate)}\";");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"{nameof(PlanVersion.AnchorStageCode)}\";");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"{nameof(PlanVersion.SkipWeekends)}\";");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"{nameof(PlanVersion.TransitionRule)}\";");
+            migrationBuilder.Sql($"ALTER TABLE \"PlanVersions\" DROP COLUMN IF EXISTS \"{nameof(PlanVersion.PncApplicable)}\";");
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure EnsurePlanAnchorColumnsExist migration imports the PlanVersion model
- reference PlanVersion column names via nameof for safer SQL statements

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d54effd17083299c964a6bb209efcb