### PR TITLE
Fix duplicate foreign keys for ProjectPlanSnapshot

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -80,11 +80,11 @@ namespace ProjectManagement.Data
             {
                 e.HasIndex(x => new { x.ProjectId, x.TakenAt });
                 e.Property(x => x.TakenByUserId).HasMaxLength(450).IsRequired();
-                e.HasOne<Project>()
+                e.HasOne(x => x.Project)
                     .WithMany()
                     .HasForeignKey(x => x.ProjectId)
                     .OnDelete(DeleteBehavior.Cascade);
-                e.HasOne<ApplicationUser>()
+                e.HasOne(x => x.TakenByUser)
                     .WithMany()
                     .HasForeignKey(x => x.TakenByUserId)
                     .OnDelete(DeleteBehavior.Restrict);

--- a/Migrations/20250927013023_InitialMigrations.Designer.cs
+++ b/Migrations/20250927013023_InitialMigrations.Designer.cs
@@ -682,9 +682,6 @@ namespace ProjectManagement.Migrations
                     b.Property<int>("ProjectId")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ProjectId1")
-                        .HasColumnType("integer");
-
                     b.Property<DateTimeOffset>("TakenAt")
                         .HasColumnType("timestamp with time zone");
 
@@ -693,16 +690,9 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(450)
                         .HasColumnType("character varying(450)");
 
-                    b.Property<string>("TakenByUserId1")
-                        .HasColumnType("text");
-
                     b.HasKey("Id");
 
-                    b.HasIndex("ProjectId1");
-
                     b.HasIndex("TakenByUserId");
-
-                    b.HasIndex("TakenByUserId1");
 
                     b.HasIndex("ProjectId", "TakenAt");
 
@@ -1662,25 +1652,17 @@ namespace ProjectManagement.Migrations
 
             modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshot", b =>
                 {
-                    b.HasOne("ProjectManagement.Models.Project", null)
+                    b.HasOne("ProjectManagement.Models.Project", "Project")
                         .WithMany()
                         .HasForeignKey("ProjectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ProjectManagement.Models.Project", "Project")
-                        .WithMany()
-                        .HasForeignKey("ProjectId1");
-
-                    b.HasOne("ProjectManagement.Models.ApplicationUser", null)
+                    b.HasOne("ProjectManagement.Models.ApplicationUser", "TakenByUser")
                         .WithMany()
                         .HasForeignKey("TakenByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.HasOne("ProjectManagement.Models.ApplicationUser", "TakenByUser")
-                        .WithMany()
-                        .HasForeignKey("TakenByUserId1");
 
                     b.Navigation("Project");
 

--- a/Migrations/20250927013023_InitialMigrations.cs
+++ b/Migrations/20250927013023_InitialMigrations.cs
@@ -603,10 +603,8 @@ namespace ProjectManagement.Migrations
                     Id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     ProjectId = table.Column<int>(type: "integer", nullable: false),
-                    ProjectId1 = table.Column<int>(type: "integer", nullable: true),
                     TakenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    TakenByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
-                    TakenByUserId1 = table.Column<string>(type: "text", nullable: true)
+                    TakenByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -618,21 +616,11 @@ namespace ProjectManagement.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
-                        name: "FK_ProjectPlanSnapshots_AspNetUsers_TakenByUserId1",
-                        column: x => x.TakenByUserId1,
-                        principalTable: "AspNetUsers",
-                        principalColumn: "Id");
-                    table.ForeignKey(
                         name: "FK_ProjectPlanSnapshots_Projects_ProjectId",
                         column: x => x.ProjectId,
                         principalTable: "Projects",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_ProjectPlanSnapshots_Projects_ProjectId1",
-                        column: x => x.ProjectId1,
-                        principalTable: "Projects",
-                        principalColumn: "Id");
                 });
 
             migrationBuilder.CreateTable(
@@ -1168,19 +1156,9 @@ namespace ProjectManagement.Migrations
                 columns: new[] { "ProjectId", "TakenAt" });
 
             migrationBuilder.CreateIndex(
-                name: "IX_ProjectPlanSnapshots_ProjectId1",
-                table: "ProjectPlanSnapshots",
-                column: "ProjectId1");
-
-            migrationBuilder.CreateIndex(
                 name: "IX_ProjectPlanSnapshots_TakenByUserId",
                 table: "ProjectPlanSnapshots",
                 column: "TakenByUserId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_ProjectPlanSnapshots_TakenByUserId1",
-                table: "ProjectPlanSnapshots",
-                column: "TakenByUserId1");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ProjectPncFacts_ProjectId",

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -679,9 +679,6 @@ namespace ProjectManagement.Migrations
                     b.Property<int>("ProjectId")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("ProjectId1")
-                        .HasColumnType("integer");
-
                     b.Property<DateTimeOffset>("TakenAt")
                         .HasColumnType("timestamp with time zone");
 
@@ -690,16 +687,9 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(450)
                         .HasColumnType("character varying(450)");
 
-                    b.Property<string>("TakenByUserId1")
-                        .HasColumnType("text");
-
                     b.HasKey("Id");
 
-                    b.HasIndex("ProjectId1");
-
                     b.HasIndex("TakenByUserId");
-
-                    b.HasIndex("TakenByUserId1");
 
                     b.HasIndex("ProjectId", "TakenAt");
 
@@ -1659,25 +1649,17 @@ namespace ProjectManagement.Migrations
 
             modelBuilder.Entity("ProjectManagement.Models.Plans.ProjectPlanSnapshot", b =>
                 {
-                    b.HasOne("ProjectManagement.Models.Project", null)
+                    b.HasOne("ProjectManagement.Models.Project", "Project")
                         .WithMany()
                         .HasForeignKey("ProjectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ProjectManagement.Models.Project", "Project")
-                        .WithMany()
-                        .HasForeignKey("ProjectId1");
-
-                    b.HasOne("ProjectManagement.Models.ApplicationUser", null)
+                    b.HasOne("ProjectManagement.Models.ApplicationUser", "TakenByUser")
                         .WithMany()
                         .HasForeignKey("TakenByUserId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.HasOne("ProjectManagement.Models.ApplicationUser", "TakenByUser")
-                        .WithMany()
-                        .HasForeignKey("TakenByUserId1");
 
                     b.Navigation("Project");
 


### PR DESCRIPTION
## Summary
- update ProjectPlanSnapshot configuration to reference its navigation properties directly so EF Core does not create duplicate shadow foreign keys
- clean up the initial migration and model snapshot to remove the redundant ProjectId1 and TakenByUserId1 columns and indexes

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d73e6fa94c832986f86b5c679369bb