### PR TITLE
Fix Razor option markup to comply with tag helper restrictions

### DIFF
--- a/Pages/Projects/AssignRoles.cshtml
+++ b/Pages/Projects/AssignRoles.cshtml
@@ -25,21 +25,11 @@
             <div class="card-body row g-3">
                 <div class="col-md-6">
                     <label asp-for="Input.HodUserId" class="form-label">Head of Department</label>
-                    <select asp-for="Input.HodUserId" class="form-select">
-                        @foreach (var option in Model.HodList)
-                        {
-                            <option value="@option.Value" @(option.Selected ? "selected" : null)>@option.Text</option>
-                        }
-                    </select>
+                    <select asp-for="Input.HodUserId" asp-items="Model.HodList" class="form-select"></select>
                 </div>
                 <div class="col-md-6">
                     <label asp-for="Input.PoUserId" class="form-label">Project Officer</label>
-                    <select asp-for="Input.PoUserId" class="form-select">
-                        @foreach (var option in Model.PoList)
-                        {
-                            <option value="@option.Value" @(option.Selected ? "selected" : null)>@option.Text</option>
-                        }
-                    </select>
+                    <select asp-for="Input.PoUserId" asp-items="Model.PoList" class="form-select"></select>
                 </div>
             </div>
             <div class="card-footer d-flex justify-content-between">

--- a/Pages/Projects/_AssignRolesOffcanvas.cshtml
+++ b/Pages/Projects/_AssignRolesOffcanvas.cshtml
@@ -26,7 +26,14 @@
                         <option value="">— Unassigned —</option>
                         @foreach (var u in Model.HodOptions)
                         {
-                            <option value="@u.Id" @(u.Id == Model.HodUserId ? "selected" : null)>@u.Name</option>
+                            if (u.Id == Model.HodUserId)
+                            {
+                                <option value="@u.Id" selected>@u.Name</option>
+                            }
+                            else
+                            {
+                                <option value="@u.Id">@u.Name</option>
+                            }
                         }
                     </select>
                 </div>
@@ -37,7 +44,14 @@
                         <option value="">— Unassigned —</option>
                         @foreach (var u in Model.PoOptions)
                         {
-                            <option value="@u.Id" @(u.Id == Model.PoUserId ? "selected" : null)>@u.Name</option>
+                            if (u.Id == Model.PoUserId)
+                            {
+                                <option value="@u.Id" selected>@u.Name</option>
+                            }
+                            else
+                            {
+                                <option value="@u.Id">@u.Name</option>
+                            }
                         }
                     </select>
                 </div>


### PR DESCRIPTION
## Summary
- use asp-items on the Assign Roles page selects so Razor chooses the selected option
- render distinct selected/unselected options in the offcanvas partial to avoid conditional attributes

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a17220fc8329ba34e44cdda7144b