### PR TITLE
Fix migration BuildTargetModel access and nullable warnings

### DIFF
--- a/Migrations/20251007180000_AddProjectFactAmountChecks.Designer.cs
+++ b/Migrations/20251007180000_AddProjectFactAmountChecks.Designer.cs
@@ -16,7 +16,7 @@ namespace ProjectManagement.Migrations
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
-            new ApplicationDbContextModelSnapshot().BuildModel(modelBuilder);
+            new ApplicationDbContextModelSnapshot().PopulateModel(modelBuilder);
         }
     }
 }

--- a/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ProjectManagement.Migrations
+{
+    /// <summary>
+    /// Provides a public entry point to the protected <see cref="ApplicationDbContextModelSnapshot.BuildModel"/> method so
+    /// migration designer files can reuse the current model definition without duplicating code.
+    /// </summary>
+    public partial class ApplicationDbContextModelSnapshot
+    {
+        public void PopulateModel(ModelBuilder modelBuilder) => BuildModel(modelBuilder);
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -816,7 +816,7 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("ProjectAonFacts", (string?)null, t =>
+                    b.ToTable("ProjectAonFacts", (string)null, t =>
                     {
                         t.HasCheckConstraint("ck_aonfact_amount", "\"AonCost\" >= 0");
                     });
@@ -853,7 +853,7 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("ProjectBenchmarkFacts", (string?)null, t =>
+                    b.ToTable("ProjectBenchmarkFacts", (string)null, t =>
                     {
                         t.HasCheckConstraint("ck_bmfact_amount", "\"BenchmarkCost\" >= 0");
                     });
@@ -890,7 +890,7 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("ProjectCommercialFacts", (string?)null, t =>
+                    b.ToTable("ProjectCommercialFacts", (string)null, t =>
                     {
                         t.HasCheckConstraint("ck_l1fact_amount", "\"L1Cost\" >= 0");
                     });
@@ -927,7 +927,7 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("ProjectIpaFacts", (string?)null, t =>
+                    b.ToTable("ProjectIpaFacts", (string)null, t =>
                     {
                         t.HasCheckConstraint("ck_ipafact_amount", "\"IpaCost\" >= 0");
                     });
@@ -964,7 +964,7 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("ProjectPncFacts", (string?)null, t =>
+                    b.ToTable("ProjectPncFacts", (string)null, t =>
                     {
                         t.HasCheckConstraint("ck_pncfact_amount", "\"PncCost\" >= 0");
                     });


### PR DESCRIPTION
## Summary
- expose the model snapshot through a helper method so the latest migration designer can reuse it without protected access errors
- replace nullable table schema arguments with non-nullable casts to clear CS8669 warnings in the snapshot designer
- update the most recent migration designer to call the new helper and avoid build errors

## Testing
- dotnet build
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68d63373886c83298685feb246d00e9c