### PR TITLE
Align timeline and procurement role names

### DIFF
--- a/Pages/Projects/Procurement/Edit.cshtml
+++ b/Pages/Projects/Procurement/Edit.cshtml
@@ -1,5 +1,5 @@
 @page "{id:int}"
-@attribute [Authorize(Roles = "Admin,HoD,PO")]
+@attribute [Authorize(Roles = "Admin,HoD,Project Officer")]
 @model ProjectManagement.Pages.Projects.Procurement.EditModel
 @{
     Layout = null;

--- a/Pages/Projects/Procurement/Edit.cshtml.cs
+++ b/Pages/Projects/Procurement/Edit.cshtml.cs
@@ -15,7 +15,7 @@ using ProjectManagement.ViewModels;
 
 namespace ProjectManagement.Pages.Projects.Procurement
 {
-    [Authorize(Roles = "Admin,HoD,PO")]
+    [Authorize(Roles = "Admin,HoD,Project Officer")]
     [ValidateAntiForgeryToken]
     public class EditModel : PageModel
     {

--- a/Pages/Projects/Timeline/EditPlan.cshtml
+++ b/Pages/Projects/Timeline/EditPlan.cshtml
@@ -1,5 +1,5 @@
 @page "{id:int}"
-@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,HoD,PO")]
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,Project Officer")]
 @model ProjectManagement.Pages.Projects.Timeline.EditPlanModel
 @{
     Layout = null;

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -30,7 +30,7 @@
       <i class="bi bi-receipt me-2" aria-hidden="true"></i>
       <span class="fw-semibold">Procurement At-a-Glance</span>
     </div>
-    @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("PO"))
+    @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("Project Officer"))
     {
       <button class="btn btn-sm btn-outline-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasProcurement" aria-controls="offcanvasProcurement">
         Edit Procurement


### PR DESCRIPTION
## Summary
- align the timeline edit page authorization attribute with the defined "Project Officer" role name so it matches the page model
- update procurement edit authorization and UI logic to use the explicit "Project Officer" role name instead of the PO abbreviation

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ea08ab1883298943c2da66b1074f