### PR TITLE
Block HoD plan approvals when backfill is pending

### DIFF
--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -72,6 +72,14 @@ public class PlanApprovalService
             throw new InvalidOperationException("No plan is currently pending approval for this project.");
         }
 
+        var requiresBackfill = await _db.ProjectStages
+            .AnyAsync(s => s.ProjectId == projectId && s.RequiresBackfill, cancellationToken);
+
+        if (requiresBackfill)
+        {
+            throw new PlanApprovalValidationException(new[] { "Backfill required data before approval." });
+        }
+
         var project = await _db.Projects
             .FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken)
             ?? throw new InvalidOperationException("Project not found.");


### PR DESCRIPTION
## Summary
- prevent plan approvals when any project stage still has a pending backfill flag so HoD cannot sign off prematurely

## Testing
- ⚠️ `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ce72c9a4832997f2b66dbfed962c