### PR TITLE
Add draft deletion flow for project timelines

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -246,18 +246,26 @@
                                 </div>
                                 @if (hasMyDraft && !pendingOwnedByCurrentUser)
                                 {
-                                    <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
-                                            type="button"
-                                            data-bs-toggle="offcanvas"
-                                            data-bs-target="#offcanvasPlanEdit"
-                                            aria-controls="offcanvasPlanEdit">
-                                        <span>Your draft saved</span>
-                                        @if (planState.LastSavedOn is DateTimeOffset savedOn)
-                                        {
-                                            <span class="text-muted">@savedOn.ToLocalTime().ToString("dd MMM HH:mm")</span>
-                                        }
-                                        <span class="fw-semibold">Continue editing</span>
-                                    </button>
+                                    <div class="d-flex flex-wrap align-items-center gap-2">
+                                        <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+                                                type="button"
+                                                data-bs-toggle="offcanvas"
+                                                data-bs-target="#offcanvasPlanEdit"
+                                                aria-controls="offcanvasPlanEdit">
+                                            <span>Your draft saved</span>
+                                            @if (planState.LastSavedOn is DateTimeOffset savedOn)
+                                            {
+                                                <span class="text-muted">@savedOn.ToLocalTime().ToString("dd MMM HH:mm")</span>
+                                            }
+                                            <span class="fw-semibold">Continue editing</span>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-secondary"
+                                                type="button"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#discardDraftModal">
+                                            Discard draft
+                                        </button>
+                                    </div>
                                 }
                             </div>
                             <div class="d-flex flex-wrap align-items-center gap-2 justify-content-lg-end">
@@ -347,6 +355,8 @@
     </div>
 
 </div>
+
+<partial name="_PlanDiscardDraftModal" model="Model.Project.Id" />
 
 @section Scripts {
     <script src="~/js/projects/overview.js"></script>

--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -151,6 +151,10 @@
                 </div>
 
                 <div class="pt-3 mt-3 border-top d-flex justify-content-end gap-2">
+                    @if (!isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
+                    {
+                        <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#discardDraftModal">Discard draft</button>
+                    }
                     <button class="btn btn-outline-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
                     <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
                 </div>
@@ -240,6 +244,10 @@
 
                 <div class="d-flex gap-2 justify-content-end mt-3 pt-3 border-top">
                     <button class="btn btn-outline-secondary" type="submit" name="Input.Action" value="@PlanEditActions.Calculate" @(disableAttr)>Calculate</button>
+                    @if (!isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
+                    {
+                        <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#discardDraftModal">Discard draft</button>
+                    }
                     <button class="btn btn-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
                     <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
                 </div>

--- a/Pages/Projects/_PlanDiscardDraftModal.cshtml
+++ b/Pages/Projects/_PlanDiscardDraftModal.cshtml
@@ -1,0 +1,22 @@
+@model int
+
+<div class="modal fade" id="discardDraftModal" tabindex="-1" aria-labelledby="discardDraftModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <form method="post" asp-page="/Projects/Timeline/EditPlan" asp-page-handler="DeleteDraft" asp-route-id="@Model">
+                @Html.AntiForgeryToken()
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="discardDraftModalLabel">Discard draft?</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-0">This will remove your saved timeline draft. You can create a new draft later if needed.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Discard draft</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -134,6 +134,7 @@ builder.Services.Configure<ForwardedHeadersOptions>(o =>
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IAuditService, AuditService>();
+builder.Services.AddScoped<IUserContext, HttpUserContext>();
 builder.Services.Configure<UserLifecycleOptions>(
     builder.Configuration.GetSection("UserLifecycle"));
 builder.Services.AddScoped<IUserLifecycleService, UserLifecycleService>();

--- a/ProjectManagement.Tests/PlanDraftDeletionIntegrationTests.cs
+++ b/ProjectManagement.Tests/PlanDraftDeletionIntegrationTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectManagement.Data;
+using ProjectManagement.Helpers;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Pages.Projects.Timeline;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Plans;
+using ProjectManagement.Services.Stages;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class PlanDraftDeletionIntegrationTests
+{
+    [Fact]
+    public async Task OwnerCanDeleteDraftAndRedirectsWithSuccessMessage()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+
+        var project = new Project
+        {
+            Id = 41,
+            Name = "Integration",
+            LeadPoUserId = "po-user"
+        };
+
+        var plan = new PlanVersion
+        {
+            ProjectId = 41,
+            VersionNo = 1,
+            Title = "Draft",
+            Status = PlanVersionStatus.Draft,
+            CreatedByUserId = "po-user",
+            OwnerUserId = "po-user",
+            CreatedOn = DateTimeOffset.UtcNow
+        };
+
+        plan.StagePlans.Add(new StagePlan
+        {
+            StageCode = StageCodes.EOI,
+            PlannedStart = new DateOnly(2024, 1, 5),
+            PlannedDue = new DateOnly(2024, 1, 12)
+        });
+
+        db.Projects.Add(project);
+        db.PlanVersions.Add(plan);
+        await db.SaveChangesAsync();
+
+        var clock = new TestClock(new DateTimeOffset(2024, 3, 5, 8, 30, 0, TimeSpan.Zero));
+        var audit = new RecordingAudit();
+        var planDraft = new PlanDraftService(db, clock, NullLogger<PlanDraftService>.Instance, audit);
+        var userContext = new PrincipalUserContext(CreatePrincipal("po-user", "Project Officer"));
+        var page = new EditPlanModel(
+            db,
+            audit,
+            new PlanGenerationService(db),
+            planDraft,
+            new PlanApprovalService(db, clock, NullLogger<PlanApprovalService>.Instance, new PlanSnapshotService(db)),
+            NullLogger<EditPlanModel>.Instance,
+            userContext);
+
+        ConfigurePageContext(page, userContext);
+
+        var result = await page.OnPostDeleteDraftAsync(41, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("/Projects/Overview", redirect.PageName);
+        Assert.Equal("Draft discarded.", page.TempData["Flash"]);
+        Assert.Empty(await db.PlanVersions.ToListAsync());
+        Assert.Empty(await db.StagePlans.ToListAsync());
+        Assert.Single(audit.Entries);
+    }
+
+    private static void ConfigurePageContext(PageModel page, PrincipalUserContext userContext)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = userContext.User;
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor());
+        page.PageContext = new PageContext(actionContext);
+        page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(string userId, string role)
+    {
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Name, userId),
+            new Claim(ClaimTypes.Role, role)
+        };
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private sealed class PrincipalUserContext : IUserContext
+    {
+        public PrincipalUserContext(ClaimsPrincipal user)
+        {
+            User = user;
+        }
+
+        public ClaimsPrincipal User { get; }
+
+        public string? UserId => User.FindFirstValue(ClaimTypes.NameIdentifier);
+    }
+
+    private sealed class DictionaryTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => new Dictionary<string, object?>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+        }
+    }
+
+    private sealed class RecordingAudit : IAuditService
+    {
+        public List<(string Action, IDictionary<string, string?> Data, string? UserId)> Entries { get; } = new();
+
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, HttpContext? http = null)
+        {
+            Entries.Add((action, data ?? new Dictionary<string, string?>(), userId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestClock : IClock
+    {
+        public TestClock(DateTimeOffset now)
+        {
+            UtcNow = now;
+        }
+
+        public DateTimeOffset UtcNow { get; }
+    }
+}

--- a/Services/AuditEvents.cs
+++ b/Services/AuditEvents.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services;
+
+public static class Audit
+{
+    public static class Events
+    {
+        public static AuditEvent DraftDeleted(int projectId, int planVersionId, string userId, DateTimeOffset deletedAt)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["ProjectId"] = projectId.ToString(),
+                ["PlanVersionId"] = planVersionId.ToString(),
+                ["DeletedOnUtc"] = deletedAt.UtcDateTime.ToString("O")
+            };
+
+            return new AuditEvent("Plan.DraftDeleted", userId, data);
+        }
+    }
+}
+
+public readonly record struct AuditEvent(string Action, string? UserId, IDictionary<string, string?> Data)
+{
+    public Task WriteAsync(IAuditService audit, string? message = null, string level = "Info", string? userName = null)
+        => audit.LogAsync(Action, message, level, UserId, userName, Data);
+}

--- a/Services/HttpUserContext.cs
+++ b/Services/HttpUserContext.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace ProjectManagement.Services;
+
+public sealed class HttpUserContext : IUserContext
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public HttpUserContext(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public ClaimsPrincipal User => _httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal(new ClaimsIdentity());
+
+    public string? UserId => User.FindFirstValue(ClaimTypes.NameIdentifier);
+}

--- a/Services/IUserContext.cs
+++ b/Services/IUserContext.cs
@@ -1,0 +1,10 @@
+using System.Security.Claims;
+
+namespace ProjectManagement.Services;
+
+public interface IUserContext
+{
+    ClaimsPrincipal User { get; }
+
+    string? UserId { get; }
+}


### PR DESCRIPTION
## Summary
- add a draft deletion flow to PlanDraftService with audit logging support
- expose a discard draft action via the timeline editor handler and overview/offcanvas UI
- cover owner, access, and status rules with new unit and integration tests

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d825c03abc832983c4dcff69add065