### PR TITLE
Add audit logging and duplicate category validation

### DIFF
--- a/Areas/Admin/Pages/Categories/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Categories/Create.cshtml.cs
@@ -43,9 +43,19 @@ namespace ProjectManagement.Areas.Admin.Pages.Categories
                 return Page();
             }
 
+            var trimmedName = Input.Name.Trim();
+            var duplicateExists = await _db.ProjectCategories
+                .AnyAsync(c => c.ParentId == Input.ParentId && c.Name == trimmedName);
+
+            if (duplicateExists)
+            {
+                ModelState.AddModelError("Input.Name", "A category with this name already exists under the selected parent.");
+                return Page();
+            }
+
             var category = new ProjectCategory
             {
-                Name = Input.Name.Trim(),
+                Name = trimmedName,
                 ParentId = Input.ParentId,
                 IsActive = Input.IsActive
             };

--- a/Areas/Admin/Pages/Categories/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Categories/Edit.cshtml.cs
@@ -79,9 +79,19 @@ namespace ProjectManagement.Areas.Admin.Pages.Categories
                 }
             }
 
+            var trimmedName = Input.Name.Trim();
+            var duplicateExists = await _db.ProjectCategories
+                .AnyAsync(c => c.ParentId == Input.ParentId && c.Name == trimmedName && c.Id != category.Id);
+
+            if (duplicateExists)
+            {
+                ModelState.AddModelError("Input.Name", "A category with this name already exists under the selected parent.");
+                return Page();
+            }
+
             var parentChanged = category.ParentId != Input.ParentId;
 
-            category.Name = Input.Name.Trim();
+            category.Name = trimmedName;
             category.IsActive = Input.IsActive;
             category.ParentId = Input.ParentId;
 

--- a/ProjectManagement.Tests/ProjectFactsServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectFactsServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
@@ -17,7 +18,7 @@ public class ProjectFactsServiceTests
         var clock = new TestClock(new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero));
         await using var db = CreateContext();
         await SeedProjectAsync(db);
-        var service = new ProjectFactsService(db, clock);
+        var service = new ProjectFactsService(db, clock, new FakeAudit());
 
         await service.UpsertIpaCostAsync(1, 1250.25m, "user-a");
 
@@ -41,7 +42,7 @@ public class ProjectFactsServiceTests
             CreatedOnUtc = new DateTime(2024, 5, 1, 0, 0, 0, DateTimeKind.Utc)
         });
         await db.SaveChangesAsync();
-        var service = new ProjectFactsService(db, clock);
+        var service = new ProjectFactsService(db, clock, new FakeAudit());
 
         await service.UpsertIpaCostAsync(1, 2200m, "user-b");
 
@@ -57,7 +58,7 @@ public class ProjectFactsServiceTests
         var clock = new TestClock(new DateTimeOffset(2024, 7, 15, 0, 0, 0, TimeSpan.Zero));
         await using var db = CreateContext();
         await SeedProjectAsync(db);
-        var service = new ProjectFactsService(db, clock);
+        var service = new ProjectFactsService(db, clock, new FakeAudit());
 
         await service.UpsertSowSponsorsAsync(1, "Operations", "Line A", "user-a");
 
@@ -80,7 +81,7 @@ public class ProjectFactsServiceTests
         var clock = new TestClock(new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero));
         await using var db = CreateContext();
         await SeedProjectAsync(db);
-        var service = new ProjectFactsService(db, clock);
+        var service = new ProjectFactsService(db, clock, new FakeAudit());
 
         await service.UpsertSupplyOrderDateAsync(1, new DateOnly(2024, 2, 15), "user-a");
 
@@ -125,5 +126,11 @@ public class ProjectFactsServiceTests
         }
 
         public DateTimeOffset UtcNow { get; set; }
+    }
+
+    private sealed class FakeAudit : IAuditService
+    {
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, Microsoft.AspNetCore.Http.HttpContext? http = null)
+            => Task.CompletedTask;
     }
 }

--- a/ProjectManagement.Tests/StageProgressServiceTests.cs
+++ b/ProjectManagement.Tests/StageProgressServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
@@ -20,7 +21,7 @@ public class StageProgressServiceTests
         await using var db = CreateContext();
         await SeedStageAsync(db, StageStatus.NotStarted);
 
-        var service = new StageProgressService(db, clock);
+        var service = new StageProgressService(db, clock, new FakeAudit());
 
         await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.InProgress, null, "tester");
 
@@ -38,7 +39,7 @@ public class StageProgressServiceTests
         await using var db = CreateContext();
         await SeedStageAsync(db, StageStatus.NotStarted);
 
-        var service = new StageProgressService(db, clock);
+        var service = new StageProgressService(db, clock, new FakeAudit());
 
         await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.InProgress, null, "tester");
 
@@ -58,7 +59,7 @@ public class StageProgressServiceTests
         await using var db = CreateContext();
         await SeedStageAsync(db, StageStatus.Completed, actualStart: new DateOnly(2024, 1, 1), completedOn: new DateOnly(2024, 1, 2));
 
-        var service = new StageProgressService(db, clock);
+        var service = new StageProgressService(db, clock, new FakeAudit());
 
         await service.UpdateStageStatusAsync(1, StageCodes.IPA, StageStatus.NotStarted, null, "tester");
 
@@ -106,5 +107,11 @@ public class StageProgressServiceTests
         }
 
         public DateTimeOffset UtcNow { get; set; }
+    }
+
+    private sealed class FakeAudit : IAuditService
+    {
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, Microsoft.AspNetCore.Http.HttpContext? http = null)
+            => Task.CompletedTask;
     }
 }

--- a/Services/Projects/ProjectFactsService.cs
+++ b/Services/Projects/ProjectFactsService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -12,21 +14,32 @@ namespace ProjectManagement.Services.Projects
     {
         private readonly ApplicationDbContext _db;
         private readonly IClock _clock;
+        private readonly IAuditService _audit;
 
-        public ProjectFactsService(ApplicationDbContext db, IClock clock)
+        public ProjectFactsService(ApplicationDbContext db, IClock clock, IAuditService audit)
         {
             _db = db;
             _clock = clock;
+            _audit = audit;
         }
 
         public async Task UpsertIpaCostAsync(int projectId, decimal ipaCost, string userId, CancellationToken ct = default)
         {
-            await UpsertMoneyFactAsync(
+            var created = await UpsertMoneyFactAsync(
                 _db.ProjectIpaFacts,
                 projectId,
                 userId,
                 fact => fact.IpaCost = ipaCost,
                 ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.IpaCostCreated" : "ProjectFacts.IpaCostUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["IpaCost"] = ipaCost.ToString(CultureInfo.InvariantCulture)
+                });
         }
 
         public async Task UpsertSowSponsorsAsync(int projectId, string sponsoringUnit, string sponsoringLineDirectorate, string userId, CancellationToken ct = default)
@@ -35,6 +48,7 @@ namespace ProjectManagement.Services.Projects
             ArgumentNullException.ThrowIfNull(sponsoringLineDirectorate);
 
             var fact = await _db.ProjectSowFacts.SingleOrDefaultAsync(x => x.ProjectId == projectId, ct);
+            var created = false;
             if (fact is null)
             {
                 fact = new ProjectSowFact
@@ -46,6 +60,7 @@ namespace ProjectManagement.Services.Projects
                     CreatedOnUtc = _clock.UtcNow.UtcDateTime
                 };
                 await _db.ProjectSowFacts.AddAsync(fact, ct);
+                created = true;
             }
             else
             {
@@ -54,51 +69,98 @@ namespace ProjectManagement.Services.Projects
             }
 
             await _db.SaveChangesAsync(ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.SowSponsorsCreated" : "ProjectFacts.SowSponsorsUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["SponsoringUnit"] = sponsoringUnit,
+                    ["SponsoringLineDirectorate"] = sponsoringLineDirectorate
+                });
         }
 
         public async Task UpsertAonCostAsync(int projectId, decimal aonCost, string userId, CancellationToken ct = default)
         {
-            await UpsertMoneyFactAsync(
+            var created = await UpsertMoneyFactAsync(
                 _db.ProjectAonFacts,
                 projectId,
                 userId,
                 fact => fact.AonCost = aonCost,
                 ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.AonCostCreated" : "ProjectFacts.AonCostUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["AonCost"] = aonCost.ToString(CultureInfo.InvariantCulture)
+                });
         }
 
         public async Task UpsertBenchmarkCostAsync(int projectId, decimal benchmarkCost, string userId, CancellationToken ct = default)
         {
-            await UpsertMoneyFactAsync(
+            var created = await UpsertMoneyFactAsync(
                 _db.ProjectBenchmarkFacts,
                 projectId,
                 userId,
                 fact => fact.BenchmarkCost = benchmarkCost,
                 ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.BenchmarkCostCreated" : "ProjectFacts.BenchmarkCostUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["BenchmarkCost"] = benchmarkCost.ToString(CultureInfo.InvariantCulture)
+                });
         }
 
         public async Task UpsertL1CostAsync(int projectId, decimal l1Cost, string userId, CancellationToken ct = default)
         {
-            await UpsertMoneyFactAsync(
+            var created = await UpsertMoneyFactAsync(
                 _db.ProjectCommercialFacts,
                 projectId,
                 userId,
                 fact => fact.L1Cost = l1Cost,
                 ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.L1CostCreated" : "ProjectFacts.L1CostUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["L1Cost"] = l1Cost.ToString(CultureInfo.InvariantCulture)
+                });
         }
 
         public async Task UpsertPncCostAsync(int projectId, decimal pncCost, string userId, CancellationToken ct = default)
         {
-            await UpsertMoneyFactAsync(
+            var created = await UpsertMoneyFactAsync(
                 _db.ProjectPncFacts,
                 projectId,
                 userId,
                 fact => fact.PncCost = pncCost,
                 ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.PncCostCreated" : "ProjectFacts.PncCostUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["PncCost"] = pncCost.ToString(CultureInfo.InvariantCulture)
+                });
         }
 
         public async Task UpsertSupplyOrderDateAsync(int projectId, DateOnly supplyOrderDate, string userId, CancellationToken ct = default)
         {
             var fact = await _db.ProjectSupplyOrderFacts.SingleOrDefaultAsync(x => x.ProjectId == projectId, ct);
+            var created = false;
             if (fact is null)
             {
                 fact = new ProjectSupplyOrderFact
@@ -109,6 +171,7 @@ namespace ProjectManagement.Services.Projects
                     CreatedOnUtc = _clock.UtcNow.UtcDateTime
                 };
                 await _db.ProjectSupplyOrderFacts.AddAsync(fact, ct);
+                created = true;
             }
             else
             {
@@ -116,12 +179,22 @@ namespace ProjectManagement.Services.Projects
             }
 
             await _db.SaveChangesAsync(ct);
+
+            await _audit.LogAsync(
+                created ? "ProjectFacts.SupplyOrderDateCreated" : "ProjectFacts.SupplyOrderDateUpdated",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                    ["SupplyOrderDate"] = supplyOrderDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                });
         }
 
-        private async Task UpsertMoneyFactAsync<TFact>(DbSet<TFact> set, int projectId, string userId, Action<TFact> update, CancellationToken ct)
+        private async Task<bool> UpsertMoneyFactAsync<TFact>(DbSet<TFact> set, int projectId, string userId, Action<TFact> update, CancellationToken ct)
             where TFact : ProjectFactBase, new()
         {
             var fact = await set.SingleOrDefaultAsync(x => x.ProjectId == projectId, ct);
+            var created = false;
             if (fact is null)
             {
                 fact = new TFact
@@ -132,6 +205,7 @@ namespace ProjectManagement.Services.Projects
                 };
                 update(fact);
                 await set.AddAsync(fact, ct);
+                created = true;
             }
             else
             {
@@ -139,6 +213,7 @@ namespace ProjectManagement.Services.Projects
             }
 
             await _db.SaveChangesAsync(ct);
+            return created;
         }
     }
 }


### PR DESCRIPTION
## Summary
- log project fact and stage status updates through the existing audit service
- surface friendly validation errors when an admin attempts to create or rename a category to a duplicate name
- update unit tests to accommodate the new auditing dependencies

## Testing
- dotnet test *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63aed4e888329bc02c471aa04f7a9