### PR TITLE
Fix missing principal context in edit plan handler

### DIFF
--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -99,7 +100,7 @@ public class EditPlanModel : PageModel
             return await HandleDurationsAsync(id, userId, cancellationToken);
         }
 
-        return await HandleExactAsync(id, userId, cancellationToken);
+        return await HandleExactAsync(id, userId, principal, cancellationToken);
     }
 
     [IgnoreAntiforgeryToken]
@@ -188,7 +189,7 @@ public class EditPlanModel : PageModel
         return RedirectToPage("/Projects/Overview", new { id });
     }
 
-    private async Task<IActionResult> HandleExactAsync(int id, string userId, CancellationToken cancellationToken)
+    private async Task<IActionResult> HandleExactAsync(int id, string userId, ClaimsPrincipal principal, CancellationToken cancellationToken)
     {
         if (Input.Rows is not null)
         {


### PR DESCRIPTION
## Summary
- pass the authenticated principal into the exact plan handler so the user name is available for auditing
- add the necessary ClaimsPrincipal dependency to the edit plan page model

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d82909ca988329993c656ebfd210f4