### PR TITLE
Fix Today helper naming collision in stages page

### DIFF
--- a/Pages/Projects/Stages.cshtml.cs
+++ b/Pages/Projects/Stages.cshtml.cs
@@ -190,7 +190,7 @@ public class StagesModel : PageModel
                         return RedirectToPage(new { id });
                     }
 
-                    var today = Today();
+                    var today = GetToday();
                     var baseline = completionDate > today ? today : completionDate;
                     autoStart = flow.Bump(baseline);
                 }
@@ -214,7 +214,7 @@ public class StagesModel : PageModel
             var fallback = flow.ComputeAutoStart(stageCode, completedMap, skippedStages);
             if (fallback is null)
             {
-                var today = Today();
+                var today = GetToday();
                 var baseline = completionDate > today ? today : completionDate;
                 fallback = flow.Bump(baseline);
             }
@@ -564,7 +564,7 @@ public class StagesModel : PageModel
             .ToDictionary(ps => ps.StageCode, ps => ps, StringComparer.OrdinalIgnoreCase);
 
         var context = await _rules.BuildContextAsync(projectStages, cancellationToken);
-        Today = Today();
+        Today = GetToday();
         var health = StageHealthCalculator.Compute(projectStages, Today);
 
         StageSlips = templates
@@ -889,7 +889,7 @@ public class StagesModel : PageModel
         return stage.Trim().ToUpperInvariant();
     }
 
-    private DateOnly Today() => DateOnly.FromDateTime(_clock.UtcNow.DateTime);
+    private DateOnly GetToday() => DateOnly.FromDateTime(_clock.UtcNow.DateTime);
 
     private bool UserCanComment()
     {


### PR DESCRIPTION
## Summary
- rename the private helper on the project stages page to `GetToday` to avoid colliding with the `Today` property
- update all call sites to use the new helper name so the page continues to obtain the current date

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d56b32e76c8329918f1d8b6ec6b238