### PR TITLE
Clarify rejection messaging for plan review

### DIFF
--- a/Pages/Projects/Timeline/Review.cshtml.cs
+++ b/Pages/Projects/Timeline/Review.cshtml.cs
@@ -98,7 +98,7 @@ public class ReviewModel : PageModel
                 }
                 else
                 {
-                    TempData["Error"] = "No pending draft to reject.";
+                    TempData["Error"] = "No pending draft found to reject.";
                     TempData["OpenOffcanvas"] = "plan-review";
                     _logger.LogWarning("Plan rejection attempted for project {ProjectId} by user {UserId}, but no draft was available.", id, userId);
                 }


### PR DESCRIPTION
## Summary
- ensure the rejection flow reports when no pending draft exists and keeps the review pane open

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7928be69483298f4a28eb24c6e985