### PR TITLE
Add HttpContext helpers for stage change responses

### DIFF
--- a/Helpers/HttpContextExtensions.cs
+++ b/Helpers/HttpContextExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ProjectManagement.Helpers;
+
+public static class HttpContextExtensions
+{
+    public static IActionResult SetSuccess(this HttpContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        return new JsonResult(new { ok = true })
+        {
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
+
+    public static IActionResult SetStatusCode(this HttpContext context, int statusCode, object? value)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        return new ObjectResult(value)
+        {
+            StatusCode = statusCode
+        };
+    }
+
+    public static IActionResult SetInternalServerError(this HttpContext context)
+    {
+        return context.SetStatusCode(StatusCodes.Status500InternalServerError, new { ok = false });
+    }
+}

--- a/Pages/Projects/Stages/RequestChange.cshtml.cs
+++ b/Pages/Projects/Stages/RequestChange.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Helpers;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Stages;
 
@@ -41,12 +42,18 @@ public class RequestChangeModel : PageModel
 
         return result.Outcome switch
         {
-            StageRequestOutcome.Success => new JsonResult(new { ok = true }),
+            StageRequestOutcome.Success => HttpContext.SetSuccess(),
             StageRequestOutcome.NotProjectOfficer => Forbid(),
-            StageRequestOutcome.StageNotFound => NotFound(new { ok = false, error = "Stage not found." }),
-            StageRequestOutcome.DuplicatePending => StatusCode(StatusCodes.Status409Conflict, new { ok = false, error = result.Error }),
-            StageRequestOutcome.ValidationFailed => UnprocessableEntity(new { ok = false, error = result.Error }),
-            _ => StatusCode(StatusCodes.Status500InternalServerError, new { ok = false })
+            StageRequestOutcome.StageNotFound => HttpContext.SetStatusCode(
+                StatusCodes.Status404NotFound,
+                new { ok = false, error = "Stage not found." }),
+            StageRequestOutcome.DuplicatePending => HttpContext.SetStatusCode(
+                StatusCodes.Status409Conflict,
+                new { ok = false, error = result.Error }),
+            StageRequestOutcome.ValidationFailed => HttpContext.SetStatusCode(
+                StatusCodes.Status422UnprocessableEntity,
+                new { ok = false, error = result.Error }),
+            _ => HttpContext.SetInternalServerError()
         };
     }
 }


### PR DESCRIPTION
## Summary
- add HttpContext helper extensions for returning consistent JSON responses
- update stage change request page model to use the new helpers

## Testing
- not run (environment missing dotnet runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d83486d62c8329ba488cb533e39b8d