### PR TITLE
Fix review plan partial lookup

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -263,17 +263,7 @@
                 ViewBag.HasBackfill = Model.HasBackfill;
                 ViewBag.PlanState = planState;
                 var diffs = await Model.PlanCompare.GetDraftVsCurrentAsync(Model.Project!.Id);
-                if (diffs == null || diffs.Count == 0)
-                {
-                    <div class="alert alert-secondary">No draft plan found to review.</div>
-                    <div class="text-end">
-                        <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="offcanvas">Close</button>
-                    </div>
-                }
-                else
-                {
-                    await Html.RenderPartialAsync("/Pages/Projects/Timeline/_ReviewPlan", diffs);
-                }
+                await Html.RenderPartialAsync("~/Pages/Projects/Timeline/_ReviewPlan.cshtml", diffs ?? Array.Empty<ProjectManagement.Services.Stages.PlanDiffRow>());
             }
         </div>
     </div>


### PR DESCRIPTION
## Summary
- render the plan review offcanvas using an absolute Razor path to the shared partial
- default to an empty diff list so the partial can handle the no-draft scenario

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b393126c832982f17a24375f511f