### PR TITLE
Add dev test users to identity seeder

### DIFF
--- a/Data/IdentitySeeder.cs
+++ b/Data/IdentitySeeder.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
 using ProjectManagement.Models;
 
 namespace ProjectManagement.Data
@@ -38,6 +43,72 @@ namespace ProjectManagement.Data
                 await userMgr.CreateAsync(admin, "ChangeMe!123");
                 await userMgr.AddToRoleAsync(admin, "Admin");
             }
+
+            var env = services.GetRequiredService<IWebHostEnvironment>();
+            if (env.IsDevelopment())
+            {
+                await EnsureTestUserAsync(
+                    userMgr,
+                    userName: "test_hod",
+                    fullName: "Test HoD",
+                    rank: "Test",
+                    role: "HoD",
+                    password: "ChangeMe!123",
+                    mustChangePassword: false);
+
+                await EnsureTestUserAsync(
+                    userMgr,
+                    userName: "test_project_offr",
+                    fullName: "Test Project Officer",
+                    rank: "Test",
+                    role: "Project Officer",
+                    password: "ChangeMe!123",
+                    mustChangePassword: false);
+            }
+        }
+
+        private static async Task EnsureTestUserAsync(
+            UserManager<ApplicationUser> userMgr,
+            string userName,
+            string fullName,
+            string rank,
+            string role,
+            string password,
+            bool mustChangePassword)
+        {
+            var user = await userMgr.FindByNameAsync(userName);
+            if (user == null)
+            {
+                user = new ApplicationUser
+                {
+                    UserName = userName,
+                    Email = $"{userName}@example.local",
+                    MustChangePassword = mustChangePassword,
+                    FullName = fullName,
+                    Rank = rank,
+                    LockoutEnabled = false
+                };
+                var res = await userMgr.CreateAsync(user, password);
+                if (!res.Succeeded)
+                {
+                    throw new InvalidOperationException($"Failed creating {userName}: {string.Join(", ", res.Errors.Select(e => e.Description))}");
+                }
+            }
+            else
+            {
+                user.MustChangePassword = mustChangePassword;
+                user.FullName = fullName;
+                user.Rank = rank;
+                user.LockoutEnabled = false;
+                await userMgr.UpdateAsync(user);
+            }
+
+            if (!await userMgr.IsInRoleAsync(user, role))
+            {
+                await userMgr.AddToRoleAsync(user, role);
+            }
+
+            await userMgr.UpdateSecurityStampAsync(user);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the identity seeder to add development-only test HoD and Project Officer users
- ensure the dev test accounts stay synchronized with expected role membership and password flags
- refresh the security stamp for the dev accounts after updates to keep sessions consistent

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d550d1e95083299709e10131d0ac81