### PR TITLE
Fix test doubles to implement service interfaces

### DIFF
--- a/ProjectManagement.Tests/PlanDraftAndApprovalServiceTests.cs
+++ b/ProjectManagement.Tests/PlanDraftAndApprovalServiceTests.cs
@@ -8,6 +8,7 @@ using ProjectManagement.Helpers;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
 using ProjectManagement.Services.Plans;
 using ProjectManagement.Services.Stages;
 using Xunit;


### PR DESCRIPTION
## Summary
- make PlanDraftAndApprovalServiceTests reference the application service interfaces so fakes implement the correct contracts

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d83b43ea7083299c75aee496c99e57