### PR TITLE
Fix timeline stage imports and null-safety

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -2,7 +2,8 @@
 @using ProjectManagement.Models
 @model ProjectManagement.Pages.Projects.OverviewModel
 @{
-    var pageTitle = Model.Project?.Name ?? "Project";
+    var project = Model.Project;
+    var pageTitle = project?.Name ?? "Project";
     ViewData["Title"] = pageTitle;
 }
 
@@ -18,12 +19,12 @@
         <div>
             <h1 class="h3 mb-1">
                 @pageTitle
-                @if (!string.IsNullOrWhiteSpace(Model.Project?.CaseFileNumber))
+                @if (!string.IsNullOrWhiteSpace(project?.CaseFileNumber))
                 {
-                    <small class="text-muted">(@Model.Project.CaseFileNumber)</small>
+                    <small class="text-muted">(@project?.CaseFileNumber)</small>
                 }
             </h1>
-            <div class="text-muted">Created on @Model.Project?.CreatedAt.ToString("dd MMM yyyy")</div>
+            <div class="text-muted">Created on @(project is { } p ? p.CreatedAt.ToString("dd MMM yyyy") : "—")</div>
         </div>
         <partial name="_AssignRolesOffcanvas" model="Model.AssignRoles" />
     </div>
@@ -51,15 +52,15 @@
         </div>
     }
 
-    @if (Model.Project.HodUserId == null || Model.Project.LeadPoUserId == null)
+    @if (project?.HodUserId == null || project?.LeadPoUserId == null)
     {
         <div class="alert alert-warning d-flex align-items-center" role="alert">
             <div class="me-3">
-                @if (Model.Project.HodUserId == null)
+                @if (project?.HodUserId == null)
                 {
                     <div>Head of Department not assigned.</div>
                 }
-                @if (Model.Project.LeadPoUserId == null)
+                @if (project?.LeadPoUserId == null)
                 {
                     <div>Project Officer not assigned.</div>
                 }
@@ -84,7 +85,7 @@
                 <div class="card-body">
                     <dl class="row mb-0">
                         <dt class="col-sm-4">Description</dt>
-                        <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(Model.Project.Description) ? Model.Project.Description : "—")</dd>
+                        <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(project?.Description) ? project.Description : "—")</dd>
 
                         <dt class="col-sm-4">Category</dt>
                         <dd class="col-sm-8">
@@ -99,10 +100,10 @@
                         </dd>
 
                         <dt class="col-sm-4">Head of Department</dt>
-                        <dd class="col-sm-8">@DisplayUser(Model.Project.HodUser)</dd>
+                        <dd class="col-sm-8">@DisplayUser(project?.HodUser)</dd>
 
                         <dt class="col-sm-4">Project Officer</dt>
-                        <dd class="col-sm-8">@DisplayUser(Model.Project.LeadPoUser)</dd>
+                        <dd class="col-sm-8">@DisplayUser(project?.LeadPoUser)</dd>
                     </dl>
                 </div>
             </div>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,12 +1,13 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
+@using ProjectManagement.Models.Execution
 @functions{
     string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
-    string StatusChip(ProjectManagement.Models.Stages.StageStatus s) =>
+    string StatusChip(StageStatus s) =>
         s switch {
-            ProjectManagement.Models.Stages.StageStatus.Completed  => "badge bg-success",
-            ProjectManagement.Models.Stages.StageStatus.InProgress => "badge bg-primary",
-            _                                                     => "badge bg-secondary"
+            StageStatus.Completed  => "badge bg-success",
+            StageStatus.InProgress => "badge bg-primary",
+            _                      => "badge bg-secondary"
         };
 }
 <link rel="stylesheet" href="~/css/projects/timeline.css" />
@@ -31,9 +32,9 @@
       @foreach (var s in Model.Items.OrderBy(i => i.SortOrder))
       {
         var itemClass = s.Status switch {
-          ProjectManagement.Models.Stages.StageStatus.Completed  => "pm-item is-complete",
-          ProjectManagement.Models.Stages.StageStatus.InProgress => "pm-item is-active",
-          _                                                     => "pm-item"
+          StageStatus.Completed  => "pm-item is-complete",
+          StageStatus.InProgress => "pm-item is-active",
+          _                      => "pm-item"
         };
         <li class="@itemClass">
           <div class="pm-marker" aria-hidden="true"></div>

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.ViewModels;
 

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -1,4 +1,4 @@
-using ProjectManagement.Models.Stages;
+using ProjectManagement.Models.Execution;
 
 namespace ProjectManagement.ViewModels;
 


### PR DESCRIPTION
## Summary
- import the ApplicationDbContext and stage status namespace in the timeline read service
- reference the execution namespace for StageStatus in the timeline view model and partial
- guard project overview fields when the project record is missing

## Testing
- dotnet build *(fails: `dotnet` CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b12c334483298779d64e88d9b06b