### PR TITLE
Add procurement overview panel

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -93,6 +93,10 @@
         </div>
     </div>
 
+    <div class="mb-4">
+        <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
+    </div>
+
     <div class="card">
         <div class="card-header">Stage progress</div>
         <div class="card-body">

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -1,0 +1,53 @@
+@model ProjectManagement.Services.Projects.ProcurementAtAGlanceVm
+@using System.Globalization
+@{
+    string Money(decimal? v) => v.HasValue ? v.Value.ToString("N2", CultureInfo.CurrentCulture) : "—";
+    string DateDmy(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
+}
+
+<div class="card">
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <div class="d-flex align-items-center">
+      <i class="bi bi-receipt me-2" aria-hidden="true"></i>
+      <span class="fw-semibold">Procurement At-a-Glance</span>
+    </div>
+  </div>
+
+  <div class="card-body">
+    <div class="row g-3">
+      <div class="col-md-6">
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">IPA Cost</span>
+          <span class="fw-semibold">@Money(Model.IpaCost)</span>
+        </div>
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">AON Cost</span>
+          <span class="fw-semibold">@Money(Model.AonCost)</span>
+        </div>
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">Benchmark Cost</span>
+          <span class="fw-semibold">@Money(Model.BenchmarkCost)</span>
+        </div>
+      </div>
+
+      <div class="col-md-6">
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">L1 Cost</span>
+          <span class="fw-semibold">@Money(Model.L1Cost)</span>
+        </div>
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">PNC Cost</span>
+          <span class="fw-semibold">@Money(Model.PncCost)</span>
+        </div>
+        <div class="d-flex justify-content-between">
+          <span class="text-muted">Supply Order Date</span>
+          <span class="fw-semibold">@DateDmy(Model.SupplyOrderDate)</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-2 small text-muted">
+      Latest recorded values. Edit from the relevant stage or the procurement edit pages.
+    </div>
+  </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -149,6 +149,7 @@ builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<ProjectFactsService>();
+builder.Services.AddScoped<ProjectProcurementReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<IScheduleEngine, ScheduleEngine>();
 builder.Services.AddScoped<IForecastWriter, ForecastWriter>();

--- a/Services/Projects/ProjectProcurementReadService.cs
+++ b/Services/Projects/ProjectProcurementReadService.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectProcurementReadService
+{
+    private readonly ApplicationDbContext _db;
+
+    public ProjectProcurementReadService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<ProcurementAtAGlanceVm> GetAsync(int projectId, CancellationToken ct = default)
+    {
+        decimal? latestIpa = await _db.ProjectIpaFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (decimal?)f.IpaCost)
+            .FirstOrDefaultAsync(ct);
+
+        decimal? latestAon = await _db.ProjectAonFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (decimal?)f.AonCost)
+            .FirstOrDefaultAsync(ct);
+
+        decimal? latestBenchmark = await _db.ProjectBenchmarkFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (decimal?)f.BenchmarkCost)
+            .FirstOrDefaultAsync(ct);
+
+        decimal? latestL1 = await _db.ProjectCommercialFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (decimal?)f.L1Cost)
+            .FirstOrDefaultAsync(ct);
+
+        decimal? latestPnc = await _db.ProjectPncFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (decimal?)f.PncCost)
+            .FirstOrDefaultAsync(ct);
+
+        DateOnly? latestSo = await _db.ProjectSupplyOrderFacts
+            .Where(f => f.ProjectId == projectId)
+            .OrderByDescending(f => f.CreatedOnUtc)
+            .Select(f => (DateOnly?)f.SupplyOrderDate)
+            .FirstOrDefaultAsync(ct);
+
+        return new ProcurementAtAGlanceVm(
+            latestIpa,
+            latestAon,
+            latestBenchmark,
+            latestL1,
+            latestPnc,
+            latestSo);
+    }
+}
+
+public sealed record ProcurementAtAGlanceVm(
+    decimal? IpaCost,
+    decimal? AonCost,
+    decimal? BenchmarkCost,
+    decimal? L1Cost,
+    decimal? PncCost,
+    DateOnly? SupplyOrderDate);


### PR DESCRIPTION
## Summary
- add a ProjectProcurementReadService that aggregates latest procurement facts per project
- expose the procurement snapshot on the project overview model and render a dedicated partial
- register the new service in dependency injection for reuse

## Testing
- not run (environment lacks the .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d684eed5248329a3c1c4a55f98a9a0