### PR TITLE
Keep project timeline edits in draft until approval

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -207,6 +207,7 @@
         <div class="offcanvas-body">
             @{
                 ViewBag.ProjectId = Model.Project.Id;
+                ViewBag.HasBackfill = Model.HasBackfill;
                 var diffs = await Model.PlanCompare.GetDraftVsCurrentAsync(Model.Project.Id);
                 await Html.RenderPartialAsync("Projects/Timeline/_ReviewPlan", diffs);
             }

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -12,9 +12,15 @@
 else
 {
     var hasChanges = Model.Any(row => row.NewStart != row.OldStart || row.NewDue != row.OldDue);
+    var requiresBackfill = ViewBag.HasBackfill is bool hb && hb;
     <div class="small text-muted mb-2">
         <span>Draft plan compared against the current timeline.</span>
     </div>
+
+    if (requiresBackfill)
+    {
+        <div class="alert alert-warning">Backfill required data before approval.</div>
+    }
 
     @if (!hasChanges)
     {
@@ -55,6 +61,6 @@ else
         @Html.AntiForgeryToken()
         <input type="hidden" name="Input.ProjectId" value="@ViewBag.ProjectId" />
         <button name="Input.Decision" value="Reject" class="btn btn-outline-secondary">Reject</button>
-        <button name="Input.Decision" value="Approve" class="btn btn-primary" @(hasChanges ? null : "disabled")>Approve plan</button>
+        <button name="Input.Decision" value="Approve" class="btn btn-primary" @((hasChanges && !requiresBackfill) ? null : "disabled")>Approve plan</button>
     </form>
 }

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -16,9 +16,9 @@
   <div class="card-header d-flex align-items-center justify-content-between">
     <div class="fw-semibold d-flex align-items-center gap-2">
       <span>Timeline</span>
-      @if (Model.PlanPendingApproval && (User.IsInRole("HoD") || User.IsInRole("Admin")))
+      @if (Model.PlanPendingApproval)
       {
-        <span class="badge text-bg-warning">Pending approval</span>
+        <span class="badge text-bg-warning">Draft pending approval</span>
       }
     </div>
     <div class="d-flex align-items-center gap-2">

--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -61,6 +61,9 @@ public class PlanApprovalService
         _logger.LogInformation("Plan version {PlanVersionId} for project {ProjectId} submitted for approval by {UserId}.", plan.Id, projectId, userId);
     }
 
+    public Task SubmitForApprovalAsync(int projectId, string userId, CancellationToken cancellationToken = default)
+        => SubmitAsync(projectId, userId, cancellationToken);
+
     public async Task<bool> ApproveLatestDraftAsync(int projectId, string approverUserId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(approverUserId))


### PR DESCRIPTION
## Summary
- keep PO timeline edits in draft plan versions and submit them for approval instead of updating live project stages
- add draft-aware plan generation and editing so recalculations write to StagePlans and reuse pending drafts
- expose draft status in the UI, including disabling approvals when backfill is required

## Testing
- dotnet build *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d759bf3f0c8329b138187df890d703