### PR TITLE
Fix stage ordering and Razor bindings in plan editor

### DIFF
--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -15,22 +15,22 @@
                     </div>
                     <div class="row g-2">
                         <div class="col-sm-6">
-                            <label for="Rows_@i__PlannedStart" class="form-label">Planned start</label>
+                            <label for="Rows_@(i)__PlannedStart" class="form-label">Planned start</label>
                             <input class="form-control" type="date"
-                                   id="Rows_@i__PlannedStart"
-                                   name="Input.Rows[@i].PlannedStart"
+                                   id="Rows_@(i)__PlannedStart"
+                                   name="Input.Rows[@(i)].PlannedStart"
                                    value="@(row.PlannedStart.HasValue ? row.PlannedStart.Value.ToString("yyyy-MM-dd") : null)" />
                         </div>
                         <div class="col-sm-6">
-                            <label for="Rows_@i__PlannedDue" class="form-label">Planned due</label>
+                            <label for="Rows_@(i)__PlannedDue" class="form-label">Planned due</label>
                             <input class="form-control" type="date"
-                                   id="Rows_@i__PlannedDue"
-                                   name="Input.Rows[@i].PlannedDue"
+                                   id="Rows_@(i)__PlannedDue"
+                                   name="Input.Rows[@(i)].PlannedDue"
                                    value="@(row.PlannedDue.HasValue ? row.PlannedDue.Value.ToString("yyyy-MM-dd") : null)" />
                         </div>
                     </div>
-                    <input type="hidden" name="Input.Rows[@i].Code" value="@row.Code" />
-                    <input type="hidden" name="Input.Rows[@i].Name" value="@row.Name" />
+                    <input type="hidden" name="Input.Rows[@(i)].Code" value="@row.Code" />
+                    <input type="hidden" name="Input.Rows[@(i)].Name" value="@row.Name" />
                 </div>
             }
         </div>

--- a/Services/Stages/PlanReadService.cs
+++ b/Services/Stages/PlanReadService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,12 +23,35 @@ public sealed class PlanReadService
     {
         var stages = await _db.ProjectStages
             .Where(stage => stage.ProjectId == projectId)
-            .OrderBy(stage => stage.SortOrder)
             .ToListAsync(cancellationToken);
 
         var viewModel = new PlanEditVm { ProjectId = projectId };
+        var stageMap = stages
+            .Where(stage => !string.IsNullOrWhiteSpace(stage.StageCode))
+            .ToDictionary(stage => stage.StageCode, StringComparer.OrdinalIgnoreCase);
+
+        var knownCodes = new HashSet<string>(StageCodes.All, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var code in StageCodes.All)
+        {
+            stageMap.TryGetValue(code, out var stage);
+
+            viewModel.Rows.Add(new PlanEditVm.PlanEditRow
+            {
+                Code = code,
+                Name = StageCodes.DisplayNameOf(code),
+                PlannedStart = stage?.PlannedStart,
+                PlannedDue = stage?.PlannedDue,
+            });
+        }
+
         foreach (var stage in stages)
         {
+            if (string.IsNullOrWhiteSpace(stage.StageCode) || knownCodes.Contains(stage.StageCode))
+            {
+                continue;
+            }
+
             viewModel.Rows.Add(new PlanEditVm.PlanEditRow
             {
                 Code = stage.StageCode,


### PR DESCRIPTION
## Summary
- ensure the plan editor form generates valid field names and IDs by wrapping the row index in Razor expressions
- load project stages without relying on a missing SortOrder column and map them to the canonical stage order before building the view model

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6d477b44c83298ab4178ba49488f4