### PR TITLE
Add project stage navigation property

### DIFF
--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models.Execution;
 
 namespace ProjectManagement.Models
 {
@@ -24,5 +26,7 @@ namespace ProjectManagement.Models
 
         public string? LeadPoUserId { get; set; }
         public ApplicationUser? LeadPoUser { get; set; }
+
+        public ICollection<ProjectStage> Stages { get; set; } = new List<ProjectStage>();
     }
 }


### PR DESCRIPTION
## Summary
- expose the project stage collection on `Project` so services can access stage data
- add the necessary namespace imports for the new navigation property

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d57c2d1e608329854da5a9ba66dd2a