### PR TITLE
Add project number support and stage progress guardrails

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -49,6 +49,10 @@ namespace ProjectManagement.Data
             {
                 e.Property(x => x.Name).HasMaxLength(100).IsRequired();
                 e.HasIndex(x => x.Name);
+                e.Property(x => x.ProjectNumber).HasMaxLength(64);
+                e.HasIndex(x => x.ProjectNumber)
+                    .IsUnique()
+                    .HasFilter("\"ProjectNumber\" IS NOT NULL");
                 e.Property(x => x.RowVersion).IsRowVersion();
                 e.Property(x => x.CreatedByUserId).HasMaxLength(64).IsRequired();
                 e.HasOne(x => x.Category)
@@ -222,6 +226,9 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Status).HasConversion<string>().HasMaxLength(32);
                 e.Property(x => x.ForecastStart).HasColumnType("date");
                 e.Property(x => x.ForecastDue).HasColumnType("date");
+                e.ToTable("ProjectStages", tb =>
+                    tb.HasCheckConstraint("CK_ProjectStages_CompletedHasDate",
+                        "NOT(\"Status\" = 'Completed' AND \"CompletedOn\" IS NULL)"));
             });
 
             builder.Entity<StageShiftLog>(e =>

--- a/Data/StageFlowSeeder.cs
+++ b/Data/StageFlowSeeder.cs
@@ -22,30 +22,30 @@ public static class StageFlowSeeder
 
         var stages = new[]
         {
-            new StageTemplate { Version = version, Code = "FS",  Name = "Feasibility Study",              Sequence = 10 },
-            new StageTemplate { Version = version, Code = "IPA",   Name = "In-Principle Approval",          Sequence = 20 },
-            new StageTemplate { Version = version, Code = "SOW",   Name = "Scope of Work Vetting",          Sequence = 30 },
-            new StageTemplate { Version = version, Code = "AON",   Name = "Acceptance of Necessity",        Sequence = 40 },
-            new StageTemplate { Version = version, Code = "BID",   Name = "Bid Upload",                     Sequence = 50 },
-            new StageTemplate { Version = version, Code = "TEC",   Name = "Technical Evaluation Committee", Sequence = 60 },
-            new StageTemplate { Version = version, Code = "BM", Name = "Benchmarking",                   Sequence = 65, ParallelGroup = "PRE_COB" },
-            new StageTemplate { Version = version, Code = "COB",   Name = "Commercial Opening Board",       Sequence = 70 },
-            new StageTemplate { Version = version, Code = "PNC",   Name = "Price Negotiation Committee",    Sequence = 80, Optional = true },
-            new StageTemplate { Version = version, Code = "EAS",   Name = "Expenditure Angle Sanction",     Sequence = 90 },
-            new StageTemplate { Version = version, Code = "SO",    Name = "Supply Order",                   Sequence = 100 },
-            new StageTemplate { Version = version, Code = "DEVP",   Name = "Development",                    Sequence = 110 },
-            new StageTemplate { Version = version, Code = "ATP",    Name = "Acceptance Testing",             Sequence = 120 },
-            new StageTemplate { Version = version, Code = "PAYMENT",   Name = "Payment",                        Sequence = 130 },
+            new StageTemplate { Version = version, Code = StageCodes.FS,  Name = "Feasibility Study",              Sequence = 10 },
+            new StageTemplate { Version = version, Code = StageCodes.IPA,   Name = "In-Principle Approval",          Sequence = 20 },
+            new StageTemplate { Version = version, Code = StageCodes.SOW,   Name = "Scope of Work Vetting",          Sequence = 30 },
+            new StageTemplate { Version = version, Code = StageCodes.AON,   Name = "Acceptance of Necessity",        Sequence = 40 },
+            new StageTemplate { Version = version, Code = StageCodes.BID,   Name = "Bid Upload",                     Sequence = 50 },
+            new StageTemplate { Version = version, Code = StageCodes.TEC,   Name = "Technical Evaluation Committee", Sequence = 60 },
+            new StageTemplate { Version = version, Code = StageCodes.BM, Name = "Benchmarking",                   Sequence = 65, ParallelGroup = "PRE_COB" },
+            new StageTemplate { Version = version, Code = StageCodes.COB,   Name = "Commercial Opening Board",       Sequence = 70 },
+            new StageTemplate { Version = version, Code = StageCodes.PNC,   Name = "Price Negotiation Committee",    Sequence = 80, Optional = true },
+            new StageTemplate { Version = version, Code = StageCodes.EAS,   Name = "Expenditure Angle Sanction",     Sequence = 90 },
+            new StageTemplate { Version = version, Code = StageCodes.SO,    Name = "Supply Order",                   Sequence = 100 },
+            new StageTemplate { Version = version, Code = StageCodes.DEVP,   Name = "Development",                    Sequence = 110 },
+            new StageTemplate { Version = version, Code = StageCodes.ATP,    Name = "Acceptance Testing",             Sequence = 120 },
+            new StageTemplate { Version = version, Code = StageCodes.PAYMENT,   Name = "Payment",                        Sequence = 130 },
         };
 
         var deps = new[]
         {
-            D("IPA", "FS"), D("SOW", "IPA"), D("AON", "SOW"), D("BID", "AON"),
-            D("TEC", "BID"), D("BM", "BID"),
-            D("COB", "TEC"), D("COB", "BM"),
-            D("PNC", "COB"),
-            D("EAS", "COB"), D("EAS", "PNC"),
-            D("SO", "EAS"), D("DEVP", "SO"), D("ATP", "DEVP"), D("PAYMENT", "ATP")
+            D(StageCodes.IPA, StageCodes.FS), D(StageCodes.SOW, StageCodes.IPA), D(StageCodes.AON, StageCodes.SOW), D(StageCodes.BID, StageCodes.AON),
+            D(StageCodes.TEC, StageCodes.BID), D(StageCodes.BM, StageCodes.BID),
+            D(StageCodes.COB, StageCodes.TEC), D(StageCodes.COB, StageCodes.BM),
+            D(StageCodes.PNC, StageCodes.COB),
+            D(StageCodes.EAS, StageCodes.COB), D(StageCodes.EAS, StageCodes.PNC),
+            D(StageCodes.SO, StageCodes.EAS), D(StageCodes.DEVP, StageCodes.SO), D(StageCodes.ATP, StageCodes.DEVP), D(StageCodes.PAYMENT, StageCodes.ATP)
         };
 
         var changesMade = false;

--- a/Migrations/20251006150000_AddProjectNumberAndStageGuards.Designer.cs
+++ b/Migrations/20251006150000_AddProjectNumberAndStageGuards.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,10 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251006150000_AddProjectNumberAndStageGuards")]
+    partial class AddProjectNumberAndStageGuards : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251006150000_AddProjectNumberAndStageGuards.cs
+++ b/Migrations/20251006150000_AddProjectNumberAndStageGuards.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectNumberAndStageGuards : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProjectNumber",
+                table: "Projects",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_ProjectNumber",
+                table: "Projects",
+                column: "ProjectNumber",
+                unique: true,
+                filter: "\"ProjectNumber\" IS NOT NULL");
+
+            migrationBuilder.Sql("""
+                ALTER TABLE "ProjectStages"
+                ADD CONSTRAINT "CK_ProjectStages_CompletedHasDate"
+                CHECK (NOT("Status" = 'Completed' AND "CompletedOn" IS NULL));
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                ALTER TABLE "ProjectStages"
+                DROP CONSTRAINT IF EXISTS "CK_ProjectStages_CompletedHasDate";
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_ProjectNumber",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectNumber",
+                table: "Projects");
+        }
+    }
+}

--- a/Models/Plans/PlanConstants.cs
+++ b/Models/Plans/PlanConstants.cs
@@ -1,7 +1,9 @@
+using ProjectManagement.Models.Stages;
+
 namespace ProjectManagement.Models.Plans;
 
 public static class PlanConstants
 {
     public const string StageTemplateVersion = "SDD-1.0";
-    public const string DefaultAnchorStageCode = "IPA";
+    public const string DefaultAnchorStageCode = StageCodes.IPA;
 }

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -18,6 +18,9 @@ namespace ProjectManagement.Models
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+        [MaxLength(64)]
+        public string? ProjectNumber { get; set; }
+
         [Required]
         [MaxLength(64)]
         public string CreatedByUserId { get; set; } = string.Empty;

--- a/Models/Stages/StageCodes.cs
+++ b/Models/Stages/StageCodes.cs
@@ -1,0 +1,37 @@
+namespace ProjectManagement.Models.Stages;
+
+public static class StageCodes
+{
+    public const string FS = "FS";
+    public const string IPA = "IPA";
+    public const string SOW = "SOW";
+    public const string AON = "AON";
+    public const string BID = "BID";
+    public const string TEC = "TEC";
+    public const string BM = "BM";
+    public const string COB = "COB";
+    public const string PNC = "PNC";
+    public const string SO = "SO";
+    public const string DEVP = "DEVP";
+    public const string ATP = "ATP";
+    public const string EAS = "EAS";
+    public const string PAYMENT = "PAYMENT";
+
+    public static readonly string[] All =
+    {
+        FS,
+        IPA,
+        SOW,
+        AON,
+        BID,
+        TEC,
+        BM,
+        COB,
+        PNC,
+        EAS,
+        SO,
+        DEVP,
+        ATP,
+        PAYMENT
+    };
+}

--- a/Program.cs
+++ b/Program.cs
@@ -140,6 +140,7 @@ builder.Services.AddHostedService<TodoPurgeWorker>();
 builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
+builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<IScheduleEngine, ScheduleEngine>();
 builder.Services.AddScoped<IForecastWriter, ForecastWriter>();

--- a/ProjectManagement.Tests/PlanCalculatorTests.cs
+++ b/ProjectManagement.Tests/PlanCalculatorTests.cs
@@ -13,20 +13,20 @@ public class PlanCalculatorTests
     {
         return new List<StageTemplate>
         {
-            new() { Code = "FS", Name = "Feasibility", Sequence = 10 },
-            new() { Code = "IPA", Name = "In-Principle Approval", Sequence = 20 },
-            new() { Code = "SOW", Name = "Scope of Work", Sequence = 30 },
-            new() { Code = "AON", Name = "Acceptance of Necessity", Sequence = 40 },
-            new() { Code = "BID", Name = "Bid Upload", Sequence = 50 },
-            new() { Code = "TEC", Name = "Technical Evaluation", Sequence = 60 },
-            new() { Code = "BM", Name = "Benchmarking", Sequence = 65, ParallelGroup = "PRE_COB" },
-            new() { Code = "COB", Name = "Commercial Opening Board", Sequence = 70 },
-            new() { Code = "PNC", Name = "Price Negotiation Committee", Sequence = 80, Optional = true },
-            new() { Code = "EAS", Name = "Expenditure Angle Sanction", Sequence = 90 },
-            new() { Code = "SO", Name = "Supply Order", Sequence = 100 },
-            new() { Code = "DEVP", Name = "Development", Sequence = 110 },
-            new() { Code = "ATC", Name = "Acceptance Testing", Sequence = 120 },
-            new() { Code = "PAYMENT", Name = "Payment", Sequence = 130 }
+            new() { Code = StageCodes.FS, Name = "Feasibility", Sequence = 10 },
+            new() { Code = StageCodes.IPA, Name = "In-Principle Approval", Sequence = 20 },
+            new() { Code = StageCodes.SOW, Name = "Scope of Work", Sequence = 30 },
+            new() { Code = StageCodes.AON, Name = "Acceptance of Necessity", Sequence = 40 },
+            new() { Code = StageCodes.BID, Name = "Bid Upload", Sequence = 50 },
+            new() { Code = StageCodes.TEC, Name = "Technical Evaluation", Sequence = 60 },
+            new() { Code = StageCodes.BM, Name = "Benchmarking", Sequence = 65, ParallelGroup = "PRE_COB" },
+            new() { Code = StageCodes.COB, Name = "Commercial Opening Board", Sequence = 70 },
+            new() { Code = StageCodes.PNC, Name = "Price Negotiation Committee", Sequence = 80, Optional = true },
+            new() { Code = StageCodes.EAS, Name = "Expenditure Angle Sanction", Sequence = 90 },
+            new() { Code = StageCodes.SO, Name = "Supply Order", Sequence = 100 },
+            new() { Code = StageCodes.DEVP, Name = "Development", Sequence = 110 },
+            new() { Code = StageCodes.ATP, Name = "Acceptance Testing", Sequence = 120 },
+            new() { Code = StageCodes.PAYMENT, Name = "Payment", Sequence = 130 }
         };
     }
 
@@ -34,21 +34,21 @@ public class PlanCalculatorTests
     {
         return new List<StageDependencyTemplate>
         {
-            new() { FromStageCode = "IPA", DependsOnStageCode = "FS" },
-            new() { FromStageCode = "SOW", DependsOnStageCode = "IPA" },
-            new() { FromStageCode = "AON", DependsOnStageCode = "SOW" },
-            new() { FromStageCode = "BID", DependsOnStageCode = "AON" },
-            new() { FromStageCode = "TEC", DependsOnStageCode = "BID" },
-            new() { FromStageCode = "BM", DependsOnStageCode = "BID" },
-            new() { FromStageCode = "COB", DependsOnStageCode = "TEC" },
-            new() { FromStageCode = "COB", DependsOnStageCode = "BM" },
-            new() { FromStageCode = "PNC", DependsOnStageCode = "COB" },
-            new() { FromStageCode = "EAS", DependsOnStageCode = "COB" },
-            new() { FromStageCode = "EAS", DependsOnStageCode = "PNC" },
-            new() { FromStageCode = "SO", DependsOnStageCode = "EAS" },
-            new() { FromStageCode = "DEVP", DependsOnStageCode = "SO" },
-            new() { FromStageCode = "ATC", DependsOnStageCode = "DEVP" },
-            new() { FromStageCode = "PAYMENT", DependsOnStageCode = "ATC" }
+            new() { FromStageCode = StageCodes.IPA, DependsOnStageCode = StageCodes.FS },
+            new() { FromStageCode = StageCodes.SOW, DependsOnStageCode = StageCodes.IPA },
+            new() { FromStageCode = StageCodes.AON, DependsOnStageCode = StageCodes.SOW },
+            new() { FromStageCode = StageCodes.BID, DependsOnStageCode = StageCodes.AON },
+            new() { FromStageCode = StageCodes.TEC, DependsOnStageCode = StageCodes.BID },
+            new() { FromStageCode = StageCodes.BM, DependsOnStageCode = StageCodes.BID },
+            new() { FromStageCode = StageCodes.COB, DependsOnStageCode = StageCodes.TEC },
+            new() { FromStageCode = StageCodes.COB, DependsOnStageCode = StageCodes.BM },
+            new() { FromStageCode = StageCodes.PNC, DependsOnStageCode = StageCodes.COB },
+            new() { FromStageCode = StageCodes.EAS, DependsOnStageCode = StageCodes.COB },
+            new() { FromStageCode = StageCodes.EAS, DependsOnStageCode = StageCodes.PNC },
+            new() { FromStageCode = StageCodes.SO, DependsOnStageCode = StageCodes.EAS },
+            new() { FromStageCode = StageCodes.DEVP, DependsOnStageCode = StageCodes.SO },
+            new() { FromStageCode = StageCodes.ATP, DependsOnStageCode = StageCodes.DEVP },
+            new() { FromStageCode = StageCodes.PAYMENT, DependsOnStageCode = StageCodes.ATP }
         };
     }
 
@@ -63,18 +63,18 @@ public class PlanCalculatorTests
         var calculator = CreateCalculator();
         var durations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["IPA"] = 1,
-            ["SOW"] = 5,
-            ["AON"] = 1,
-            ["BID"] = 10,
-            ["TEC"] = 3,
-            ["BM"] = 4,
-            ["COB"] = 2,
-            ["EAS"] = 5
+            [StageCodes.IPA] = 1,
+            [StageCodes.SOW] = 5,
+            [StageCodes.AON] = 1,
+            [StageCodes.BID] = 10,
+            [StageCodes.TEC] = 3,
+            [StageCodes.BM] = 4,
+            [StageCodes.COB] = 2,
+            [StageCodes.EAS] = 5
         };
 
         var options = new PlanCalculatorOptions(
-            "IPA",
+            StageCodes.IPA,
             new DateOnly(2024, 1, 2),
             SkipWeekends: true,
             TransitionRule: PlanTransitionRule.NextWorkingDay,
@@ -84,9 +84,9 @@ public class PlanCalculatorTests
 
         var schedule = calculator.Compute(options);
 
-        Assert.False(schedule.ContainsKey("PNC"));
-        Assert.True(schedule.TryGetValue("COB", out var cob));
-        Assert.True(schedule.TryGetValue("EAS", out var eas));
+        Assert.False(schedule.ContainsKey(StageCodes.PNC));
+        Assert.True(schedule.TryGetValue(StageCodes.COB, out var cob));
+        Assert.True(schedule.TryGetValue(StageCodes.EAS, out var eas));
         Assert.Equal(cob.due.AddDays(1), eas.start);
     }
 
@@ -96,19 +96,19 @@ public class PlanCalculatorTests
         var calculator = CreateCalculator();
         var durations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["IPA"] = 2,
-            ["SOW"] = 4,
-            ["AON"] = 2,
-            ["BID"] = 6,
-            ["TEC"] = 3,
-            ["BM"] = 2,
-            ["COB"] = 2,
-            ["PNC"] = 7,
-            ["EAS"] = 5
+            [StageCodes.IPA] = 2,
+            [StageCodes.SOW] = 4,
+            [StageCodes.AON] = 2,
+            [StageCodes.BID] = 6,
+            [StageCodes.TEC] = 3,
+            [StageCodes.BM] = 2,
+            [StageCodes.COB] = 2,
+            [StageCodes.PNC] = 7,
+            [StageCodes.EAS] = 5
         };
 
         var options = new PlanCalculatorOptions(
-            "IPA",
+            StageCodes.IPA,
             new DateOnly(2024, 4, 8),
             SkipWeekends: true,
             TransitionRule: PlanTransitionRule.NextWorkingDay,
@@ -118,9 +118,9 @@ public class PlanCalculatorTests
 
         var schedule = calculator.Compute(options);
 
-        Assert.True(schedule.ContainsKey("PNC"));
-        Assert.True(schedule.TryGetValue("PNC", out var pnc));
-        Assert.True(schedule.TryGetValue("EAS", out var eas));
+        Assert.True(schedule.ContainsKey(StageCodes.PNC));
+        Assert.True(schedule.TryGetValue(StageCodes.PNC, out var pnc));
+        Assert.True(schedule.TryGetValue(StageCodes.EAS, out var eas));
         Assert.Equal(pnc.due.AddDays(1), eas.start);
     }
 
@@ -130,12 +130,12 @@ public class PlanCalculatorTests
         var calculator = CreateCalculator();
         var durations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["IPA"] = 1,
-            ["SOW"] = 1
+            [StageCodes.IPA] = 1,
+            [StageCodes.SOW] = 1
         };
 
         var options = new PlanCalculatorOptions(
-            "IPA",
+            StageCodes.IPA,
             new DateOnly(2024, 1, 5),
             SkipWeekends: true,
             TransitionRule: PlanTransitionRule.NextWorkingDay,
@@ -145,7 +145,7 @@ public class PlanCalculatorTests
 
         var schedule = calculator.Compute(options);
 
-        Assert.True(schedule.TryGetValue("SOW", out var sow));
+        Assert.True(schedule.TryGetValue(StageCodes.SOW, out var sow));
         Assert.Equal(new DateOnly(2024, 1, 8), sow.start);
     }
 
@@ -155,12 +155,12 @@ public class PlanCalculatorTests
         var calculator = CreateCalculator();
         var durations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["IPA"] = 3,
-            ["SOW"] = 2
+            [StageCodes.IPA] = 3,
+            [StageCodes.SOW] = 2
         };
 
         var options = new PlanCalculatorOptions(
-            "IPA",
+            StageCodes.IPA,
             new DateOnly(2024, 2, 1),
             SkipWeekends: false,
             TransitionRule: PlanTransitionRule.SameDay,
@@ -170,8 +170,8 @@ public class PlanCalculatorTests
 
         var schedule = calculator.Compute(options);
 
-        Assert.True(schedule.TryGetValue("IPA", out var ipa));
-        Assert.True(schedule.TryGetValue("SOW", out var sow));
+        Assert.True(schedule.TryGetValue(StageCodes.IPA, out var ipa));
+        Assert.True(schedule.TryGetValue(StageCodes.SOW, out var sow));
         Assert.Equal(ipa.due, sow.start);
     }
 
@@ -181,20 +181,20 @@ public class PlanCalculatorTests
         var calculator = CreateCalculator();
         var durations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            ["IPA"] = 1,
-            ["SOW"] = 1,
-            ["AON"] = 1,
-            ["BID"] = 1,
-            ["TEC"] = 2
+            [StageCodes.IPA] = 1,
+            [StageCodes.SOW] = 1,
+            [StageCodes.AON] = 1,
+            [StageCodes.BID] = 1,
+            [StageCodes.TEC] = 2
         };
 
         var overrides = new Dictionary<string, PlanCalculatorManualOverride>(StringComparer.OrdinalIgnoreCase)
         {
-            ["TEC"] = new(new DateOnly(2024, 3, 15), null)
+            [StageCodes.TEC] = new(new DateOnly(2024, 3, 15), null)
         };
 
         var options = new PlanCalculatorOptions(
-            "IPA",
+            StageCodes.IPA,
             new DateOnly(2024, 3, 1),
             SkipWeekends: false,
             TransitionRule: PlanTransitionRule.NextWorkingDay,
@@ -204,7 +204,7 @@ public class PlanCalculatorTests
 
         var schedule = calculator.Compute(options);
 
-        Assert.True(schedule.TryGetValue("TEC", out var tec));
+        Assert.True(schedule.TryGetValue(StageCodes.TEC, out var tec));
         Assert.Equal(new DateOnly(2024, 3, 15), tec.start);
     }
 }

--- a/ProjectManagement.Tests/StageProgressServiceTests.cs
+++ b/ProjectManagement.Tests/StageProgressServiceTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageProgressServiceTests
+{
+    [Fact]
+    public async Task UpdateStageStatusAsync_SetsActualStartWhenMovingToInProgress()
+    {
+        var initial = new DateTimeOffset(2024, 1, 5, 0, 0, 0, TimeSpan.Zero);
+        var clock = new TestClock(initial);
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        var service = new StageProgressService(db, clock);
+
+        await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.InProgress, null, "tester");
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.InProgress, stage.Status);
+        Assert.Equal(DateOnly.FromDateTime(clock.UtcNow.UtcDateTime), stage.ActualStart);
+        Assert.Null(stage.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateStageStatusAsync_SetsCompletedOnWhenFinishingStage()
+    {
+        var initial = new DateTimeOffset(2024, 1, 5, 0, 0, 0, TimeSpan.Zero);
+        var clock = new TestClock(initial);
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        var service = new StageProgressService(db, clock);
+
+        await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.InProgress, null, "tester");
+
+        clock.UtcNow = new DateTimeOffset(2024, 1, 12, 0, 0, 0, TimeSpan.Zero);
+        await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.Completed, null, "tester");
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.Completed, stage.Status);
+        Assert.Equal(DateOnly.FromDateTime(initial.UtcDateTime), stage.ActualStart);
+        Assert.Equal(DateOnly.FromDateTime(clock.UtcNow.UtcDateTime), stage.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateStageStatusAsync_ResetToNotStartedClearsDates()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 1, 5, 0, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.Completed, actualStart: new DateOnly(2024, 1, 1), completedOn: new DateOnly(2024, 1, 2));
+
+        var service = new StageProgressService(db, clock);
+
+        await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.NotStarted, null, "tester");
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.NotStarted, stage.Status);
+        Assert.Null(stage.ActualStart);
+        Assert.Null(stage.CompletedOn);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static async Task SeedStageAsync(ApplicationDbContext db, StageStatus status, DateOnly? actualStart = null, DateOnly? completedOn = null)
+    {
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Project",
+            CreatedByUserId = "seed"
+        });
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            Status = status,
+            ActualStart = actualStart,
+            CompletedOn = completedOn
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private sealed class TestClock : IClock
+    {
+        public TestClock(DateTimeOffset now)
+        {
+            UtcNow = now;
+        }
+
+        public DateTimeOffset UtcNow { get; set; }
+    }
+}

--- a/Services/StageRulesService.cs
+++ b/Services/StageRulesService.cs
@@ -82,9 +82,9 @@ public class StageRulesService
             }
         }
 
-        if (string.Equals(stage.Code, "EAS", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(stage.Code, StageCodes.EAS, StringComparison.OrdinalIgnoreCase))
         {
-            if (context.TryGetStage("PNC", out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            if (context.TryGetStage(StageCodes.PNC, out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
             {
                 return StageGuardResult.Deny("EAS cannot start until PNC is completed or skipped.");
             }
@@ -115,22 +115,22 @@ public class StageRulesService
             return StageGuardResult.Deny($"Start {stage.Code} before completing it.");
         }
 
-        if (string.Equals(stage.Code, "COB", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(stage.Code, StageCodes.COB, StringComparison.OrdinalIgnoreCase))
         {
-            if (!context.TryGetStage("TEC", out var tec) || tec.Status != StageStatus.Completed)
+            if (!context.TryGetStage(StageCodes.TEC, out var tec) || tec.Status != StageStatus.Completed)
             {
                 return StageGuardResult.Deny("COB cannot complete until TEC is completed.");
             }
 
-            if (!context.TryGetStage("BM", out var bench) || bench.Status != StageStatus.Completed)
+            if (!context.TryGetStage(StageCodes.BM, out var bench) || bench.Status != StageStatus.Completed)
             {
                 return StageGuardResult.Deny("COB cannot complete until Benchmarking (BM) is completed.");
             }
         }
 
-        if (string.Equals(stage.Code, "EAS", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(stage.Code, StageCodes.EAS, StringComparison.OrdinalIgnoreCase))
         {
-            if (context.TryGetStage("PNC", out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            if (context.TryGetStage(StageCodes.PNC, out var pnc) && pnc.Status is not StageStatus.Completed and not StageStatus.Skipped)
             {
                 return StageGuardResult.Deny("EAS cannot complete until PNC is completed or skipped.");
             }
@@ -141,7 +141,7 @@ public class StageRulesService
 
     public StageGuardResult CanSkip(StageRulesContext context, string stageCode)
     {
-        if (!string.Equals(stageCode, "PNC", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(stageCode, StageCodes.PNC, StringComparison.OrdinalIgnoreCase))
         {
             return StageGuardResult.Deny("Only PNC can be skipped.");
         }

--- a/Services/Stages/StageProgressService.cs
+++ b/Services/Stages/StageProgressService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+
+namespace ProjectManagement.Services;
+
+public class StageProgressService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public StageProgressService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db;
+        _clock = clock;
+    }
+
+    public async Task UpdateStageStatusAsync(
+        int projectId,
+        string stageCode,
+        StageStatus newStatus,
+        DateOnly? effectiveDate,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(stageCode))
+        {
+            throw new ArgumentException("A valid stage code is required.", nameof(stageCode));
+        }
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new ArgumentException("A valid user identifier is required.", nameof(userId));
+        }
+
+        var stage = await _db.ProjectStages
+            .SingleOrDefaultAsync(
+                s => s.ProjectId == projectId && s.StageCode == stageCode,
+                cancellationToken)
+            ?? throw new InvalidOperationException($"Stage {stageCode} was not found for project {projectId}.");
+
+        var today = DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime);
+        var resolvedDate = effectiveDate ?? today;
+
+        if (newStatus == StageStatus.InProgress && stage.Status != StageStatus.InProgress)
+        {
+            stage.ActualStart ??= resolvedDate;
+        }
+
+        if (newStatus == StageStatus.Completed)
+        {
+            stage.ActualStart ??= resolvedDate;
+            stage.CompletedOn = effectiveDate ?? stage.CompletedOn ?? resolvedDate;
+        }
+        else if (newStatus == StageStatus.NotStarted)
+        {
+            stage.ActualStart = null;
+            stage.CompletedOn = null;
+        }
+        else if (newStatus != StageStatus.Completed && stage.Status == StageStatus.Completed)
+        {
+            stage.CompletedOn = null;
+        }
+
+        stage.Status = newStatus;
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional project number field with a filtered unique index and a migration that also enforces completed stages to store a completion date
- introduce a StageProgressService plus unit tests to ensure stage transitions populate actual and completed dates consistently
- centralize stage codes through a StageCodes helper and update seeding, rules, and plan calculator tests to rely on the canonical constants

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61cee47ac832995d81ebe293835b7