### PR TITLE
Fix missing ProjectStage namespace import

### DIFF
--- a/Services/Stages/PlanReadService.cs
+++ b/Services/Stages/PlanReadService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Scheduling;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.ViewModels;


### PR DESCRIPTION
## Summary
- add the missing namespace import for `ProjectStage` in `PlanReadService`

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7351bfc008329a8d15f2fb23d8172