### PR TITLE
Restore ProjectStages navigation property on Project

### DIFF
--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using ProjectManagement.Models.Execution;
 
 namespace ProjectManagement.Models
@@ -40,6 +41,20 @@ namespace ProjectManagement.Models
         public string? LeadPoUserId { get; set; }
         public ApplicationUser? LeadPoUser { get; set; }
 
-        public ICollection<ProjectStage> Stages { get; set; } = new List<ProjectStage>();
+        private ICollection<ProjectStage> _projectStages = new List<ProjectStage>();
+
+        public ICollection<ProjectStage> ProjectStages
+        {
+            get => _projectStages;
+            set => _projectStages = value ?? new List<ProjectStage>();
+        }
+
+        [NotMapped]
+        [Obsolete("Use ProjectStages instead.")]
+        public ICollection<ProjectStage> Stages
+        {
+            get => ProjectStages;
+            set => ProjectStages = value;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a ProjectStages navigation property on Project backed by the existing stage collection
- retain the legacy Stages property as an obsolete, non-mapped alias to avoid breaking callers

## Testing
- not run (dotnet SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d64c1b472883298a0c4a22355c38fa