### PR TITLE
Add HoD timeline review and approval workflow

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -39,6 +39,8 @@ namespace ProjectManagement.Data
         public DbSet<PlanVersion> PlanVersions => Set<PlanVersion>();
         public DbSet<StagePlan> StagePlans => Set<StagePlan>();
         public DbSet<PlanApprovalLog> PlanApprovalLogs => Set<PlanApprovalLog>();
+        public DbSet<ProjectPlanSnapshot> ProjectPlanSnapshots => Set<ProjectPlanSnapshot>();
+        public DbSet<ProjectPlanSnapshotRow> ProjectPlanSnapshotRows => Set<ProjectPlanSnapshotRow>();
         public DbSet<ProjectStage> ProjectStages => Set<ProjectStage>();
         public DbSet<ProjectComment> ProjectComments => Set<ProjectComment>();
         public DbSet<ProjectCommentAttachment> ProjectCommentAttachments => Set<ProjectCommentAttachment>();
@@ -72,6 +74,31 @@ namespace ProjectManagement.Data
                     .WithMany()
                     .HasForeignKey(x => x.PlanApprovedByUserId)
                     .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            builder.Entity<ProjectPlanSnapshot>(e =>
+            {
+                e.HasIndex(x => new { x.ProjectId, x.TakenAt });
+                e.Property(x => x.TakenByUserId).HasMaxLength(450).IsRequired();
+                e.HasOne<Project>()
+                    .WithMany()
+                    .HasForeignKey(x => x.ProjectId)
+                    .OnDelete(DeleteBehavior.Cascade);
+                e.HasOne<ApplicationUser>()
+                    .WithMany()
+                    .HasForeignKey(x => x.TakenByUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<ProjectPlanSnapshotRow>(e =>
+            {
+                e.Property(x => x.StageCode).HasMaxLength(32).IsRequired();
+                e.Property(x => x.PlannedStart).HasColumnType("date");
+                e.Property(x => x.PlannedDue).HasColumnType("date");
+                e.HasOne(x => x.Snapshot)
+                    .WithMany(x => x.Rows)
+                    .HasForeignKey(x => x.SnapshotId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             builder.Entity<ProjectCategory>(e =>

--- a/Migrations/20251201130000_ProjectPlanApprovalAndSnapshots.cs
+++ b/Migrations/20251201130000_ProjectPlanApprovalAndSnapshots.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProjectPlanApprovalAndSnapshots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProjectPlanSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    TakenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    TakenByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectPlanSnapshots", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectPlanSnapshots_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectPlanSnapshots_AspNetUsers_TakenByUserId",
+                        column: x => x.TakenByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectPlanSnapshotRows",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SnapshotId = table.Column<int>(type: "integer", nullable: false),
+                    StageCode = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    PlannedStart = table.Column<DateOnly>(type: "date", nullable: true),
+                    PlannedDue = table.Column<DateOnly>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectPlanSnapshotRows", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectPlanSnapshotRows_ProjectPlanSnapshots_SnapshotId",
+                        column: x => x.SnapshotId,
+                        principalTable: "ProjectPlanSnapshots",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPlanSnapshotRows_SnapshotId",
+                table: "ProjectPlanSnapshotRows",
+                column: "SnapshotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPlanSnapshots_ProjectId_TakenAt",
+                table: "ProjectPlanSnapshots",
+                columns: new[] { "ProjectId", "TakenAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPlanSnapshots_TakenByUserId",
+                table: "ProjectPlanSnapshots",
+                column: "TakenByUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectPlanSnapshotRows");
+
+            migrationBuilder.DropTable(
+                name: "ProjectPlanSnapshots");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -579,6 +579,63 @@ namespace ProjectManagement.Migrations
                     b.ToTable("PlanApprovalLogs");
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshot", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset>("TakenAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("TakenByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ProjectId", "TakenAt");
+
+                    b.HasIndex("TakenByUserId");
+
+                    b.ToTable("ProjectPlanSnapshots");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshotRow", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<DateOnly?>("PlannedDue")
+                        .HasColumnType("date");
+
+                    b.Property<DateOnly?>("PlannedStart")
+                        .HasColumnType("date");
+
+                    b.Property<int>("SnapshotId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StageCode")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SnapshotId");
+
+                    b.ToTable("ProjectPlanSnapshotRows");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.Plans.PlanVersion", b =>
                 {
                     b.Property<int>("Id")
@@ -1555,6 +1612,38 @@ namespace ProjectManagement.Migrations
                     b.Navigation("PerformedByUser");
 
                     b.Navigation("PlanVersion");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshot", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Project", "Project")
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("ProjectManagement.Models.ApplicationUser", "TakenByUser")
+                        .WithMany()
+                        .HasForeignKey("TakenByUserId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Project");
+
+                    b.Navigation("TakenByUser");
+
+                    b.Navigation("Rows");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshotRow", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Plans.ProjectPlanSnapshot", "Snapshot")
+                        .WithMany("Rows")
+                        .HasForeignKey("SnapshotId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Snapshot");
                 });
 
             modelBuilder.Entity("ProjectManagement.Models.Plans.PlanVersion", b =>

--- a/Models/Execution/ProjectStage.cs
+++ b/Models/Execution/ProjectStage.cs
@@ -20,6 +20,7 @@ public class ProjectStage
     public Project? Project { get; set; }
 
     public string StageCode { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
     public StageStatus Status { get; set; } = StageStatus.NotStarted;
 
     public DateOnly? PlannedStart { get; set; }

--- a/Models/Plans/ProjectPlanSnapshot.cs
+++ b/Models/Plans/ProjectPlanSnapshot.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Models.Plans;
+
+public class ProjectPlanSnapshot
+{
+    public int Id { get; set; }
+
+    public int ProjectId { get; set; }
+    public Project? Project { get; set; }
+
+    public DateTimeOffset TakenAt { get; set; }
+
+    [MaxLength(450)]
+    public string TakenByUserId { get; set; } = string.Empty;
+    public ApplicationUser? TakenByUser { get; set; }
+
+    public ICollection<ProjectPlanSnapshotRow> Rows { get; set; } = new List<ProjectPlanSnapshotRow>();
+}
+
+public class ProjectPlanSnapshotRow
+{
+    public int Id { get; set; }
+
+    public int SnapshotId { get; set; }
+    public ProjectPlanSnapshot? Snapshot { get; set; }
+
+    [MaxLength(32)]
+    public string StageCode { get; set; } = string.Empty;
+
+    public DateOnly? PlannedStart { get; set; }
+    public DateOnly? PlannedDue { get; set; }
+}

--- a/Pages/Projects/Create.cshtml.cs
+++ b/Pages/Projects/Create.cshtml.cs
@@ -162,6 +162,7 @@ namespace ProjectManagement.Pages.Projects
                 {
                     ProjectId = project.Id,
                     StageCode = completedCode,
+                    SortOrder = Array.IndexOf(StageCodes.All, completedCode),
                     Status = StageStatus.Completed,
                     ActualStart = completedDate,
                     CompletedOn = completedDate

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -41,6 +41,10 @@
     {
         <div id="open-plan-edit" data-open="1"></div>
     }
+    @if (TempData["OpenOffcanvas"] as string == "plan-review")
+    {
+        <div id="open-plan-review" data-open="1"></div>
+    }
     @if (TempData["Error"] is string err)
     {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -161,7 +165,17 @@
         <div class="col-lg-4 d-flex flex-column gap-3">
             @if (User.IsInRole("Admin") || User.IsInRole("PO") || User.IsInRole("HoD"))
             {
-                <div class="d-flex justify-content-end">
+                <div class="d-flex justify-content-end gap-2">
+                    @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+                    {
+                        <button class="btn btn-sm btn-outline-primary"
+                                type="button"
+                                data-bs-toggle="offcanvas"
+                                data-bs-target="#offcanvasPlanReview"
+                                aria-controls="offcanvasPlanReview">
+                            Review &amp; approve
+                        </button>
+                    }
                     <button class="btn btn-sm btn-outline-primary"
                             type="button"
                             data-bs-toggle="offcanvas"
@@ -182,6 +196,20 @@
         </div>
         <div class="offcanvas-body">
             <partial name="Projects/Procurement/_EditFormBody" model="Model.ProcurementEdit" />
+        </div>
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasPlanReview" aria-labelledby="offcanvasPlanReviewLabel">
+        <div class="offcanvas-header">
+            <h5 id="offcanvasPlanReviewLabel" class="mb-0">Review current plan</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            @{
+                ViewBag.ProjectId = Model.Project.Id;
+                var diffs = await Model.PlanCompare.GetDiffAsync(Model.Project.Id);
+                await Html.RenderPartialAsync("/Pages/Projects/Timeline/_ReviewPlan", diffs);
+            }
         </div>
     </div>
 

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -27,13 +27,16 @@ namespace ProjectManagement.Pages.Projects
         private readonly UserManager<ApplicationUser> _users;
         private readonly PlanReadService _planRead;
 
-        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, ProjectTimelineReadService timelineRead, UserManager<ApplicationUser> users, PlanReadService planRead)
+        public PlanCompareService PlanCompare { get; }
+
+        public OverviewModel(ApplicationDbContext db, ProjectProcurementReadService procureRead, ProjectTimelineReadService timelineRead, UserManager<ApplicationUser> users, PlanReadService planRead, PlanCompareService planCompare)
         {
             _db = db;
             _procureRead = procureRead;
             _timelineRead = timelineRead;
             _users = users;
             _planRead = planRead;
+            PlanCompare = planCompare;
         }
 
         public Project Project { get; private set; } = default!;

--- a/Pages/Projects/Timeline/Review.cshtml
+++ b/Pages/Projects/Timeline/Review.cshtml
@@ -1,0 +1,6 @@
+@page "{id:int}"
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,HoD")]
+@model ProjectManagement.Pages.Projects.Timeline.ReviewModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Timeline/Review.cshtml.cs
+++ b/Pages/Projects/Timeline/Review.cshtml.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Stages;
+
+namespace ProjectManagement.Pages.Projects.Timeline;
+
+[Authorize(Roles = "Admin,HoD")]
+[ValidateAntiForgeryToken]
+public class ReviewModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly PlanSnapshotService _snapshots;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly ILogger<ReviewModel> _logger;
+
+    public ReviewModel(ApplicationDbContext db, PlanSnapshotService snapshots, UserManager<ApplicationUser> users, ILogger<ReviewModel> logger)
+    {
+        _db = db;
+        _snapshots = snapshots;
+        _users = users;
+        _logger = logger;
+    }
+
+    public sealed class InputModel
+    {
+        public int ProjectId { get; set; }
+        public string Decision { get; set; } = string.Empty;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public IActionResult OnGet(int id) => NotFound();
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken ct)
+    {
+        if (id != Input.ProjectId)
+        {
+            return BadRequest();
+        }
+
+        var decision = Input.Decision ?? string.Empty;
+        var isApprove = string.Equals(decision, "Approve", StringComparison.OrdinalIgnoreCase);
+
+        if (isApprove)
+        {
+            var hasBackfill = await _db.ProjectStages
+                .AnyAsync(s => s.ProjectId == id && s.RequiresBackfill, ct);
+            if (hasBackfill)
+            {
+                TempData["Error"] = "Backfill required data before approval.";
+                TempData["OpenOffcanvas"] = "plan-review";
+                _logger.LogInformation("Plan approval blocked for project {ProjectId} due to pending backfill.", id);
+                return RedirectToPage("/Projects/Overview", new { id });
+            }
+        }
+
+        var project = await _db.Projects.SingleOrDefaultAsync(p => p.Id == id, ct);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        var userId = _users.GetUserId(User);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        if (isApprove)
+        {
+            await _snapshots.CreateSnapshotAsync(id, userId, ct);
+            project.PlanApprovedAt = DateTimeOffset.UtcNow;
+            project.PlanApprovedByUserId = userId;
+            await _db.SaveChangesAsync(ct);
+            TempData["Flash"] = "Plan approved.";
+            _logger.LogInformation("Plan approved for project {ProjectId} by user {UserId}.", id, userId);
+        }
+        else
+        {
+            TempData["Flash"] = "Plan review rejected.";
+            _logger.LogInformation("Plan review rejected for project {ProjectId} by user {UserId}.", id, userId);
+        }
+
+        return RedirectToPage("/Projects/Overview", new { id });
+    }
+}

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -1,0 +1,50 @@
+@model IReadOnlyList<ProjectManagement.Services.Stages.PlanCompareService.PlanDiffRow>
+@using ProjectManagement.Models.Stages
+
+<div class="small text-muted mb-2">
+    @if (Model.Count == 0)
+    {
+        <span>No stages found.</span>
+    }
+    else
+    {
+        <span>Differences vs last approved plan.</span>
+    }
+</div>
+
+<div class="table-responsive">
+    <table class="table table-sm align-middle">
+        <thead>
+            <tr>
+                <th>Stage</th>
+                <th class="text-center">Approved</th>
+                <th class="text-center">Current</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var row in Model)
+        {
+            var changed = row.OldStart != row.NewStart || row.OldDue != row.NewDue;
+            <tr class="@(changed ? "table-warning" : string.Empty)">
+                <td>
+                    <span class="fw-semibold">@StageCodes.DisplayNameOf(row.Code)</span>
+                    <div class="text-muted small">@row.Code</div>
+                </td>
+                <td class="text-center">
+                    @((row.OldStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.OldDue?.ToString("yyyy-MM-dd") ?? "—"))
+                </td>
+                <td class="text-center">
+                    @((row.NewStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.NewDue?.ToString("yyyy-MM-dd") ?? "—"))
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>
+
+<form method="post" asp-page="/Projects/Timeline/Review" asp-route-id="@ViewBag.ProjectId" class="d-flex gap-2 justify-content-end mt-3">
+    @Html.AntiForgeryToken()
+    <input type="hidden" name="Input.ProjectId" value="@ViewBag.ProjectId" />
+    <button name="Input.Decision" value="Reject" class="btn btn-outline-secondary">Reject</button>
+    <button name="Input.Decision" value="Approve" class="btn btn-primary">Approve plan</button>
+</form>

--- a/Program.cs
+++ b/Program.cs
@@ -149,6 +149,8 @@ builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
+builder.Services.AddScoped<PlanSnapshotService>();
+builder.Services.AddScoped<PlanCompareService>();
 builder.Services.AddScoped<ProjectFactsService>();
 builder.Services.AddScoped<ProjectFactsReadService>();
 builder.Services.AddScoped<ProjectProcurementReadService>();

--- a/ProjectManagement.Tests/StageProgressServiceTests.cs
+++ b/ProjectManagement.Tests/StageProgressServiceTests.cs
@@ -185,6 +185,7 @@ public class StageProgressServiceTests
             {
                 ProjectId = 1,
                 StageCode = code,
+                SortOrder = Array.IndexOf(StageCodes.All, code),
                 Status = status
             });
         }

--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using ProjectManagement.Data;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 
 namespace ProjectManagement.Services.Plans;
@@ -108,6 +109,7 @@ public class PlanApprovalService
             {
                 ProjectId = projectId,
                 StageCode = stagePlan.StageCode,
+                SortOrder = Array.IndexOf(StageCodes.All, stagePlan.StageCode),
                 PlannedStart = stagePlan.PlannedStart,
                 PlannedDue = stagePlan.PlannedDue,
                 Status = StageStatus.NotStarted

--- a/Services/Stages/PlanCompareService.cs
+++ b/Services/Stages/PlanCompareService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class PlanCompareService
+{
+    private readonly ApplicationDbContext _db;
+
+    public PlanCompareService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public sealed record PlanDiffRow(
+        string Code,
+        DateOnly? NewStart,
+        DateOnly? NewDue,
+        DateOnly? OldStart,
+        DateOnly? OldDue);
+
+    public async Task<IReadOnlyList<PlanDiffRow>> GetDiffAsync(int projectId, CancellationToken ct = default)
+    {
+        var lastSnapshot = await _db.ProjectPlanSnapshots
+            .Where(s => s.ProjectId == projectId)
+            .OrderByDescending(s => s.TakenAt)
+            .FirstOrDefaultAsync(ct);
+
+        var currentStages = await _db.ProjectStages
+            .Where(s => s.ProjectId == projectId)
+            .OrderBy(s => s.SortOrder)
+            .ThenBy(s => s.StageCode)
+            .ToListAsync(ct);
+
+        if (lastSnapshot is null)
+        {
+            return currentStages
+                .Select(stage => new PlanDiffRow(
+                    stage.StageCode,
+                    stage.PlannedStart,
+                    stage.PlannedDue,
+                    null,
+                    null))
+                .ToList();
+        }
+
+        var approved = await _db.ProjectPlanSnapshotRows
+            .Where(r => r.SnapshotId == lastSnapshot.Id)
+            .ToDictionaryAsync(r => r.StageCode, ct);
+
+        return currentStages
+            .Select(stage =>
+            {
+                approved.TryGetValue(stage.StageCode, out var row);
+                return new PlanDiffRow(
+                    stage.StageCode,
+                    stage.PlannedStart,
+                    stage.PlannedDue,
+                    row?.PlannedStart,
+                    row?.PlannedDue);
+            })
+            .ToList();
+    }
+}

--- a/Services/Stages/PlanGenerationService.cs
+++ b/Services/Stages/PlanGenerationService.cs
@@ -72,6 +72,8 @@ public sealed class PlanGenerationService
                 continue;
             }
 
+            stage.SortOrder = ResolveSortOrder(stage.StageCode, durationMap);
+
             var start = i == 0
                 ? cursor
                 : settings.NextStageStartPolicy == NextStageStartPolicies.SameDay

--- a/Services/Stages/PlanSnapshotService.cs
+++ b/Services/Stages/PlanSnapshotService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Plans;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class PlanSnapshotService
+{
+    private readonly ApplicationDbContext _db;
+
+    public PlanSnapshotService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<int> CreateSnapshotAsync(int projectId, string userId, CancellationToken ct = default)
+    {
+        var stages = await _db.ProjectStages
+            .Where(s => s.ProjectId == projectId)
+            .OrderBy(s => s.SortOrder)
+            .ThenBy(s => s.StageCode)
+            .ToListAsync(ct);
+
+        var snapshot = new ProjectPlanSnapshot
+        {
+            ProjectId = projectId,
+            TakenAt = DateTimeOffset.UtcNow,
+            TakenByUserId = userId
+        };
+
+        _db.ProjectPlanSnapshots.Add(snapshot);
+        await _db.SaveChangesAsync(ct);
+
+        var rows = stages.Select(stage => new ProjectPlanSnapshotRow
+        {
+            SnapshotId = snapshot.Id,
+            StageCode = stage.StageCode,
+            PlannedStart = stage.PlannedStart,
+            PlannedDue = stage.PlannedDue
+        });
+
+        await _db.ProjectPlanSnapshotRows.AddRangeAsync(rows, ct);
+        await _db.SaveChangesAsync(ct);
+
+        return snapshot.Id;
+    }
+}

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -50,4 +50,20 @@
             instance.show();
         }
     }
+
+    const planReview = document.getElementById('offcanvasPlanReview');
+    if (planReview) {
+        planReview.addEventListener('shown.bs.offcanvas', function () {
+            const firstAction = planReview.querySelector('button, input, select, textarea');
+            if (firstAction) {
+                firstAction.focus();
+            }
+        });
+
+        const reviewMarker = document.getElementById('open-plan-review');
+        if (reviewMarker && reviewMarker.dataset.open === '1') {
+            const instance = bootstrap.Offcanvas.getOrCreateInstance(planReview);
+            instance.show();
+        }
+    }
 })();


### PR DESCRIPTION
## Summary
- add plan snapshot entities and a migration to persist approved project timelines
- implement snapshot/diff services with a protected review Razor Page that enforces backfill requirements before approval
- surface a HoD/Admin "Review & approve" off-canvas on the project overview with client-side auto-open support

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d73a7e531c83299ada823951d336ba