### PR TITLE
Fix row version generation for new entities

### DIFF
--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -26,7 +26,7 @@ namespace ProjectManagement.Models
         [MaxLength(64)]
         public string CreatedByUserId { get; set; } = string.Empty;
 
-        [Timestamp]
+        [ConcurrencyCheck]
         public byte[] RowVersion { get; set; } = Array.Empty<byte>();
 
         public int? ActivePlanVersionNo { get; set; }

--- a/Models/ProjectFacts.cs
+++ b/Models/ProjectFacts.cs
@@ -16,7 +16,7 @@ namespace ProjectManagement.Models
 
         public DateTime CreatedOnUtc { get; set; } = DateTime.UtcNow;
 
-        [Timestamp]
+        [ConcurrencyCheck]
         public byte[] RowVersion { get; set; } = Array.Empty<byte>();
     }
 


### PR DESCRIPTION
## Summary
- configure entity mappings so row version columns are treated as concurrency tokens managed by the application
- generate fresh row version values for added and modified entities before saving
- update project models to use concurrency-check attributes instead of timestamp markers

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d64f5ebb2c832984abfed351a09476