### PR TITLE
Rename Baseline to Project Timeline

### DIFF
--- a/Models/Plans/PlanVersion.cs
+++ b/Models/Plans/PlanVersion.cs
@@ -7,7 +7,7 @@ namespace ProjectManagement.Models.Plans;
 
 public class PlanVersion
 {
-    public const string BaselineTitle = "Baseline";
+    public const string ProjectTimelineTitle = "Project Timeline";
 
     public int Id { get; set; }
     public int ProjectId { get; set; }
@@ -15,7 +15,7 @@ public class PlanVersion
     public int VersionNo { get; set; }
 
     [MaxLength(64)]
-    public string Title { get; set; } = BaselineTitle;
+    public string Title { get; set; } = ProjectTimelineTitle;
 
     public PlanVersionStatus Status { get; set; } = PlanVersionStatus.Draft;
 

--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -4,10 +4,10 @@
 @using ProjectManagement.Models.Plans
 @model ProjectManagement.Pages.Projects.Plan.DraftModel
 @{
-    ViewData["Title"] = "Baseline Plan Draft";
+    ViewData["Title"] = "Project Timeline Draft";
 }
 
-<h1 class="mb-3">Baseline Plan Draft</h1>
+<h1 class="mb-3">Project Timeline Draft</h1>
 <p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
 @if (Model.Draft is not null)
 {

--- a/Pages/Projects/Plan/Draft.cshtml.cs
+++ b/Pages/Projects/Plan/Draft.cshtml.cs
@@ -181,7 +181,7 @@ public class DraftModel : PageModel
             return Page();
         }
 
-        StatusMessage = "Baseline plan submitted for approval.";
+        StatusMessage = "Project Timeline submitted for approval.";
         return RedirectToPage(new { id });
     }
 
@@ -349,14 +349,14 @@ public class DraftModel : PageModel
             durations,
             new Dictionary<string, PlanCalculatorManualOverride>(StringComparer.OrdinalIgnoreCase));
 
-        IDictionary<string, (DateOnly start, DateOnly due)> baseline;
+        IDictionary<string, (DateOnly start, DateOnly due)> projectTimeline;
         try
         {
-            baseline = calculator.Compute(baseOptions);
+            projectTimeline = calculator.Compute(baseOptions);
         }
         catch (InvalidOperationException)
         {
-            baseline = new Dictionary<string, (DateOnly start, DateOnly due)>(StringComparer.OrdinalIgnoreCase);
+            projectTimeline = new Dictionary<string, (DateOnly start, DateOnly due)>(StringComparer.OrdinalIgnoreCase);
         }
 
         foreach (var stage in planStages.Values)
@@ -366,7 +366,7 @@ public class DraftModel : PageModel
                 continue;
             }
 
-            if (!baseline.TryGetValue(stage.StageCode, out var computed) || computed.start != start || computed.due != due)
+            if (!projectTimeline.TryGetValue(stage.StageCode, out var computed) || computed.start != start || computed.due != due)
             {
                 var row = Input.Stages.FirstOrDefault(r => string.Equals(r.StageCode, stage.StageCode, StringComparison.OrdinalIgnoreCase));
                 if (row != null)

--- a/Pages/Projects/Plan/Review.cshtml
+++ b/Pages/Projects/Plan/Review.cshtml
@@ -1,10 +1,10 @@
 @page
 @model ProjectManagement.Pages.Projects.Plan.ReviewModel
 @{
-    ViewData["Title"] = "Baseline Plan Review";
+    ViewData["Title"] = "Project Timeline Review";
 }
 
-<h1 class="mb-3">Baseline Plan Review</h1>
+<h1 class="mb-3">Project Timeline Review</h1>
 <p class="text-muted">Project: <strong>@Model.ProjectName</strong></p>
 @if (Model.Plan is not null)
 {

--- a/Pages/Projects/Plan/Review.cshtml.cs
+++ b/Pages/Projects/Plan/Review.cshtml.cs
@@ -76,7 +76,7 @@ public class ReviewModel : PageModel
             return loadResult ?? Page();
         }
 
-        StatusMessage = "Baseline plan approved.";
+        StatusMessage = "Project Timeline approved.";
         return RedirectToPage("/Projects/View", new { id });
     }
 
@@ -119,7 +119,7 @@ public class ReviewModel : PageModel
             return loadResult ?? Page();
         }
 
-        StatusMessage = "Baseline plan rejected and returned to draft.";
+        StatusMessage = "Project Timeline rejected and returned to draft.";
         return RedirectToPage("/Projects/View", new { id });
     }
 

--- a/Pages/Projects/View.cshtml
+++ b/Pages/Projects/View.cshtml
@@ -40,7 +40,7 @@
           {
               if (canDraftPlan)
               {
-                  <a class="btn btn-outline-primary" asp-page="/Projects/Plan/Draft" asp-route-id="@Model.Item.Id" title="Draft or submit baseline">Plan</a>
+                  <a class="btn btn-outline-primary" asp-page="/Projects/Plan/Draft" asp-route-id="@Model.Item.Id" title="Draft or submit Project Timeline">Plan</a>
               }
               else
               {
@@ -77,7 +77,7 @@
     @if (Model.HasApprovedPlan)
     {
       <div class="alert alert-success mt-3 mb-0" role="status">
-        <strong>Baseline v@(Model.ActivePlanVersionNo) approved.</strong>
+        <strong>Project Timeline v@(Model.ActivePlanVersionNo) approved.</strong>
         <span class="ms-2">Next due: <span class="badge bg-secondary">@Model.NextDueText</span></span>
       </div>
     }
@@ -90,7 +90,7 @@
     else
     {
       <div class="alert alert-info mt-3 mb-0" role="status">
-        No approved plan yet. Create a baseline to start execution.
+        No approved plan yet. Create a Project Timeline to start execution.
       </div>
     }
   </div>

--- a/Pages/Projects/View.cshtml.cs
+++ b/Pages/Projects/View.cshtml.cs
@@ -113,7 +113,7 @@ namespace ProjectManagement.Pages.Projects
 
             if (!HasApprovedPlan || !ActivePlanVersionNo.HasValue)
             {
-                NextDueText = "Baseline not approved.";
+                NextDueText = "Project Timeline not approved.";
                 await LoadRecentActivityAsync(projectId, stageNames, cancellationToken);
                 return;
             }

--- a/Services/Plans/PlanDraftService.cs
+++ b/Services/Plans/PlanDraftService.cs
@@ -68,7 +68,7 @@ public class PlanDraftService
         {
             ProjectId = projectId,
             VersionNo = latestVersion + 1,
-            Title = PlanVersion.BaselineTitle,
+            Title = PlanVersion.ProjectTimelineTitle,
             Status = PlanVersionStatus.Draft,
             CreatedByUserId = userId,
             CreatedOn = _clock.UtcNow,


### PR DESCRIPTION
## Summary
- rename project planning views and status messages to use the "Project Timeline" terminology
- update the plan version default title constant and draft service to reflect the new name
- align draft page logic with the Project Timeline wording

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d558dfb22883298b15be3d8bd4defe