### PR TITLE
Align timeline plan editing permissions with role names

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -163,7 +163,7 @@
             </div>
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">
-            @if (User.IsInRole("Admin") || User.IsInRole("PO") || User.IsInRole("HoD"))
+            @if (User.IsInRole("HoD") || User.IsInRole("Project Officer"))
             {
                 <div class="d-flex justify-content-end gap-2">
                     @if (User.IsInRole("HoD"))

--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -19,7 +19,7 @@ using ProjectManagement.ViewModels;
 
 namespace ProjectManagement.Pages.Projects.Timeline;
 
-[Authorize(Roles = "Admin,HoD,PO")]
+[Authorize(Roles = "HoD,Project Officer")]
 [ValidateAntiForgeryToken]
 public class EditPlanModel : PageModel
 {


### PR DESCRIPTION
## Summary
- allow timeline editing only for HoD and Project Officer roles by correcting the authorization attribute
- update the overview page UI logic to show the edit timeline button to HoD or Project Officer users

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d751e70a7883298df4a64c24dd35e8