### PR TITLE
Fix Razor option markup and stage progress tuple handling

### DIFF
--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -97,8 +97,8 @@
                         <div class="col-md-6">
                             <label class="form-label" for="DurationsPolicy">Next stage starts</label>
                             <select class="form-select" id="DurationsPolicy" name="Input.NextStageStartPolicy">
-                                <option value="@ProjectManagement.Models.Scheduling.NextStageStartPolicies.SameDay" @(Model.Durations.NextStageStartPolicy == ProjectManagement.Models.Scheduling.NextStageStartPolicies.SameDay ? "selected" : null)>Same day</option>
-                                <option value="@ProjectManagement.Models.Scheduling.NextStageStartPolicies.NextWorkingDay" @(Model.Durations.NextStageStartPolicy == ProjectManagement.Models.Scheduling.NextStageStartPolicies.NextWorkingDay ? "selected" : null)>Next working day</option>
+                                <option value="@ProjectManagement.Models.Scheduling.NextStageStartPolicies.SameDay" selected="@(Model.Durations.NextStageStartPolicy == ProjectManagement.Models.Scheduling.NextStageStartPolicies.SameDay ? "selected" : null)">Same day</option>
+                                <option value="@ProjectManagement.Models.Scheduling.NextStageStartPolicies.NextWorkingDay" selected="@(Model.Durations.NextStageStartPolicy == ProjectManagement.Models.Scheduling.NextStageStartPolicies.NextWorkingDay ? "selected" : null)">Next working day</option>
                             </select>
                         </div>
                         <div class="col-12">

--- a/Services/Stages/StageProgressService.cs
+++ b/Services/Stages/StageProgressService.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Scheduling;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Services.Projects;
 using ProjectManagement.Services.Stages;
 
@@ -153,8 +154,9 @@ public class StageProgressService
 
         await _audit.LogAsync("Stages.StageStatusChanged", userId: userId, data: data);
 
-        if (autoStart is { Stage: { } nextStage })
+        if (autoStart.HasValue && autoStart.Value.Stage is { } nextStage)
         {
+            var startDate = autoStart.Value.StartDate;
             await _audit.LogAsync(
                 "Stages.StageAutoStarted",
                 userId: userId,
@@ -163,7 +165,7 @@ public class StageProgressService
                     ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
                     ["StageCode"] = nextStage.StageCode,
                     ["TriggeredBy"] = stage.StageCode,
-                    ["StartDate"] = autoStart.StartDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                    ["StartDate"] = startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                 });
         }
 


### PR DESCRIPTION
## Summary
- update the plan editor options to use standard selected attributes so Razor tag helpers compile
- fix StageProgressService to reference stage codes and safely access the auto-start tuple values

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d73608a79c83299cb4431a8192296f