### PR TITLE
Add EOI stage code to stage constants

### DIFF
--- a/Models/Stages/StageCodes.cs
+++ b/Models/Stages/StageCodes.cs
@@ -5,6 +5,7 @@ namespace ProjectManagement.Models.Stages;
 
 public static class StageCodes
 {
+    public const string EOI = "EOI";
     public const string FS = "FS";
     public const string IPA = "IPA";
     public const string SOW = "SOW";
@@ -22,6 +23,7 @@ public static class StageCodes
 
     public static readonly string[] All =
     {
+        EOI,
         FS,
         IPA,
         SOW,
@@ -39,6 +41,7 @@ public static class StageCodes
     };
     private static readonly Dictionary<string, string> DisplayNames = new(StringComparer.OrdinalIgnoreCase)
     {
+        [EOI] = "Expression of Interest",
         [FS] = "Feasibility Study",
         [IPA] = "In-Principle Approval",
         [SOW] = "SOW Vetting",


### PR DESCRIPTION
## Summary
- add the missing Expression of Interest stage code constant
- expose the display name so lookups return the friendly text

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d83a223b0c8329a12e84317566a9ee