### PR TITLE
Fix nightly maintenance workers

### DIFF
--- a/Services/TodoPurgeWorker.cs
+++ b/Services/TodoPurgeWorker.cs
@@ -17,6 +17,7 @@ namespace ProjectManagement.Services
         private readonly IServiceProvider _sp;
         private readonly ILogger<TodoPurgeWorker> _log;
         private readonly int _retentionDays;
+        private bool _loggedMissingDeletedUtc;
 
         public TodoPurgeWorker(IServiceProvider sp, ILogger<TodoPurgeWorker> log, IOptions<TodoOptions> options)
         {
@@ -30,32 +31,62 @@ namespace ProjectManagement.Services
             try
             {
                 using var timer = new PeriodicTimer(TimeSpan.FromHours(24));
+
+                await PurgeAsync(stoppingToken);
+
                 while (await timer.WaitForNextTickAsync(stoppingToken))
                 {
-                    using var scope = _sp.CreateScope();
-                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-                    var hasDeletedUtc = await db.Database.ExecuteSqlRawAsync(
-                        "SELECT 1 FROM information_schema.columns WHERE table_name='TodoItems' AND column_name='DeletedUtc'") > 0;
-                    if (!hasDeletedUtc)
-                    {
-                        _log.LogWarning("TodoItems.DeletedUtc missing; skipping purge.");
-                        continue;
-                    }
-
-                    var cutoff = DateTimeOffset.UtcNow.AddDays(-_retentionDays);
-                    var deleted = await db.TodoItems
-                        .Where(t => t.DeletedUtc != null && t.DeletedUtc < cutoff)
-                        .ExecuteDeleteAsync(stoppingToken);
-                    if (deleted > 0)
-                        _log.LogInformation("Purged {Count} todo items", deleted);
+                    await PurgeAsync(stoppingToken);
                 }
             }
-            catch (TaskCanceledException) { }
-            catch (OperationCanceledException) { }
+            catch (TaskCanceledException)
+            {
+                // Allow graceful shutdown
+            }
+            catch (OperationCanceledException)
+            {
+                // Allow graceful shutdown
+            }
             catch (Exception ex)
             {
                 _log.LogError(ex, "Todo purge worker failed.");
+            }
+        }
+
+        private async Task PurgeAsync(CancellationToken stoppingToken)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            using var scope = _sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var columnCount = await db.Database
+                .SqlQueryRaw<long>("SELECT COUNT(*) FROM information_schema.columns WHERE table_name='TodoItems' AND column_name='DeletedUtc'")
+                .SingleAsync(stoppingToken);
+            var hasDeletedUtc = columnCount > 0;
+
+            if (!hasDeletedUtc)
+            {
+                if (!_loggedMissingDeletedUtc)
+                {
+                    _loggedMissingDeletedUtc = true;
+                    _log.LogWarning("TodoItems.DeletedUtc missing; skipping purge.");
+                }
+
+                return;
+            }
+
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-_retentionDays);
+            var deleted = await db.TodoItems
+                .Where(t => t.DeletedUtc != null && t.DeletedUtc < cutoff)
+                .ExecuteDeleteAsync(stoppingToken);
+
+            if (deleted > 0)
+            {
+                _log.LogInformation("Purged {Count} todo items", deleted);
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure the login aggregation worker runs immediately on startup and reuses a helper for each daily aggregation
- make the todo purge worker execute its first purge without waiting and use a reliable schema check for the DeletedUtc column
- reduce noisy warnings by logging the missing DeletedUtc column only once per service lifetime

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d83600bc848329a33725c8cb8ecffd