### PR TITLE
feat: add project creation workflow with case file numbers

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -49,10 +49,10 @@ namespace ProjectManagement.Data
             {
                 e.Property(x => x.Name).HasMaxLength(100).IsRequired();
                 e.HasIndex(x => x.Name);
-                e.Property(x => x.ProjectNumber).HasMaxLength(64);
-                e.HasIndex(x => x.ProjectNumber)
+                e.Property(x => x.CaseFileNumber).HasMaxLength(64);
+                e.HasIndex(x => x.CaseFileNumber)
                     .IsUnique()
-                    .HasFilter("\"ProjectNumber\" IS NOT NULL");
+                    .HasFilter("\"CaseFileNumber\" IS NOT NULL");
                 e.Property(x => x.RowVersion).IsRowVersion();
                 e.Property(x => x.CreatedByUserId).HasMaxLength(64).IsRequired();
                 e.HasOne(x => x.Category)

--- a/Migrations/20251008000000_RenameProjectNumberToCaseFileNumber.Designer.cs
+++ b/Migrations/20251008000000_RenameProjectNumberToCaseFileNumber.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,10 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251008000000_RenameProjectNumberToCaseFileNumber")]
+    partial class RenameProjectNumberToCaseFileNumber : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251008000000_RenameProjectNumberToCaseFileNumber.cs
+++ b/Migrations/20251008000000_RenameProjectNumberToCaseFileNumber.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    public partial class RenameProjectNumberToCaseFileNumber : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_ProjectNumber",
+                table: "Projects");
+
+            migrationBuilder.RenameColumn(
+                name: "ProjectNumber",
+                table: "Projects",
+                newName: "CaseFileNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_CaseFileNumber",
+                table: "Projects",
+                column: "CaseFileNumber",
+                unique: true,
+                filter: "\"CaseFileNumber\" IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_CaseFileNumber",
+                table: "Projects");
+
+            migrationBuilder.RenameColumn(
+                name: "CaseFileNumber",
+                table: "Projects",
+                newName: "ProjectNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_ProjectNumber",
+                table: "Projects",
+                column: "ProjectNumber",
+                unique: true,
+                filter: "\"ProjectNumber\" IS NOT NULL");
+        }
+    }
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -19,7 +19,7 @@ namespace ProjectManagement.Models
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         [MaxLength(64)]
-        public string? ProjectNumber { get; set; }
+        public string? CaseFileNumber { get; set; }
 
         [Required]
         [MaxLength(64)]

--- a/Pages/Projects/AssignRoles.cshtml
+++ b/Pages/Projects/AssignRoles.cshtml
@@ -1,0 +1,43 @@
+@page "{id:int}"
+@attribute [Authorize(Roles = "Admin,HoD")]
+@model ProjectManagement.Pages.Projects.AssignRolesModel
+@{
+    ViewData["Title"] = "Assign Roles";
+}
+
+<div class="container-xxl">
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-page="/Projects/Index">Projects</a></li>
+            <li class="breadcrumb-item"><a asp-page="/Projects/Overview" asp-route-id="@Model.Input.ProjectId">@Model.ProjectName</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Assign Roles</li>
+        </ol>
+    </nav>
+
+    <h1 class="h4 mb-3">Assign Roles — @Model.ProjectName</h1>
+
+    <form method="post">
+        <input type="hidden" asp-for="Input.ProjectId" />
+
+        <div class="card">
+            <div class="card-body row g-3">
+                <div class="col-md-6">
+                    <label asp-for="Input.HodUserId" class="form-label">Head of Directorate</label>
+                    <select asp-for="Input.HodUserId" class="form-select" asp-items="Model.HodList"></select>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="Input.PoUserId" class="form-label">Project Officer</label>
+                    <select asp-for="Input.PoUserId" class="form-select" asp-items="Model.PoList"></select>
+                </div>
+            </div>
+            <div class="card-footer d-flex justify-content-between">
+                <a asp-page="/Projects/Overview" asp-route-id="@Model.Input.ProjectId" class="btn btn-outline-secondary">Cancel</a>
+                <button type="submit" class="btn btn-primary">Save</button>
+            </div>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/AssignRoles.cshtml.cs
+++ b/Pages/Projects/AssignRoles.cshtml.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize(Roles = "Admin,HoD")]
+    public class AssignRolesModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _users;
+
+        public AssignRolesModel(ApplicationDbContext db, UserManager<ApplicationUser> users)
+        {
+            _db = db;
+            _users = users;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public string ProjectName { get; private set; } = string.Empty;
+        public IEnumerable<SelectListItem> HodList { get; private set; } = Array.Empty<SelectListItem>();
+        public IEnumerable<SelectListItem> PoList { get; private set; } = Array.Empty<SelectListItem>();
+
+        public class InputModel
+        {
+            public int ProjectId { get; set; }
+            public string? HodUserId { get; set; }
+            public string? PoUserId { get; set; }
+        }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            var project = await _db.Projects.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id);
+            if (project is null)
+            {
+                return NotFound();
+            }
+
+            ProjectName = project.Name;
+            Input.ProjectId = project.Id;
+            Input.HodUserId = project.HodUserId;
+            Input.PoUserId = project.LeadPoUserId;
+
+            await LoadListsAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == Input.ProjectId);
+            if (project is null)
+            {
+                return NotFound();
+            }
+
+            project.HodUserId = string.IsNullOrWhiteSpace(Input.HodUserId) ? null : Input.HodUserId;
+            project.LeadPoUserId = string.IsNullOrWhiteSpace(Input.PoUserId) ? null : Input.PoUserId;
+
+            await _db.SaveChangesAsync();
+
+            return RedirectToPage("/Projects/Overview", new { id = project.Id });
+        }
+
+        private async Task LoadListsAsync()
+        {
+            var hodUsers = await _users.GetUsersInRoleAsync("HoD");
+            HodList = BuildUserOptions(hodUsers);
+
+            var poUsers = await _users.GetUsersInRoleAsync("Project Officer");
+            PoList = BuildUserOptions(poUsers);
+        }
+
+        private static IEnumerable<SelectListItem> BuildUserOptions(IEnumerable<ApplicationUser> users)
+        {
+            var items = new List<SelectListItem>
+            {
+                new("— Unassigned —", string.Empty)
+            };
+
+            items.AddRange(users
+                .OrderBy(u => string.IsNullOrWhiteSpace(u.FullName) ? u.UserName : u.FullName)
+                .Select(u => new SelectListItem(DisplayName(u), u.Id)));
+
+            return items;
+        }
+
+        private static string DisplayName(ApplicationUser user)
+        {
+            if (!string.IsNullOrWhiteSpace(user.FullName))
+            {
+                return user.FullName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(user.UserName))
+            {
+                return user.UserName!;
+            }
+
+            return user.Email ?? user.Id;
+        }
+    }
+}

--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -1,0 +1,112 @@
+@page
+@attribute [Authorize(Policy = "Project.Create")]
+@model ProjectManagement.Pages.Projects.CreateModel
+@{
+    ViewData["Title"] = "Create Project";
+}
+
+<div class="container-xxl">
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-page="/Projects/Index">Projects</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Create</li>
+        </ol>
+    </nav>
+
+    <h1 class="h3 mb-3">Create Project</h1>
+
+    <form method="post" class="needs-validation" novalidate>
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="card mb-3">
+            <div class="card-header">Project Details</div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label asp-for="Input.Name" class="form-label"></label>
+                    <input asp-for="Input.Name" class="form-control" />
+                    <span asp-validation-for="Input.Name" class="text-danger"></span>
+                </div>
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.CaseFileNumber" class="form-label">Case File Number (optional)</label>
+                        <input asp-for="Input.CaseFileNumber" class="form-control" />
+                        <span asp-validation-for="Input.CaseFileNumber" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.Description" class="form-label"></label>
+                        <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+                        <span asp-validation-for="Input.Description" class="text-danger"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header">Classification</div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.CategoryId" class="form-label">Category</label>
+                        <select asp-for="Input.CategoryId" class="form-select" asp-items="Model.TopCategories"></select>
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">Subcategory</label>
+                        <select id="SubCategoryId" name="Input.SubCategoryId" class="form-select" disabled data-selected="@Model.Input?.SubCategoryId">
+                            <option value="">— (none) —</option>
+                        </select>
+                        <div class="form-text">Appears when the category has active children.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header">Roles (optional)</div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.HodUserId" class="form-label">Head of Directorate</label>
+                        <select asp-for="Input.HodUserId" class="form-select" asp-items="Model.HodList"></select>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.PoUserId" class="form-label">Project Officer</label>
+                        <select asp-for="Input.PoUserId" class="form-select" asp-items="Model.PoList"></select>
+                    </div>
+                </div>
+                <div class="form-text">You can assign these later from the overview page.</div>
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">Current Status (optional)</div>
+            <div class="card-body">
+                <div class="form-check form-switch mb-2">
+                    <input class="form-check-input" type="checkbox" id="IsOngoing" asp-for="Input.IsOngoing" />
+                    <label class="form-check-label" for="IsOngoing">Project already in progress</label>
+                </div>
+                <div id="OngoingFields" class="row g-3 visually-hidden">
+                    <div class="col-md-6">
+                        <label asp-for="Input.LastStageCompleted" class="form-label">Last stage completed</label>
+                        <select asp-for="Input.LastStageCompleted" class="form-select" asp-items="Model.StageOptions"></select>
+                        <span asp-validation-for="Input.LastStageCompleted" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.LastStageCompletedOn" class="form-label">Completed on</label>
+                        <input asp-for="Input.LastStageCompletedOn" type="date" class="form-control" />
+                        <span asp-validation-for="Input.LastStageCompletedOn" class="text-danger"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a asp-page="/Projects/Index" class="btn btn-outline-secondary">Cancel</a>
+            <button type="submit" class="btn btn-primary">Create Project</button>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/projects/create.js" asp-append-version="true"></script>
+}

--- a/Pages/Projects/Create.cshtml.cs
+++ b/Pages/Projects/Create.cshtml.cs
@@ -1,0 +1,201 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize(Policy = "Project.Create")]
+    public class CreateModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _users;
+        private readonly IClock _clock;
+
+        public CreateModel(ApplicationDbContext db, UserManager<ApplicationUser> users, IClock clock)
+        {
+            _db = db;
+            _users = users;
+            _clock = clock;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public IEnumerable<SelectListItem> TopCategories { get; private set; } = Array.Empty<SelectListItem>();
+        public IEnumerable<SelectListItem> HodList { get; private set; } = Array.Empty<SelectListItem>();
+        public IEnumerable<SelectListItem> PoList { get; private set; } = Array.Empty<SelectListItem>();
+        public IEnumerable<SelectListItem> StageOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+        public class InputModel
+        {
+            [Required]
+            [MaxLength(100)]
+            public string Name { get; set; } = string.Empty;
+
+            [MaxLength(64)]
+            public string? CaseFileNumber { get; set; }
+
+            [MaxLength(1000)]
+            public string? Description { get; set; }
+
+            public int? CategoryId { get; set; }
+
+            public int? SubCategoryId { get; set; }
+
+            public string? HodUserId { get; set; }
+
+            public string? PoUserId { get; set; }
+
+            public bool IsOngoing { get; set; }
+
+            public string? LastStageCompleted { get; set; }
+
+            [DataType(DataType.Date)]
+            public DateTime? LastStageCompletedOn { get; set; }
+        }
+
+        public async Task OnGetAsync()
+        {
+            await LoadAsync();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            await LoadAsync();
+
+            if (Input.IsOngoing)
+            {
+                if (string.IsNullOrWhiteSpace(Input.LastStageCompleted))
+                {
+                    ModelState.AddModelError("Input.LastStageCompleted", "Select the last stage that was completed.");
+                }
+                else if (!StageCodes.All.Contains(Input.LastStageCompleted, StringComparer.OrdinalIgnoreCase))
+                {
+                    ModelState.AddModelError("Input.LastStageCompleted", "Unknown stage code.");
+                }
+
+                if (Input.LastStageCompletedOn is null)
+                {
+                    ModelState.AddModelError("Input.LastStageCompletedOn", "Provide the completion date.");
+                }
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            string? caseFileNumber = null;
+            if (!string.IsNullOrWhiteSpace(Input.CaseFileNumber))
+            {
+                caseFileNumber = Input.CaseFileNumber.Trim();
+                var exists = await _db.Projects.AnyAsync(p => p.CaseFileNumber == caseFileNumber);
+                if (exists)
+                {
+                    ModelState.AddModelError("Input.CaseFileNumber", "Case file number already exists.");
+                    return Page();
+                }
+            }
+
+            var currentUserId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(currentUserId))
+            {
+                return Forbid();
+            }
+
+            var categoryId = Input.SubCategoryId ?? Input.CategoryId;
+
+            var project = new Project
+            {
+                Name = Input.Name.Trim(),
+                CaseFileNumber = caseFileNumber,
+                Description = string.IsNullOrWhiteSpace(Input.Description) ? null : Input.Description.Trim(),
+                CategoryId = categoryId,
+                HodUserId = string.IsNullOrWhiteSpace(Input.HodUserId) ? null : Input.HodUserId,
+                LeadPoUserId = string.IsNullOrWhiteSpace(Input.PoUserId) ? null : Input.PoUserId,
+                CreatedByUserId = currentUserId,
+                CreatedAt = _clock.UtcNow.UtcDateTime
+            };
+
+            _db.Projects.Add(project);
+            await _db.SaveChangesAsync();
+
+            if (Input.IsOngoing && !string.IsNullOrWhiteSpace(Input.LastStageCompleted) && Input.LastStageCompletedOn.HasValue)
+            {
+                var completedCode = StageCodes.All.First(code => string.Equals(code, Input.LastStageCompleted, StringComparison.OrdinalIgnoreCase));
+                var completedDate = DateOnly.FromDateTime(Input.LastStageCompletedOn.Value.Date);
+                var stage = new ProjectStage
+                {
+                    ProjectId = project.Id,
+                    StageCode = completedCode,
+                    Status = StageStatus.Completed,
+                    ActualStart = completedDate,
+                    CompletedOn = completedDate
+                };
+
+                _db.ProjectStages.Add(stage);
+                await _db.SaveChangesAsync();
+            }
+
+            return RedirectToPage("/Projects/Overview", new { id = project.Id });
+        }
+
+        private async Task LoadAsync()
+        {
+            TopCategories = await _db.ProjectCategories
+                .Where(c => c.ParentId == null && c.IsActive)
+                .OrderBy(c => c.SortOrder)
+                .ThenBy(c => c.Name)
+                .Select(c => new SelectListItem(c.Name, c.Id.ToString()))
+                .ToListAsync();
+
+            var hodUsers = await _users.GetUsersInRoleAsync("HoD");
+            HodList = BuildUserOptions(hodUsers);
+
+            var poUsers = await _users.GetUsersInRoleAsync("Project Officer");
+            PoList = BuildUserOptions(poUsers);
+
+            StageOptions = StageCodes.All
+                .Select(code => new SelectListItem(code, code))
+                .ToList();
+        }
+
+        private static IEnumerable<SelectListItem> BuildUserOptions(IEnumerable<ApplicationUser> users)
+        {
+            var items = new List<SelectListItem>
+            {
+                new("— Unassigned —", string.Empty)
+            };
+
+            items.AddRange(users
+                .OrderBy(u => string.IsNullOrWhiteSpace(u.FullName) ? u.UserName : u.FullName)
+                .Select(u => new SelectListItem(DisplayName(u), u.Id)));
+
+            return items;
+        }
+
+        private static string DisplayName(ApplicationUser user)
+        {
+            if (!string.IsNullOrWhiteSpace(user.FullName))
+            {
+                return user.FullName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(user.UserName))
+            {
+                return user.UserName!;
+            }
+
+            return user.Email ?? user.Id;
+        }
+    }
+}

--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -1,0 +1,67 @@
+@page
+@model ProjectManagement.Pages.Projects.IndexModel
+@{
+    ViewData["Title"] = "Projects";
+}
+
+<div class="container-xxl">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h1 class="h3 mb-0">Projects</h1>
+            <p class="text-muted mb-0">Showing the 100 most recent projects.</p>
+        </div>
+        @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+        {
+            <a asp-page="/Projects/Create" class="btn btn-primary">Create Project</a>
+        }
+    </div>
+
+    <form method="get" class="row g-2 align-items-end mb-4">
+        <div class="col-sm-4 col-md-3">
+            <label for="CaseFileQuery" class="form-label">Case File Number</label>
+            <input id="CaseFileQuery" name="CaseFileQuery" value="@Model.CaseFileQuery" class="form-control" placeholder="Search Case File #" />
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-outline-primary">Search</button>
+        </div>
+    </form>
+
+    @if (!Model.Projects.Any())
+    {
+        <div class="alert alert-info">No projects found.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Case File #</th>
+                        <th>Category</th>
+                        <th>HoD</th>
+                        <th>Project Officer</th>
+                        <th>Created</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var project in Model.Projects)
+                {
+                    <tr>
+                        <td>
+                            <a asp-page="/Projects/Overview" asp-route-id="@project.Id" class="fw-semibold text-decoration-none">
+                                @project.Name
+                            </a>
+                        </td>
+                        <td>@project.CaseFileNumber</td>
+                        <td>@project.Category?.Name</td>
+                        <td>@(project.HodUser?.FullName ?? project.HodUser?.UserName)</td>
+                        <td>@(project.LeadPoUser?.FullName ?? project.LeadPoUser?.UserName)</td>
+                        <td>@project.CreatedAt.ToString("dd MMM yyyy")</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+
+        public IndexModel(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public IList<Project> Projects { get; private set; } = new List<Project>();
+
+        [BindProperty(SupportsGet = true)]
+        public string? CaseFileQuery { get; set; }
+
+        public async Task OnGetAsync()
+        {
+            var query = _db.Projects
+                .AsNoTracking()
+                .Include(p => p.Category)
+                .Include(p => p.HodUser)
+                .Include(p => p.LeadPoUser)
+                .OrderByDescending(p => p.CreatedAt)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(CaseFileQuery))
+            {
+                var term = CaseFileQuery.Trim();
+                query = query.Where(p => p.CaseFileNumber != null && EF.Functions.ILike(p.CaseFileNumber!, $"%{term}%"));
+            }
+
+            Projects = await query.Take(100).ToListAsync();
+        }
+    }
+}

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1,0 +1,146 @@
+@page "{id:int}"
+@using ProjectManagement.Models
+@model ProjectManagement.Pages.Projects.OverviewModel
+@{
+    ViewData["Title"] = Model.Project.Name;
+}
+
+<div class="container-xxl">
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-page="/Projects/Index">Projects</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Overview</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3 gap-3">
+        <div>
+            <h1 class="h3 mb-1">
+                @Model.Project.Name
+                @if (!string.IsNullOrWhiteSpace(Model.Project.CaseFileNumber))
+                {
+                    <small class="text-muted">(@Model.Project.CaseFileNumber)</small>
+                }
+            </h1>
+            <div class="text-muted">Created on @Model.Project.CreatedAt.ToString("dd MMM yyyy")</div>
+        </div>
+        @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+        {
+            <a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id" class="btn btn-outline-primary">Assign Roles</a>
+        }
+    </div>
+
+    @if (Model.Project.HodUserId == null || Model.Project.LeadPoUserId == null)
+    {
+        <div class="alert alert-warning d-flex align-items-center" role="alert">
+            <div class="me-3">
+                @if (Model.Project.HodUserId == null)
+                {
+                    <div>Head of Directorate not assigned.</div>
+                }
+                @if (Model.Project.LeadPoUserId == null)
+                {
+                    <div>Project Officer not assigned.</div>
+                }
+            </div>
+            @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+            {
+                <a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id" class="btn btn-sm btn-warning">Assign Roles</a>
+            }
+        </div>
+    }
+
+    <div class="row g-3 mb-4">
+        <div class="col-lg-8">
+            <div class="card h-100">
+                <div class="card-header">Project details</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Description</dt>
+                        <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(Model.Project.Description) ? Model.Project.Description : "—")</dd>
+
+                        <dt class="col-sm-4">Category</dt>
+                        <dd class="col-sm-8">
+                            @if (Model.CategoryPath.Any())
+                            {
+                                <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
+                            }
+                            else
+                            {
+                                <span>—</span>
+                            }
+                        </dd>
+
+                        <dt class="col-sm-4">Head of Directorate</dt>
+                        <dd class="col-sm-8">@DisplayUser(Model.Project.HodUser)</dd>
+
+                        <dt class="col-sm-4">Project Officer</dt>
+                        <dd class="col-sm-8">@DisplayUser(Model.Project.LeadPoUser)</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <div class="card h-100">
+                <div class="card-header">Quick links</div>
+                <div class="card-body">
+                    <ul class="list-unstyled mb-0">
+                        <li><a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id">Assign or change roles</a></li>
+                        <li><a asp-page="/Projects/Create">Create another project</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">Stage progress</div>
+        <div class="card-body">
+            @if (!Model.Stages.Any())
+            {
+                <p class="mb-0 text-muted">No stage updates recorded yet.</p>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Stage</th>
+                                <th>Status</th>
+                                <th>Completed On</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var stage in Model.Stages)
+                        {
+                            <tr>
+                                <td>@stage.StageCode</td>
+                                <td>@stage.Status</td>
+                                <td>@(stage.CompletedOn?.ToString("dd MMM yyyy") ?? "—")</td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@functions {
+    private static string DisplayUser(ApplicationUser? user)
+    {
+        if (user is null)
+        {
+            return "—";
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.FullName))
+        {
+            return user.FullName;
+        }
+
+        return user.UserName ?? "—";
+    }
+}

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Pages.Projects
+{
+    [Authorize]
+    public class OverviewModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+
+        public OverviewModel(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public Project Project { get; private set; } = default!;
+        public IList<ProjectStage> Stages { get; private set; } = new List<ProjectStage>();
+        public IReadOnlyList<ProjectCategory> CategoryPath { get; private set; } = Array.Empty<ProjectCategory>();
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            var project = await _db.Projects
+                .Include(p => p.Category)
+                .Include(p => p.HodUser)
+                .Include(p => p.LeadPoUser)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (project is null)
+            {
+                return NotFound();
+            }
+
+            Project = project;
+
+            Stages = await _db.ProjectStages
+                .Where(s => s.ProjectId == id)
+                .OrderBy(s =>
+                {
+                    var index = Array.IndexOf(StageCodes.All, s.StageCode);
+                    return index >= 0 ? index : int.MaxValue;
+                })
+                .ThenBy(s => s.StageCode)
+                .ToListAsync();
+
+            if (project.CategoryId.HasValue)
+            {
+                CategoryPath = await BuildCategoryPathAsync(project.CategoryId.Value);
+            }
+
+            return Page();
+        }
+
+        private async Task<IReadOnlyList<ProjectCategory>> BuildCategoryPathAsync(int categoryId)
+        {
+            var path = new List<ProjectCategory>();
+            var visited = new HashSet<int>();
+            var currentId = categoryId;
+
+            while (true)
+            {
+                if (!visited.Add(currentId))
+                {
+                    break;
+                }
+
+                var category = await _db.ProjectCategories.AsNoTracking().FirstOrDefaultAsync(c => c.Id == currentId);
+                if (category is null)
+                {
+                    break;
+                }
+
+                path.Insert(0, category);
+
+                if (category.ParentId is null)
+                {
+                    break;
+                }
+
+                currentId = category.ParentId.Value;
+            }
+
+            return path;
+        }
+    }
+}

--- a/ProjectManagement.Tests/ProjectTests.cs
+++ b/ProjectManagement.Tests/ProjectTests.cs
@@ -1,14 +1,54 @@
 using System;
 using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Pages.Projects;
+using ProjectManagement.Services;
 using Xunit;
 
 namespace ProjectManagement.Tests
 {
     public class ProjectTests
     {
+        private static (ApplicationDbContext Context, UserManager<ApplicationUser> UserManager) CreateContextWithIdentity()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            var context = new ApplicationDbContext(options);
+
+            var services = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            var userManager = new UserManager<ApplicationUser>(
+                new UserStore<ApplicationUser>(context),
+                Options.Create(new IdentityOptions()),
+                new PasswordHasher<ApplicationUser>(),
+                Array.Empty<IUserValidator<ApplicationUser>>(),
+                Array.Empty<IPasswordValidator<ApplicationUser>>(),
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                services,
+                new Logger<UserManager<ApplicationUser>>(new LoggerFactory()));
+
+            return (context, userManager);
+        }
+
         [Fact]
         public void CanAddProjectToContext()
         {
@@ -27,6 +67,91 @@ namespace ProjectManagement.Tests
             context.SaveChanges();
 
             Assert.Equal(1, context.Projects.Count());
+        }
+
+        [Fact]
+        public async Task CreateModel_AllowsMissingRoleAssignments()
+        {
+            var (context, userManager) = CreateContextWithIdentity();
+            await userManager.CreateAsync(new ApplicationUser { Id = "creator", UserName = "creator" });
+
+            var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 12, 0, 0, TimeSpan.Zero));
+            var page = new CreateModel(context, userManager, clock)
+            {
+                Input = new CreateModel.InputModel
+                {
+                    Name = "Project Alpha",
+                    Description = "New project"
+                },
+                PageContext = BuildPageContext("creator")
+            };
+
+            var result = await page.OnPostAsync();
+
+            var redirect = Assert.IsType<RedirectToPageResult>(result);
+            Assert.Equal("/Projects/Overview", redirect.PageName);
+            var project = Assert.Single(context.Projects);
+            Assert.Null(project.HodUserId);
+            Assert.Null(project.LeadPoUserId);
+            Assert.Null(project.CaseFileNumber);
+            Assert.Equal(clock.UtcNow.UtcDateTime, project.CreatedAt);
+        }
+
+        [Fact]
+        public async Task CreateModel_FlagsDuplicateCaseFileNumber()
+        {
+            var (context, userManager) = CreateContextWithIdentity();
+            await userManager.CreateAsync(new ApplicationUser { Id = "creator", UserName = "creator" });
+
+            context.Projects.Add(new Project
+            {
+                Name = "Existing",
+                CaseFileNumber = "CF-123",
+                CreatedByUserId = "someone",
+                CreatedAt = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+
+            var clock = new FixedClock(DateTimeOffset.UtcNow);
+            var page = new CreateModel(context, userManager, clock)
+            {
+                Input = new CreateModel.InputModel
+                {
+                    Name = "New Project",
+                    CaseFileNumber = "CF-123"
+                },
+                PageContext = BuildPageContext("creator")
+            };
+
+            var result = await page.OnPostAsync();
+
+            Assert.IsType<PageResult>(result);
+            Assert.True(page.ModelState.TryGetValue("Input.CaseFileNumber", out var entry));
+            Assert.Single(entry!.Errors);
+            Assert.Equal(1, context.Projects.Count());
+        }
+
+        private static PageContext BuildPageContext(string userId)
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, userId)
+                }, "TestAuth"))
+            };
+
+            return new PageContext(new ActionContext(httpContext, new RouteData(), new ActionDescriptor()));
+        }
+
+        private sealed class FixedClock : IClock
+        {
+            public FixedClock(DateTimeOffset now)
+            {
+                UtcNow = now;
+            }
+
+            public DateTimeOffset UtcNow { get; }
         }
     }
 }

--- a/wwwroot/js/projects/create.js
+++ b/wwwroot/js/projects/create.js
@@ -1,0 +1,75 @@
+(function () {
+  const isOngoing = document.getElementById('IsOngoing');
+  const ongoingFields = document.getElementById('OngoingFields');
+  const categorySelect = document.querySelector('[name="Input.CategoryId"]');
+  const subCategorySelect = document.getElementById('SubCategoryId');
+
+  function toggleOngoing() {
+    if (!ongoingFields) {
+      return;
+    }
+
+    const active = Boolean(isOngoing && isOngoing.checked);
+    ongoingFields.classList.toggle('visually-hidden', !active);
+  }
+
+  async function loadSubCategories(categoryId, selectedValue) {
+    if (!subCategorySelect) {
+      return;
+    }
+
+    subCategorySelect.innerHTML = '<option value="">— (none) —</option>';
+    subCategorySelect.disabled = true;
+
+    if (!categoryId) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/categories/children?parentId=${encodeURIComponent(categoryId)}`, {
+        credentials: 'same-origin'
+      });
+
+      if (!response.ok) {
+        return;
+      }
+
+      const items = await response.json();
+      if (!Array.isArray(items) || items.length === 0) {
+        return;
+      }
+
+      for (const item of items) {
+        const option = document.createElement('option');
+        option.value = String(item.id);
+        option.textContent = item.name;
+        subCategorySelect.appendChild(option);
+      }
+
+      subCategorySelect.disabled = false;
+
+      if (selectedValue) {
+        subCategorySelect.value = selectedValue;
+      }
+    } catch (err) {
+      // Network errors are ignored; the base category selection still works.
+    }
+  }
+
+  isOngoing?.addEventListener('change', toggleOngoing);
+  toggleOngoing();
+
+  const preselectedSub = subCategorySelect?.dataset.selected || '';
+  if (categorySelect && categorySelect.value) {
+    loadSubCategories(categorySelect.value, preselectedSub);
+  }
+
+  categorySelect?.addEventListener('change', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    loadSubCategories(target.value, '');
+  });
+})();


### PR DESCRIPTION
## Summary
- replace the legacy ProjectNumber with the optional CaseFileNumber field and keep it unique per database rules
- add project list, create, overview, and assign-roles Razor Pages backed by a minimal API endpoint and client script for category selection
- update authorization policies and unit tests to cover the new project creation behaviour and duplicate case file guard

## Testing
- `dotnet test` *(fails: .NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63f40e5bc8329ac79fbaa8a53a16d