### PR TITLE
Improve timeline draft visibility and feedback

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -110,6 +110,26 @@
         </div>
     }
 
+    @if (Model.Timeline.PlanPendingApproval)
+    {
+        <div class="alert alert-info d-flex align-items-center justify-content-between" role="alert">
+            <div>
+                <strong>Timeline plan awaiting HoD review.</strong>
+                <span class="ms-1">The latest draft has been submitted for approval.</span>
+            </div>
+            @if (isHoD)
+            {
+                <button class="btn btn-sm btn-primary"
+                        type="button"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#offcanvasPlanReview"
+                        aria-controls="offcanvasPlanReview">
+                    Review &amp; approve
+                </button>
+            }
+        </div>
+    }
+
     <div class="row g-3 mb-4">
         <div class="col-lg-8 d-flex flex-column gap-3">
             <div class="card">
@@ -188,6 +208,10 @@
                                     {
                                         <span class="badge text-bg-warning">Draft pending approval</span>
                                     }
+                                    else if (Model.Timeline.HasDraft)
+                                    {
+                                        <span class="badge text-bg-secondary">Draft saved (not submitted)</span>
+                                    }
                                     @if (Model.HasBackfill)
                                     {
                                         <span class="badge text-bg-secondary" title="Resolve procurement backfill to proceed">Backfill required</span>
@@ -199,7 +223,7 @@
                                 </div>
                             </div>
                             <div class="d-flex align-items-center gap-2">
-                                @if (isHoD)
+                                @if (Model.Timeline.PlanPendingApproval && isHoD)
                                 {
                                     <button class="btn btn-sm btn-outline-primary"
                                             type="button"
@@ -209,7 +233,17 @@
                                         Review &amp; approve
                                     </button>
                                 }
-                                @if (canEditTimeline)
+                                else if (Model.Timeline.HasDraft && !Model.Timeline.PlanPendingApproval && canEditTimeline)
+                                {
+                                    <button class="btn btn-sm btn-outline-secondary"
+                                            type="button"
+                                            data-bs-toggle="offcanvas"
+                                            data-bs-target="#offcanvasPlanEdit"
+                                            aria-controls="offcanvasPlanEdit">
+                                        Resume draft
+                                    </button>
+                                }
+                                @if (canEditTimeline && !(Model.Timeline.HasDraft && !Model.Timeline.PlanPendingApproval))
                                 {
                                     <button class="btn btn-sm btn-outline-primary"
                                             type="button"

--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -240,15 +240,20 @@ public class EditPlanModel : PageModel
                 return RedirectToPage("/Projects/Overview", new { id });
             }
 
-            TempData["Flash"] = "Draft submitted for approval.";
-        }
-        else if (changes.Count > 0)
-        {
-            TempData["Flash"] = "Timeline saved as draft.";
+            TempData["Flash"] = "Plan submitted for HoD review.";
         }
         else
         {
-            TempData["Flash"] = "No changes were made.";
+            TempData["OpenOffcanvas"] = "plan-edit";
+
+            if (changes.Count > 0)
+            {
+                TempData["Flash"] = "Draft saved.";
+            }
+            else
+            {
+                TempData["Flash"] = "Draft saved. No changes detected.";
+            }
         }
 
         return RedirectToPage("/Projects/Overview", new { id });
@@ -398,15 +403,24 @@ public class EditPlanModel : PageModel
 
         if (submitForApproval)
         {
-            TempData["Flash"] = "Draft submitted for approval.";
-        }
-        else if (saveDraft)
-        {
-            TempData["Flash"] = "Timeline saved as draft.";
+            TempData["Flash"] = "Plan submitted for HoD review.";
         }
         else
         {
-            TempData["Flash"] = "Timeline recalculated as draft.";
+            TempData["OpenOffcanvas"] = "plan-edit";
+
+            if (saveDraft)
+            {
+                TempData["Flash"] = "Draft saved.";
+            }
+            else if (calculateOnly)
+            {
+                TempData["Flash"] = "Draft recalculated.";
+            }
+            else
+            {
+                TempData["Flash"] = "Draft updated.";
+            }
         }
 
         return RedirectToPage("/Projects/Overview", new { id });

--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -1,4 +1,5 @@
 @model ProjectManagement.ViewModels.PlanEditorVm
+@using ProjectManagement.Models.Plans
 @using ProjectManagement.ViewModels
 @{
     var activeMode = Model.ActiveMode ?? PlanEditorModes.Exact;
@@ -41,6 +42,14 @@
             {
                 <div class="mt-2">Note: @state.RejectionNote</div>
             }
+        </div>
+    }
+
+    @if (!isLocked && state.RejectedOn is null && state.HasDraft && state.Status == PlanVersionStatus.Draft)
+    {
+        <div class="alert alert-secondary mb-3" role="status">
+            <div class="fw-semibold">Draft saved</div>
+            <div class="small text-muted">You can continue editing or submit for approval when ready.</div>
         </div>
     }
 


### PR DESCRIPTION
## Summary
- surface pending approval and saved draft states prominently on the project overview timeline card
- add a draft status banner inside the timeline edit offcanvas so project officers know they are editing a draft
- standardise flash messaging after save/submit actions and reopen the editor when keeping a draft in progress

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7da933a788329a6a03a53c1e84f03