### PR TITLE
Rename Projects CaseFileNumber index

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -55,6 +55,7 @@ namespace ProjectManagement.Data
                 e.HasIndex(x => x.Name);
                 e.Property(x => x.CaseFileNumber).HasMaxLength(64);
                 e.HasIndex(x => x.CaseFileNumber)
+                    .HasDatabaseName("UX_Projects_CaseFileNumber")
                     .IsUnique()
                     .HasFilter("\"CaseFileNumber\" IS NOT NULL");
                 ConfigureRowVersion(e);

--- a/Migrations/20251010120000_RenameProjectsCaseFileIndex.cs
+++ b/Migrations/20251010120000_RenameProjectsCaseFileIndex.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameProjectsCaseFileIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameIndex(
+                name: "IX_Projects_CaseFileNumber",
+                table: "Projects",
+                newName: "UX_Projects_CaseFileNumber");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameIndex(
+                name: "UX_Projects_CaseFileNumber",
+                table: "Projects",
+                newName: "IX_Projects_CaseFileNumber");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -737,6 +737,7 @@ namespace ProjectManagement.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("CaseFileNumber")
+                        .HasDatabaseName("UX_Projects_CaseFileNumber")
                         .IsUnique()
                         .HasFilter("\"CaseFileNumber\" IS NOT NULL");
 


### PR DESCRIPTION
## Summary
- name the filtered unique CaseFileNumber index UX_Projects_CaseFileNumber to match the expected database schema
- add a migration to rename the existing database index accordingly and update the model snapshot

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6821e1e7083298a4b71872f1ad59e