### PR TITLE
Fix LINQ translation error when creating categories

### DIFF
--- a/Areas/Admin/Pages/Categories/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Categories/Create.cshtml.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -49,13 +50,13 @@ namespace ProjectManagement.Areas.Admin.Pages.Categories
                 IsActive = Input.IsActive
             };
 
-            var nextSort = await _db.ProjectCategories
+            var maxSortOrder = await _db.ProjectCategories
                 .Where(c => c.ParentId == Input.ParentId)
-                .Select(c => c.SortOrder)
-                .DefaultIfEmpty(-1)
-                .MaxAsync();
+                .MaxAsync(c => (int?)c.SortOrder);
 
-            category.SortOrder = nextSort + 1;
+            var nextSort = (maxSortOrder ?? -1) + 1;
+
+            category.SortOrder = nextSort;
 
             _db.ProjectCategories.Add(category);
             await _db.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- rewrite the category sort-order lookup to avoid a DefaultIfEmpty translation failure when creating categories

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d637bb59988329971a4acae3ad4ac1