### PR TITLE
Add assign roles offcanvas to project overview

### DIFF
--- a/Pages/Projects/AssignRoles.cshtml
+++ b/Pages/Projects/AssignRoles.cshtml
@@ -19,6 +19,7 @@
 
     <form method="post">
         <input type="hidden" asp-for="Input.ProjectId" />
+        <input type="hidden" asp-for="Input.RowVersion" />
 
         <div class="card">
             <div class="card-body row g-3">

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -24,15 +24,16 @@
             </h1>
             <div class="text-muted">Created on @Model.Project.CreatedAt.ToString("dd MMM yyyy")</div>
         </div>
-        @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
-        {
-            <a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id" class="btn btn-outline-primary">Assign Roles</a>
-        }
+        <partial name="_AssignRolesOffcanvas" model="Model.AssignRoles" />
     </div>
 
     @if (TempData["OpenOffcanvas"] as string == "procurement")
     {
         <div id="open-procurement" data-open="1"></div>
+    }
+    @if (TempData["OpenOffcanvas"] as string == "assign-roles")
+    {
+        <div id="open-assign-roles" data-open="1"></div>
     }
     @if (TempData["Error"] is string err)
     {
@@ -64,7 +65,13 @@
             </div>
             @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
             {
-                <a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id" class="btn btn-sm btn-warning">Assign Roles</a>
+                <button type="button"
+                        class="btn btn-sm btn-warning"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#offcanvasAssignRoles"
+                        aria-controls="offcanvasAssignRoles">
+                    Assign Roles
+                </button>
             }
         </div>
     }
@@ -104,7 +111,13 @@
                 <div class="card-header">Quick links</div>
                 <div class="card-body">
                     <ul class="list-unstyled mb-0">
-                        <li><a asp-page="/Projects/AssignRoles" asp-route-id="@Model.Project.Id">Assign or change roles</a></li>
+                        @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+                        {
+                            <li><a href="#"
+                                   data-bs-toggle="offcanvas"
+                                   data-bs-target="#offcanvasAssignRoles"
+                                   aria-controls="offcanvasAssignRoles">Assign or change roles</a></li>
+                        }
                         <li><a asp-page="/Projects/Create">Create another project</a></li>
                     </ul>
                 </div>

--- a/Pages/Projects/_AssignRolesOffcanvas.cshtml
+++ b/Pages/Projects/_AssignRolesOffcanvas.cshtml
@@ -1,0 +1,51 @@
+@model ProjectManagement.ViewModels.AssignRolesVm
+
+@if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+{
+    <button class="btn btn-sm btn-outline-secondary"
+            data-bs-toggle="offcanvas"
+            data-bs-target="#offcanvasAssignRoles"
+            aria-controls="offcanvasAssignRoles">
+        Assign Roles
+    </button>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasAssignRoles" aria-labelledby="offcanvasAssignRolesLabel">
+        <div class="offcanvas-header">
+            <h5 id="offcanvasAssignRolesLabel" class="mb-0">Assign Roles</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <form method="post" asp-page="/Projects/AssignRoles">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="Input.ProjectId" value="@Model.ProjectId" />
+                <input type="hidden" name="Input.RowVersion" value="@Convert.ToBase64String(Model.RowVersion)" />
+
+                <div class="mb-3">
+                    <label class="form-label" for="HodUserId">Head of Department</label>
+                    <select id="HodUserId" name="Input.HodUserId" class="form-select">
+                        <option value="">— Unassigned —</option>
+                        @foreach (var u in Model.HodOptions)
+                        {
+                            <option value="@u.Id" @(u.Id == Model.HodUserId ? "selected" : null)>@u.Name</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label" for="PoUserId">Project Officer</label>
+                    <select id="PoUserId" name="Input.PoUserId" class="form-select">
+                        <option value="">— Unassigned —</option>
+                        @foreach (var u in Model.PoOptions)
+                        {
+                            <option value="@u.Id" @(u.Id == Model.PoUserId ? "selected" : null)>@u.Name</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="d-flex justify-content-end">
+                    <button class="btn btn-primary" type="submit">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+}

--- a/ViewModels/AssignRolesVm.cs
+++ b/ViewModels/AssignRolesVm.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class AssignRolesVm
+{
+    public int ProjectId { get; init; }
+    public byte[] RowVersion { get; init; } = Array.Empty<byte>();
+
+    public string? HodUserId { get; init; }
+    public string? PoUserId { get; init; }
+
+    public IReadOnlyList<(string Id, string Name)> HodOptions { get; init; } = Array.Empty<(string, string)>();
+    public IReadOnlyList<(string Id, string Name)> PoOptions { get; init; } = Array.Empty<(string, string)>();
+}

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -1,19 +1,37 @@
 (function () {
-    const offcanvas = document.getElementById('offcanvasProcurement');
-    if (!offcanvas) {
+    if (typeof bootstrap === 'undefined') {
         return;
     }
 
-    offcanvas.addEventListener('shown.bs.offcanvas', function () {
-        const firstField = offcanvas.querySelector('input,select,textarea');
-        if (firstField) {
-            firstField.focus();
-        }
-    });
+    const procurement = document.getElementById('offcanvasProcurement');
+    if (procurement) {
+        procurement.addEventListener('shown.bs.offcanvas', function () {
+            const firstField = procurement.querySelector('input,select,textarea');
+            if (firstField) {
+                firstField.focus();
+            }
+        });
 
-    const marker = document.getElementById('open-procurement');
-    if (marker && marker.dataset.open === '1' && typeof bootstrap !== 'undefined') {
-        const instance = bootstrap.Offcanvas.getOrCreateInstance(offcanvas);
-        instance.show();
+        const marker = document.getElementById('open-procurement');
+        if (marker && marker.dataset.open === '1') {
+            const instance = bootstrap.Offcanvas.getOrCreateInstance(procurement);
+            instance.show();
+        }
+    }
+
+    const assignRoles = document.getElementById('offcanvasAssignRoles');
+    if (assignRoles) {
+        assignRoles.addEventListener('shown.bs.offcanvas', function () {
+            const firstField = assignRoles.querySelector('select, input, textarea');
+            if (firstField) {
+                firstField.focus();
+            }
+        });
+
+        const assignMarker = document.getElementById('open-assign-roles');
+        if (assignMarker && assignMarker.dataset.open === '1') {
+            const instance = bootstrap.Offcanvas.getOrCreateInstance(assignRoles);
+            instance.show();
+        }
     }
 })();


### PR DESCRIPTION
## Summary
- add an AssignRoles view model and partial offcanvas so project roles can be updated directly from the overview page
- preload role options and concurrency tokens in the overview PageModel and wire up TempData markers for auto-opening on errors
- enhance the AssignRoles handler with row version checks, flash messaging, and shared offcanvas open behaviour, plus JS to drive both offcanvas panels

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d698f4e3a0832988ca382eafbdbda3