### PR TITLE
Add access denied page for identity area

### DIFF
--- a/Areas/Identity/Pages/Account/AccessDenied.cshtml
+++ b/Areas/Identity/Pages/Account/AccessDenied.cshtml
@@ -1,0 +1,21 @@
+@page
+@model ProjectManagement.Areas.Identity.Pages.Account.AccessDeniedModel
+@{
+    ViewData["Title"] = "Access denied";
+}
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+            <div class="card shadow-sm">
+                <div class="card-body text-center">
+                    <h1 class="h4 mb-3">Access denied</h1>
+                    <p class="text-muted mb-4">
+                        You don't have permission to view this resource. If you believe this is an error, please contact your administrator.
+                    </p>
+                    <a class="btn btn-primary" asp-page="/Index">Return to dashboard</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
+++ b/Areas/Identity/Pages/Account/AccessDenied.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Areas.Identity.Pages.Account;
+
+public class AccessDeniedModel : PageModel
+{
+    public void OnGet()
+    {
+        Response.StatusCode = StatusCodes.Status403Forbidden;
+    }
+}


### PR DESCRIPTION
## Summary
- add an Identity access denied Razor Page to handle authorization failures gracefully
- set the response status code to 403 so the page is correctly reported to clients

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d762c9ea70832982deb7753746c48f