### PR TITLE
Ensure project overview retains project context after modal posts

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -2,7 +2,8 @@
 @using ProjectManagement.Models
 @model ProjectManagement.Pages.Projects.OverviewModel
 @{
-    ViewData["Title"] = Model.Project.Name;
+    var pageTitle = Model.Project?.Name ?? "Project";
+    ViewData["Title"] = pageTitle;
 }
 
 <div class="container-xxl">
@@ -16,13 +17,13 @@
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3 gap-3">
         <div>
             <h1 class="h3 mb-1">
-                @Model.Project.Name
-                @if (!string.IsNullOrWhiteSpace(Model.Project.CaseFileNumber))
+                @pageTitle
+                @if (!string.IsNullOrWhiteSpace(Model.Project?.CaseFileNumber))
                 {
                     <small class="text-muted">(@Model.Project.CaseFileNumber)</small>
                 }
             </h1>
-            <div class="text-muted">Created on @Model.Project.CreatedAt.ToString("dd MMM yyyy")</div>
+            <div class="text-muted">Created on @Model.Project?.CreatedAt.ToString("dd MMM yyyy")</div>
         </div>
         <partial name="_AssignRolesOffcanvas" model="Model.AssignRoles" />
     </div>

--- a/Pages/Projects/_AssignRolesOffcanvas.cshtml
+++ b/Pages/Projects/_AssignRolesOffcanvas.cshtml
@@ -15,7 +15,9 @@
             <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body">
-            <form method="post" asp-page="/Projects/AssignRoles">
+            <form method="post"
+                  asp-page="/Projects/AssignRoles"
+                  asp-route-id="@Model.ProjectId">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="Input.ProjectId" value="@Model.ProjectId" />
                 <input type="hidden" name="Input.RowVersion" value="@Convert.ToBase64String(Model.RowVersion)" />


### PR DESCRIPTION
## Summary
- guard the project overview page title and header against a missing project model
- include the project id route value when submitting the assign-roles off-canvas form to preserve the redirect context

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6a48e4a848329b436ceafc60b7112