### PR TITLE
Fix project overview stage ordering query and update forecast writer

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -38,15 +38,14 @@ namespace ProjectManagement.Pages.Projects
 
             Project = project;
 
-            Stages = await _db.ProjectStages
+            var projectStages = await _db.ProjectStages
                 .Where(s => s.ProjectId == id)
-                .OrderBy(s =>
-                {
-                    var index = Array.IndexOf(StageCodes.All, s.StageCode);
-                    return index >= 0 ? index : int.MaxValue;
-                })
-                .ThenBy(s => s.StageCode)
                 .ToListAsync();
+
+            Stages = projectStages
+                .OrderBy(s => StageOrder(s.StageCode))
+                .ThenBy(s => s.StageCode, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             if (project.CategoryId.HasValue)
             {
@@ -86,6 +85,17 @@ namespace ProjectManagement.Pages.Projects
             }
 
             return path;
+        }
+
+        private static int StageOrder(string? stageCode)
+        {
+            if (stageCode is null)
+            {
+                return int.MaxValue;
+            }
+
+            var index = Array.IndexOf(StageCodes.All, stageCode);
+            return index >= 0 ? index : int.MaxValue;
         }
     }
 }

--- a/Services/Scheduling/ForecastWriter.cs
+++ b/Services/Scheduling/ForecastWriter.cs
@@ -34,7 +34,7 @@ public class ForecastWriter : IForecastWriter
         }
 
         var project = await _db.Projects
-            .Include(p => p.Stages)
+            .Include(p => p.ProjectStages)
             .FirstOrDefaultAsync(p => p.Id == projectId, ct);
 
         if (project == null)
@@ -80,7 +80,7 @@ public class ForecastWriter : IForecastWriter
             .Where(sp => sp.PlanVersionId == planVersion.Id)
             .ToDictionaryAsync(sp => sp.StageCode, sp => sp.DurationDays, StringComparer.OrdinalIgnoreCase, ct);
 
-        var execution = project.Stages.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
+        var execution = project.ProjectStages.ToDictionary(s => s.StageCode, StringComparer.OrdinalIgnoreCase);
 
         var options = new ScheduleOptions(
             planVersion.SkipWeekends,


### PR DESCRIPTION
## Summary
- sort project stages for the overview page after materializing the query to avoid expression tree conversion errors
- switch forecast recomputation to load and use the ProjectStages navigation property instead of the obsolete Stages alias

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d64d8736a48329b70168d63c892f9b