### PR TITLE
Implement project stage change request flow

### DIFF
--- a/Pages/Projects/Stages/RequestChange.cshtml
+++ b/Pages/Projects/Stages/RequestChange.cshtml
@@ -1,0 +1,2 @@
+@page
+@model ProjectManagement.Pages.Projects.Stages.RequestChangeModel

--- a/Pages/Projects/Stages/RequestChange.cshtml.cs
+++ b/Pages/Projects/Stages/RequestChange.cshtml.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects.Stages;
+
+[Authorize(Roles = "Project Officer")]
+[AutoValidateAntiforgeryToken]
+public class RequestChangeModel : PageModel
+{
+    private readonly StageRequestService _stageRequestService;
+    private readonly IUserContext _userContext;
+
+    public RequestChangeModel(StageRequestService stageRequestService, IUserContext userContext)
+    {
+        _stageRequestService = stageRequestService;
+        _userContext = userContext;
+    }
+
+    public IActionResult OnGet() => NotFound();
+
+    public async Task<IActionResult> OnPostAsync([FromBody] StageChangeRequestInput input, CancellationToken cancellationToken)
+    {
+        if (input is null)
+        {
+            return BadRequest(new { ok = false, error = "Request body is required." });
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var result = await _stageRequestService.RequestChangeAsync(input, userId, cancellationToken);
+
+        return result.Outcome switch
+        {
+            StageRequestOutcome.Success => new JsonResult(new { ok = true }),
+            StageRequestOutcome.NotProjectOfficer => Forbid(),
+            StageRequestOutcome.StageNotFound => NotFound(new { ok = false, error = "Stage not found." }),
+            StageRequestOutcome.DuplicatePending => StatusCode(StatusCodes.Status409Conflict, new { ok = false, error = result.Error }),
+            StageRequestOutcome.ValidationFailed => UnprocessableEntity(new { ok = false, error = result.Error }),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, new { ok = false })
+        };
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -150,6 +150,7 @@ builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
+builder.Services.AddScoped<StageRequestService>();
 builder.Services.AddScoped<PlanSnapshotService>();
 builder.Services.AddScoped<PlanCompareService>();
 builder.Services.AddScoped<ProjectFactsService>();

--- a/ProjectManagement.Tests/StageRequestServiceTests.cs
+++ b/ProjectManagement.Tests/StageRequestServiceTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageRequestServiceTests
+{
+    [Fact]
+    public async Task RequestChangeAsync_CreatesPendingRequestAndLog()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 1, 10, 8, 30, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        var service = new StageRequestService(db, clock);
+
+        var input = new StageChangeRequestInput
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            RequestedStatus = StageStatus.InProgress.ToString(),
+            RequestedDate = new DateOnly(2024, 1, 9),
+            Note = "  Please begin  "
+        };
+
+        var result = await service.RequestChangeAsync(input, "po-1");
+
+        Assert.Equal(StageRequestOutcome.Success, result.Outcome);
+
+        var request = await db.StageChangeRequests.SingleAsync();
+        Assert.Equal("po-1", request.RequestedByUserId);
+        Assert.Equal(StageStatus.InProgress.ToString(), request.RequestedStatus);
+        Assert.Equal(new DateOnly(2024, 1, 9), request.RequestedDate);
+        Assert.Equal("Please begin", request.Note);
+        Assert.Equal("Pending", request.DecisionStatus);
+
+        var log = await db.StageChangeLogs.SingleAsync();
+        Assert.Equal("Requested", log.Action);
+        Assert.Equal(StageStatus.NotStarted.ToString(), log.FromStatus);
+        Assert.Equal(StageStatus.InProgress.ToString(), log.ToStatus);
+        Assert.Equal(new DateOnly(2024, 1, 9), log.ToActualStart);
+        Assert.Null(log.ToCompletedOn);
+        Assert.Equal(clock.UtcNow, log.At);
+        Assert.Equal("Please begin", log.Note);
+    }
+
+    [Fact]
+    public async Task RequestChangeAsync_DuplicatePendingReturnsConflict()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        var service = new StageRequestService(db, clock);
+
+        var input = new StageChangeRequestInput
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            RequestedStatus = StageStatus.InProgress.ToString()
+        };
+
+        var first = await service.RequestChangeAsync(input, "po-1");
+        var second = await service.RequestChangeAsync(input, "po-1");
+
+        Assert.Equal(StageRequestOutcome.Success, first.Outcome);
+        Assert.Equal(StageRequestOutcome.DuplicatePending, second.Outcome);
+    }
+
+    [Fact]
+    public async Task RequestChangeAsync_DisallowedTransitionReturnsValidationError()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        var service = new StageRequestService(db, clock);
+
+        var result = await service.RequestChangeAsync(new StageChangeRequestInput
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            RequestedStatus = StageStatus.Completed.ToString(),
+            RequestedDate = new DateOnly(2024, 3, 5)
+        }, "po-1");
+
+        Assert.Equal(StageRequestOutcome.ValidationFailed, result.Outcome);
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public async Task RequestChangeAsync_CompletedBeforeActualStartReturnsValidationError()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.InProgress, new DateOnly(2024, 4, 10));
+
+        var service = new StageRequestService(db, clock);
+
+        var result = await service.RequestChangeAsync(new StageChangeRequestInput
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            RequestedStatus = StageStatus.Completed.ToString(),
+            RequestedDate = new DateOnly(2024, 4, 5)
+        }, "po-1");
+
+        Assert.Equal(StageRequestOutcome.ValidationFailed, result.Outcome);
+        Assert.Equal("Completion date cannot be before the actual start date.", result.Error);
+    }
+
+    private static async Task SeedStageAsync(ApplicationDbContext db, StageStatus status, DateOnly? actualStart = null)
+    {
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Project",
+            CreatedByUserId = "seed",
+            LeadPoUserId = "po-1"
+        });
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = status,
+            ActualStart = actualStart
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class TestClock : IClock
+    {
+        public TestClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; set; }
+    }
+}

--- a/Services/Stages/StageRequestService.cs
+++ b/Services/Stages/StageRequestService.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Services;
+
+public class StageRequestService
+{
+    private const string PendingDecisionStatus = "Pending";
+    private const string RequestedLogAction = "Requested";
+
+    private static readonly IReadOnlyDictionary<StageStatus, IReadOnlyCollection<StageStatus>> AllowedTransitions =
+        new Dictionary<StageStatus, IReadOnlyCollection<StageStatus>>
+        {
+            [StageStatus.NotStarted] = new[] { StageStatus.InProgress, StageStatus.Blocked },
+            [StageStatus.InProgress] = new[] { StageStatus.Completed, StageStatus.Blocked },
+            [StageStatus.Blocked] = new[] { StageStatus.InProgress }
+        };
+
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public StageRequestService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async Task<StageRequestResult> RequestChangeAsync(
+        StageChangeRequestInput input,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (input is null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new ArgumentException("A valid user identifier is required.", nameof(userId));
+        }
+
+        if (string.IsNullOrWhiteSpace(input.StageCode))
+        {
+            return StageRequestResult.ValidationFailed("A stage code is required.");
+        }
+
+        var stageCode = input.StageCode.Trim().ToUpperInvariant();
+
+        var stage = await _db.ProjectStages
+            .Include(s => s.Project)
+            .SingleOrDefaultAsync(
+                s => s.ProjectId == input.ProjectId && s.StageCode == stageCode,
+                cancellationToken);
+
+        if (stage is null)
+        {
+            return StageRequestResult.StageNotFound();
+        }
+
+        if (!string.Equals(stage.Project?.LeadPoUserId, userId, StringComparison.Ordinal))
+        {
+            return StageRequestResult.NotProjectOfficer();
+        }
+
+        if (!Enum.TryParse<StageStatus>(input.RequestedStatus, ignoreCase: true, out var requestedStatus))
+        {
+            return StageRequestResult.ValidationFailed("The requested status is not recognised.");
+        }
+
+        if (!AllowedTransitions.TryGetValue(stage.Status, out var allowed) || !allowed.Contains(requestedStatus))
+        {
+            return StageRequestResult.ValidationFailed(
+                $"Changing from {stage.Status} to {requestedStatus} is not allowed.");
+        }
+
+        var requestedDate = input.RequestedDate;
+
+        if (requestedStatus == StageStatus.Completed)
+        {
+            if (requestedDate is null)
+            {
+                return StageRequestResult.ValidationFailed(
+                    "A completion date is required when requesting completion.");
+            }
+
+            if (stage.ActualStart.HasValue && requestedDate.Value < stage.ActualStart.Value)
+            {
+                return StageRequestResult.ValidationFailed(
+                    "Completion date cannot be before the actual start date.");
+            }
+        }
+
+        var trimmedNote = string.IsNullOrWhiteSpace(input.Note) ? null : input.Note.Trim();
+
+        var hasPending = await _db.StageChangeRequests
+            .AnyAsync(
+                r => r.ProjectId == stage.ProjectId
+                    && r.StageCode == stage.StageCode
+                    && r.DecisionStatus == PendingDecisionStatus,
+                cancellationToken);
+
+        if (hasPending)
+        {
+            return StageRequestResult.DuplicatePending();
+        }
+
+        var now = _clock.UtcNow;
+
+        var request = new StageChangeRequest
+        {
+            ProjectId = stage.ProjectId,
+            StageCode = stage.StageCode,
+            RequestedStatus = requestedStatus.ToString(),
+            RequestedDate = requestedDate,
+            Note = trimmedNote,
+            RequestedByUserId = userId,
+            RequestedOn = now,
+            DecisionStatus = PendingDecisionStatus
+        };
+
+        var log = new StageChangeLog
+        {
+            ProjectId = stage.ProjectId,
+            StageCode = stage.StageCode,
+            Action = RequestedLogAction,
+            FromStatus = stage.Status.ToString(),
+            ToStatus = requestedStatus.ToString(),
+            FromActualStart = stage.ActualStart,
+            ToActualStart = requestedStatus == StageStatus.InProgress ? requestedDate : null,
+            FromCompletedOn = stage.CompletedOn,
+            ToCompletedOn = requestedStatus == StageStatus.Completed ? requestedDate : null,
+            UserId = userId,
+            At = now,
+            Note = trimmedNote
+        };
+
+        await _db.StageChangeRequests.AddAsync(request, cancellationToken);
+        await _db.StageChangeLogs.AddAsync(log, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return StageRequestResult.Success();
+    }
+}
+
+public sealed record StageChangeRequestInput
+{
+    public int ProjectId { get; set; }
+    public string StageCode { get; set; } = string.Empty;
+    public string RequestedStatus { get; set; } = string.Empty;
+    public DateOnly? RequestedDate { get; set; }
+    public string? Note { get; set; }
+}
+
+public sealed record StageRequestResult(StageRequestOutcome Outcome, string? Error = null)
+{
+    public static StageRequestResult Success() => new(StageRequestOutcome.Success, null);
+    public static StageRequestResult NotProjectOfficer() => new(StageRequestOutcome.NotProjectOfficer, null);
+    public static StageRequestResult StageNotFound() => new(StageRequestOutcome.StageNotFound, null);
+    public static StageRequestResult DuplicatePending() => new(StageRequestOutcome.DuplicatePending, "A pending request already exists for this stage.");
+    public static StageRequestResult ValidationFailed(string message) => new(StageRequestOutcome.ValidationFailed, message);
+}
+
+public enum StageRequestOutcome
+{
+    Success,
+    NotProjectOfficer,
+    StageNotFound,
+    DuplicatePending,
+    ValidationFailed
+}


### PR DESCRIPTION
## Summary
- add a StageRequestService that validates status transitions, records pending requests, and logs the proposal
- expose a Razor Page JSON endpoint for Project Officers to submit stage change requests
- add unit tests covering successful requests, duplicates, and invalid transitions

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d83108f8dc83298b104c974be92fe7