### PR TITLE
Implement schedule forecasting engine and UI updates

### DIFF
--- a/Pages/Projects/Stages.cshtml
+++ b/Pages/Projects/Stages.cshtml
@@ -221,7 +221,7 @@ else
                                 <th scope="col" style="width: 6rem;">Stage</th>
                                 <th scope="col">Description</th>
                                 <th scope="col" style="width: 12rem;">Planned start</th>
-                                <th scope="col" style="width: 12rem;">Planned due</th>
+                                <th scope="col" style="width: 14rem;">Due dates</th>
                                 <th scope="col" style="width: 10rem;">Status</th>
                                 <th scope="col" style="width: 8rem;">Slip</th>
                                 <th scope="col" style="width: 12rem;">Actual start</th>
@@ -248,7 +248,24 @@ else
                                     </div>
                                 </td>
                                 <td>@stage.PlannedStart?.ToString("dd MMM yyyy")</td>
-                                <td>@stage.PlannedDue?.ToString("dd MMM yyyy")</td>
+                                <td>
+                                    @{
+                                        var plannedDue = stage.PlannedDue;
+                                        var forecastDue = stage.ForecastDue ?? stage.PlannedDue;
+                                    }
+                                    <div class="text-muted small">Planned</div>
+                                    <div class="text-muted small mb-1">@(plannedDue?.ToString("dd MMM yyyy") ?? "—")</div>
+                                    <div>
+                                        <span class="text-muted small me-1">Forecast</span>
+                                        <span class="fw-semibold">@(forecastDue?.ToString("dd MMM yyyy") ?? "—")</span>
+                                        @if (plannedDue.HasValue && forecastDue.HasValue && plannedDue.Value != forecastDue.Value)
+                                        {
+                                            var shift = forecastDue.Value.DayNumber - plannedDue.Value.DayNumber;
+                                            var prefix = shift >= 0 ? "+" : string.Empty;
+                                            <span class="badge bg-light text-dark border ms-1">@($"{prefix}{shift}d")</span>
+                                        }
+                                    </div>
+                                </td>
                                 <td>@stage.Status</td>
                                 <td>@stage.SlipDays</td>
                                 <td>@stage.ActualStart?.ToString("dd MMM yyyy")</td>

--- a/Services/Scheduling/ForecastWriter.cs
+++ b/Services/Scheduling/ForecastWriter.cs
@@ -1,13 +1,128 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Scheduling;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
 
 namespace ProjectManagement.Services.Scheduling;
 
 public class ForecastWriter : IForecastWriter
 {
-    public Task RecomputeAsync(int projectId, string? causeStageCode, string causeType, string? userId, CancellationToken ct = default)
+    private readonly ApplicationDbContext _db;
+    private readonly IScheduleEngine _engine;
+    private readonly IClock _clock;
+
+    public ForecastWriter(ApplicationDbContext db, IScheduleEngine engine, IClock clock)
     {
-        throw new NotImplementedException();
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async Task RecomputeAsync(int projectId, string? causeStageCode, string causeType, string? userId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(causeType))
+        {
+            throw new ArgumentException("Cause type is required.", nameof(causeType));
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Stages)
+            .FirstOrDefaultAsync(p => p.Id == projectId, ct);
+
+        if (project == null)
+        {
+            throw new InvalidOperationException($"Project {projectId} was not found.");
+        }
+
+        if (!project.ActivePlanVersionNo.HasValue)
+        {
+            return;
+        }
+
+        var planVersion = await _db.PlanVersions
+            .AsNoTracking()
+            .Where(p => p.ProjectId == projectId && p.VersionNo == project.ActivePlanVersionNo.Value)
+            .Select(p => new
+            {
+                p.Id,
+                p.SkipWeekends,
+                p.TransitionRule,
+                p.PncApplicable
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (planVersion == null)
+        {
+            return;
+        }
+
+        var templates = await _db.StageTemplates
+            .AsNoTracking()
+            .Where(t => t.Version == PlanConstants.StageTemplateVersion)
+            .OrderBy(t => t.Sequence)
+            .ToListAsync(ct);
+
+        var dependencies = await _db.StageDependencyTemplates
+            .AsNoTracking()
+            .Where(d => d.Version == PlanConstants.StageTemplateVersion)
+            .ToListAsync(ct);
+
+        var durations = await _db.StagePlans
+            .AsNoTracking()
+            .Where(sp => sp.PlanVersionId == planVersion.Id)
+            .ToDictionaryAsync(sp => sp.StageCode, sp => sp.DurationDays, StringComparer.OrdinalIgnoreCase, ct);
+
+        var execution = project.Stages.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
+
+        var options = new ScheduleOptions(
+            planVersion.SkipWeekends,
+            planVersion.TransitionRule,
+            planVersion.PncApplicable,
+            DateOnly.FromDateTime(_clock.UtcNow.DateTime));
+
+        var forecast = _engine.ComputeForecast(templates, dependencies, durations, execution, options);
+
+        foreach (var (code, window) in forecast)
+        {
+            if (!execution.TryGetValue(code, out var stage))
+            {
+                continue;
+            }
+
+            var previousDue = stage.ForecastDue;
+
+            stage.ForecastStart = window.start;
+            stage.ForecastDue = window.due;
+
+            if (previousDue != stage.ForecastDue)
+            {
+                var delta = previousDue.HasValue
+                    ? stage.ForecastDue.Value.DayNumber - previousDue.Value.DayNumber
+                    : 0;
+
+                _db.StageShiftLogs.Add(new StageShiftLog
+                {
+                    ProjectId = projectId,
+                    StageCode = code,
+                    OldForecastDue = previousDue,
+                    NewForecastDue = stage.ForecastDue!.Value,
+                    DeltaDays = delta,
+                    CauseStageCode = causeStageCode ?? code,
+                    CauseType = causeType,
+                    CreatedOn = _clock.UtcNow,
+                    CreatedByUserId = userId
+                });
+            }
+        }
+
+        await _db.SaveChangesAsync(ct);
     }
 }

--- a/Services/Scheduling/ScheduleEngine.cs
+++ b/Services/Scheduling/ScheduleEngine.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Stages;
 
 namespace ProjectManagement.Services.Scheduling;
@@ -14,6 +16,121 @@ public class ScheduleEngine : IScheduleEngine
         IReadOnlyDictionary<string, ProjectStage> execution,
         ScheduleOptions opts)
     {
-        throw new NotImplementedException();
+        if (templates is null)
+        {
+            throw new ArgumentNullException(nameof(templates));
+        }
+
+        if (deps is null)
+        {
+            throw new ArgumentNullException(nameof(deps));
+        }
+
+        if (durationsDays is null)
+        {
+            throw new ArgumentNullException(nameof(durationsDays));
+        }
+
+        if (execution is null)
+        {
+            throw new ArgumentNullException(nameof(execution));
+        }
+
+        // Filter stages based on PNC applicability and prepare lookup for quick membership tests.
+        var nodes = templates
+            .Where(t => opts.PncApplicable || !string.Equals(t.Code, "PNC", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.Sequence)
+            .ToList();
+
+        var nodeSet = new HashSet<string>(nodes.Select(n => n.Code), StringComparer.OrdinalIgnoreCase);
+
+        // Build predecessor lookup respecting the filtered nodes.
+        var relevantDeps = deps
+            .Where(d => nodeSet.Contains(d.FromStageCode) && nodeSet.Contains(d.DependsOnStageCode))
+            .ToLookup(d => d.FromStageCode, d => d.DependsOnStageCode, StringComparer.OrdinalIgnoreCase);
+
+        var result = new Dictionary<string, (DateOnly start, DateOnly due)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var node in nodes)
+        {
+            if (!execution.TryGetValue(node.Code, out var stage))
+            {
+                throw new InvalidOperationException($"Execution stage '{node.Code}' is missing.");
+            }
+
+            DateOnly? ready = null;
+            foreach (var predecessor in relevantDeps[node.Code])
+            {
+                if (!execution.TryGetValue(predecessor, out var predecessorStage))
+                {
+                    throw new InvalidOperationException($"Execution stage '{predecessor}' is missing.");
+                }
+
+                if (predecessorStage.Status == StageStatus.Skipped)
+                {
+                    continue;
+                }
+
+                var predecessorFinish = predecessorStage.CompletedOn
+                    ?? (result.TryGetValue(predecessor, out var computed) ? computed.due
+                        : predecessorStage.ForecastDue ?? predecessorStage.PlannedDue ?? predecessorStage.PlannedStart
+                        ?? opts.Today);
+
+                var nextReady = AddGap(predecessorFinish, opts);
+                ready = ready is null ? nextReady : Max(ready.Value, nextReady);
+            }
+
+            var start = stage.ActualStart
+                ?? ready
+                ?? stage.PlannedStart
+                ?? opts.Today;
+
+            if (!durationsDays.TryGetValue(node.Code, out var duration))
+            {
+                throw new InvalidOperationException($"DurationDays missing for stage '{node.Code}'.");
+            }
+
+            duration = Math.Max(1, duration);
+            var due = stage.CompletedOn ?? AddWorkingDays(start, duration - 1, opts);
+
+            result[node.Code] = (start, due);
+        }
+
+        return result;
     }
+
+    private static DateOnly AddGap(DateOnly date, ScheduleOptions opts)
+    {
+        var adjusted = opts.TransitionRule == PlanTransitionRule.NextWorkingDay ? date.AddDays(1) : date;
+        return BumpWeekend(adjusted, opts.SkipWeekends);
+    }
+
+    private static DateOnly AddWorkingDays(DateOnly start, int additionalDays, ScheduleOptions opts)
+    {
+        var current = start;
+        for (var i = 0; i < additionalDays; i++)
+        {
+            current = current.AddDays(1);
+            current = BumpWeekend(current, opts.SkipWeekends);
+        }
+
+        return current;
+    }
+
+    private static DateOnly BumpWeekend(DateOnly date, bool skipWeekends)
+    {
+        if (!skipWeekends)
+        {
+            return date;
+        }
+
+        return date.DayOfWeek switch
+        {
+            DayOfWeek.Saturday => date.AddDays(2),
+            DayOfWeek.Sunday => date.AddDays(1),
+            _ => date
+        };
+    }
+
+    private static DateOnly Max(DateOnly left, DateOnly right) => left > right ? left : right;
 }


### PR DESCRIPTION
## Summary
- implement the scheduling engine to compute forecast start and due dates with dependency handling and weekend rules
- add a forecast writer that persists the computed dates, records shift logs, and wire it into stage completion/skip handlers
- surface forecast due dates alongside planned dates in the stages table with Bootstrap styling

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5790883e08329939ba934ed02b461