### PR TITLE
Harden timeline approval and review flow

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -14,7 +14,11 @@
         string.Equals(Model.Project?.LeadPoUserId, Model.CurrentUserId, StringComparison.Ordinal);
     var planState = Model.PlanEdit?.State ?? new PlanEditorStateVm();
     var planLocked = planState.IsLocked;
-    var canEditPlan = (isAdmin || isThisProjectsPo) && !planLocked;
+    var canEditPlan = (isAdmin || isThisProjectsPo) && !planLocked && !Model.Timeline.PlanPendingApproval;
+    var completedStages = Model.Timeline.CompletedCount;
+    var totalStages = Model.Timeline.TotalStages;
+    var progressPercent = totalStages == 0 ? 0 : (completedStages * 100 / totalStages);
+    var showTimelineActions = isHoD || canEditPlan;
     ViewData["Title"] = pageTitle;
 }
 
@@ -35,27 +39,6 @@
                     <small class="text-muted">(@project?.CaseFileNumber)</small>
                 }
             </h1>
-            <div class="d-flex flex-wrap gap-2 mt-2">
-                @if (Model.HasBackfill)
-                {
-                    <a class="badge rounded-pill text-bg-warning text-decoration-none"
-                       asp-page="/Projects/Procurement/Edit"
-                       asp-route-id="@Model.Project!.Id">
-                        Backfill required
-                    </a>
-                }
-                @if (Model.Timeline.PlanPendingApproval)
-                {
-                    <span class="badge rounded-pill text-bg-warning">Draft pending approval</span>
-                }
-                @if (project?.PlanApprovedAt is DateTimeOffset approvedAt)
-                {
-                    var approvedBy = DisplayUser(project.PlanApprovedByUser);
-                    <span class="badge rounded-pill text-bg-success">
-                        Approved on @approvedAt.ToString("dd MMM yyyy") by @approvedBy
-                    </span>
-                }
-            </div>
             <div class="text-muted">Created on @(project is { } p ? p.CreatedAt.ToString("dd MMM yyyy") : "—")</div>
         </div>
         <partial name="_AssignRolesOffcanvas" model="Model.AssignRoles" />
@@ -195,32 +178,69 @@
             </div>
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">
-            @if (isHoD || canEditPlan)
-            {
-                <div class="d-flex justify-content-end gap-2">
-                    @if (isHoD)
-                    {
-                        <button class="btn btn-sm btn-outline-primary"
-                                type="button"
-                                data-bs-toggle="offcanvas"
-                                data-bs-target="#offcanvasPlanReview"
-                                aria-controls="offcanvasPlanReview">
-                            Review &amp; approve
-                        </button>
-                    }
-                    @if (canEditPlan)
-                    {
-                        <button class="btn btn-sm btn-outline-primary"
-                                type="button"
-                                data-bs-toggle="offcanvas"
-                                data-bs-target="#offcanvasPlanEdit"
-                                aria-controls="offcanvasPlanEdit">
-                            Edit timeline
-                        </button>
-                    }
+            <div class="card">
+                <div class="card-header">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                        <div class="d-flex flex-wrap align-items-center gap-2">
+                            <h5 class="mb-0">Timeline</h5>
+                            <div class="d-flex flex-wrap align-items-center gap-2">
+                                @if (Model.Timeline.PlanPendingApproval)
+                                {
+                                    <span class="badge text-bg-warning">Draft pending approval</span>
+                                }
+                                @if (Model.HasBackfill)
+                                {
+                                    <span class="badge text-bg-secondary" title="Resolve procurement backfill to proceed">Backfill required</span>
+                                }
+                                @if (project?.PlanApprovedAt is DateTimeOffset approvedAt)
+                                {
+                                    <span class="badge text-bg-success">Approved on @approvedAt.ToLocalTime().ToString("dd MMM yyyy")</span>
+                                }
+                            </div>
+                        </div>
+                        <div class="d-flex flex-wrap align-items-center gap-2 justify-content-end">
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="progress" style="width: 180px" aria-label="Stages completed">
+                                    <div class="progress-bar" role="progressbar"
+                                         style="width:@progressPercent%"
+                                         aria-valuenow="@completedStages"
+                                         aria-valuemin="0"
+                                         aria-valuemax="@totalStages"></div>
+                                </div>
+                                <span class="text-muted small">@completedStages of @totalStages</span>
+                            </div>
+                            @if (showTimelineActions)
+                            {
+                                <div class="d-flex gap-2">
+                                    @if (isHoD)
+                                    {
+                                        <button class="btn btn-sm btn-outline-primary"
+                                                type="button"
+                                                data-bs-toggle="offcanvas"
+                                                data-bs-target="#offcanvasPlanReview"
+                                                aria-controls="offcanvasPlanReview">
+                                            Review &amp; approve
+                                        </button>
+                                    }
+                                    @if (canEditPlan)
+                                    {
+                                        <button class="btn btn-sm btn-outline-primary"
+                                                type="button"
+                                                data-bs-toggle="offcanvas"
+                                                data-bs-target="#offcanvasPlanEdit"
+                                                aria-controls="offcanvasPlanEdit">
+                                            Edit timeline
+                                        </button>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    </div>
                 </div>
-            }
-            <partial name="_ProjectTimeline" model="Model.Timeline" />
+                <div class="card-body">
+                    <partial name="_ProjectTimeline" model="Model.Timeline" />
+                </div>
+            </div>
         </div>
     </div>
 

--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -88,6 +88,15 @@ public class EditPlanModel : PageModel
             return Forbid();
         }
 
+        var hasPending = await _db.PlanVersions
+            .AnyAsync(v => v.ProjectId == id && v.Status == PlanVersionStatus.PendingApproval, cancellationToken);
+
+        if (hasPending)
+        {
+            TempData["Error"] = "This plan is awaiting HoD review. You can’t edit until it’s approved or rejected.";
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+
         if (string.Equals(Input.Mode, PlanEditorModes.Durations, StringComparison.OrdinalIgnoreCase))
         {
             return await HandleDurationsAsync(id, userId, cancellationToken);

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -38,12 +38,12 @@ else
     }
     else if (requiresBackfill)
     {
-        <div class="alert alert-warning">Backfill required data before approval.</div>
+        <div class="alert alert-warning">Resolve required procurement backfill before approval.</div>
     }
 
     @if (!hasChanges)
     {
-        <div class="alert alert-info">The draft plan matches the current timeline.</div>
+        <div class="alert alert-info">No differences between the current timeline and this draft. You can still approve to stamp the plan.</div>
     }
 
     <div class="table-responsive">

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -12,67 +12,43 @@
 }
 <link rel="stylesheet" href="~/css/projects/timeline.css" />
 
-<div class="card">
-  <div class="card-header d-flex align-items-center justify-content-between">
-    <div class="fw-semibold d-flex align-items-center gap-2">
-      <span>Timeline</span>
-      @if (Model.PlanPendingApproval)
-      {
-        <span class="badge text-bg-warning">Draft pending approval</span>
-      }
-    </div>
-    <div class="d-flex align-items-center gap-2">
-      <div class="progress" style="width:180px" aria-label="Stages completed">
-        <div class="progress-bar" role="progressbar"
-             style="width:@(Model.TotalStages == 0 ? 0 : (Model.CompletedCount * 100 / Model.TotalStages))%"
-             aria-valuenow="@(Model.CompletedCount)"
-             aria-valuemin="0"
-             aria-valuemax="@(Model.TotalStages)"></div>
-      </div>
-      <span class="text-muted small">@Model.CompletedCount of @Model.TotalStages</span>
-    </div>
+<div class="pm-timeline-grid">
+  <div class="pm-rail" aria-hidden="true">
+    <div class="pm-rail-line"></div>
   </div>
-
-  <div class="card-body py-4">
-    <div class="pm-timeline-grid">
-      <div class="pm-rail" aria-hidden="true">
-        <div class="pm-rail-line"></div>
-      </div>
-      <div class="pm-items">
-        @foreach (var s in Model.Items.OrderBy(i => i.SortOrder))
-        {
-          var itemClass = s.Status switch
+  <div class="pm-items">
+    @foreach (var s in Model.Items.OrderBy(i => i.SortOrder))
+    {
+      var itemClass = s.Status switch
+      {
+        StageStatus.Completed  => "pm-item is-complete",
+        StageStatus.InProgress => "pm-item is-active",
+        _                      => "pm-item"
+      };
+      <div class="@itemClass">
+        <div class="pm-item-header">
+          <span class="pm-item-title">@s.Name</span>
+          <span class="@StatusChip(s.Status)">@s.Status</span>
+          @if (s.IsAutoCompleted)
           {
-            StageStatus.Completed  => "pm-item is-complete",
-            StageStatus.InProgress => "pm-item is-active",
-            _                      => "pm-item"
-          };
-          <div class="@itemClass">
-            <div class="pm-item-header">
-              <span class="pm-item-title">@s.Name</span>
-              <span class="@StatusChip(s.Status)">@s.Status</span>
-              @if (s.IsAutoCompleted)
-              {
-                <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
-              }
-              @if (s.RequiresBackfill)
-              {
-                <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
-                <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
-              }
-            </div>
-            <div class="pm-item-meta">
-              <div>Planned: @D(s.PlannedStart) — @D(s.PlannedEnd)</div>
-              <div>Actual: @D(s.ActualStart) — @D(s.CompletedOn)
-                @if (s.ActualDurationDays.HasValue)
-                {
-                  <span class="text-muted ms-2">(@s.ActualDurationDays d)</span>
-                }
-              </div>
-            </div>
+            <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
+          }
+          @if (s.RequiresBackfill)
+          {
+            <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
+            <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
+          }
+        </div>
+        <div class="pm-item-meta">
+          <div>Planned: @D(s.PlannedStart) — @D(s.PlannedEnd)</div>
+          <div>Actual: @D(s.ActualStart) — @D(s.CompletedOn)
+            @if (s.ActualDurationDays.HasValue)
+            {
+              <span class="text-muted ms-2">(@s.ActualDurationDays d)</span>
+            }
           </div>
-        }
+        </div>
       </div>
-    </div>
+    }
   </div>
 </div>

--- a/Services/Stages/PlanCompareService.cs
+++ b/Services/Stages/PlanCompareService.cs
@@ -82,17 +82,7 @@ public sealed class PlanCompareService
 
         if (draft is null)
         {
-            draft = await _db.PlanVersions
-                .AsNoTracking()
-                .Include(v => v.StagePlans)
-                .Where(v => v.ProjectId == projectId)
-                .OrderByDescending(v => v.VersionNo)
-                .FirstOrDefaultAsync(ct);
-
-            if (draft is null)
-            {
-                return Array.Empty<PlanDiffRow>();
-            }
+            return Array.Empty<PlanDiffRow>();
         }
 
         var draftLookup = draft.StagePlans
@@ -114,7 +104,7 @@ public sealed class PlanCompareService
             .OrderBy(code =>
             {
                 var index = Array.IndexOf(StageCodes.All, code);
-                return index >= 0 ? index : int.MaxValue;
+                return index < 0 ? int.MaxValue : index;
             })
             .ThenBy(code => code, StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,0 +1,73 @@
+# Timeline pipeline
+
+This document summarizes how timeline planning works after the latest updates.
+
+## Roles
+
+| Role | Capabilities |
+| --- | --- |
+| Project Officer | Edit timelines for assigned projects, save drafts, submit for approval. |
+| Head of Department (HoD) | Review drafts, approve or reject timelines. |
+| Admin | Can edit any project timeline and view approvals. |
+| Viewer | Read-only access. |
+
+## Plan states
+
+Timeline plans transition through these states:
+
+1. **Draft** – Created or edited by the Project Officer. Stored in `PlanVersions` and `StagePlans`.
+2. **PendingApproval** – Set when the Project Officer requests HoD approval. Editing is locked until approval or rejection.
+3. **Approved** – Set by the HoD. Copies plan data into `ProjectStages`, stamps the project with approval metadata, and creates a snapshot.
+4. **Rejected** – Stored in `PlanVersions` via `RejectedOn`, `RejectedByUserId`, and `RejectionNote`. Status reverts to `Draft` so the Project Officer can continue editing.
+
+Only one open plan (Draft or PendingApproval) exists per project.
+
+## Pages
+
+- **Projects / Overview**
+  - Shows current `ProjectStages` timeline.
+  - Displays badges for Pending Approval, Backfill Required, and Approved dates.
+  - Provides Review and Edit buttons depending on role and state.
+- **Timeline Edit (Project Officer)**
+  - Supports duration-based generation and exact date editing.
+  - “Save & request approval” submits to the HoD after validation.
+- **Timeline Review (HoD)**
+  - Shows draft vs. current differences.
+  - Approve always stamps and snapshots, even if no changes.
+  - Reject returns the draft to the Project Officer with optional notes.
+
+## Key behaviors
+
+- Pending approval locks Project Officer editing both in the UI and server-side.
+- Approval publishes draft stage dates into `ProjectStages`, captures a snapshot, and records approval metadata on the project and plan.
+- Rejection leaves the draft editable and records who rejected and why.
+- Approvals are allowed even when there are no date differences.
+- Backfill requirements block approval until resolved.
+- All forms use anti-forgery tokens; role checks are enforced on GET and POST.
+
+## Data and auditing
+
+- Draft plan data lives in `PlanVersions` and related `StagePlans` rows.
+- Live timeline uses `ProjectStages`.
+- Snapshots are stored in `ProjectPlanSnapshots` and rows.
+- Approval events are logged via `_logger` in `PlanApprovalService` and tracked with timestamps on the plan and project.
+
+## QA checklist
+
+1. **Project Officer (assigned)**
+   - Save draft via durations or exact dates.
+   - Submit for approval; verify pending badge and edit button hidden.
+2. **HoD approval**
+   - Approve draft with and without date differences.
+   - Confirm snapshot exists and approval badge shows date.
+3. **HoD rejection**
+   - Reject draft with and without notes.
+   - Verify flash message and that Project Officer can edit again.
+4. **Backfill guard**
+   - With unresolved backfill, approval button disabled and server returns friendly error.
+5. **Unauthorized editing**
+   - Non-assigned Project Officer receives 403 on POST.
+6. **Pending lock enforcement**
+   - Attempting to edit while pending shows friendly error toast.
+7. **Audit/logging**
+   - Review logs for approval/rejection entries.


### PR DESCRIPTION
## Summary
- lock timeline editing when a plan is pending approval and enforce role checks on the edit/review endpoints
- refresh the overview timeline card with badges, progress, and clearer HoD actions while surfacing plan review messaging
- ensure plan approvals publish the latest draft, improve diff retrieval, and document the end-to-end timeline workflow

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a5b0b0288329bd6b5354bfc6e2c1