### PR TITLE
Align stage template codes with new naming

### DIFF
--- a/Data/StageFlowSeeder.cs
+++ b/Data/StageFlowSeeder.cs
@@ -22,30 +22,30 @@ public static class StageFlowSeeder
 
         var stages = new[]
         {
-            new StageTemplate { Version = version, Code = "FEAS",  Name = "Feasibility Study",              Sequence = 10 },
+            new StageTemplate { Version = version, Code = "FS",  Name = "Feasibility Study",              Sequence = 10 },
             new StageTemplate { Version = version, Code = "IPA",   Name = "In-Principle Approval",          Sequence = 20 },
             new StageTemplate { Version = version, Code = "SOW",   Name = "Scope of Work Vetting",          Sequence = 30 },
             new StageTemplate { Version = version, Code = "AON",   Name = "Acceptance of Necessity",        Sequence = 40 },
             new StageTemplate { Version = version, Code = "BID",   Name = "Bid Upload",                     Sequence = 50 },
             new StageTemplate { Version = version, Code = "TEC",   Name = "Technical Evaluation Committee", Sequence = 60 },
-            new StageTemplate { Version = version, Code = "BENCH", Name = "Benchmarking",                   Sequence = 65, ParallelGroup = "PRE_COB" },
+            new StageTemplate { Version = version, Code = "BM", Name = "Benchmarking",                   Sequence = 65, ParallelGroup = "PRE_COB" },
             new StageTemplate { Version = version, Code = "COB",   Name = "Commercial Opening Board",       Sequence = 70 },
             new StageTemplate { Version = version, Code = "PNC",   Name = "Price Negotiation Committee",    Sequence = 80, Optional = true },
             new StageTemplate { Version = version, Code = "EAS",   Name = "Expenditure Angle Sanction",     Sequence = 90 },
             new StageTemplate { Version = version, Code = "SO",    Name = "Supply Order",                   Sequence = 100 },
-            new StageTemplate { Version = version, Code = "DEV",   Name = "Development",                    Sequence = 110 },
-            new StageTemplate { Version = version, Code = "AT",    Name = "Acceptance Testing",             Sequence = 120 },
-            new StageTemplate { Version = version, Code = "PAY",   Name = "Payment",                        Sequence = 130 },
+            new StageTemplate { Version = version, Code = "DEVP",   Name = "Development",                    Sequence = 110 },
+            new StageTemplate { Version = version, Code = "ATC",    Name = "Acceptance Testing",             Sequence = 120 },
+            new StageTemplate { Version = version, Code = "PAYMENT",   Name = "Payment",                        Sequence = 130 },
         };
 
         var deps = new[]
         {
-            D("IPA", "FEAS"), D("SOW", "IPA"), D("AON", "SOW"), D("BID", "AON"),
-            D("TEC", "BID"), D("BENCH", "BID"),
-            D("COB", "TEC"), D("COB", "BENCH"),
+            D("IPA", "FS"), D("SOW", "IPA"), D("AON", "SOW"), D("BID", "AON"),
+            D("TEC", "BID"), D("BM", "BID"),
+            D("COB", "TEC"), D("COB", "BM"),
             D("PNC", "COB"),
             D("EAS", "COB"), D("EAS", "PNC"),
-            D("SO", "EAS"), D("DEV", "SO"), D("AT", "DEV"), D("PAY", "AT")
+            D("SO", "EAS"), D("DEVP", "SO"), D("ATC", "DEVP"), D("PAYMENT", "ATC")
         };
 
         var changesMade = false;

--- a/Pages/Projects/Plan/Draft.cshtml
+++ b/Pages/Projects/Plan/Draft.cshtml
@@ -104,7 +104,7 @@
                                 {
                                     <span class="badge bg-info text-dark">Parallel @template.ParallelGroup</span>
                                 }
-                                @if (string.Equals(template.Code, "BENCH", StringComparison.OrdinalIgnoreCase))
+                                @if (string.Equals(template.Code, "BM", StringComparison.OrdinalIgnoreCase))
                                 {
                                     <div class="text-muted small">Runs in parallel after BID; must finish before COB.</div>
                                 }

--- a/ProjectManagement.Tests/PlanCalculatorTests.cs
+++ b/ProjectManagement.Tests/PlanCalculatorTests.cs
@@ -13,20 +13,20 @@ public class PlanCalculatorTests
     {
         return new List<StageTemplate>
         {
-            new() { Code = "FEAS", Name = "Feasibility", Sequence = 10 },
+            new() { Code = "FS", Name = "Feasibility", Sequence = 10 },
             new() { Code = "IPA", Name = "In-Principle Approval", Sequence = 20 },
             new() { Code = "SOW", Name = "Scope of Work", Sequence = 30 },
             new() { Code = "AON", Name = "Acceptance of Necessity", Sequence = 40 },
             new() { Code = "BID", Name = "Bid Upload", Sequence = 50 },
             new() { Code = "TEC", Name = "Technical Evaluation", Sequence = 60 },
-            new() { Code = "BENCH", Name = "Benchmarking", Sequence = 65, ParallelGroup = "PRE_COB" },
+            new() { Code = "BM", Name = "Benchmarking", Sequence = 65, ParallelGroup = "PRE_COB" },
             new() { Code = "COB", Name = "Commercial Opening Board", Sequence = 70 },
             new() { Code = "PNC", Name = "Price Negotiation Committee", Sequence = 80, Optional = true },
             new() { Code = "EAS", Name = "Expenditure Angle Sanction", Sequence = 90 },
             new() { Code = "SO", Name = "Supply Order", Sequence = 100 },
-            new() { Code = "DEV", Name = "Development", Sequence = 110 },
-            new() { Code = "AT", Name = "Acceptance Testing", Sequence = 120 },
-            new() { Code = "PAY", Name = "Payment", Sequence = 130 }
+            new() { Code = "DEVP", Name = "Development", Sequence = 110 },
+            new() { Code = "ATC", Name = "Acceptance Testing", Sequence = 120 },
+            new() { Code = "PAYMENT", Name = "Payment", Sequence = 130 }
         };
     }
 
@@ -34,21 +34,21 @@ public class PlanCalculatorTests
     {
         return new List<StageDependencyTemplate>
         {
-            new() { FromStageCode = "IPA", DependsOnStageCode = "FEAS" },
+            new() { FromStageCode = "IPA", DependsOnStageCode = "FS" },
             new() { FromStageCode = "SOW", DependsOnStageCode = "IPA" },
             new() { FromStageCode = "AON", DependsOnStageCode = "SOW" },
             new() { FromStageCode = "BID", DependsOnStageCode = "AON" },
             new() { FromStageCode = "TEC", DependsOnStageCode = "BID" },
-            new() { FromStageCode = "BENCH", DependsOnStageCode = "BID" },
+            new() { FromStageCode = "BM", DependsOnStageCode = "BID" },
             new() { FromStageCode = "COB", DependsOnStageCode = "TEC" },
-            new() { FromStageCode = "COB", DependsOnStageCode = "BENCH" },
+            new() { FromStageCode = "COB", DependsOnStageCode = "BM" },
             new() { FromStageCode = "PNC", DependsOnStageCode = "COB" },
             new() { FromStageCode = "EAS", DependsOnStageCode = "COB" },
             new() { FromStageCode = "EAS", DependsOnStageCode = "PNC" },
             new() { FromStageCode = "SO", DependsOnStageCode = "EAS" },
-            new() { FromStageCode = "DEV", DependsOnStageCode = "SO" },
-            new() { FromStageCode = "AT", DependsOnStageCode = "DEV" },
-            new() { FromStageCode = "PAY", DependsOnStageCode = "AT" }
+            new() { FromStageCode = "DEVP", DependsOnStageCode = "SO" },
+            new() { FromStageCode = "ATC", DependsOnStageCode = "DEVP" },
+            new() { FromStageCode = "PAYMENT", DependsOnStageCode = "ATC" }
         };
     }
 
@@ -68,7 +68,7 @@ public class PlanCalculatorTests
             ["AON"] = 1,
             ["BID"] = 10,
             ["TEC"] = 3,
-            ["BENCH"] = 4,
+            ["BM"] = 4,
             ["COB"] = 2,
             ["EAS"] = 5
         };
@@ -101,7 +101,7 @@ public class PlanCalculatorTests
             ["AON"] = 2,
             ["BID"] = 6,
             ["TEC"] = 3,
-            ["BENCH"] = 2,
+            ["BM"] = 2,
             ["COB"] = 2,
             ["PNC"] = 7,
             ["EAS"] = 5

--- a/Services/StageRulesService.cs
+++ b/Services/StageRulesService.cs
@@ -122,9 +122,9 @@ public class StageRulesService
                 return StageGuardResult.Deny("COB cannot complete until TEC is completed.");
             }
 
-            if (!context.TryGetStage("BENCH", out var bench) || bench.Status != StageStatus.Completed)
+            if (!context.TryGetStage("BM", out var bench) || bench.Status != StageStatus.Completed)
             {
-                return StageGuardResult.Deny("COB cannot complete until BENCH is completed.");
+                return StageGuardResult.Deny("COB cannot complete until Benchmarking (BM) is completed.");
             }
         }
 

--- a/Services/Stages/TrackerBuilder.cs
+++ b/Services/Stages/TrackerBuilder.cs
@@ -49,7 +49,7 @@ public sealed class TrackerBuilder
             {
                 vm.BranchTop.Add(node);
             }
-            else if (string.Equals(template.Code, "BENCH", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(template.Code, "BM", StringComparison.OrdinalIgnoreCase))
             {
                 vm.BranchBottom.Add(node);
             }


### PR DESCRIPTION
## Summary
- update the stage template seeding to keep the new FS/BM/DEVP/ATC/PAYMENT codes and dependencies
- bring the plan UI, tracker, and stage rules into alignment with the renamed benchmarking code
- refresh the plan calculator tests to match the new stage codes

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d60c93fbd883299d1ae2307616ba01