### PR TITLE
Add vertical timeline stepper to project overview

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -130,6 +130,10 @@
         <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
     </div>
 
+    <div class="mb-4">
+        <partial name="_ProjectTimeline" model="Model.Timeline" />
+    </div>
+
     <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasProcurement" aria-labelledby="offcanvasProcurementLabel">
         <div class="offcanvas-header">
             <h5 id="offcanvasProcurementLabel" class="mb-0">Edit Procurement</h5>

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -22,12 +22,14 @@ namespace ProjectManagement.Pages.Projects
     {
         private readonly ApplicationDbContext _db;
         private readonly ProjectProcurementReadService _procureRead;
+        private readonly ProjectTimelineReadService _timelineRead;
         private readonly UserManager<ApplicationUser> _users;
 
-        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, UserManager<ApplicationUser> users)
+        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, ProjectTimelineReadService timelineRead, UserManager<ApplicationUser> users)
         {
             _db = db;
             _procureRead = procureRead;
+            _timelineRead = timelineRead;
             _users = users;
         }
 
@@ -37,6 +39,7 @@ namespace ProjectManagement.Pages.Projects
         public ProcurementAtAGlanceVm Procurement { get; private set; } = default!;
         public ProcurementEditVm ProcurementEdit { get; private set; } = default!;
         public AssignRolesVm AssignRoles { get; private set; } = default!;
+        public TimelineVm Timeline { get; private set; } = default!;
 
         public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
         {
@@ -74,6 +77,7 @@ namespace ProjectManagement.Pages.Projects
             }
 
             Procurement = await _procureRead.GetAsync(id, ct);
+            Timeline = await _timelineRead.GetAsync(id, ct);
 
             ProcurementEdit = new ProcurementEditVm
             {

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,0 +1,57 @@
+@model ProjectManagement.ViewModels.TimelineVm
+@using System.Globalization
+@functions{
+    string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
+    string StatusChip(ProjectManagement.Models.Stages.StageStatus s) =>
+        s switch {
+            ProjectManagement.Models.Stages.StageStatus.Completed  => "badge bg-success",
+            ProjectManagement.Models.Stages.StageStatus.InProgress => "badge bg-primary",
+            _                                                     => "badge bg-secondary"
+        };
+}
+<link rel="stylesheet" href="~/css/projects/timeline.css" />
+
+<div class="card">
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <div class="fw-semibold">Timeline</div>
+    <div class="d-flex align-items-center gap-2">
+      <div class="progress" style="width:180px" aria-label="Stages completed">
+        <div class="progress-bar" role="progressbar"
+             style="width:@(Model.TotalStages == 0 ? 0 : (Model.CompletedCount * 100 / Model.TotalStages))%"
+             aria-valuenow="@(Model.CompletedCount)"
+             aria-valuemin="0"
+             aria-valuemax="@(Model.TotalStages)"></div>
+      </div>
+      <span class="text-muted small">@Model.CompletedCount of @Model.TotalStages</span>
+    </div>
+  </div>
+
+  <div class="card-body py-4">
+    <ol class="pm-timeline">
+      @foreach (var s in Model.Items.OrderBy(i => i.SortOrder))
+      {
+        var itemClass = s.Status switch {
+          ProjectManagement.Models.Stages.StageStatus.Completed  => "pm-item is-complete",
+          ProjectManagement.Models.Stages.StageStatus.InProgress => "pm-item is-active",
+          _                                                     => "pm-item"
+        };
+        <li class="@itemClass">
+          <div class="pm-marker" aria-hidden="true"></div>
+          <div class="pm-content">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <div class="pm-title">@s.Name</div>
+              <span class="@StatusChip(s.Status)">@s.Status</span>
+            </div>
+            <div class="pm-meta small text-muted">
+              <div>Planned: @D(s.PlannedStart) → @D(s.PlannedEnd)</div>
+              <div>Actual: @D(s.ActualStart) → @D(s.CompletedOn)
+                @if (s.ActualDurationDays.HasValue)
+                { <span class="ms-2">( @s.ActualDurationDays d )</span> }
+              </div>
+            </div>
+          </div>
+        </li>
+      }
+    </ol>
+  </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -150,6 +150,7 @@ builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<ProjectFactsService>();
 builder.Services.AddScoped<ProjectProcurementReadService>();
+builder.Services.AddScoped<ProjectTimelineReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<IScheduleEngine, ScheduleEngine>();
 builder.Services.AddScoped<IForecastWriter, ForecastWriter>();

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.ViewModels;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectTimelineReadService
+{
+    private readonly ApplicationDbContext _db;
+    public ProjectTimelineReadService(ApplicationDbContext db) => _db = db;
+
+    public async Task<TimelineVm> GetAsync(int projectId, CancellationToken ct = default)
+    {
+        var rows = await _db.ProjectStages
+            .Where(x => x.ProjectId == projectId)
+            .ToListAsync(ct);
+
+        var items = new List<TimelineItemVm>();
+        var index = 0;
+        foreach (var code in StageCodes.All)
+        {
+            var r = rows.FirstOrDefault(x => x.StageCode == code);
+            items.Add(new TimelineItemVm
+            {
+                Code = code,
+                Name = StageCodes.DisplayNameOf(code),
+                Status = r?.Status ?? StageStatus.NotStarted,
+                PlannedStart = null,
+                PlannedEnd = null,
+                ActualStart = r?.ActualStart,
+                CompletedOn = r?.CompletedOn,
+                SortOrder = index++
+            });
+        }
+
+        var completed = items.Count(i => i.Status == StageStatus.Completed);
+
+        return new TimelineVm
+        {
+            ProjectId = projectId,
+            TotalStages = items.Count,
+            CompletedCount = completed,
+            Items = items
+        };
+    }
+}

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -1,0 +1,29 @@
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class TimelineVm
+{
+    public int ProjectId { get; init; }
+    public int TotalStages { get; init; }
+    public int CompletedCount { get; init; }
+    public IReadOnlyList<TimelineItemVm> Items { get; init; } = Array.Empty<TimelineItemVm>();
+}
+
+public sealed class TimelineItemVm
+{
+    public string Code { get; init; } = "";
+    public string Name { get; init; } = "";
+    public StageStatus Status { get; init; } = StageStatus.NotStarted;
+
+    public DateOnly? PlannedStart { get; init; }
+    public DateOnly? PlannedEnd { get; init; }
+    public DateOnly? ActualStart { get; init; }
+    public DateOnly? CompletedOn { get; init; }
+
+    public int SortOrder { get; init; }
+    public int? PlannedDurationDays =>
+        (PlannedStart.HasValue && PlannedEnd.HasValue) ? (PlannedEnd.Value.DayNumber - PlannedStart.Value.DayNumber + 1) : null;
+    public int? ActualDurationDays =>
+        (ActualStart.HasValue && CompletedOn.HasValue) ? (CompletedOn.Value.DayNumber - ActualStart.Value.DayNumber + 1) : null;
+}

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -1,0 +1,76 @@
+/* Container */
+.pm-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+}
+
+/* The vertical rail */
+.pm-timeline::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--bs-border-color, #dee2e6);
+}
+
+/* Each step */
+.pm-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 12px;
+  padding: 8px 0 16px 0;
+}
+
+/* Marker (bullet) */
+.pm-marker {
+  align-self: start;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--bs-border-color, #dee2e6);
+  background: #fff;
+  margin-left: 4px;
+  z-index: 1;
+}
+
+/* Content */
+.pm-content { padding-top: 2px; }
+.pm-title { font-weight: 600; }
+
+/* States */
+.pm-item.is-complete .pm-marker {
+  border-color: var(--bs-success);
+  background: var(--bs-success);
+}
+.pm-item.is-active .pm-marker {
+  border-color: var(--bs-primary);
+  background: var(--bs-primary);
+}
+.pm-item:not(.is-complete):not(.is-active) .pm-marker {
+  border-color: var(--bs-secondary);
+}
+
+/* Adjust rail behind markers */
+.pm-item { position: relative; }
+.pm-item::before {
+  content: "";
+  position: absolute;
+  left: 20px;
+  top: 16px;
+  bottom: -8px;
+  width: 2px;
+  background: var(--bs-border-color, #dee2e6);
+}
+.pm-item:last-child::before { bottom: 0; }
+.pm-item.is-complete::before { background: var(--bs-success); }
+.pm-item.is-active::before { background: linear-gradient(var(--bs-success), var(--bs-primary)); }
+
+/* Responsive */
+@media (max-width: 576px) {
+  .pm-meta { margin-top: 4px; }
+}


### PR DESCRIPTION
## Summary
- add timeline view models and read service to compose project stage data
- create a reusable vertical stepper partial with supporting styles for the project timeline
- surface the new timeline on the project overview page and register the read service in DI

## Testing
- dotnet build *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6aa4bfdb48329ad4eb3824d8e1c7d