### PR TITLE
Enable automatic stage starts and modal completion

### DIFF
--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -14,6 +14,7 @@
     };
     var canManage = Model.CanManageStages;
     var manageTooltip = "Only Admin, HoD, or the assigned Lead PO can update stages.";
+    var todayIso = DateOnly.FromDateTime(DateTime.Today).ToString("yyyy-MM-dd");
 }
 
 <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-3">
@@ -26,6 +27,37 @@
         <a class="btn btn-outline-dark" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId" title="Comments &amp; files">Activity</a>
     </div>
 </div>
+
+<div class="modal fade" id="completeModal" tabindex="-1" aria-hidden="true" aria-labelledby="completeModalLabel">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-content">
+            <form method="post" asp-page-handler="Complete">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="completeModalLabel">Mark stage complete</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="id" value="@Model.ProjectId" />
+                    <input type="hidden" name="stage" id="complete-stage" />
+                    <p class="small text-muted mb-3" id="complete-stage-label"></p>
+                    <div class="mb-3">
+                        <label class="form-label" for="complete-date">Completion date</label>
+                        <input class="form-control" type="date" id="complete-date" name="completionDate" value="@todayIso" required />
+                    </div>
+                    <div class="form-text">Predecessor rules will be enforced.</div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-success">Confirm</button>
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/stages.js" asp-append-version="true"></script>
+}
 
 @if (!string.IsNullOrEmpty(Model.StatusMessage))
 {
@@ -85,12 +117,8 @@
                         @foreach (var stage in Model.Stages)
                         {
                             var prereqHint = Model.GetPrereqHint(stage.Code);
-                            var startAllowed = stage.StartGuard.Allowed && canManage;
                             var completeAllowed = stage.CompleteGuard.Allowed && canManage;
                             var skipAllowed = stage.SkipGuard.Allowed && canManage;
-                            var startTitle = !canManage
-                                ? manageTooltip
-                                : stage.StartGuard.Allowed ? "Start stage" : stage.StartGuard.Reason ?? "Stage cannot start yet";
                             var completeTitle = !canManage
                                 ? manageTooltip
                                 : stage.CompleteGuard.Allowed ? "Mark complete" : stage.CompleteGuard.Reason ?? "Stage cannot complete yet";
@@ -121,12 +149,17 @@
                                 <td>@stage.CompletedOn?.ToString("dd MMM yyyy")</td>
                                 <td class="text-end">
                                     <div class="d-flex flex-wrap justify-content-end gap-2">
-                                        <form method="post" asp-page-handler="Start" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
-                                            <button type="submit" class="btn btn-outline-primary btn-sm" disabled="@(startAllowed ? null : "disabled")" title="@startTitle">Start</button>
-                                        </form>
-                                        <form method="post" asp-page-handler="Complete" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-inline">
-                                            <button type="submit" class="btn btn-outline-success btn-sm" disabled="@(completeAllowed ? null : "disabled")" title="@completeTitle">Complete</button>
-                                        </form>
+                                        <button type="button"
+                                                class="btn btn-outline-success btn-sm"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#completeModal"
+                                                data-stage="@stage.Code"
+                                                data-stage-name="@stage.Name"
+                                                data-default-date="@todayIso"
+                                                disabled="@(completeAllowed ? null : "disabled")"
+                                                title="@completeTitle">
+                                            Complete
+                                        </button>
                                         @if (string.Equals(stage.Code, "PNC", System.StringComparison.OrdinalIgnoreCase))
                                         {
                                             <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-flex flex-wrap gap-2">

--- a/ProjectManagement.Tests/StageFlowServiceTests.cs
+++ b/ProjectManagement.Tests/StageFlowServiceTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services.Plans;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageFlowServiceTests
+{
+    private static StageFlowService CreateService(bool skipWeekends, PlanTransitionRule rule)
+    {
+        var dependencies = new[]
+        {
+            new StageDependencyTemplate { FromStageCode = "B", DependsOnStageCode = "A" },
+            new StageDependencyTemplate { FromStageCode = "C", DependsOnStageCode = "A" },
+            new StageDependencyTemplate { FromStageCode = "C", DependsOnStageCode = "B" }
+        };
+
+        return new StageFlowService(dependencies, skipWeekends, rule);
+    }
+
+    [Fact]
+    public void ComputeAutoStart_RespectsNextWorkingDayRule()
+    {
+        var service = CreateService(skipWeekends: true, rule: PlanTransitionRule.NextWorkingDay);
+        var completed = new Dictionary<string, DateOnly?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new DateOnly(2024, 1, 5)
+        };
+
+        var start = service.ComputeAutoStart("B", completed, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Equal(new DateOnly(2024, 1, 8), start);
+    }
+
+    [Fact]
+    public void ComputeAutoStart_IgnoresSkippedPredecessors()
+    {
+        var service = CreateService(skipWeekends: false, rule: PlanTransitionRule.SameDay);
+        var completed = new Dictionary<string, DateOnly?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new DateOnly(2024, 2, 1),
+            ["B"] = null
+        };
+
+        var skipped = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "B" };
+        var start = service.ComputeAutoStart("C", completed, skipped);
+
+        Assert.Equal(new DateOnly(2024, 2, 1), start);
+    }
+
+    [Fact]
+    public void ComputeAutoStart_ReturnsNullWhenPredecessorIncomplete()
+    {
+        var service = CreateService(skipWeekends: false, rule: PlanTransitionRule.SameDay);
+        var completed = new Dictionary<string, DateOnly?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = null
+        };
+
+        var start = service.ComputeAutoStart("B", completed, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.Null(start);
+    }
+}

--- a/Services/Plans/StageFlowService.cs
+++ b/Services/Plans/StageFlowService.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Services.Plans;
+
+public sealed class StageFlowService
+{
+    private readonly IReadOnlyDictionary<string, string[]> _predecessors;
+    private readonly IReadOnlyDictionary<string, string[]> _successors;
+    private readonly bool _skipWeekends;
+    private readonly bool _nextWorkingDay;
+
+    public StageFlowService(IEnumerable<StageDependencyTemplate> dependencies, bool skipWeekends, PlanTransitionRule transitionRule)
+    {
+        if (dependencies is null)
+        {
+            throw new ArgumentNullException(nameof(dependencies));
+        }
+
+        _skipWeekends = skipWeekends;
+        _nextWorkingDay = transitionRule == PlanTransitionRule.NextWorkingDay;
+
+        var predecessorLookup = dependencies
+            .GroupBy(d => d.FromStageCode, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(d => d.DependsOnStageCode).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+        _predecessors = predecessorLookup;
+
+        var successorMap = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dependency in dependencies)
+        {
+            if (string.IsNullOrWhiteSpace(dependency.DependsOnStageCode) || string.IsNullOrWhiteSpace(dependency.FromStageCode))
+            {
+                continue;
+            }
+
+            if (!successorMap.TryGetValue(dependency.DependsOnStageCode, out var list))
+            {
+                list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                successorMap[dependency.DependsOnStageCode] = list;
+            }
+
+            list.Add(dependency.FromStageCode);
+        }
+
+        _successors = successorMap.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlyList<string> GetPredecessors(string stageCode)
+    {
+        if (stageCode == null)
+        {
+            throw new ArgumentNullException(nameof(stageCode));
+        }
+
+        return _predecessors.TryGetValue(stageCode, out var preds) ? preds : Array.Empty<string>();
+    }
+
+    public IReadOnlyList<string> GetSuccessors(string stageCode)
+    {
+        if (stageCode == null)
+        {
+            throw new ArgumentNullException(nameof(stageCode));
+        }
+
+        return _successors.TryGetValue(stageCode, out var list) ? list : Array.Empty<string>();
+    }
+
+    public DateOnly Bump(DateOnly date)
+    {
+        if (!_skipWeekends)
+        {
+            return date;
+        }
+
+        return date.DayOfWeek switch
+        {
+            DayOfWeek.Saturday => date.AddDays(2),
+            DayOfWeek.Sunday => date.AddDays(1),
+            _ => date
+        };
+    }
+
+    public DateOnly GapAfter(DateOnly date)
+    {
+        var next = _nextWorkingDay ? date.AddDays(1) : date;
+        return Bump(next);
+    }
+
+    public DateOnly? ComputeAutoStart(
+        string stageCode,
+        IReadOnlyDictionary<string, DateOnly?> completedOn,
+        IReadOnlySet<string>? skipped)
+    {
+        if (stageCode == null)
+        {
+            throw new ArgumentNullException(nameof(stageCode));
+        }
+
+        if (completedOn == null)
+        {
+            throw new ArgumentNullException(nameof(completedOn));
+        }
+
+        skipped ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!_predecessors.TryGetValue(stageCode, out var predecessors) || predecessors.Length == 0)
+        {
+            return null;
+        }
+
+        var edges = new List<DateOnly>();
+        foreach (var predecessor in predecessors)
+        {
+            if (skipped.Contains(predecessor))
+            {
+                continue;
+            }
+
+            if (!completedOn.TryGetValue(predecessor, out var completed) || completed is null)
+            {
+                return null;
+            }
+
+            edges.Add(GapAfter(completed.Value));
+        }
+
+        return edges.Count == 0 ? null : edges.Max();
+    }
+}

--- a/wwwroot/js/stages.js
+++ b/wwwroot/js/stages.js
@@ -1,0 +1,47 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    const modal = document.getElementById('completeModal');
+    if (!modal) {
+      return;
+    }
+
+    modal.addEventListener('show.bs.modal', function (event) {
+      const trigger = event.relatedTarget;
+      if (!trigger) {
+        return;
+      }
+
+      const stageCode = trigger.getAttribute('data-stage') || '';
+      const stageName = trigger.getAttribute('data-stage-name') || '';
+      const defaultDate = trigger.getAttribute('data-default-date');
+
+      const stageInput = modal.querySelector('#complete-stage');
+      if (stageInput) {
+        stageInput.value = stageCode;
+      }
+
+      const stageLabel = modal.querySelector('#complete-stage-label');
+      if (stageLabel) {
+        let label;
+        if (stageCode) {
+          label = stageName ? `${stageCode} — ${stageName}` : stageCode;
+        } else {
+          label = stageName;
+        }
+
+        stageLabel.textContent = (label || '').trim();
+      }
+
+      const dateInput = modal.querySelector('#complete-date');
+      if (dateInput) {
+        if (defaultDate) {
+          dateInput.value = defaultDate;
+        } else if (!dateInput.value) {
+          const today = new Date();
+          const iso = today.toISOString().slice(0, 10);
+          dateInput.value = iso;
+        }
+      }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add a StageFlowService that calculates successor start dates with plan transition rules and weekend handling
- replace the stage Start action with a modal Complete flow and supporting script that captures user-specified completion dates
- update stage mutations to auto-start successors after completion or skip and cover the flow with unit tests

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d55a3683488329b23df031dca288d8