### PR TITLE
Add procurement offcanvas editor to project overview

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -97,6 +97,16 @@
         <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
     </div>
 
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasProcurement" aria-labelledby="offcanvasProcurementLabel">
+        <div class="offcanvas-header">
+            <h5 id="offcanvasProcurementLabel" class="mb-0">Edit Procurement</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <partial name="/Pages/Projects/Procurement/_EditFormBody" model="Model.ProcurementEdit" />
+        </div>
+    </div>
+
     <div class="card">
         <div class="card-header">Stage progress</div>
         <div class="card-body">
@@ -131,6 +141,10 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script src="~/js/projects/overview.js"></script>
+}
 
 @functions {
     private static string DisplayUser(ApplicationUser? user)

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -9,6 +9,7 @@ using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Services.Projects;
+using ProjectManagement.ViewModels;
 
 namespace ProjectManagement.Pages.Projects
 {
@@ -28,6 +29,7 @@ namespace ProjectManagement.Pages.Projects
         public IList<ProjectStage> Stages { get; private set; } = new List<ProjectStage>();
         public IReadOnlyList<ProjectCategory> CategoryPath { get; private set; } = Array.Empty<ProjectCategory>();
         public ProcurementAtAGlanceVm Procurement { get; private set; } = default!;
+        public ProcurementEditInput ProcurementEdit { get; private set; } = default!;
 
         public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
         {
@@ -59,6 +61,17 @@ namespace ProjectManagement.Pages.Projects
             }
 
             Procurement = await _procureRead.GetAsync(id, ct);
+
+            ProcurementEdit = new ProcurementEditInput
+            {
+                ProjectId = id,
+                IpaCost = Procurement.IpaCost,
+                AonCost = Procurement.AonCost,
+                BenchmarkCost = Procurement.BenchmarkCost,
+                L1Cost = Procurement.L1Cost,
+                PncCost = Procurement.PncCost,
+                SupplyOrderDate = Procurement.SupplyOrderDate
+            };
 
             return Page();
         }

--- a/Pages/Projects/Procurement/Edit.cshtml
+++ b/Pages/Projects/Procurement/Edit.cshtml
@@ -1,0 +1,6 @@
+@page "{id:int}"
+@attribute [Authorize(Roles = "Admin,HoD,PO")]
+@model ProjectManagement.Pages.Projects.Procurement.EditModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Procurement/Edit.cshtml.cs
+++ b/Pages/Projects/Procurement/Edit.cshtml.cs
@@ -1,0 +1,99 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.ViewModels;
+
+namespace ProjectManagement.Pages.Projects.Procurement
+{
+    [Authorize(Roles = "Admin,HoD,PO")]
+    [ValidateAntiForgeryToken]
+    public class EditModel : PageModel
+    {
+        private readonly ProjectFactsService _facts;
+        private readonly UserManager<ApplicationUser> _users;
+        private readonly ApplicationDbContext _db;
+
+        public EditModel(ProjectFactsService facts, UserManager<ApplicationUser> users, ApplicationDbContext db)
+        {
+            _facts = facts;
+            _users = users;
+            _db = db;
+        }
+
+        [BindProperty]
+        public ProcurementEditInput Input { get; set; } = new();
+
+        public IActionResult OnGet(int id)
+        {
+            return NotFound();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int id, CancellationToken ct)
+        {
+            if (id != Input.ProjectId)
+            {
+                return BadRequest();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return RedirectToPage("/Projects/Overview", new { id });
+            }
+
+            var userId = _users.GetUserId(User);
+            if (userId is null)
+            {
+                return Forbid();
+            }
+
+            await using var tx = await _db.Database.BeginTransactionAsync(ct);
+            try
+            {
+                if (Input.IpaCost.HasValue)
+                {
+                    await _facts.UpsertIpaCostAsync(id, Input.IpaCost.Value, userId, ct);
+                }
+
+                if (Input.AonCost.HasValue)
+                {
+                    await _facts.UpsertAonCostAsync(id, Input.AonCost.Value, userId, ct);
+                }
+
+                if (Input.BenchmarkCost.HasValue)
+                {
+                    await _facts.UpsertBenchmarkCostAsync(id, Input.BenchmarkCost.Value, userId, ct);
+                }
+
+                if (Input.L1Cost.HasValue)
+                {
+                    await _facts.UpsertL1CostAsync(id, Input.L1Cost.Value, userId, ct);
+                }
+
+                if (Input.PncCost.HasValue)
+                {
+                    await _facts.UpsertPncCostAsync(id, Input.PncCost.Value, userId, ct);
+                }
+
+                if (Input.SupplyOrderDate.HasValue)
+                {
+                    await _facts.UpsertSupplyOrderDateAsync(id, Input.SupplyOrderDate.Value, userId, ct);
+                }
+
+                await tx.CommitAsync(ct);
+            }
+            catch
+            {
+                await tx.RollbackAsync(ct);
+                throw;
+            }
+
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+    }
+}

--- a/Pages/Projects/Procurement/_EditFormBody.cshtml
+++ b/Pages/Projects/Procurement/_EditFormBody.cshtml
@@ -1,0 +1,37 @@
+@model ProjectManagement.ViewModels.ProcurementEditInput
+
+<form method="post" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">
+    @Html.AntiForgeryToken()
+    <input type="hidden" name="Input.ProjectId" value="@Model.ProjectId" />
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <label for="Input_IpaCost" class="form-label">IPA Cost</label>
+            <input class="form-control" id="Input_IpaCost" name="Input.IpaCost" value="@(Model.IpaCost?.ToString("0.##"))" />
+        </div>
+        <div class="col-md-6">
+            <label for="Input_AonCost" class="form-label">AON Cost</label>
+            <input class="form-control" id="Input_AonCost" name="Input.AonCost" value="@(Model.AonCost?.ToString("0.##"))" />
+        </div>
+        <div class="col-md-6">
+            <label for="Input_BenchmarkCost" class="form-label">Benchmark Cost</label>
+            <input class="form-control" id="Input_BenchmarkCost" name="Input.BenchmarkCost" value="@(Model.BenchmarkCost?.ToString("0.##"))" />
+        </div>
+        <div class="col-md-6">
+            <label for="Input_L1Cost" class="form-label">L1 Cost</label>
+            <input class="form-control" id="Input_L1Cost" name="Input.L1Cost" value="@(Model.L1Cost?.ToString("0.##"))" />
+        </div>
+        <div class="col-md-6">
+            <label for="Input_PncCost" class="form-label">PNC Cost</label>
+            <input class="form-control" id="Input_PncCost" name="Input.PncCost" value="@(Model.PncCost?.ToString("0.##"))" />
+        </div>
+        <div class="col-md-6">
+            <label for="Input_SupplyOrderDate" class="form-label">Supply Order Date</label>
+            <input class="form-control" type="date" id="Input_SupplyOrderDate" name="Input.SupplyOrderDate" value="@(Model.SupplyOrderDate.HasValue ? Model.SupplyOrderDate.Value.ToString("yyyy-MM-dd") : null)" />
+        </div>
+    </div>
+
+    <div class="d-flex justify-content-end mt-3">
+        <button class="btn btn-primary" type="submit">Save</button>
+    </div>
+</form>

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -11,6 +11,12 @@
       <i class="bi bi-receipt me-2" aria-hidden="true"></i>
       <span class="fw-semibold">Procurement At-a-Glance</span>
     </div>
+    @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("PO"))
+    {
+      <button class="btn btn-sm btn-outline-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasProcurement" aria-controls="offcanvasProcurement">
+        Edit Procurement
+      </button>
+    }
   </div>
 
   <div class="card-body">
@@ -47,7 +53,7 @@
     </div>
 
     <div class="mt-2 small text-muted">
-      Latest recorded values. Edit from the relevant stage or the procurement edit pages.
+      Latest recorded values. Use the Edit Procurement panel to update these figures.
     </div>
   </div>
 </div>

--- a/ViewModels/ProcurementEditInput.cs
+++ b/ViewModels/ProcurementEditInput.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProcurementEditInput
+{
+    public int ProjectId { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal? IpaCost { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal? AonCost { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal? BenchmarkCost { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal? L1Cost { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal? PncCost { get; set; }
+
+    public DateOnly? SupplyOrderDate { get; set; }
+}

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -1,0 +1,13 @@
+(function () {
+    const offcanvas = document.getElementById('offcanvasProcurement');
+    if (!offcanvas) {
+        return;
+    }
+
+    offcanvas.addEventListener('shown.bs.offcanvas', function () {
+        const firstField = offcanvas.querySelector('input,select,textarea');
+        if (firstField) {
+            firstField.focus();
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- add a shared procurement edit input model and Razor Page handler to post updates for multiple fields at once
- render an Overview page off-canvas that reuses the shared form and pre-fills the latest procurement values
- wire an external script to focus the first field and expose the edit action from the Procurement At-a-Glance card

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d68d2bbeb883298caa40c16548dbe4