### PR TITLE
Rename HoD label to Head of Department

### DIFF
--- a/Pages/Projects/AssignRoles.cshtml
+++ b/Pages/Projects/AssignRoles.cshtml
@@ -23,7 +23,7 @@
         <div class="card">
             <div class="card-body row g-3">
                 <div class="col-md-6">
-                    <label asp-for="Input.HodUserId" class="form-label">Head of Directorate</label>
+                    <label asp-for="Input.HodUserId" class="form-label">Head of Department</label>
                     <select asp-for="Input.HodUserId" class="form-select" asp-items="Model.HodList"></select>
                 </div>
                 <div class="col-md-6">

--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -65,7 +65,7 @@
             <div class="card-body">
                 <div class="row g-3">
                     <div class="col-md-6">
-                        <label asp-for="Input.HodUserId" class="form-label">Head of Directorate</label>
+                        <label asp-for="Input.HodUserId" class="form-label">Head of Department</label>
                         <select asp-for="Input.HodUserId" class="form-select" asp-items="Model.HodList"></select>
                     </div>
                     <div class="col-md-6">

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -36,7 +36,7 @@
             <div class="me-3">
                 @if (Model.Project.HodUserId == null)
                 {
-                    <div>Head of Directorate not assigned.</div>
+                    <div>Head of Department not assigned.</div>
                 }
                 @if (Model.Project.LeadPoUserId == null)
                 {
@@ -71,7 +71,7 @@
                             }
                         </dd>
 
-                        <dt class="col-sm-4">Head of Directorate</dt>
+                        <dt class="col-sm-4">Head of Department</dt>
                         <dd class="col-sm-8">@DisplayUser(Model.Project.HodUser)</dd>
 
                         <dt class="col-sm-4">Project Officer</dt>


### PR DESCRIPTION
## Summary
- update project pages to refer to the HoD role as "Head of Department"
- adjust missing-role alert to match the new terminology

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d67f8d0a1883299bb58694ba767a07