### PR TITLE
Fix draft plan handlers and load jQuery

### DIFF
--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -192,11 +192,24 @@
     <div class="d-flex flex-wrap gap-2">
         @if (Model.AllowEdit)
         {
-            <button type="submit" class="btn btn-primary" asp-page-handler="Save">Save Draft</button>
+            <button type="submit"
+                    class="btn btn-primary"
+                    form="plan-draft-form"
+                    formaction="@Url.Page("./Draft", new { id = Model.ProjectId, handler = "Save" })"
+                    formmethod="post">
+                Save Draft
+            </button>
         }
         @if (Model.AllowEdit)
         {
-            <button type="submit" class="btn btn-success" asp-page-handler="Submit" disabled="@(Model.CanSubmit ? null : "disabled")">Submit for approval</button>
+            <button type="submit"
+                    class="btn btn-success"
+                    form="plan-draft-form"
+                    formaction="@Url.Page("./Draft", new { id = Model.ProjectId, handler = "Submit" })"
+                    formmethod="post"
+                    disabled="@(Model.CanSubmit ? null : "disabled")">
+                Submit for approval
+            </button>
         }
         <a class="btn btn-outline-secondary" asp-page="/Projects/View" asp-route-id="@Model.ProjectId">Back</a>
     </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -84,6 +84,7 @@
       </div>
     </div>
 
+    <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/comments.js" asp-append-version="true" defer></script>


### PR DESCRIPTION
## Summary
- ensure the draft plan save and submit buttons perform POST requests to their handlers
- load jQuery from the local library bundle so unobtrusive validation scripts can execute

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5545ff6a0832998224f56cb323b5f