### PR TITLE
Add off-canvas plan editor for project timelines

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -37,6 +37,10 @@
     {
         <div id="open-assign-roles" data-open="1"></div>
     }
+    @if (TempData["OpenOffcanvas"] as string == "plan-edit")
+    {
+        <div id="open-plan-edit" data-open="1"></div>
+    }
     @if (TempData["Error"] is string err)
     {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -155,6 +159,18 @@
             </div>
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">
+            @if (User.IsInRole("Admin") || User.IsInRole("PO"))
+            {
+                <div class="d-flex justify-content-end">
+                    <button class="btn btn-sm btn-outline-primary"
+                            type="button"
+                            data-bs-toggle="offcanvas"
+                            data-bs-target="#offcanvasPlanEdit"
+                            aria-controls="offcanvasPlanEdit">
+                        Edit timeline
+                    </button>
+                </div>
+            }
             <partial name="_ProjectTimeline" model="Model.Timeline" />
         </div>
     </div>
@@ -166,6 +182,16 @@
         </div>
         <div class="offcanvas-body">
             <partial name="Projects/Procurement/_EditFormBody" model="Model.ProcurementEdit" />
+        </div>
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasPlanEdit" aria-labelledby="offcanvasPlanEditLabel">
+        <div class="offcanvas-header">
+            <h5 id="offcanvasPlanEditLabel" class="mb-0">Edit timeline plan</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <partial name="/Pages/Projects/Timeline/_EditPlanForm" model="Model.PlanEdit" />
         </div>
     </div>
 

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -13,6 +13,7 @@ using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Services.Projects;
+using ProjectManagement.Services.Stages;
 using ProjectManagement.ViewModels;
 
 namespace ProjectManagement.Pages.Projects
@@ -24,13 +25,15 @@ namespace ProjectManagement.Pages.Projects
         private readonly ProjectProcurementReadService _procureRead;
         private readonly ProjectTimelineReadService _timelineRead;
         private readonly UserManager<ApplicationUser> _users;
+        private readonly PlanReadService _planRead;
 
-        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, ProjectTimelineReadService timelineRead, UserManager<ApplicationUser> users)
+        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, ProjectTimelineReadService timelineRead, UserManager<ApplicationUser> users, PlanReadService planRead)
         {
             _db = db;
             _procureRead = procureRead;
             _timelineRead = timelineRead;
             _users = users;
+            _planRead = planRead;
         }
 
         public Project Project { get; private set; } = default!;
@@ -40,6 +43,7 @@ namespace ProjectManagement.Pages.Projects
         public ProcurementEditVm ProcurementEdit { get; private set; } = default!;
         public AssignRolesVm AssignRoles { get; private set; } = default!;
         public TimelineVm Timeline { get; private set; } = default!;
+        public PlanEditVm PlanEdit { get; private set; } = default!;
         public bool HasBackfill { get; private set; }
 
         public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
@@ -79,6 +83,7 @@ namespace ProjectManagement.Pages.Projects
 
             Procurement = await _procureRead.GetAsync(id, ct);
             Timeline = await _timelineRead.GetAsync(id, ct);
+            PlanEdit = await _planRead.GetAsync(id, ct);
             HasBackfill = Timeline.HasBackfill;
 
             ProcurementEdit = new ProcurementEditVm

--- a/Pages/Projects/Timeline/EditPlan.cshtml
+++ b/Pages/Projects/Timeline/EditPlan.cshtml
@@ -1,0 +1,6 @@
+@page "{id:int}"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,HoD,PO")]
+@model ProjectManagement.Pages.Projects.Timeline.EditPlanModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.ViewModels;
+
+namespace ProjectManagement.Pages.Projects.Timeline;
+
+[Authorize(Roles = "Admin,HoD,PO")]
+[ValidateAntiForgeryToken]
+public class EditPlanModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly IAuditService _audit;
+
+    public EditPlanModel(ApplicationDbContext db, UserManager<ApplicationUser> users, IAuditService audit)
+    {
+        _db = db;
+        _users = users;
+        _audit = audit;
+    }
+
+    [BindProperty]
+    public PlanEditVm Input { get; set; } = new();
+
+    public IActionResult OnGet(int id) => NotFound();
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId)
+        {
+            TempData["Error"] = "Unable to process the request. Please reload and try again.";
+            TempData["OpenOffcanvas"] = "plan-edit";
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+
+        var validationErrors = ValidateInput();
+        if (validationErrors.Count > 0)
+        {
+            TempData["Error"] = string.Join(" ", validationErrors);
+            TempData["OpenOffcanvas"] = "plan-edit";
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+
+        var stageList = await _db.ProjectStages
+            .Where(stage => stage.ProjectId == id)
+            .ToListAsync(cancellationToken);
+
+        var stageMap = stageList
+            .Where(stage => !string.IsNullOrWhiteSpace(stage.StageCode))
+            .ToDictionary(stage => stage.StageCode, StringComparer.OrdinalIgnoreCase);
+
+        var changes = new List<StageChange>();
+
+        foreach (var row in Input.Rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Code))
+            {
+                continue;
+            }
+
+            if (!stageMap.TryGetValue(row.Code, out var stage))
+            {
+                continue;
+            }
+
+            var previousStart = stage.PlannedStart;
+            var previousDue = stage.PlannedDue;
+
+            if (previousStart == row.PlannedStart && previousDue == row.PlannedDue)
+            {
+                continue;
+            }
+
+            stage.PlannedStart = row.PlannedStart;
+            stage.PlannedDue = row.PlannedDue;
+
+            changes.Add(new StageChange(row.Code, row.Name, previousStart, previousDue, row.PlannedStart, row.PlannedDue));
+        }
+
+        if (changes.Count == 0)
+        {
+            TempData["Flash"] = "No changes.";
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+
+        await using var transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+        await _db.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        var userId = _users.GetUserId(User);
+        var userName = User.Identity?.Name;
+
+        var data = new Dictionary<string, string?>
+        {
+            ["ProjectId"] = id.ToString(CultureInfo.InvariantCulture),
+            ["ChangedStages"] = string.Join(";", changes.Select(change => change.Code))
+        };
+
+        for (var index = 0; index < changes.Count; index++)
+        {
+            var change = changes[index];
+            var prefix = $"Stage[{index}]";
+            data[$"{prefix}.Code"] = change.Code;
+            data[$"{prefix}.Name"] = change.Name;
+            data[$"{prefix}.Start.Before"] = FormatDate(change.PreviousStart);
+            data[$"{prefix}.Start.After"] = FormatDate(change.NewStart);
+            data[$"{prefix}.Due.Before"] = FormatDate(change.PreviousDue);
+            data[$"{prefix}.Due.After"] = FormatDate(change.NewDue);
+        }
+
+        await _audit.LogAsync(
+            "Projects.PlanUpdated",
+            userId: userId,
+            userName: userName,
+            data: data);
+
+        TempData["Flash"] = "Timeline plan updated.";
+        return RedirectToPage("/Projects/Overview", new { id });
+    }
+
+    private List<string> ValidateInput()
+    {
+        var errors = new List<string>();
+
+        if (Input.Rows is null)
+        {
+            return errors;
+        }
+
+        foreach (var row in Input.Rows)
+        {
+            if (row.PlannedStart.HasValue && row.PlannedDue.HasValue && row.PlannedStart > row.PlannedDue)
+            {
+                var name = string.IsNullOrWhiteSpace(row.Name) ? row.Code : row.Name;
+                errors.Add($"Planned start must be on or before planned due for {name}.");
+            }
+        }
+
+        return errors;
+    }
+
+    private static string? FormatDate(DateOnly? value)
+        => value?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private sealed record StageChange(
+        string Code,
+        string Name,
+        DateOnly? PreviousStart,
+        DateOnly? PreviousDue,
+        DateOnly? NewStart,
+        DateOnly? NewDue);
+}

--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -1,0 +1,42 @@
+@model ProjectManagement.ViewModels.PlanEditVm
+<form method="post" asp-page="/Projects/Timeline/EditPlan" asp-route-id="@Model.ProjectId" class="d-flex flex-column h-100">
+    @Html.AntiForgeryToken()
+    <input type="hidden" name="Input.ProjectId" value="@Model.ProjectId" />
+
+    <div class="flex-grow-1 overflow-auto pe-1">
+        <div class="row gy-3">
+            @for (var i = 0; i < Model.Rows.Count; i++)
+            {
+                var row = Model.Rows[i];
+                <div class="col-12 border-bottom pb-3">
+                    <div class="d-flex justify-content-between align-items-center mb-1">
+                        <strong>@row.Name</strong>
+                        <span class="text-muted small">@row.Code</span>
+                    </div>
+                    <div class="row g-2">
+                        <div class="col-sm-6">
+                            <label for="Rows_@i__PlannedStart" class="form-label">Planned start</label>
+                            <input class="form-control" type="date"
+                                   id="Rows_@i__PlannedStart"
+                                   name="Input.Rows[@i].PlannedStart"
+                                   value="@(row.PlannedStart.HasValue ? row.PlannedStart.Value.ToString("yyyy-MM-dd") : null)" />
+                        </div>
+                        <div class="col-sm-6">
+                            <label for="Rows_@i__PlannedDue" class="form-label">Planned due</label>
+                            <input class="form-control" type="date"
+                                   id="Rows_@i__PlannedDue"
+                                   name="Input.Rows[@i].PlannedDue"
+                                   value="@(row.PlannedDue.HasValue ? row.PlannedDue.Value.ToString("yyyy-MM-dd") : null)" />
+                        </div>
+                    </div>
+                    <input type="hidden" name="Input.Rows[@i].Code" value="@row.Code" />
+                    <input type="hidden" name="Input.Rows[@i].Name" value="@row.Name" />
+                </div>
+            }
+        </div>
+    </div>
+
+    <div class="pt-3 mt-3 border-top text-end">
+        <button class="btn btn-primary" type="submit">Save plan</button>
+    </div>
+</form>

--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,7 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using ProjectManagement.Utilities;
+using ProjectManagement.Services.Stages;
 
 var runForecastBackfill = args.Any(a => string.Equals(a, "--backfill-forecast", StringComparison.OrdinalIgnoreCase));
 
@@ -153,6 +154,7 @@ builder.Services.AddScoped<ProjectFactsReadService>();
 builder.Services.AddScoped<ProjectProcurementReadService>();
 builder.Services.AddScoped<ProjectTimelineReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
+builder.Services.AddScoped<PlanReadService>();
 builder.Services.AddScoped<IScheduleEngine, ScheduleEngine>();
 builder.Services.AddScoped<IForecastWriter, ForecastWriter>();
 builder.Services.AddScoped<ForecastBackfillService>();

--- a/Services/Stages/PlanReadService.cs
+++ b/Services/Stages/PlanReadService.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.ViewModels;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class PlanReadService
+{
+    private readonly ApplicationDbContext _db;
+
+    public PlanReadService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<PlanEditVm> GetAsync(int projectId, CancellationToken cancellationToken = default)
+    {
+        var stages = await _db.ProjectStages
+            .Where(stage => stage.ProjectId == projectId)
+            .OrderBy(stage => stage.SortOrder)
+            .ToListAsync(cancellationToken);
+
+        var viewModel = new PlanEditVm { ProjectId = projectId };
+        foreach (var stage in stages)
+        {
+            viewModel.Rows.Add(new PlanEditVm.PlanEditRow
+            {
+                Code = stage.StageCode,
+                Name = StageCodes.DisplayNameOf(stage.StageCode),
+                PlannedStart = stage.PlannedStart,
+                PlannedDue = stage.PlannedDue,
+            });
+        }
+
+        return viewModel;
+    }
+}

--- a/ViewModels/PlanEditVm.cs
+++ b/ViewModels/PlanEditVm.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class PlanEditVm
+{
+    public int ProjectId { get; set; }
+    public List<PlanEditRow> Rows { get; set; } = new();
+
+    public sealed class PlanEditRow
+    {
+        public string Code { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public DateOnly? PlannedStart { get; set; }
+        public DateOnly? PlannedDue { get; set; }
+    }
+}

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -34,4 +34,20 @@
             instance.show();
         }
     }
+
+    const planEdit = document.getElementById('offcanvasPlanEdit');
+    if (planEdit) {
+        planEdit.addEventListener('shown.bs.offcanvas', function () {
+            const firstDate = planEdit.querySelector('input[type="date"]');
+            if (firstDate) {
+                firstDate.focus();
+            }
+        });
+
+        const planMarker = document.getElementById('open-plan-edit');
+        if (planMarker && planMarker.dataset.open === '1') {
+            const instance = bootstrap.Offcanvas.getOrCreateInstance(planEdit);
+            instance.show();
+        }
+    }
 })();


### PR DESCRIPTION
## Summary
- add a plan edit view model and read service to surface planned dates for editing
- create an off-canvas Razor Page that validates and persists plan date changes with audit logging
- expose the edit entry point on the overview page and enhance the overview script to manage the new panel

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d09603148329a988daf72575e548