### PR TITLE
Ensure consistent dd MMM yyyy date displays

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml
@@ -42,7 +42,7 @@
 
   <div style="position:relative; height:240px;">
     <canvas id="loginsPerDayChart"
-            data-labels='@JsonSerializer.Serialize(Model.LoginsPerDay.Select(x => x.Date.ToString("yyyy-MM-dd")))'
+            data-labels='@JsonSerializer.Serialize(Model.LoginsPerDay.Select(x => x.Date.ToString("dd MMM yyyy")))'
             data-values='@JsonSerializer.Serialize(Model.LoginsPerDay.Select(x => x.Count))'>
     </canvas>
   </div>

--- a/Areas/Admin/Pages/Logs/Index.cshtml
+++ b/Areas/Admin/Pages/Logs/Index.cshtml
@@ -142,7 +142,7 @@
     @foreach (var r in Model.Rows)
     {
       <tr>
-        <td class="text-nowrap">@IstClock.ToIst(r.TimeUtc).ToString("yyyy-MM-dd HH:mm")</td>
+        <td class="text-nowrap">@IstClock.ToIst(r.TimeUtc).ToString("dd MMM yyyy HH:mm")</td>
         <td>
           <span class="badge bg-@LevelColor(r.Level)">@r.Level</span>
         </td>

--- a/Areas/Admin/Pages/Logs/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Logs/Index.cshtml.cs
@@ -6,6 +6,7 @@ using ProjectManagement.Data;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Models;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 
@@ -91,7 +92,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Logs
                 .OrderBy(x => x.Day)
                 .ToListAsync();
 
-            SeriesLabels = perDay.Select(d => d.Day.ToString("yyyy-MM-dd")).ToList();
+            SeriesLabels = perDay.Select(d => d.Day.ToString("dd MMM yyyy", CultureInfo.InvariantCulture)).ToList();
             SeriesCounts = perDay.Select(d => d.Count).ToList();
 
             return Page();
@@ -110,7 +111,7 @@ namespace ProjectManagement.Areas.Admin.Pages.Logs
 
             foreach (var x in rows)
             {
-                var tIst = IstClock.ToIst(x.TimeUtc).ToString("yyyy-MM-dd HH:mm:ss");
+                var tIst = IstClock.ToIst(x.TimeUtc).ToString("dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
                 sb.AppendLine(string.Join(",", new[]
                 {
                     Csv(tIst), Csv(x.Level), Csv(x.Action), Csv(x.UserName), Csv(x.Ip),

--- a/Helpers/TodoViewHelpers.cs
+++ b/Helpers/TodoViewHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Helpers
@@ -16,7 +17,7 @@ namespace ProjectManagement.Helpers
             if (dueLocal < nowLocal) return "Overdue";
             if (dueLocal < endOfTodayLocal) return "Today";
             if (dueLocal < endOfTodayLocal.AddDays(1)) return "Tomorrow";
-            return dueLocal.ToString("dd-MMM");
+            return dueLocal.ToString("dd MMM yyyy", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Infrastructure/TimeFmt.cs
+++ b/Infrastructure/TimeFmt.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Globalization;
 
 namespace ProjectManagement.Infrastructure
 {
     public static class TimeFmt
     {
         public static string ToIst(DateTime? dt) =>
-            dt is null ? "—" : IstClock.ToIst(dt.Value).ToString("dd MMM yyyy, HH:mm");
+            dt is null ? "—" : IstClock.ToIst(dt.Value).ToString("dd MMM yyyy, HH:mm", CultureInfo.InvariantCulture);
     }
 }

--- a/Pages/Celebrations/Index.cshtml
+++ b/Pages/Celebrations/Index.cshtml
@@ -105,7 +105,7 @@
         <tr>
             <td>@r.Name</td>
             <td>@r.EventType</td>
-            <td>@r.NextOccurrence.ToString("dd MMM") (@(r.DaysAway==0?"today":$"{r.DaysAway}d"))</td>
+            <td>@r.NextOccurrence.ToString("dd MMM yyyy") (@(r.DaysAway==0?"today":$"{r.DaysAway}d"))</td>
             <td class="text-end">
                 @if (Model.CanEdit)
                 {

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -7,6 +7,7 @@ using ProjectManagement.Models;
 using ProjectManagement.Services;
 using ProjectManagement.Helpers;
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
@@ -59,7 +60,9 @@ namespace ProjectManagement.Pages.Dashboard
             foreach (var ev in events)
             {
                 var startLocal = TimeZoneInfo.ConvertTime(ev.StartUtc, IST);
-                var when = ev.IsAllDay ? startLocal.ToString("dd MMM") : startLocal.ToString("dd MMM, HH:mm");
+                var when = ev.IsAllDay
+                    ? startLocal.ToString("dd MMM yyyy", CultureInfo.InvariantCulture)
+                    : startLocal.ToString("dd MMM yyyy, HH:mm", CultureInfo.InvariantCulture);
                 UpcomingEvents.Add(new UpcomingEventVM { Id = ev.Id, Title = ev.Title, When = when });
             }
         }

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -66,10 +66,10 @@ else
                         <div class="text-muted small">@row.StageCode</div>
                     </td>
                     <td class="text-center">
-                        @((row.OldStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.OldDue?.ToString("yyyy-MM-dd") ?? "—"))
+                        @((row.OldStart?.ToString("dd MMM yyyy") ?? "—") + " → " + (row.OldDue?.ToString("dd MMM yyyy") ?? "—"))
                     </td>
                     <td class="text-center">
-                        @((row.NewStart?.ToString("yyyy-MM-dd") ?? "—") + " → " + (row.NewDue?.ToString("yyyy-MM-dd") ?? "—"))
+                        @((row.NewStart?.ToString("dd MMM yyyy") ?? "—") + " → " + (row.NewDue?.ToString("dd MMM yyyy") ?? "—"))
                     </td>
                 </tr>
             }

--- a/wwwroot/js/analytics-logins.js
+++ b/wwwroot/js/analytics-logins.js
@@ -7,6 +7,18 @@ const elUser = document.getElementById('user');
 const elExport = document.getElementById('export');
 let chart;
 
+const monthFormatter = new Intl.DateTimeFormat('en-GB', { month: 'short' });
+const formatDisplayDate = (date) => {
+  const d = date instanceof Date ? date : new Date(date);
+  return `${String(d.getDate()).padStart(2,'0')} ${monthFormatter.format(d)} ${d.getFullYear()}`;
+};
+const formatDisplayDateTime = (date) => {
+  const d = date instanceof Date ? date : new Date(date);
+  const hh = String(d.getHours()).padStart(2,'0');
+  const mm = String(d.getMinutes()).padStart(2,'0');
+  return `${formatDisplayDate(d)} ${hh}:${mm}`;
+};
+
 const BandAndLines = {
   id: 'bandAndLines',
   afterDraw(chart, args, opts) {
@@ -76,10 +88,7 @@ async function load() {
         x: {
           type: 'linear',
           ticks: {
-            callback: (v) => {
-              const d = new Date(v);
-              return `${d.getDate()}/${d.getMonth()+1}`;
-            }
+            callback: (v) => formatDisplayDate(new Date(v))
           },
           title: { display: true, text: 'Date' }
         },
@@ -100,8 +109,7 @@ async function load() {
             label: ctx => {
               const hh = String(Math.floor(ctx.raw.y/60)).padStart(2,'0');
               const mm = String(ctx.raw.y%60).padStart(2,'0');
-              const d = new Date(ctx.raw.x);
-              const date = d.toLocaleDateString();
+              const date = formatDisplayDate(new Date(ctx.raw.x));
               return `${date} ${hh}:${mm} — ${ctx.raw.userName}${ctx.raw.reason ? ' · '+ctx.raw.reason : ''}`;
             }
           }
@@ -141,7 +149,7 @@ function renderOddTable(rows) {
     const mm = String(d.getMinutes()).padStart(2,'0');
     const tr = document.createElement('tr');
     const tdDate = document.createElement('td');
-    tdDate.textContent = `${d.toLocaleDateString()} ${hh}:${mm}`;
+    tdDate.textContent = formatDisplayDateTime(d);
     const tdUser = document.createElement('td');
     tdUser.textContent = r.userName;
     const tdReason = document.createElement('td');

--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -40,6 +40,16 @@
     return `${dt.getFullYear()}-${pad(dt.getMonth()+1)}-${pad(dt.getDate())}`;
   };
 
+  const monthFormatter = new Intl.DateTimeFormat('en-GB', { month: 'short' });
+  const formatDisplayDate = (date) => {
+    const d = date instanceof Date ? date : new Date(date);
+    return `${pad(d.getDate())} ${monthFormatter.format(d)} ${d.getFullYear()}`;
+  };
+  const formatDisplayDateTime = (date) => {
+    const d = date instanceof Date ? date : new Date(date);
+    return `${formatDisplayDate(d)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+
   // cache form elements
   const form = document.getElementById('eventForm');
   const titleBox = form ? form.querySelector('[name="title"]') : null;
@@ -511,9 +521,9 @@
       const end = new Date(data.end);
       if (data.allDay) {
         const endInc = new Date(end); endInc.setDate(endInc.getDate() - 1);
-        viewTime.textContent = `${start.toLocaleDateString()} – ${endInc.toLocaleDateString()}`;
+        viewTime.textContent = `${formatDisplayDate(start)} – ${formatDisplayDate(endInc)}`;
       } else {
-        viewTime.textContent = `${start.toLocaleString()} – ${end.toLocaleString()}`;
+        viewTime.textContent = `${formatDisplayDateTime(start)} – ${formatDisplayDateTime(end)}`;
       }
       viewCategory.textContent = data.category;
       viewLocation.textContent = data.location || '';


### PR DESCRIPTION
## Summary
- update server-side Razor pages and helpers to format displayed dates as `dd MMM yyyy`
- adjust admin analytics and log exports to use the new display format
- add shared JavaScript helpers so calendar and analytics dashboards render dates consistently

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7f1dd1d108329a6d86c488caf975b