### PR TITLE
Fix StageRequestService namespace mismatch

### DIFF
--- a/Pages/Projects/Stages/RequestChange.cshtml.cs
+++ b/Pages/Projects/Stages/RequestChange.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Services;
+using ProjectManagement.Services.Stages;
 
 namespace ProjectManagement.Pages.Projects.Stages;
 

--- a/ProjectManagement.Tests/StageRequestServiceTests.cs
+++ b/ProjectManagement.Tests/StageRequestServiceTests.cs
@@ -6,6 +6,7 @@ using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
+using ProjectManagement.Services.Stages;
 using Xunit;
 
 namespace ProjectManagement.Tests;

--- a/Services/Stages/StageRequestService.cs
+++ b/Services/Stages/StageRequestService.cs
@@ -7,8 +7,9 @@ using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
 
-namespace ProjectManagement.Services;
+namespace ProjectManagement.Services.Stages;
 
 public class StageRequestService
 {


### PR DESCRIPTION
## Summary
- move StageRequestService and its DTOs into the ProjectManagement.Services.Stages namespace to match usage across the app
- update the Razor page handler and unit tests to import the corrected namespace

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8337ab89083299d907912f9e3a6d2