### PR TITLE
Fix Razor expression for plan version banner

### DIFF
--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -77,7 +77,7 @@
     @if (Model.HasApprovedPlan)
     {
       <div class="alert alert-success mt-3 mb-0" role="status">
-        <strong>Baseline v@Model.ActivePlanVersionNo approved.</strong>
+        <strong>Baseline v@(Model.ActivePlanVersionNo) approved.</strong>
         <span class="ms-2">Next due: <span class="badge bg-secondary">@Model.NextDueText</span></span>
       </div>
     }


### PR DESCRIPTION
## Summary
- wrap the ActivePlanVersionNo Razor expression so the baseline banner shows the actual version number instead of a literal `@`

## Testing
- `dotnet test` *(fails: command not found `dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_68d5579130d48329a3588dc38d98e024