### PR TITLE
Implement HoD stage decision workflow

### DIFF
--- a/Pages/Projects/Stages/DecideChange.cshtml.cs
+++ b/Pages/Projects/Stages/DecideChange.cshtml.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Helpers;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Stages;
+
+namespace ProjectManagement.Pages.Projects.Stages;
+
+[Authorize(Roles = "HoD")]
+[AutoValidateAntiforgeryToken]
+public class DecideChangeModel : PageModel
+{
+    private readonly StageDecisionService _stageDecisionService;
+    private readonly IUserContext _userContext;
+
+    public DecideChangeModel(StageDecisionService stageDecisionService, IUserContext userContext)
+    {
+        _stageDecisionService = stageDecisionService;
+        _userContext = userContext;
+    }
+
+    public IActionResult OnGet() => NotFound();
+
+    public async Task<IActionResult> OnPostAsync([FromBody] StageDecisionRequest input, CancellationToken cancellationToken)
+    {
+        if (input is null)
+        {
+            return BadRequest(new { ok = false, error = "Request body is required." });
+        }
+
+        if (!StageDecisionRequest.TryParseDecision(input.Decision, out var action))
+        {
+            return BadRequest(new { ok = false, error = "Decision must be Approve or Reject." });
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var serviceInput = new StageDecisionInput(input.RequestId, action, input.DecisionNote);
+        var result = await _stageDecisionService.DecideAsync(serviceInput, userId, cancellationToken);
+
+        return result.Outcome switch
+        {
+            StageDecisionOutcome.Success => HttpContext.SetSuccess(),
+            StageDecisionOutcome.NotHeadOfDepartment => Forbid(),
+            StageDecisionOutcome.RequestNotFound => HttpContext.SetStatusCode(
+                StatusCodes.Status404NotFound,
+                new { ok = false, error = "Request not found." }),
+            StageDecisionOutcome.StageNotFound => HttpContext.SetStatusCode(
+                StatusCodes.Status404NotFound,
+                new { ok = false, error = "Stage not found." }),
+            StageDecisionOutcome.AlreadyDecided => HttpContext.SetStatusCode(
+                StatusCodes.Status409Conflict,
+                new { ok = false, error = "This request has already been decided." }),
+            StageDecisionOutcome.ValidationFailed => HttpContext.SetStatusCode(
+                StatusCodes.Status422UnprocessableEntity,
+                new { ok = false, error = result.Error }),
+            _ => HttpContext.SetInternalServerError()
+        };
+    }
+}
+
+public sealed record StageDecisionRequest
+{
+    public int RequestId { get; init; }
+    public string Decision { get; init; } = string.Empty;
+    public string? DecisionNote { get; init; }
+
+    public static bool TryParseDecision(string? value, out StageDecisionAction action)
+    {
+        if (string.Equals(value, "Approve", StringComparison.OrdinalIgnoreCase))
+        {
+            action = StageDecisionAction.Approve;
+            return true;
+        }
+
+        if (string.Equals(value, "Reject", StringComparison.OrdinalIgnoreCase))
+        {
+            action = StageDecisionAction.Reject;
+            return true;
+        }
+
+        action = default;
+        return false;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -151,6 +151,7 @@ builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<StageRequestService>();
+builder.Services.AddScoped<StageDecisionService>();
 builder.Services.AddScoped<PlanSnapshotService>();
 builder.Services.AddScoped<PlanCompareService>();
 builder.Services.AddScoped<ProjectFactsService>();

--- a/ProjectManagement.Tests/StageDecisionServiceTests.cs
+++ b/ProjectManagement.Tests/StageDecisionServiceTests.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Services.Stages;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class StageDecisionServiceTests
+{
+    [Fact]
+    public async Task ApproveAsync_UpdatesStageAndLogs()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 1, 20, 8, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedProjectAsync(
+            db,
+            "hod-1",
+            (StageCodes.FS, StageStatus.Completed),
+            (StageCodes.IPA, StageStatus.NotStarted));
+
+        var request = await SeedRequestAsync(
+            db,
+            projectId: 1,
+            StageCodes.IPA,
+            StageStatus.InProgress.ToString(),
+            new DateOnly(2024, 1, 15),
+            note: null);
+
+        var service = CreateService(db, clock);
+        var result = await service.DecideAsync(
+            new StageDecisionInput(request.Id, StageDecisionAction.Approve, "  Please approve  "),
+            "hod-1");
+
+        Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
+        Assert.Empty(result.Warnings);
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.InProgress, stage.Status);
+        Assert.Equal(new DateOnly(2024, 1, 15), stage.ActualStart);
+
+        var persistedRequest = await db.StageChangeRequests.SingleAsync();
+        Assert.Equal("Approved", persistedRequest.DecisionStatus);
+        Assert.Equal("Please approve", persistedRequest.DecisionNote);
+        Assert.Equal("hod-1", persistedRequest.DecidedByUserId);
+        Assert.NotNull(persistedRequest.DecidedOn);
+
+        var logs = await db.StageChangeLogs.OrderBy(l => l.Id).ToListAsync();
+        Assert.Collection(
+            logs,
+            log =>
+            {
+                Assert.Equal("Approved", log.Action);
+                Assert.Equal(StageStatus.NotStarted.ToString(), log.FromStatus);
+                Assert.Equal(StageStatus.InProgress.ToString(), log.ToStatus);
+                Assert.Equal(new DateOnly(2024, 1, 15), log.ToActualStart);
+                Assert.Equal("Please approve", log.Note);
+            },
+            log =>
+            {
+                Assert.Equal("Applied", log.Action);
+                Assert.Equal(StageStatus.NotStarted.ToString(), log.FromStatus);
+                Assert.Equal(StageStatus.InProgress.ToString(), log.ToStatus);
+                Assert.Equal(new DateOnly(2024, 1, 15), log.ToActualStart);
+                Assert.Equal("Please approve", log.Note);
+            });
+    }
+
+    [Fact]
+    public async Task RejectAsync_DoesNotModifyStage()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 2, 10, 9, 30, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedProjectAsync(
+            db,
+            "hod-9",
+            (StageCodes.FS, StageStatus.Completed),
+            (StageCodes.IPA, StageStatus.NotStarted));
+
+        var request = await SeedRequestAsync(
+            db,
+            projectId: 1,
+            StageCodes.IPA,
+            StageStatus.InProgress.ToString(),
+            new DateOnly(2024, 2, 5),
+            note: null);
+
+        var service = CreateService(db, clock);
+        var result = await service.DecideAsync(
+            new StageDecisionInput(request.Id, StageDecisionAction.Reject, " Need more info "),
+            "hod-9");
+
+        Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.NotStarted, stage.Status);
+        Assert.Null(stage.ActualStart);
+
+        var persistedRequest = await db.StageChangeRequests.SingleAsync();
+        Assert.Equal("Rejected", persistedRequest.DecisionStatus);
+        Assert.Equal("Need more info", persistedRequest.DecisionNote);
+        Assert.Equal("hod-9", persistedRequest.DecidedByUserId);
+
+        var log = await db.StageChangeLogs.SingleAsync();
+        Assert.Equal("Rejected", log.Action);
+        Assert.Equal(StageStatus.NotStarted.ToString(), log.FromStatus);
+        Assert.Equal(StageStatus.NotStarted.ToString(), log.ToStatus);
+        Assert.Equal("Need more info", log.Note);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_ClampsCompletionDateAndAddsWarning()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 3, 20, 12, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedProjectAsync(
+            db,
+            "hod-5",
+            (StageCodes.FS, StageStatus.Completed),
+            (StageCodes.IPA, StageStatus.InProgress, new DateOnly(2024, 3, 10)));
+
+        db.ProjectIpaFacts.Add(new ProjectIpaFact
+        {
+            ProjectId = 1,
+            IpaCost = 200m,
+            CreatedByUserId = "seed",
+            CreatedOnUtc = clock.UtcNow.UtcDateTime
+        });
+        await db.SaveChangesAsync();
+
+        var request = await SeedRequestAsync(
+            db,
+            projectId: 1,
+            StageCodes.IPA,
+            StageStatus.Completed.ToString(),
+            new DateOnly(2024, 3, 5),
+            note: " Close stage ");
+
+        var service = CreateService(db, clock);
+        var result = await service.DecideAsync(
+            new StageDecisionInput(request.Id, StageDecisionAction.Approve, " Close stage "),
+            "hod-5");
+
+        Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
+        Assert.Contains(result.Warnings, w => w.Contains("Completion date was earlier"));
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.Completed, stage.Status);
+        Assert.Equal(new DateOnly(2024, 3, 10), stage.CompletedOn);
+        Assert.Equal(new DateOnly(2024, 3, 10), stage.ActualStart);
+
+        var persistedRequest = await db.StageChangeRequests.SingleAsync();
+        Assert.Equal("Approved", persistedRequest.DecisionStatus);
+        Assert.Contains("Warning:", persistedRequest.DecisionNote);
+        Assert.Contains("adjusted", persistedRequest.DecisionNote, StringComparison.OrdinalIgnoreCase);
+
+        var appliedLog = await db.StageChangeLogs.SingleAsync(l => l.Action == "Applied");
+        Assert.Equal(new DateOnly(2024, 3, 10), appliedLog.ToCompletedOn);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_AddsPredecessorWarning()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 4, 15, 7, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedProjectAsync(
+            db,
+            "hod-4",
+            (StageCodes.FS, StageStatus.Completed),
+            (StageCodes.IPA, StageStatus.NotStarted),
+            (StageCodes.SOW, StageStatus.NotStarted));
+
+        var request = await SeedRequestAsync(
+            db,
+            projectId: 1,
+            StageCodes.SOW,
+            StageStatus.InProgress.ToString(),
+            new DateOnly(2024, 4, 14),
+            note: null);
+
+        var service = CreateService(db, clock);
+        var result = await service.DecideAsync(
+            new StageDecisionInput(request.Id, StageDecisionAction.Approve, null),
+            "hod-4");
+
+        Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
+        Assert.Contains(result.Warnings, w => w.Contains(StageCodes.IPA));
+
+        var persistedRequest = await db.StageChangeRequests.SingleAsync(r => r.Id == request.Id);
+        Assert.Contains(StageCodes.IPA, persistedRequest.DecisionNote);
+
+        var stage = await db.ProjectStages.SingleAsync(s => s.StageCode == StageCodes.SOW);
+        Assert.Equal(StageStatus.InProgress, stage.Status);
+        Assert.Equal(new DateOnly(2024, 4, 14), stage.ActualStart);
+    }
+
+    private static async Task SeedProjectAsync(
+        ApplicationDbContext db,
+        string hodUserId,
+        params (string Code, StageStatus Status, DateOnly? ActualStart, DateOnly? CompletedOn)[] stages)
+    {
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Project",
+            CreatedByUserId = "seed",
+            HodUserId = hodUserId
+        });
+
+        foreach (var (code, status, actualStart, completedOn) in stages)
+        {
+            db.ProjectStages.Add(new ProjectStage
+            {
+                ProjectId = 1,
+                StageCode = code,
+                SortOrder = Array.IndexOf(StageCodes.All, code),
+                Status = status,
+                ActualStart = actualStart,
+                CompletedOn = completedOn
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedProjectAsync(
+        ApplicationDbContext db,
+        string hodUserId,
+        params (string Code, StageStatus Status)[] stages)
+    {
+        var expanded = stages
+            .Select(s => (s.Code, s.Status, (DateOnly?)null, (DateOnly?)null))
+            .ToArray();
+
+        await SeedProjectAsync(db, hodUserId, expanded);
+    }
+
+    private static async Task<StageChangeRequest> SeedRequestAsync(
+        ApplicationDbContext db,
+        int projectId,
+        string stageCode,
+        string requestedStatus,
+        DateOnly? requestedDate,
+        string? note)
+    {
+        var request = new StageChangeRequest
+        {
+            ProjectId = projectId,
+            StageCode = stageCode,
+            RequestedStatus = requestedStatus,
+            RequestedDate = requestedDate,
+            Note = note,
+            RequestedByUserId = "po-1",
+            RequestedOn = DateTimeOffset.UtcNow,
+            DecisionStatus = "Pending"
+        };
+
+        db.StageChangeRequests.Add(request);
+        await db.SaveChangesAsync();
+        return request;
+    }
+
+    private static StageDecisionService CreateService(ApplicationDbContext db, TestClock clock)
+    {
+        var progress = new StageProgressService(db, clock, new FakeAudit(), new ProjectFactsReadService(db));
+        return new StageDecisionService(db, clock, progress);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class TestClock : IClock
+    {
+        public TestClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; set; }
+    }
+
+    private sealed class FakeAudit : IAuditService
+    {
+        public Task LogAsync(
+            string action,
+            string? message = null,
+            string level = "Info",
+            string? userId = null,
+            string? userName = null,
+            IDictionary<string, string?>? data = null,
+            Microsoft.AspNetCore.Http.HttpContext? http = null)
+            => Task.CompletedTask;
+    }
+}

--- a/Services/Stages/StageDecisionService.cs
+++ b/Services/Stages/StageDecisionService.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class StageDecisionService
+{
+    private const string PendingDecisionStatus = "Pending";
+    private const string ApprovedDecisionStatus = "Approved";
+    private const string RejectedDecisionStatus = "Rejected";
+
+    private const string ApprovedLogAction = "Approved";
+    private const string RejectedLogAction = "Rejected";
+    private const string AppliedLogAction = "Applied";
+
+    private const string CompletionClampedWarning =
+        "Completion date was earlier than the actual start date and has been adjusted to match the start date.";
+
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+    private readonly StageProgressService _stageProgressService;
+
+    public StageDecisionService(ApplicationDbContext db, IClock clock, StageProgressService stageProgressService)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _stageProgressService = stageProgressService ?? throw new ArgumentNullException(nameof(stageProgressService));
+    }
+
+    public async Task<StageDecisionResult> DecideAsync(StageDecisionInput input, string hodUserId, CancellationToken cancellationToken = default)
+    {
+        if (input is null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        if (string.IsNullOrWhiteSpace(hodUserId))
+        {
+            throw new ArgumentException("A valid user identifier is required.", nameof(hodUserId));
+        }
+
+        var request = await _db.StageChangeRequests
+            .SingleOrDefaultAsync(r => r.Id == input.RequestId, cancellationToken);
+
+        if (request is null)
+        {
+            return StageDecisionResult.RequestNotFound();
+        }
+
+        var stage = await _db.ProjectStages
+            .Include(s => s.Project)
+            .SingleOrDefaultAsync(
+                s => s.ProjectId == request.ProjectId && s.StageCode == request.StageCode,
+                cancellationToken);
+
+        if (stage is null)
+        {
+            return StageDecisionResult.StageNotFound();
+        }
+
+        if (!string.Equals(stage.Project?.HodUserId, hodUserId, StringComparison.Ordinal))
+        {
+            return StageDecisionResult.NotHeadOfDepartment();
+        }
+
+        if (!string.Equals(request.DecisionStatus, PendingDecisionStatus, StringComparison.Ordinal))
+        {
+            return StageDecisionResult.AlreadyDecided();
+        }
+
+        var trimmedNote = string.IsNullOrWhiteSpace(input.DecisionNote) ? null : input.DecisionNote.Trim();
+        var now = _clock.UtcNow;
+
+        if (input.Action == StageDecisionAction.Reject)
+        {
+            request.DecisionStatus = RejectedDecisionStatus;
+            request.DecidedByUserId = hodUserId;
+            request.DecidedOn = now;
+            request.DecisionNote = trimmedNote;
+
+            var rejectionLog = new StageChangeLog
+            {
+                ProjectId = stage.ProjectId,
+                StageCode = stage.StageCode,
+                Action = RejectedLogAction,
+                FromStatus = stage.Status.ToString(),
+                ToStatus = stage.Status.ToString(),
+                FromActualStart = stage.ActualStart,
+                ToActualStart = stage.ActualStart,
+                FromCompletedOn = stage.CompletedOn,
+                ToCompletedOn = stage.CompletedOn,
+                UserId = hodUserId,
+                At = now,
+                Note = trimmedNote
+            };
+
+            await _db.StageChangeLogs.AddAsync(rejectionLog, cancellationToken);
+            await _db.SaveChangesAsync(cancellationToken);
+
+            return StageDecisionResult.Success();
+        }
+
+        if (!Enum.TryParse<StageStatus>(request.RequestedStatus, ignoreCase: true, out var requestedStatus))
+        {
+            return StageDecisionResult.ValidationFailed("The requested status is not recognised.");
+        }
+
+        if (stage.Status == requestedStatus)
+        {
+            return StageDecisionResult.ValidationFailed("The project stage already has the requested status.");
+        }
+
+        if (!StageTransitionRules.IsTransitionAllowed(stage.Status, requestedStatus))
+        {
+            return StageDecisionResult.ValidationFailed(
+                $"Changing from {stage.Status} to {requestedStatus} is not allowed.");
+        }
+
+        var warnings = new List<string>();
+        DateOnly? effectiveDate = request.RequestedDate;
+
+        if (requestedStatus == StageStatus.Completed)
+        {
+            if (!request.RequestedDate.HasValue)
+            {
+                return StageDecisionResult.ValidationFailed(
+                    "A completion date is required when approving completion.");
+            }
+
+            if (stage.ActualStart.HasValue && request.RequestedDate.Value < stage.ActualStart.Value)
+            {
+                effectiveDate = stage.ActualStart;
+                warnings.Add(CompletionClampedWarning);
+            }
+        }
+
+        if (requestedStatus is StageStatus.InProgress or StageStatus.Completed)
+        {
+            var incompletePredecessors = await FindIncompletePredecessorsAsync(
+                stage.ProjectId,
+                stage.StageCode,
+                cancellationToken);
+
+            if (incompletePredecessors.Count > 0)
+            {
+                warnings.Add(
+                    $"Predecessor stages are incomplete: {string.Join(", ", incompletePredecessors)}.");
+            }
+        }
+
+        var beforeStatus = stage.Status;
+        var beforeActualStart = stage.ActualStart;
+        var beforeCompletedOn = stage.CompletedOn;
+
+        await using var transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+        await _stageProgressService.UpdateStageStatusAsync(
+            stage.ProjectId,
+            stage.StageCode,
+            requestedStatus,
+            effectiveDate,
+            hodUserId,
+            cancellationToken);
+
+        await _db.Entry(stage).ReloadAsync(cancellationToken);
+
+        var afterStatus = stage.Status;
+        var afterActualStart = stage.ActualStart;
+        var afterCompletedOn = stage.CompletedOn;
+        var finalNote = CombineNoteAndWarnings(trimmedNote, warnings);
+
+        request.DecisionStatus = ApprovedDecisionStatus;
+        request.DecidedByUserId = hodUserId;
+        request.DecidedOn = now;
+        request.DecisionNote = finalNote;
+
+        var approvedLog = new StageChangeLog
+        {
+            ProjectId = stage.ProjectId,
+            StageCode = stage.StageCode,
+            Action = ApprovedLogAction,
+            FromStatus = beforeStatus.ToString(),
+            ToStatus = afterStatus.ToString(),
+            FromActualStart = beforeActualStart,
+            ToActualStart = afterActualStart,
+            FromCompletedOn = beforeCompletedOn,
+            ToCompletedOn = afterCompletedOn,
+            UserId = hodUserId,
+            At = now,
+            Note = finalNote
+        };
+
+        var appliedLog = new StageChangeLog
+        {
+            ProjectId = stage.ProjectId,
+            StageCode = stage.StageCode,
+            Action = AppliedLogAction,
+            FromStatus = beforeStatus.ToString(),
+            ToStatus = afterStatus.ToString(),
+            FromActualStart = beforeActualStart,
+            ToActualStart = afterActualStart,
+            FromCompletedOn = beforeCompletedOn,
+            ToCompletedOn = afterCompletedOn,
+            UserId = hodUserId,
+            At = now,
+            Note = finalNote
+        };
+
+        await _db.StageChangeLogs.AddAsync(approvedLog, cancellationToken);
+        await _db.StageChangeLogs.AddAsync(appliedLog, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return StageDecisionResult.Success(warnings);
+    }
+
+    private async Task<IReadOnlyList<string>> FindIncompletePredecessorsAsync(
+        int projectId,
+        string stageCode,
+        CancellationToken cancellationToken)
+    {
+        var required = StageDependencies.RequiredPredecessors(stageCode);
+
+        if (required.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var predecessors = await _db.ProjectStages
+            .Where(ps => ps.ProjectId == projectId && required.Contains(ps.StageCode))
+            .Select(ps => new { ps.StageCode, ps.Status })
+            .ToListAsync(cancellationToken);
+
+        var incomplete = new List<string>();
+
+        foreach (var code in required)
+        {
+            var match = predecessors.FirstOrDefault(
+                p => string.Equals(p.StageCode, code, StringComparison.OrdinalIgnoreCase));
+
+            if (match is null || match.Status is not StageStatus.Completed and not StageStatus.Skipped)
+            {
+                incomplete.Add(code);
+            }
+        }
+
+        return incomplete;
+    }
+
+    private static string? CombineNoteAndWarnings(string? note, IReadOnlyList<string> warnings)
+    {
+        if (warnings.Count == 0)
+        {
+            return note;
+        }
+
+        var warningText = string.Join(Environment.NewLine, warnings.Select(w => $"Warning: {w}"));
+
+        if (string.IsNullOrEmpty(note))
+        {
+            return warningText;
+        }
+
+        return note + Environment.NewLine + warningText;
+    }
+}
+
+public sealed record StageDecisionInput(int RequestId, StageDecisionAction Action, string? DecisionNote);
+
+public enum StageDecisionAction
+{
+    Approve,
+    Reject
+}
+
+public sealed record StageDecisionResult
+{
+    private StageDecisionResult(StageDecisionOutcome outcome, string? error, IReadOnlyList<string>? warnings)
+    {
+        Outcome = outcome;
+        Error = error;
+        Warnings = warnings ?? Array.Empty<string>();
+    }
+
+    public StageDecisionOutcome Outcome { get; }
+    public string? Error { get; }
+    public IReadOnlyList<string> Warnings { get; }
+
+    public static StageDecisionResult Success(IReadOnlyList<string>? warnings = null)
+        => new(StageDecisionOutcome.Success, null, warnings);
+
+    public static StageDecisionResult NotHeadOfDepartment()
+        => new(StageDecisionOutcome.NotHeadOfDepartment, null, Array.Empty<string>());
+
+    public static StageDecisionResult RequestNotFound()
+        => new(StageDecisionOutcome.RequestNotFound, null, Array.Empty<string>());
+
+    public static StageDecisionResult StageNotFound()
+        => new(StageDecisionOutcome.StageNotFound, null, Array.Empty<string>());
+
+    public static StageDecisionResult AlreadyDecided()
+        => new(StageDecisionOutcome.AlreadyDecided, null, Array.Empty<string>());
+
+    public static StageDecisionResult ValidationFailed(string message)
+        => new(StageDecisionOutcome.ValidationFailed, message, Array.Empty<string>());
+}
+
+public enum StageDecisionOutcome
+{
+    Success,
+    NotHeadOfDepartment,
+    RequestNotFound,
+    StageNotFound,
+    AlreadyDecided,
+    ValidationFailed
+}


### PR DESCRIPTION
## Summary
- add a StageDecisionService that enforces HoD permissions, re-validates pending requests, and applies approvals with logging and warnings
- expose a /Projects/Stages/DecideChange endpoint for HoD JSON decisions and register the service for DI
- add unit tests covering approval, rejection, date clamping, and predecessor warning scenarios

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8445dc48c83299c1abdb99e0d1fa7