### PR TITLE
Allow HoDs to edit project timelines

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -12,9 +12,12 @@
     var isProjectOfficer = User.IsInRole("Project Officer");
     var isThisProjectsPo = isProjectOfficer &&
         string.Equals(Model.Project?.LeadPoUserId, Model.CurrentUserId, StringComparison.Ordinal);
+    var isThisProjectsHod = isHoD &&
+        string.Equals(Model.Project?.HodUserId, Model.CurrentUserId, StringComparison.Ordinal);
     var planState = Model.PlanEdit?.State ?? new PlanEditorStateVm();
     var planLocked = planState.IsLocked;
-    var canEditTimeline = (isAdmin || isThisProjectsPo) && !Model.Timeline.PlanPendingApproval && !planLocked;
+    var canEditTimeline = (isAdmin || isThisProjectsPo || isThisProjectsHod) &&
+        !Model.Timeline.PlanPendingApproval && !planLocked;
     var completedStages = Model.Timeline.CompletedCount;
     var totalStages = Model.Timeline.TotalStages;
     var progressPercent = totalStages == 0 ? 0 : (completedStages * 100 / totalStages);

--- a/Pages/Projects/Timeline/EditPlan.cshtml
+++ b/Pages/Projects/Timeline/EditPlan.cshtml
@@ -1,5 +1,5 @@
 @page "{id:int}"
-@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,Project Officer")]
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Admin,Project Officer,HoD")]
 @model ProjectManagement.Pages.Projects.Timeline.EditPlanModel
 @{
     Layout = null;

--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -22,7 +22,7 @@ using ProjectManagement.ViewModels;
 
 namespace ProjectManagement.Pages.Projects.Timeline;
 
-[Authorize(Roles = "Admin,Project Officer")]
+[Authorize(Roles = "Admin,Project Officer,HoD")]
 [ValidateAntiForgeryToken]
 public class EditPlanModel : PageModel
 {
@@ -73,6 +73,7 @@ public class EditPlanModel : PageModel
         }
 
         var isAdmin = User.IsInRole("Admin");
+        var isHoD = User.IsInRole("HoD");
 
         var project = await _db.Projects
             .AsNoTracking()
@@ -83,7 +84,10 @@ public class EditPlanModel : PageModel
             return NotFound();
         }
 
-        if (!isAdmin && !string.Equals(project.LeadPoUserId, userId, StringComparison.Ordinal))
+        var isProjectsHod = isHoD && string.Equals(project.HodUserId, userId, StringComparison.Ordinal);
+        var isProjectsPo = string.Equals(project.LeadPoUserId, userId, StringComparison.Ordinal);
+
+        if (!isAdmin && !isProjectsPo && !isProjectsHod)
         {
             _logger.LogWarning("User {UserId} attempted to edit plan for project {ProjectId} without permission.", userId, id);
             return Forbid();


### PR DESCRIPTION
## Summary
- allow the assigned HoD to open the project timeline editor alongside admins and project officers
- relax the page checks so the HoD for the project can submit timeline updates

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f0c8f9bc8329b2838be683208bc1