### PR TITLE
Enforce procurement stage gating and INR display improvements

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -30,6 +30,25 @@
         }
     </div>
 
+    @if (TempData["OpenOffcanvas"] as string == "procurement")
+    {
+        <div id="open-procurement" data-open="1"></div>
+    }
+    @if (TempData["Error"] is string err)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @err
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+    @if (TempData["Flash"] is string ok)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @ok
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
     @if (Model.Project.HodUserId == null || Model.Project.LeadPoUserId == null)
     {
         <div class="alert alert-warning d-flex align-items-center" role="alert">

--- a/Pages/Projects/Procurement/_EditFormBody.cshtml
+++ b/Pages/Projects/Procurement/_EditFormBody.cshtml
@@ -1,33 +1,74 @@
-@model ProjectManagement.ViewModels.ProcurementEditInput
+@model ProjectManagement.ViewModels.ProcurementEditVm
 
-<form method="post" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">
+<form method="post" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.Input.ProjectId">
     @Html.AntiForgeryToken()
-    <input type="hidden" name="Input.ProjectId" value="@Model.ProjectId" />
+    <input type="hidden" name="Input.ProjectId" value="@Model.Input.ProjectId" />
 
     <div class="row g-3">
         <div class="col-md-6">
             <label for="Input_IpaCost" class="form-label">IPA Cost</label>
-            <input class="form-control" id="Input_IpaCost" name="Input.IpaCost" value="@(Model.IpaCost?.ToString("0.##"))" />
+            <input class="form-control" id="Input_IpaCost" name="Input.IpaCost"
+                   value="@(Model.Input.IpaCost?.ToString("0.##"))"
+                   @(Model.CanEditIpaCost ? null : "disabled") />
+            @if (!Model.CanEditIpaCost)
+            {
+                <div class="form-text">Enabled after IPA stage is completed.</div>
+            }
         </div>
+
         <div class="col-md-6">
             <label for="Input_AonCost" class="form-label">AON Cost</label>
-            <input class="form-control" id="Input_AonCost" name="Input.AonCost" value="@(Model.AonCost?.ToString("0.##"))" />
+            <input class="form-control" id="Input_AonCost" name="Input.AonCost"
+                   value="@(Model.Input.AonCost?.ToString("0.##"))"
+                   @(Model.CanEditAonCost ? null : "disabled") />
+            @if (!Model.CanEditAonCost)
+            {
+                <div class="form-text">Enabled after AON stage is completed.</div>
+            }
         </div>
+
         <div class="col-md-6">
             <label for="Input_BenchmarkCost" class="form-label">Benchmark Cost</label>
-            <input class="form-control" id="Input_BenchmarkCost" name="Input.BenchmarkCost" value="@(Model.BenchmarkCost?.ToString("0.##"))" />
+            <input class="form-control" id="Input_BenchmarkCost" name="Input.BenchmarkCost"
+                   value="@(Model.Input.BenchmarkCost?.ToString("0.##"))"
+                   @(Model.CanEditBenchmarkCost ? null : "disabled") />
+            @if (!Model.CanEditBenchmarkCost)
+            {
+                <div class="form-text">Enabled after BM stage is completed.</div>
+            }
         </div>
+
         <div class="col-md-6">
             <label for="Input_L1Cost" class="form-label">L1 Cost</label>
-            <input class="form-control" id="Input_L1Cost" name="Input.L1Cost" value="@(Model.L1Cost?.ToString("0.##"))" />
+            <input class="form-control" id="Input_L1Cost" name="Input.L1Cost"
+                   value="@(Model.Input.L1Cost?.ToString("0.##"))"
+                   @(Model.CanEditL1Cost ? null : "disabled") />
+            @if (!Model.CanEditL1Cost)
+            {
+                <div class="form-text">Enabled after COB stage is completed.</div>
+            }
         </div>
+
         <div class="col-md-6">
             <label for="Input_PncCost" class="form-label">PNC Cost</label>
-            <input class="form-control" id="Input_PncCost" name="Input.PncCost" value="@(Model.PncCost?.ToString("0.##"))" />
+            <input class="form-control" id="Input_PncCost" name="Input.PncCost"
+                   value="@(Model.Input.PncCost?.ToString("0.##"))"
+                   @(Model.CanEditPncCost ? null : "disabled") />
+            @if (!Model.CanEditPncCost)
+            {
+                <div class="form-text">Enabled after PNC stage is completed.</div>
+            }
         </div>
+
         <div class="col-md-6">
             <label for="Input_SupplyOrderDate" class="form-label">Supply Order Date</label>
-            <input class="form-control" type="date" id="Input_SupplyOrderDate" name="Input.SupplyOrderDate" value="@(Model.SupplyOrderDate.HasValue ? Model.SupplyOrderDate.Value.ToString("yyyy-MM-dd") : null)" />
+            <input class="form-control" type="date" id="Input_SupplyOrderDate" name="Input.SupplyOrderDate"
+                   value="@(Model.Input.SupplyOrderDate.HasValue ? Model.Input.SupplyOrderDate.Value.ToString("yyyy-MM-dd") : null)"
+                   @(Model.CanEditSupplyOrderDate ? null : "disabled") />
+            @if (!Model.CanEditSupplyOrderDate)
+            {
+                <div class="form-text">Enabled after SO stage is completed.</div>
+            }
         </div>
     </div>
 

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -1,7 +1,26 @@
 @model ProjectManagement.Services.Projects.ProcurementAtAGlanceVm
 @using System.Globalization
 @{
-    string Money(decimal? v) => v.HasValue ? v.Value.ToString("N2", CultureInfo.CurrentCulture) : "—";
+    string ShortInr(decimal value)
+    {
+        var culture = CultureInfo.GetCultureInfo("en-IN");
+        var abs = System.Math.Abs(value);
+
+        if (abs >= 1_00_00_000m)
+        {
+            return $"₹ {(value / 1_00_00_000m).ToString("0.##", culture)} Cr";
+        }
+
+        if (abs >= 1_00_000m)
+        {
+            return $"₹ {(value / 1_00_000m).ToString("0.##", culture)} Lakh";
+        }
+
+        return value.ToString("C2", culture);
+    }
+
+    string Money(decimal? value) => value.HasValue ? ShortInr(value.Value) : "—";
+    string FullInr(decimal? value) => value.HasValue ? value.Value.ToString("C2", CultureInfo.GetCultureInfo("en-IN")) : "—";
     string DateDmy(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
 }
 
@@ -24,26 +43,26 @@
       <div class="col-md-6">
         <div class="d-flex justify-content-between">
           <span class="text-muted">IPA Cost</span>
-          <span class="fw-semibold">@Money(Model.IpaCost)</span>
+          <span class="fw-semibold" title="@FullInr(Model.IpaCost)">@Money(Model.IpaCost)</span>
         </div>
         <div class="d-flex justify-content-between">
           <span class="text-muted">AON Cost</span>
-          <span class="fw-semibold">@Money(Model.AonCost)</span>
+          <span class="fw-semibold" title="@FullInr(Model.AonCost)">@Money(Model.AonCost)</span>
         </div>
         <div class="d-flex justify-content-between">
           <span class="text-muted">Benchmark Cost</span>
-          <span class="fw-semibold">@Money(Model.BenchmarkCost)</span>
+          <span class="fw-semibold" title="@FullInr(Model.BenchmarkCost)">@Money(Model.BenchmarkCost)</span>
         </div>
       </div>
 
       <div class="col-md-6">
         <div class="d-flex justify-content-between">
           <span class="text-muted">L1 Cost</span>
-          <span class="fw-semibold">@Money(Model.L1Cost)</span>
+          <span class="fw-semibold" title="@FullInr(Model.L1Cost)">@Money(Model.L1Cost)</span>
         </div>
         <div class="d-flex justify-content-between">
           <span class="text-muted">PNC Cost</span>
-          <span class="fw-semibold">@Money(Model.PncCost)</span>
+          <span class="fw-semibold" title="@FullInr(Model.PncCost)">@Money(Model.PncCost)</span>
         </div>
         <div class="d-flex justify-content-between">
           <span class="text-muted">Supply Order Date</span>

--- a/Services/Projects/ProcurementStageRules.cs
+++ b/Services/Projects/ProcurementStageRules.cs
@@ -1,0 +1,13 @@
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Services.Projects;
+
+public static class ProcurementStageRules
+{
+    public const string StageForIpaCost = StageCodes.IPA;
+    public const string StageForAonCost = StageCodes.AON;
+    public const string StageForBenchmarkCost = StageCodes.BM;
+    public const string StageForL1Cost = StageCodes.COB;
+    public const string StageForPncCost = StageCodes.PNC;
+    public const string StageForSupplyOrder = StageCodes.SO;
+}

--- a/ViewModels/ProcurementEditVm.cs
+++ b/ViewModels/ProcurementEditVm.cs
@@ -1,0 +1,13 @@
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProcurementEditVm
+{
+    public ProcurementEditInput Input { get; init; } = new();
+
+    public bool CanEditIpaCost { get; init; }
+    public bool CanEditAonCost { get; init; }
+    public bool CanEditBenchmarkCost { get; init; }
+    public bool CanEditL1Cost { get; init; }
+    public bool CanEditPncCost { get; init; }
+    public bool CanEditSupplyOrderDate { get; init; }
+}

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -10,4 +10,10 @@
             firstField.focus();
         }
     });
+
+    const marker = document.getElementById('open-procurement');
+    if (marker && marker.dataset.open === '1' && typeof bootstrap !== 'undefined') {
+        const instance = bootstrap.Offcanvas.getOrCreateInstance(offcanvas);
+        instance.show();
+    }
 })();


### PR DESCRIPTION
## Summary
- introduce procurement stage gating rules and a view model to manage editability of cost inputs
- compute lock states in the overview page and enforce server-side validation with user feedback
- format procurement cost figures with Indian numbering and short units while keeping full values on hover

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d694146fac8329a6acd1e5bb8db329