### PR TITLE
Fix SQL Server provider detection without SQL Server package

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -12,6 +12,7 @@ using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Scheduling;
 using ProjectManagement.Models.Stages;
+using ProjectManagement.Helpers;
 
 namespace ProjectManagement.Data
 {

--- a/Helpers/DatabaseFacadeExtensions.cs
+++ b/Helpers/DatabaseFacadeExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace ProjectManagement.Helpers
+{
+    public static class DatabaseFacadeExtensions
+    {
+        private const string SqlServerProviderName = "Microsoft.EntityFrameworkCore.SqlServer";
+
+        public static bool IsSqlServer(this DatabaseFacade databaseFacade)
+        {
+            if (databaseFacade == null)
+            {
+                throw new ArgumentNullException(nameof(databaseFacade));
+            }
+
+            return string.Equals(databaseFacade.ProviderName, SqlServerProviderName, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a DatabaseFacade extension that checks the provider name for SQL Server
- update ApplicationDbContext to use the new helper so the build succeeds without referencing the SQL Server provider package

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d81254a0c08329aeaad53193e28283