### PR TITLE
Implement Amazon-style project stage tracker

### DIFF
--- a/Models/Stages/StageTrackerViewModels.cs
+++ b/Models/Stages/StageTrackerViewModels.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.Models.Stages;
+
+public enum TrackNodeState
+{
+    Done,
+    Current,
+    Todo
+}
+
+public sealed class TrackNodeVm
+{
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public TrackNodeState State { get; init; }
+        = TrackNodeState.Todo;
+    public DateOnly? PlannedStart { get; init; }
+        = null;
+    public DateOnly? PlannedDue { get; init; }
+        = null;
+    public DateOnly? ActualStart { get; init; }
+        = null;
+    public DateOnly? CompletedOn { get; init; }
+        = null;
+    public int SlipDays { get; init; }
+        = 0;
+    public string Tooltip { get; init; } = string.Empty;
+    public bool IsOptional { get; init; }
+        = false;
+    public bool IsVisible { get; init; } = true;
+}
+
+public sealed class TrackEdgeVm
+{
+    public string From { get; init; } = string.Empty;
+    public string To { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string Variant { get; init; } = "neutral";
+}
+
+public sealed class TrackerVm
+{
+    public List<TrackNodeVm> Main { get; init; } = new();
+    public List<TrackNodeVm> BranchTop { get; init; } = new();
+    public List<TrackNodeVm> BranchBottom { get; init; } = new();
+    public List<TrackEdgeVm> Edges { get; init; } = new();
+    public string CurrentCode { get; init; } = string.Empty;
+    public bool PncApplicable { get; init; } = true;
+}

--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -4,6 +4,7 @@
 @using System.Linq
 @using Microsoft.AspNetCore.Mvc.ViewFeatures
 @using ProjectManagement.Models.Execution
+@using ProjectManagement.Services
 @{
     ViewData["Title"] = "Project Stages";
     var ragClass = Model.ProjectRag switch
@@ -15,6 +16,43 @@
     var canManage = Model.CanManageStages;
     var manageTooltip = "Only Admin, HoD, or the assigned Lead PO can update stages.";
     var todayIso = DateOnly.FromDateTime(DateTime.Today).ToString("yyyy-MM-dd");
+    var currentStage = Model.CurrentStage;
+    var currentStageCode = currentStage?.Code;
+    var currentStageName = currentStage?.Name ?? "All stages completed";
+    var plannedStartIso = currentStage?.PlannedStart?.ToString("yyyy-MM-dd");
+    var plannedDueIso = currentStage?.PlannedDue?.ToString("yyyy-MM-dd");
+    int GetDays(DateOnly start, DateOnly end) => (end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days + 1;
+    var currentStageStart = currentStage?.ActualStart ?? currentStage?.PlannedStart;
+    string? progressLabel = null;
+    if (currentStage?.ActualStart is DateOnly actualStartValue)
+    {
+        progressLabel = $"{GetDays(actualStartValue, Model.Today)}d in progress";
+    }
+    else if (currentStage != null && currentStage.Status == StageStatus.NotStarted)
+    {
+        progressLabel = "Not started";
+    }
+
+    string? dueLabel = null;
+    if (currentStage?.PlannedDue is DateOnly dueDate)
+    {
+        var delta = (dueDate.ToDateTime(TimeOnly.MinValue) - Model.Today.ToDateTime(TimeOnly.MinValue)).Days;
+        dueLabel = delta switch
+        {
+            0 => "Due today",
+            < 0 => $"{Math.Abs(delta)}d overdue",
+            _ => $"Due in {delta}d"
+        };
+    }
+
+    var canCompleteCurrent = currentStage != null && currentStage.CompleteGuard.Allowed && canManage;
+    var currentCompleteTitle = !canManage
+        ? manageTooltip
+        : currentStage?.CompleteGuard.Allowed == true ? "Mark complete" : currentStage?.CompleteGuard.Reason ?? "Stage cannot complete yet";
+    var canSkipCurrent = currentStage != null && string.Equals(currentStage.Code, "PNC", StringComparison.OrdinalIgnoreCase) && currentStage.SkipGuard.Allowed && canManage;
+    var skipTitle = !canManage
+        ? manageTooltip
+        : currentStage?.SkipGuard.Allowed == true ? "Skip PNC with reason" : currentStage?.SkipGuard.Reason ?? "PNC cannot be skipped.";
 }
 
 <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-3">
@@ -31,7 +69,7 @@
 <div class="modal fade" id="completeModal" tabindex="-1" aria-hidden="true" aria-labelledby="completeModalLabel">
     <div class="modal-dialog modal-dialog-centered modal-sm">
         <div class="modal-content">
-            <form method="post" asp-page-handler="Complete">
+            <form method="post" asp-page-handler="Complete" enctype="multipart/form-data">
                 <div class="modal-header">
                     <h5 class="modal-title" id="completeModalLabel">Mark stage complete</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -43,6 +81,16 @@
                     <div class="mb-3">
                         <label class="form-label" for="complete-date">Completion date</label>
                         <input class="form-control" type="date" id="complete-date" name="completionDate" value="@todayIso" required />
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="complete-remark">Remark</label>
+                        <textarea class="form-control" id="complete-remark" name="remark" rows="3" placeholder="Add a short note"></textarea>
+                        <div class="form-text">Optional: this note will appear in activity.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="complete-files">Attachments</label>
+                        <input class="form-control" type="file" id="complete-files" name="files" multiple />
+                        <div class="form-text">Up to @(ProjectCommentService.MaxAttachmentSizeBytes / (1024 * 1024)) MB per file.</div>
                     </div>
                     <div class="form-text">Predecessor rules will be enforced.</div>
                 </div>
@@ -56,7 +104,8 @@
 </div>
 
 @section Scripts {
-    <script src="~/js/stages.js" asp-append-version="true"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/stages-tracker.js" asp-append-version="true"></script>
 }
 
 @if (!string.IsNullOrEmpty(Model.StatusMessage))
@@ -73,24 +122,91 @@
     </div>
 }
 
+@await Html.PartialAsync("_StageTracker", Model.Tracker)
+
+@if (currentStage != null)
+{
+    <section class="current-stage-card mb-4">
+        <div class="stage-title">
+            <div>
+                <div class="stage-code">@currentStageCode</div>
+                <div class="text-muted">@currentStageName</div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                @if (!string.IsNullOrEmpty(progressLabel))
+                {
+                    <span class="badge bg-primary-subtle text-primary fw-semibold">@progressLabel</span>
+                }
+                @if (!string.IsNullOrEmpty(dueLabel))
+                {
+                    <span class="badge bg-light text-dark border">@dueLabel</span>
+                }
+            </div>
+        </div>
+        <div class="small text-muted mt-2">Planned window: @(currentStage?.PlannedStart?.ToString("dd MMM") ?? "—") – @(currentStage?.PlannedDue?.ToString("dd MMM yyyy") ?? "—")</div>
+        @if (!string.IsNullOrEmpty(plannedStartIso) && !string.IsNullOrEmpty(plannedDueIso))
+        {
+            <div class="timeline" data-timeline data-start="@plannedStartIso" data-due="@plannedDueIso" data-today="@Model.Today.ToString("yyyy-MM-dd")"></div>
+        }
+        @if (Model.CurrentStagePrerequisites.Any())
+        {
+            <div class="fw-semibold mb-2">Prerequisites</div>
+            <ul class="stage-prereqs mb-3">
+                @foreach (var prereq in Model.CurrentStagePrerequisites)
+                {
+                    var icon = prereq.Completed ? "bi-check-circle-fill text-success" : "bi-exclamation-circle text-muted";
+                    <li>
+                        <i class="bi @icon"></i>
+                        <span>@prereq.Code</span>
+                    </li>
+                }
+            </ul>
+        }
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+            <div class="small text-muted">
+                <div>Actual start: @(currentStage?.ActualStart?.ToString("dd MMM yyyy") ?? "—")</div>
+                <div>Planned due: @(currentStage?.PlannedDue?.ToString("dd MMM yyyy") ?? "—")</div>
+            </div>
+            <div class="d-flex flex-column flex-sm-row gap-2 align-items-stretch">
+                @if (canSkipCurrent)
+                {
+                    <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@currentStageCode" class="d-flex gap-2 align-items-center">
+                        <input type="text" name="reason" class="form-control form-control-sm" placeholder="Skip reason" required minlength="3" maxlength="200" />
+                        <button type="submit" class="btn btn-outline-secondary btn-sm" title="@skipTitle">Skip</button>
+                    </form>
+                }
+                <button type="button"
+                        class="btn btn-primary"
+                        data-bs-toggle="modal"
+                        data-bs-target="#completeModal"
+                        data-stage="@currentStageCode"
+                        data-stage-name="@currentStageName"
+                        data-default-date="@todayIso"
+                        title="@currentCompleteTitle"
+                        disabled="@(canCompleteCurrent ? null : "disabled")">
+                    Complete stage
+                </button>
+            </div>
+        </div>
+    </section>
+}
+else
+{
+    <div class="alert alert-info mb-4">All stages are complete. Review the table below for the final record.</div>
+}
+
 <div class="row g-4">
     <div class="col-12 col-lg-8">
         <div class="card shadow-sm mb-3">
-            <div class="card-body">
-                <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
-                    <div>
-                        <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
-                    </div>
-                    <div class="flex-grow-1">
-                        <div class="fw-semibold mb-1">Slip (days)</div>
-                        <ul class="list-inline mb-0">
-                            @foreach (var slip in Model.StageSlips)
-                            {
-                                <li class="list-inline-item mb-1">
-                                    <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
-                                </li>
-                            }
-                        </ul>
+            <div class="card-body d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+                <span class="@ragClass">Project RAG: @Model.ProjectRag</span>
+                <div class="flex-grow-1">
+                    <div class="fw-semibold mb-1">Slip (days)</div>
+                    <div class="d-flex flex-wrap gap-2">
+                        @foreach (var slip in Model.StageSlips)
+                        {
+                            <span class="badge bg-light text-dark border">@slip.Code: @slip.SlipDays</span>
+                        }
                     </div>
                 </div>
             </div>
@@ -99,36 +215,26 @@
         <div class="card shadow-sm">
             <div class="card-body">
                 <div class="table-responsive">
-                    <table class="table table-sm align-middle">
+                    <table class="table table-sm align-middle table-striped stage-table">
                         <thead>
                             <tr>
                                 <th scope="col" style="width: 6rem;">Stage</th>
                                 <th scope="col">Description</th>
-                                <th scope="col" style="width: 12rem;">Planned Start</th>
-                                <th scope="col" style="width: 12rem;">Planned Due</th>
+                                <th scope="col" style="width: 12rem;">Planned start</th>
+                                <th scope="col" style="width: 12rem;">Planned due</th>
                                 <th scope="col" style="width: 10rem;">Status</th>
-                                <th scope="col" style="width: 8rem;">Slip (days)</th>
-                                <th scope="col" style="width: 12rem;">Actual Start</th>
-                                <th scope="col" style="width: 12rem;">Completed On</th>
-                                <th scope="col" class="text-end" style="width: 18rem;">Actions</th>
+                                <th scope="col" style="width: 8rem;">Slip</th>
+                                <th scope="col" style="width: 12rem;">Actual start</th>
+                                <th scope="col" style="width: 12rem;">Completed on</th>
                             </tr>
                         </thead>
                         <tbody>
                         @foreach (var stage in Model.Stages)
                         {
                             var prereqHint = Model.GetPrereqHint(stage.Code);
-                            var completeAllowed = stage.CompleteGuard.Allowed && canManage;
-                            var skipAllowed = stage.SkipGuard.Allowed && canManage;
-                            var completeTitle = !canManage
-                                ? manageTooltip
-                                : stage.CompleteGuard.Allowed ? "Mark complete" : stage.CompleteGuard.Reason ?? "Stage cannot complete yet";
-                            var skipTitle = !canManage
-                                ? manageTooltip
-                                : stage.SkipGuard.Allowed ? "Skip PNC with reason" : stage.SkipGuard.Reason ?? "PNC cannot be skipped.";
-                            <tr>
-                                <td>
-                                    <div class="fw-semibold">@stage.Code</div>
-                                </td>
+                            var isCurrent = !string.IsNullOrEmpty(Model.Tracker.CurrentCode) && string.Equals(stage.Code, Model.Tracker.CurrentCode, StringComparison.OrdinalIgnoreCase);
+                            <tr data-stage-row="@stage.Code" class="@(isCurrent ? string.Empty : "dim")">
+                                <td class="fw-semibold">@stage.Code</td>
                                 <td>
                                     <div class="fw-semibold d-flex align-items-center gap-2">
                                         @stage.Name
@@ -147,28 +253,6 @@
                                 <td>@stage.SlipDays</td>
                                 <td>@stage.ActualStart?.ToString("dd MMM yyyy")</td>
                                 <td>@stage.CompletedOn?.ToString("dd MMM yyyy")</td>
-                                <td class="text-end">
-                                    <div class="d-flex flex-wrap justify-content-end gap-2">
-                                        <button type="button"
-                                                class="btn btn-outline-success btn-sm"
-                                                data-bs-toggle="modal"
-                                                data-bs-target="#completeModal"
-                                                data-stage="@stage.Code"
-                                                data-stage-name="@stage.Name"
-                                                data-default-date="@todayIso"
-                                                disabled="@(completeAllowed ? null : "disabled")"
-                                                title="@completeTitle">
-                                            Complete
-                                        </button>
-                                        @if (string.Equals(stage.Code, "PNC", System.StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            <form method="post" asp-page-handler="Skip" asp-route-projectId="@Model.ProjectId" asp-route-stage="@stage.Code" class="d-flex flex-wrap gap-2">
-                                                <input type="text" name="reason" class="form-control form-control-sm" placeholder="Reason" required minlength="3" maxlength="200" @(canManage ? null : "disabled") />
-                                                <button type="submit" class="btn btn-outline-secondary btn-sm" disabled="@(skipAllowed ? null : "disabled")" title="@skipTitle">Skip</button>
-                                            </form>
-                                        }
-                                    </div>
-                                </td>
                             </tr>
                         }
                         </tbody>
@@ -181,18 +265,7 @@
         <div class="vstack gap-3">
             <div class="card shadow-sm">
                 <div class="card-body">
-                    <h2 class="h5 mb-3">Stage remarks</h2>
-                    <form method="get" class="row gy-2 gx-2 align-items-end mb-3">
-                        <input type="hidden" name="id" value="@Model.ProjectId" />
-                        <div class="col-12">
-                            <label asp-for="CommentStageId" class="form-label">Stage</label>
-                            <select asp-for="CommentStageId" asp-items="Model.CommentStageOptions" class="form-select"></select>
-                        </div>
-                        <div class="col-12">
-                            <button type="submit" class="btn btn-primary">View</button>
-                        </div>
-                    </form>
-
+                    <h2 class="h5 mb-3">Current stage remarks</h2>
                     @{
                         var routeValues = new Dictionary<string, object?>();
                         if (Model.CommentStageId.HasValue)
@@ -213,7 +286,15 @@
                         };
                     }
 
-                    @await Html.PartialAsync("_CommentThread", Model.StageComments, threadViewData)
+                    @if (Model.CurrentStage != null)
+                    {
+                        <p class="text-muted small">Latest remarks for <strong>@Model.CurrentStage.Code</strong>. Showing up to 3 items.</p>
+                        @await Html.PartialAsync("_CommentThread", Model.StageComments, threadViewData)
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">No active stage.</p>
+                    }
 
                     <div class="mt-3 text-end">
                         <a class="btn btn-sm btn-outline-secondary" asp-page="/Projects/Activity" asp-route-id="@Model.ProjectId">Open activity</a>
@@ -221,7 +302,7 @@
                 </div>
             </div>
 
-            @if (Model.CanComment && Model.CommentStageOptions.Any())
+            @if (Model.CanComment && Model.CurrentStage != null)
             {
                 @await Html.PartialAsync("_CommentComposer", Model.CommentComposer)
             }

--- a/Pages/Shared/_StageTracker.cshtml
+++ b/Pages/Shared/_StageTracker.cshtml
@@ -1,0 +1,92 @@
+@using System.Linq
+@using ProjectManagement.Models.Stages
+@model TrackerVm
+<link rel="stylesheet" href="~/css/stage-tracker.css" asp-append-version="true" />
+
+<div class="tracker-bar sticky-top">
+    <div class="trk-flow">
+        @{
+            var branch = Model.BranchTop.Any() && Model.BranchBottom.Any();
+        }
+        @for (var i = 0; i < Model.Main.Count; i++)
+        {
+            var node = Model.Main[i];
+            var isPnc = string.Equals(node.Code, "PNC", StringComparison.OrdinalIgnoreCase);
+            if (!node.IsVisible && !isPnc)
+            {
+                continue;
+            }
+
+            <div class="trk-cell">
+                <div class="trk-connector"></div>
+                <div class="trk-node @(NodeClass(node)) @(isPnc && !node.IsVisible ? "skipped" : string.Empty)">
+                    <div class="dot" data-bs-toggle="tooltip" title="@node.Tooltip"></div>
+                    <div class="label">
+                        <span class="code" data-stage-scroll="@node.Code">@node.Code</span>
+                        <div class="name text-truncate">@node.Name</div>
+                    </div>
+                </div>
+                @RenderBadge(Model.Edges, node.Code)
+                @if (isPnc && !Model.PncApplicable)
+                {
+                    <div class="badge bg-light text-muted border mt-2">Skipped</div>
+                }
+            </div>
+
+            if (branch && string.Equals(node.Code, "BID", StringComparison.OrdinalIgnoreCase))
+            {
+                var top = Model.BranchTop.First();
+                var bottom = Model.BranchBottom.First();
+                <div class="trk-cell trk-branch">
+                    <div class="trk-branch-grid">
+                        <div class="trk-node @(NodeClass(top))">
+                            <div class="dot" data-bs-toggle="tooltip" title="@top.Tooltip"></div>
+                            <div class="label">
+                                <span class="code" data-stage-scroll="@top.Code">@top.Code</span>
+                                <div class="name text-truncate">@top.Name</div>
+                            </div>
+                        </div>
+                        <div class="trk-node @(NodeClass(bottom))">
+                            <div class="dot" data-bs-toggle="tooltip" title="@bottom.Tooltip"></div>
+                            <div class="label">
+                                <span class="code" data-stage-scroll="@bottom.Code">@bottom.Code</span>
+                                <div class="name text-truncate">@bottom.Name</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="trk-branch-join"></div>
+                    @RenderBadge(Model.Edges, top.Code)
+                    @RenderBadge(Model.Edges, bottom.Code)
+                </div>
+            }
+        }
+    </div>
+
+    <div class="trk-legend">
+        <span class="done">completed</span>
+        <span class="current">current</span>
+        <span class="todo">upcoming</span>
+    </div>
+</div>
+
+@functions {
+    private static string NodeClass(TrackNodeVm node)
+        => node.State switch
+        {
+            TrackNodeState.Done => "done",
+            TrackNodeState.Current => "current",
+            _ => "todo"
+        };
+
+    private static Microsoft.AspNetCore.Html.IHtmlContent RenderBadge(IEnumerable<TrackEdgeVm> edges, string code)
+    {
+        var edge = edges.FirstOrDefault(e => string.Equals(e.From, code, StringComparison.OrdinalIgnoreCase));
+        if (edge == null || string.IsNullOrWhiteSpace(edge.Label))
+        {
+            return Microsoft.AspNetCore.Html.HtmlString.Empty;
+        }
+
+        var classes = $"trk-badge {edge.Variant}";
+        return new Microsoft.AspNetCore.Html.HtmlString($"<div class=\"{classes}\">{edge.Label}</div>");
+    }
+}

--- a/Services/Stages/TrackerBuilder.cs
+++ b/Services/Stages/TrackerBuilder.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class TrackerBuilder
+{
+    private readonly IReadOnlyList<StageTemplate> _templates;
+    private readonly ILookup<string, string> _predecessors;
+
+    public TrackerBuilder(IEnumerable<StageTemplate> templates, IEnumerable<StageDependencyTemplate> dependencies)
+    {
+        _templates = templates
+            .OrderBy(t => t.Sequence)
+            .ToList();
+
+        _predecessors = dependencies
+            .ToLookup(d => d.FromStageCode, d => d.DependsOnStageCode, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public TrackerVm Build(IEnumerable<ProjectStage> stages, bool pncApplicable, DateOnly today)
+    {
+        var stageMap = stages.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
+        var ordered = _templates
+            .Where(t => pncApplicable || !IsPnc(t.Code))
+            .ToList();
+
+        var current = DetermineCurrent(ordered, stageMap);
+        var vm = new TrackerVm
+        {
+            CurrentCode = current ?? string.Empty,
+            PncApplicable = pncApplicable
+        };
+
+        foreach (var template in _templates)
+        {
+            if (!pncApplicable && IsPnc(template.Code))
+            {
+                // Skip visible rendering later but keep placeholder for branch join logic.
+            }
+
+            stageMap.TryGetValue(template.Code, out var stage);
+            var node = BuildNode(template, stage, current, today, pncApplicable);
+
+            if (string.Equals(template.Code, "TEC", StringComparison.OrdinalIgnoreCase))
+            {
+                vm.BranchTop.Add(node);
+            }
+            else if (string.Equals(template.Code, "BENCH", StringComparison.OrdinalIgnoreCase))
+            {
+                vm.BranchBottom.Add(node);
+            }
+            else
+            {
+                vm.Main.Add(node);
+            }
+        }
+
+        AddEdges(vm, stageMap, today, pncApplicable, vm.CurrentCode);
+        return vm;
+    }
+
+    private string? DetermineCurrent(IEnumerable<StageTemplate> ordered, IDictionary<string, ProjectStage> stageMap)
+    {
+        var allDone = true;
+        foreach (var template in ordered)
+        {
+            if (!stageMap.TryGetValue(template.Code, out var stage))
+            {
+                continue;
+            }
+
+            if (stage.Status is StageStatus.Completed or StageStatus.Skipped)
+            {
+                continue;
+            }
+
+            allDone = false;
+
+            var predecessors = _predecessors[template.Code];
+            var ready = true;
+            foreach (var pred in predecessors)
+            {
+                if (!stageMap.TryGetValue(pred, out var predStage))
+                {
+                    continue;
+                }
+
+                if (predStage.Status is not StageStatus.Completed and not StageStatus.Skipped)
+                {
+                    ready = false;
+                    break;
+                }
+            }
+
+            if (ready)
+            {
+                return template.Code;
+            }
+        }
+
+        return allDone ? null : ordered.LastOrDefault()?.Code;
+    }
+
+    private static TrackNodeVm BuildNode(StageTemplate template, ProjectStage? stage, string? currentCode, DateOnly today, bool pncApplicable)
+    {
+        var state = TrackNodeState.Todo;
+        if (stage != null)
+        {
+            if (stage.Status is StageStatus.Completed or StageStatus.Skipped)
+            {
+                state = TrackNodeState.Done;
+            }
+            else if (string.Equals(stage.StageCode, currentCode, StringComparison.OrdinalIgnoreCase))
+            {
+                state = TrackNodeState.Current;
+            }
+        }
+
+        var slip = CalculateSlip(stage, today);
+        var tooltip = BuildTooltip(stage);
+
+        return new TrackNodeVm
+        {
+            Code = template.Code,
+            Name = template.Name,
+            State = state,
+            PlannedStart = stage?.PlannedStart,
+            PlannedDue = stage?.PlannedDue,
+            ActualStart = stage?.ActualStart,
+            CompletedOn = stage?.CompletedOn,
+            SlipDays = slip,
+            Tooltip = tooltip,
+            IsOptional = template.Optional,
+            IsVisible = pncApplicable || !IsPnc(template.Code)
+        };
+    }
+
+    private static void AddEdges(
+        TrackerVm vm,
+        IDictionary<string, ProjectStage> stages,
+        DateOnly today,
+        bool pncApplicable,
+        string currentCode)
+    {
+        string? previousVisible = null;
+        foreach (var node in vm.Main)
+        {
+            if (!node.IsVisible)
+            {
+                continue;
+            }
+
+            if (previousVisible != null)
+            {
+                vm.Edges.Add(BuildEdge(stages, previousVisible, node.Code, today, currentCode));
+            }
+
+            previousVisible = node.Code;
+        }
+
+        if (vm.BranchTop.Count == 0 || vm.BranchBottom.Count == 0)
+        {
+            return;
+        }
+
+        vm.Edges.Add(BuildEdge(stages, "BID", vm.BranchTop[0].Code, today, currentCode));
+        vm.Edges.Add(BuildEdge(stages, "BID", vm.BranchBottom[0].Code, today, currentCode));
+        vm.Edges.Add(BuildEdge(stages, vm.BranchTop[0].Code, "COB", today, currentCode));
+        vm.Edges.Add(BuildEdge(stages, vm.BranchBottom[0].Code, "COB", today, currentCode));
+    }
+
+    private static TrackEdgeVm BuildEdge(
+        IDictionary<string, ProjectStage> stages,
+        string fromCode,
+        string toCode,
+        DateOnly today,
+        string currentCode)
+    {
+        stages.TryGetValue(fromCode, out var from);
+        stages.TryGetValue(toCode, out var to);
+
+        var label = string.Empty;
+        var variant = "neutral";
+
+        if (from != null && from.Status == StageStatus.Completed && from.CompletedOn.HasValue && from.ActualStart.HasValue)
+        {
+            var days = Math.Max(1, DaysBetween(from.ActualStart.Value, from.CompletedOn.Value));
+            if (from.PlannedDue.HasValue)
+            {
+                var slip = DaysBetween(from.PlannedDue.Value, from.CompletedOn.Value);
+                if (slip <= 0)
+                {
+                    label = $"{days}d on time";
+                    variant = "good";
+                }
+                else
+                {
+                    label = $"{days}d late by {slip}d";
+                    variant = "bad";
+                }
+            }
+            else
+            {
+                label = $"{days}d completed";
+            }
+        }
+        else if (to != null && (to.Status == StageStatus.InProgress || string.Equals(to.StageCode, currentCode, StringComparison.OrdinalIgnoreCase)))
+        {
+            if (to.ActualStart.HasValue)
+            {
+                var duration = Math.Max(1, DaysBetween(to.ActualStart.Value, today));
+                label = $"in progress {duration}d";
+                variant = "progress";
+            }
+        }
+
+        return new TrackEdgeVm
+        {
+            From = fromCode,
+            To = toCode,
+            Label = label,
+            Variant = variant
+        };
+    }
+
+    private static int CalculateSlip(ProjectStage? stage, DateOnly today)
+    {
+        if (stage == null)
+        {
+            return 0;
+        }
+
+        if (stage.CompletedOn.HasValue && stage.PlannedDue.HasValue)
+        {
+            return Math.Max(0, DaysBetween(stage.PlannedDue.Value, stage.CompletedOn.Value));
+        }
+
+        if (stage.PlannedDue.HasValue)
+        {
+            return Math.Max(0, DaysBetween(stage.PlannedDue.Value, today));
+        }
+
+        return 0;
+    }
+
+    private static string BuildTooltip(ProjectStage? stage)
+    {
+        if (stage == null)
+        {
+            return string.Empty;
+        }
+
+        var plannedStart = stage.PlannedStart?.ToString("dd MMM yyyy") ?? "—";
+        var plannedDue = stage.PlannedDue?.ToString("dd MMM yyyy") ?? "—";
+        var actualStart = stage.ActualStart?.ToString("dd MMM yyyy") ?? "—";
+        var completed = stage.CompletedOn?.ToString("dd MMM yyyy") ?? "—";
+        return $"Planned: {plannedStart} – {plannedDue} • Actual: {actualStart} – {completed}";
+    }
+
+    private static bool IsPnc(string code)
+        => string.Equals(code, "PNC", StringComparison.OrdinalIgnoreCase);
+
+    private static int DaysBetween(DateOnly start, DateOnly end)
+        => (end.ToDateTime(TimeOnly.MinValue) - start.ToDateTime(TimeOnly.MinValue)).Days;
+}

--- a/wwwroot/css/stage-tracker.css
+++ b/wwwroot/css/stage-tracker.css
@@ -1,0 +1,307 @@
+.tracker-bar {
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: .75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: var(--bs-box-shadow-sm);
+}
+
+.tracker-bar.sticky-top {
+  top: 1rem;
+  z-index: 1020;
+}
+
+.trk-flow {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(120px, 1fr);
+  gap: .5rem;
+  align-items: center;
+}
+
+.trk-cell {
+  position: relative;
+  padding-top: 1.5rem;
+  min-height: 5rem;
+}
+
+.trk-connector {
+  position: absolute;
+  top: 1.4rem;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--bs-border-color);
+  z-index: 1;
+}
+
+.trk-node {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  padding-inline: .25rem;
+}
+
+.trk-node .dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--bs-border-color);
+  background: transparent;
+  transition: box-shadow .2s ease, transform .2s ease;
+}
+
+.trk-node.done .dot {
+  background: var(--bs-success);
+  border-color: var(--bs-success);
+}
+
+.trk-node.current .dot {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, .2);
+}
+
+.trk-node.todo .dot {
+  background: var(--bs-body-bg);
+}
+
+.trk-node.skipped .dot {
+  border-style: dashed;
+}
+
+.trk-node .code {
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.trk-node .name {
+  font-size: .75rem;
+  color: var(--bs-secondary-color);
+  letter-spacing: .01em;
+}
+
+.trk-badge {
+  position: relative;
+  margin-top: .25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+  font-size: .75rem;
+  padding: .15rem .5rem;
+  border-radius: 999px;
+  border: 1px solid var(--bs-border-color);
+  background: var(--bs-light);
+  color: inherit;
+}
+
+.trk-badge.good {
+  background: #e8f6ef;
+  border-color: #bce3c9;
+  color: #0f5132;
+}
+
+.trk-badge.bad {
+  background: #fde8e8;
+  border-color: #f5c2c7;
+  color: #842029;
+}
+
+.trk-badge.progress {
+  background: #e7f1ff;
+  border-color: #b6d4fe;
+  color: #0a58ca;
+}
+
+.trk-branch {
+  min-width: 180px;
+}
+
+.trk-branch .trk-connector {
+  display: none;
+}
+
+.trk-branch-grid {
+  display: grid;
+  grid-template-rows: repeat(2, 1fr);
+  gap: 1rem;
+  position: relative;
+  padding-top: .25rem;
+}
+
+.trk-branch-join {
+  position: absolute;
+  inset: .7rem 0 .7rem auto;
+  width: 18px;
+  background:
+    linear-gradient(var(--bs-border-color), var(--bs-border-color)) left 0 top 0 / 12px 2px no-repeat,
+    linear-gradient(var(--bs-border-color), var(--bs-border-color)) left 0 bottom 0 / 12px 2px no-repeat,
+    linear-gradient(var(--bs-border-color), var(--bs-border-color)) right 3px center / 2px 100% no-repeat;
+}
+
+.trk-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: .75rem;
+  font-size: .75rem;
+  color: var(--bs-secondary-color);
+}
+
+.trk-legend span::before {
+  margin-right: .35rem;
+}
+
+.trk-legend .done::before {
+  content: "●";
+  color: var(--bs-success);
+}
+
+.trk-legend .current::before {
+  content: "◎";
+  color: var(--bs-primary);
+}
+
+.trk-legend .todo::before {
+  content: "○";
+  color: var(--bs-border-color);
+}
+
+.current-stage-card {
+  border-radius: .75rem;
+  border: 1px solid var(--bs-border-color);
+  padding: 1.25rem;
+  background: #fff;
+  box-shadow: var(--bs-box-shadow-sm);
+}
+
+.current-stage-card .stage-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.current-stage-card .stage-code {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.current-stage-card .timeline {
+  position: relative;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bs-border-color);
+  margin: 1rem 0 .75rem;
+}
+
+.current-stage-card .timeline::after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  width: 2px;
+  height: 12px;
+  background: var(--bs-danger);
+  left: var(--today-position, 0%);
+  transform: translateX(-50%);
+}
+
+.stage-prereqs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  padding: 0;
+  list-style: none;
+  margin: 0;
+}
+
+.stage-prereqs li {
+  background: var(--bs-light);
+  border-radius: 999px;
+  padding: .25rem .65rem;
+  font-size: .8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+}
+
+.stage-table tbody tr {
+  transition: background-color .3s ease, opacity .3s ease;
+}
+
+.stage-table tbody tr.dim {
+  opacity: .5;
+}
+
+.stage-table tbody tr.highlight {
+  background: #fff3cd;
+}
+
+@media (max-width: 768px) {
+  .trk-flow {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+  }
+
+  .trk-cell {
+    padding-top: 0;
+    padding-left: 2.25rem;
+  }
+
+  .trk-connector {
+    top: 0;
+    left: .9rem;
+    right: auto;
+    width: 2px;
+    height: 100%;
+  }
+
+  .trk-node {
+    align-items: flex-start;
+  }
+
+  .trk-node .dot {
+    margin-top: .2rem;
+  }
+
+  .trk-badge {
+    margin-left: 2.5rem;
+  }
+
+  .trk-branch {
+    min-width: 0;
+  }
+
+  .trk-branch-join {
+    display: none;
+  }
+}
+
+@media print {
+  .tracker-bar {
+    position: static !important;
+    box-shadow: none;
+  }
+
+  .trk-flow {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+  }
+
+  .trk-cell {
+    padding-top: 0;
+    padding-left: 2rem;
+  }
+
+  .trk-connector {
+    top: 0;
+    left: .8rem;
+    right: auto;
+    width: 2px;
+    height: 100%;
+  }
+}

--- a/wwwroot/js/stages-tracker.js
+++ b/wwwroot/js/stages-tracker.js
@@ -1,0 +1,98 @@
+(function () {
+  const formatIso = (date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const modal = document.getElementById('completeModal');
+    if (modal) {
+      modal.addEventListener('show.bs.modal', function (event) {
+        const trigger = event.relatedTarget;
+        if (!trigger) {
+          return;
+        }
+
+        const stageCode = trigger.getAttribute('data-stage') || '';
+        const stageName = trigger.getAttribute('data-stage-name') || '';
+        const defaultDate = trigger.getAttribute('data-default-date');
+
+        const stageInput = modal.querySelector('#complete-stage');
+        if (stageInput) {
+          stageInput.value = stageCode;
+        }
+
+        const stageLabel = modal.querySelector('#complete-stage-label');
+        if (stageLabel) {
+          const label = stageName ? `${stageCode} — ${stageName}` : stageCode;
+          stageLabel.textContent = label;
+        }
+
+        const dateInput = modal.querySelector('#complete-date');
+        if (dateInput) {
+          if (defaultDate) {
+            dateInput.value = defaultDate;
+          } else if (!dateInput.value) {
+            dateInput.value = formatIso(new Date());
+          }
+        }
+
+        const remark = modal.querySelector('#complete-remark');
+        if (remark && !remark.value) {
+          remark.focus();
+        }
+      });
+    }
+
+    document.querySelectorAll('[data-stage-scroll]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const code = el.getAttribute('data-stage-scroll');
+        if (!code) {
+          return;
+        }
+
+        const row = document.querySelector(`[data-stage-row="${code}"]`);
+        if (!row) {
+          return;
+        }
+
+        row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        row.classList.add('highlight');
+        setTimeout(() => row.classList.remove('highlight'), 1600);
+      });
+    });
+
+    document.querySelectorAll('[data-timeline]').forEach((el) => {
+      const start = el.getAttribute('data-start');
+      const due = el.getAttribute('data-due');
+      const today = el.getAttribute('data-today');
+      if (!start || !due || !today) {
+        return;
+      }
+
+      const startDate = new Date(start);
+      const dueDate = new Date(due);
+      const todayDate = new Date(today);
+      if (Number.isNaN(startDate.valueOf()) || Number.isNaN(dueDate.valueOf())) {
+        return;
+      }
+
+      const span = dueDate.getTime() - startDate.getTime();
+      if (span <= 0) {
+        el.style.setProperty('--today-position', '0%');
+        return;
+      }
+
+      const progress = Math.max(0, Math.min(1, (todayDate.getTime() - startDate.getTime()) / span));
+      el.style.setProperty('--today-position', `${(progress * 100).toFixed(1)}%`);
+    });
+
+    if (window.bootstrap && typeof window.bootstrap.Tooltip === 'function') {
+      document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+        new window.bootstrap.Tooltip(el);
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- Added dedicated tracker view models and a server-side builder that calculates node states, connector badges, and the TEC/BENCH branch for the progress header.
- Expanded the stages page model to expose tracker data, compute current-stage prerequisites, streamline remarks, and capture completion notes with optional attachments.
- Rebuilt the stages UI around the sticky tracker, a focused current-stage action card, a zebra-striped table, refreshed remarks panel, and supporting styles and scripts.

## Testing
- `dotnet test` *(fails: `dotnet` command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5659e93c8832990b38042b03cd3bc