### PR TITLE
Fix plan approval flow to publish draft timeline

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -166,7 +166,7 @@
             @if (User.IsInRole("Admin") || User.IsInRole("PO") || User.IsInRole("HoD"))
             {
                 <div class="d-flex justify-content-end gap-2">
-                    @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
+                    @if (User.IsInRole("HoD"))
                     {
                         <button class="btn btn-sm btn-outline-primary"
                                 type="button"
@@ -207,7 +207,7 @@
         <div class="offcanvas-body">
             @{
                 ViewBag.ProjectId = Model.Project.Id;
-                var diffs = await Model.PlanCompare.GetDiffAsync(Model.Project.Id);
+                var diffs = await Model.PlanCompare.GetDraftVsCurrentAsync(Model.Project.Id);
                 await Html.RenderPartialAsync("Projects/Timeline/_ReviewPlan", diffs);
             }
         </div>

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -1,50 +1,60 @@
 @model IReadOnlyList<ProjectManagement.Services.Stages.PlanCompareService.PlanDiffRow>
+@using System.Linq
 @using ProjectManagement.Models.Stages
 
-<div class="small text-muted mb-2">
-    @if (Model.Count == 0)
-    {
-        <span>No stages found.</span>
-    }
-    else
-    {
-        <span>Differences vs last approved plan.</span>
-    }
-</div>
+@if (Model is null || Model.Count == 0)
+{
+    <div class="alert alert-secondary">No draft plan found to review.</div>
+    <div class="text-end">
+        <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="offcanvas">Close</button>
+    </div>
+}
+else
+{
+    var hasChanges = Model.Any(row => row.NewStart != row.OldStart || row.NewDue != row.OldDue);
+    <div class="small text-muted mb-2">
+        <span>Draft plan compared against the current timeline.</span>
+    </div>
 
-<div class="table-responsive">
-    <table class="table table-sm align-middle">
-        <thead>
-            <tr>
-                <th>Stage</th>
-                <th class="text-center">Approved</th>
-                <th class="text-center">Current</th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var row in Model)
-        {
-            var changed = row.OldStart != row.NewStart || row.OldDue != row.NewDue;
-            <tr class="@(changed ? "table-warning" : string.Empty)">
-                <td>
-                    <span class="fw-semibold">@StageCodes.DisplayNameOf(row.Code)</span>
-                    <div class="text-muted small">@row.Code</div>
-                </td>
-                <td class="text-center">
-                    @((row.OldStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.OldDue?.ToString("yyyy-MM-dd") ?? "—"))
-                </td>
-                <td class="text-center">
-                    @((row.NewStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.NewDue?.ToString("yyyy-MM-dd") ?? "—"))
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
-</div>
+    @if (!hasChanges)
+    {
+        <div class="alert alert-info">The draft plan matches the current timeline.</div>
+    }
 
-<form method="post" asp-page="/Projects/Timeline/Review" asp-route-id="@ViewBag.ProjectId" class="d-flex gap-2 justify-content-end mt-3">
-    @Html.AntiForgeryToken()
-    <input type="hidden" name="Input.ProjectId" value="@ViewBag.ProjectId" />
-    <button name="Input.Decision" value="Reject" class="btn btn-outline-secondary">Reject</button>
-    <button name="Input.Decision" value="Approve" class="btn btn-primary">Approve plan</button>
-</form>
+    <div class="table-responsive">
+        <table class="table table-sm align-middle">
+            <thead>
+                <tr>
+                    <th>Stage</th>
+                    <th class="text-center">Current timeline</th>
+                    <th class="text-center">Draft plan</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var row in Model)
+            {
+                var changed = row.OldStart != row.NewStart || row.OldDue != row.NewDue;
+                <tr class="@(changed ? "table-warning" : "table-secondary")">
+                    <td>
+                        <span class="fw-semibold">@StageCodes.DisplayNameOf(row.Code)</span>
+                        <div class="text-muted small">@row.Code</div>
+                    </td>
+                    <td class="text-center">
+                        @((row.OldStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.OldDue?.ToString("yyyy-MM-dd") ?? "—"))
+                    </td>
+                    <td class="text-center">
+                        @((row.NewStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.NewDue?.ToString("yyyy-MM-dd") ?? "—"))
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+
+    <form method="post" asp-page="/Projects/Timeline/Review" asp-route-id="@ViewBag.ProjectId" class="d-flex gap-2 justify-content-end mt-3">
+        @Html.AntiForgeryToken()
+        <input type="hidden" name="Input.ProjectId" value="@ViewBag.ProjectId" />
+        <button name="Input.Decision" value="Reject" class="btn btn-outline-secondary">Reject</button>
+        <button name="Input.Decision" value="Approve" class="btn btn-primary" @(hasChanges ? null : "disabled")>Approve plan</button>
+    </form>
+}


### PR DESCRIPTION
## Summary
- show draft versus current plan details in the review off-canvas and disable approval when nothing changed
- publish the most recent draft into project stages, snapshot it, and stamp the project when approving
- restrict the plan review UI and endpoint to HoD users and improve approval error handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d74cf1e6e883298c14280a6f24ac6a