### PR TITLE
Add HoD direct apply UI for project stages

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -318,6 +318,8 @@
         </div>
     </div>
 
+    <partial name="_StageDirectApplyModal" />
+
     <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasProcurement" aria-labelledby="offcanvasProcurementLabel">
         <div class="offcanvas-header">
             <h5 id="offcanvasProcurementLabel" class="mb-0">Edit Procurement</h5>
@@ -361,6 +363,7 @@
 @section Scripts {
     <script src="~/js/projects/overview.js"></script>
     <script src="~/js/projects/plan-edit.js"></script>
+    <script src="~/js/projects/stages.js"></script>
 }
 
 @functions {

--- a/Pages/Projects/Stages/ApplyChange.cshtml.cs
+++ b/Pages/Projects/Stages/ApplyChange.cshtml.cs
@@ -22,7 +22,8 @@ public class ApplyChangeModel : PageModel
         "InProgress",
         "Completed",
         "Blocked",
-        "Skipped"
+        "Skipped",
+        "Reopen"
     };
 
     private readonly StageDirectApplyService _service;
@@ -94,7 +95,7 @@ public class ApplyChangeModel : PageModel
                 error = "Validation failed",
                 details = new[]
                 {
-                    "Status must be one of: NotStarted, InProgress, Completed, Blocked, Skipped."
+                    "Status must be one of: NotStarted, InProgress, Completed, Blocked, Skipped, Reopen."
                 }
             });
         }

--- a/Pages/Projects/_StageDirectApplyModal.cshtml
+++ b/Pages/Projects/_StageDirectApplyModal.cshtml
@@ -1,0 +1,44 @@
+@{
+    Layout = null;
+}
+
+<div class="modal fade" id="stageDirectApplyModal" tabindex="-1" aria-labelledby="stageDirectApplyLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" data-direct-apply-form novalidate>
+                <div class="modal-header">
+                    <h5 class="modal-title" id="stageDirectApplyLabel">Update stage</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="projectId" />
+                    <input type="hidden" name="stageCode" />
+                    <input type="hidden" name="status" />
+                    @Html.AntiForgeryToken()
+
+                    <div class="mb-3">
+                        <div class="fw-semibold" data-direct-apply-stage></div>
+                        <div class="text-muted" data-direct-apply-status></div>
+                    </div>
+
+                    <div class="alert alert-danger d-none" role="alert" data-direct-apply-errors></div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="directApplyDate">Effective date</label>
+                        <input type="date" class="form-control" id="directApplyDate" name="date" />
+                        <div class="form-text" data-direct-apply-date-hint>Optional.</div>
+                    </div>
+
+                    <div class="mb-0">
+                        <label class="form-label" for="directApplyNote">Note <span class="text-muted">(optional)</span></label>
+                        <textarea class="form-control" id="directApplyNote" name="note" rows="3" maxlength="1024"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-direct-apply-submit>Apply change</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,10 +1,14 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
 @using ProjectManagement.Models.Execution
+@{
+    var showDirectApply = User.IsInRole("HoD");
+}
 @functions{
     string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
     string StatusChip(StageStatus s) =>
-        s switch {
+        s switch
+        {
             StageStatus.Completed  => "badge bg-success",
             StageStatus.InProgress => "badge bg-primary",
             _                      => "badge bg-secondary"
@@ -25,27 +29,64 @@
         StageStatus.InProgress => "pm-item is-active",
         _                      => "pm-item"
       };
-      <div class="@itemClass">
-        <div class="pm-item-header">
-          <span class="pm-item-title">@s.Name</span>
-          <span class="@StatusChip(s.Status)">@s.Status</span>
-          @if (s.IsAutoCompleted)
+      <div class="@itemClass" data-stage-row="@s.Code">
+        <div class="pm-item-header d-flex flex-wrap justify-content-between align-items-start gap-2">
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            <span class="pm-item-title" data-stage-name="@s.Name">@s.Name</span>
+            <span class="@StatusChip(s.Status)" data-stage-status>@s.Status</span>
+            @if (s.IsAutoCompleted)
+            {
+              <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
+            }
+            @if (s.RequiresBackfill)
+            {
+              <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
+              <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
+            }
+          </div>
+          @if (showDirectApply)
           {
-            <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
-          }
-          @if (s.RequiresBackfill)
-          {
-            <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
-            <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
+            <div class="dropdown">
+              <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Actions
+              </button>
+              <ul class="dropdown-menu">
+                <li>
+                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="InProgress" data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
+                    Start stage
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Completed" data-default-date="@s.CompletedOn?.ToString("yyyy-MM-dd")">
+                    Mark completed
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Blocked">
+                    Block
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Skipped">
+                    Skip
+                  </button>
+                </li>
+                <li>
+                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Reopen">
+                    Reopen
+                  </button>
+                </li>
+              </ul>
+            </div>
           }
         </div>
         <div class="pm-item-meta">
-          <div>Planned: @D(s.PlannedStart) — @D(s.PlannedEnd)</div>
-          <div>Actual: @D(s.ActualStart) — @D(s.CompletedOn)
-            @if (s.ActualDurationDays.HasValue)
-            {
-              <span class="text-muted ms-2">(@s.ActualDurationDays d)</span>
-            }
+          <div>Planned: <span data-stage-planned-start>@D(s.PlannedStart)</span> — <span data-stage-planned-end>@D(s.PlannedEnd)</span></div>
+          <div>
+            Actual: <span data-stage-actual-start>@D(s.ActualStart)</span> — <span data-stage-completed>@D(s.CompletedOn)</span>
+            <span class="text-muted ms-2@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
+              @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
+            </span>
           </div>
         </div>
       </div>

--- a/ProjectManagement.Tests/ProjectTimelineUiTests.cs
+++ b/ProjectManagement.Tests/ProjectTimelineUiTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.ViewModels;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class ProjectTimelineUiTests
+{
+    private static readonly IServiceProvider Services = BuildServiceProvider();
+
+    [Fact]
+    public async Task ActionsDropdown_RenderedForHoDOnly()
+    {
+        var model = new TimelineVm
+        {
+            ProjectId = 1,
+            Items = new[]
+            {
+                new TimelineItemVm
+                {
+                    Code = "IPA",
+                    Name = "In-Principle Approval",
+                    Status = StageStatus.NotStarted,
+                    SortOrder = 1
+                }
+            }
+        };
+
+        var hodHtml = await RenderAsync(model, new[] { "HoD" });
+        Assert.Contains("data-direct-apply", hodHtml, StringComparison.Ordinal);
+
+        var otherHtml = await RenderAsync(model, Array.Empty<string>());
+        Assert.DoesNotContain("data-direct-apply", otherHtml, StringComparison.Ordinal);
+    }
+
+    private static async Task<string> RenderAsync(TimelineVm model, string[] roles)
+    {
+        using var scope = Services.CreateScope();
+        var provider = scope.ServiceProvider;
+        var viewEngine = provider.GetRequiredService<IRazorViewEngine>();
+        var tempDataProvider = provider.GetRequiredService<ITempDataProvider>();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = provider,
+            User = BuildPrincipal(roles)
+        };
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: "/Pages/Shared/_ProjectTimeline.cshtml", isMainPage: false);
+
+        if (!viewResult.Success)
+        {
+            throw new InvalidOperationException("Unable to locate _ProjectTimeline partial view.");
+        }
+
+        await using var writer = new StringWriter();
+        var viewData = new ViewDataDictionary<TimelineVm>(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = model
+        };
+        var tempData = new TempDataDictionary(httpContext, tempDataProvider);
+        var viewContext = new ViewContext(actionContext, viewResult.View, viewData, tempData, writer, new HtmlHelperOptions());
+
+        await viewResult.View.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    private static ClaimsPrincipal BuildPrincipal(string[] roles)
+    {
+        var identity = new ClaimsIdentity("Test");
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "user"));
+        foreach (var role in roles)
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Role, role));
+        }
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static IServiceProvider BuildServiceProvider()
+    {
+        var contentRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var webRoot = Path.Combine(contentRoot, "wwwroot");
+
+        var environment = new TestWebHostEnvironment
+        {
+            ApplicationName = typeof(Program).Assembly.GetName().Name!,
+            ContentRootPath = contentRoot,
+            WebRootPath = webRoot,
+            ContentRootFileProvider = new PhysicalFileProvider(contentRoot),
+            WebRootFileProvider = Directory.Exists(webRoot) ? new PhysicalFileProvider(webRoot) : new NullFileProvider(),
+            EnvironmentName = Environments.Development
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IWebHostEnvironment>(environment);
+        services.AddSingleton<IHostEnvironment>(environment);
+        services.AddLogging();
+        services.AddRouting();
+        services.AddRazorPages();
+        services.AddControllersWithViews();
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/ProjectManagement.Tests/StageDirectApplyServiceTests.cs
+++ b/ProjectManagement.Tests/StageDirectApplyServiceTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Stages;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageDirectApplyServiceTests
+{
+    [Fact]
+    public async Task DirectApply_Completed_SetsDatesAndLogs()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 5, 10, 9, 30, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.InProgress, new DateOnly(2024, 5, 1));
+
+        var service = new StageDirectApplyService(db, clock);
+
+        var result = await service.ApplyAsync(
+            projectId: 1,
+            stageCode: StageCodes.IPA,
+            newStatus: StageStatus.Completed.ToString(),
+            date: new DateOnly(2024, 5, 12),
+            note: "  Completed ahead of schedule  ",
+            hodUserId: "hod-1",
+            CancellationToken.None);
+
+        Assert.Equal(DirectApplyOutcome.Success, result.Outcome);
+        Assert.Equal(StageStatus.Completed, result.UpdatedStatus);
+        Assert.Equal(new DateOnly(2024, 5, 1), result.ActualStart);
+        Assert.Equal(new DateOnly(2024, 5, 12), result.CompletedOn);
+        Assert.False(result.SupersededRequest);
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(StageStatus.Completed, stage.Status);
+        Assert.Equal(new DateOnly(2024, 5, 1), stage.ActualStart);
+        Assert.Equal(new DateOnly(2024, 5, 12), stage.CompletedOn);
+
+        var logs = await db.StageChangeLogs.OrderBy(l => l.At).ToListAsync();
+        Assert.Equal(2, logs.Count);
+        Assert.Contains(logs, l => l.Action == "DirectApply" && l.Note == "Completed ahead of schedule");
+        Assert.Contains(logs, l => l.Action == "Applied" && l.ToStatus == StageStatus.Completed.ToString());
+    }
+
+    [Fact]
+    public async Task DirectApply_SupersedesPending()
+    {
+        var clock = new TestClock(new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero));
+        await using var db = CreateContext();
+        await SeedStageAsync(db, StageStatus.NotStarted);
+
+        db.StageChangeRequests.Add(new StageChangeRequest
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            RequestedStatus = StageStatus.Completed.ToString(),
+            DecisionStatus = "Pending",
+            RequestedDate = new DateOnly(2024, 5, 20),
+            RequestedByUserId = "po-1",
+            RequestedOn = new DateTimeOffset(2024, 5, 20, 0, 0, 0, TimeSpan.Zero)
+        });
+        await db.SaveChangesAsync();
+
+        var service = new StageDirectApplyService(db, clock);
+        var result = await service.ApplyAsync(
+            projectId: 1,
+            stageCode: StageCodes.IPA,
+            newStatus: StageStatus.InProgress.ToString(),
+            date: new DateOnly(2024, 6, 2),
+            note: null,
+            hodUserId: "hod-1",
+            CancellationToken.None);
+
+        Assert.Equal(DirectApplyOutcome.Success, result.Outcome);
+        Assert.True(result.SupersededRequest);
+        Assert.Equal(StageStatus.InProgress, result.UpdatedStatus);
+
+        var request = await db.StageChangeRequests.SingleAsync();
+        Assert.Equal("Superseded", request.DecisionStatus);
+        Assert.Equal("hod-1", request.DecidedByUserId);
+        Assert.Equal(clock.UtcNow, request.DecidedOn);
+        Assert.Equal("Superseded by HoD direct apply", request.DecisionNote);
+
+        var logs = await db.StageChangeLogs.OrderBy(l => l.At).ToListAsync();
+        Assert.Equal(3, logs.Count);
+        Assert.Contains(logs, l => l.Action == "Superseded" && l.ToStatus == StageStatus.Completed.ToString());
+        Assert.Contains(logs, l => l.Action == "DirectApply" && l.ToStatus == StageStatus.InProgress.ToString());
+        Assert.Contains(logs, l => l.Action == "Applied" && l.ToStatus == StageStatus.InProgress.ToString());
+    }
+
+    private static async Task SeedStageAsync(ApplicationDbContext db, StageStatus status, DateOnly? actualStart = null)
+    {
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Project",
+            CreatedByUserId = "creator",
+            HodUserId = "hod-1",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = status,
+            ActualStart = actualStart
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class TestClock : IClock
+    {
+        public TestClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; set; }
+    }
+}

--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -1,0 +1,371 @@
+(function () {
+  const DATE_REQUIRED_STATUSES = new Set(['InProgress', 'Completed']);
+
+  function escapeSelector(value) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+
+    return value.replace(/([\0-\x1f\x7f-\x9f\s!"#$%&'()*+,./:;<=>?@\[\\\]\^`{|}~])/g, '\\$1');
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 'Completed':
+        return 'Completed';
+      case 'InProgress':
+        return 'In progress';
+      case 'Blocked':
+        return 'Blocked';
+      case 'Skipped':
+        return 'Skipped';
+      case 'NotStarted':
+        return 'Not started';
+      default:
+        return status || '';
+    }
+  }
+
+  function formatDate(isoDate) {
+    if (!isoDate) {
+      return '—';
+    }
+
+    const [year, month, day] = isoDate.split('-').map((part) => parseInt(part, 10));
+    if (!year || !month || !day) {
+      return '—';
+    }
+
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return date.toLocaleDateString(undefined, {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    });
+  }
+
+  function calculateDurationDays(startIso, endIso) {
+    if (!startIso || !endIso) {
+      return null;
+    }
+
+    const start = new Date(`${startIso}T00:00:00Z`);
+    const end = new Date(`${endIso}T00:00:00Z`);
+    const diff = end.getTime() - start.getTime();
+    if (Number.isNaN(diff) || diff < 0) {
+      return null;
+    }
+
+    return Math.floor(diff / 86400000) + 1;
+  }
+
+  function badgeClass(status) {
+    switch (status) {
+      case 'Completed':
+        return 'badge bg-success';
+      case 'InProgress':
+        return 'badge bg-primary';
+      default:
+        return 'badge bg-secondary';
+    }
+  }
+
+  function ensureToastContainer() {
+    let container = document.getElementById('directApplyToastContainer');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'directApplyToastContainer';
+      container.className = 'toast-container position-fixed top-0 end-0 p-3';
+      container.setAttribute('aria-live', 'polite');
+      container.setAttribute('aria-atomic', 'true');
+      document.body.appendChild(container);
+    }
+
+    return container;
+  }
+
+  function showToast(message, variant) {
+    const container = ensureToastContainer();
+    const toastEl = document.createElement('div');
+    toastEl.className = `toast align-items-center text-bg-${variant} border-0`;
+    toastEl.role = 'status';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd-flex';
+
+    const body = document.createElement('div');
+    body.className = 'toast-body';
+    body.textContent = message;
+
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.className = 'btn-close btn-close-white me-2 m-auto';
+    dismiss.setAttribute('data-bs-dismiss', 'toast');
+    dismiss.setAttribute('aria-label', 'Close');
+
+    wrapper.appendChild(body);
+    wrapper.appendChild(dismiss);
+    toastEl.appendChild(wrapper);
+    container.appendChild(toastEl);
+    const toast = bootstrap.Toast.getOrCreateInstance(toastEl, { autohide: true, delay: 4000 });
+    toastEl.addEventListener('hidden.bs.toast', () => {
+      toast.dispose();
+      toastEl.remove();
+    });
+    toast.show();
+  }
+
+  function todayIso() {
+    const today = new Date();
+    const month = `${today.getMonth() + 1}`.padStart(2, '0');
+    const day = `${today.getDate()}`.padStart(2, '0');
+    return `${today.getFullYear()}-${month}-${day}`;
+  }
+
+  function updateStageRow(stageCode, payloadStatus, updated) {
+    if (!stageCode) return;
+    const row = document.querySelector(`[data-stage-row="${escapeSelector(stageCode)}"]`);
+    if (!row) return;
+
+    const updatedStatus = (updated && updated.status) ? updated.status : payloadStatus;
+    const statusText = updatedStatus || payloadStatus;
+    const badge = row.querySelector('[data-stage-status]');
+    if (badge) {
+      badge.textContent = statusLabel(statusText);
+      badge.className = badgeClass(statusText || '');
+    }
+
+    const actualSpan = row.querySelector('[data-stage-actual-start]');
+    if (actualSpan) {
+      actualSpan.textContent = formatDate(updated?.actualStart ?? null);
+    }
+
+    const completedSpan = row.querySelector('[data-stage-completed]');
+    if (completedSpan) {
+      completedSpan.textContent = formatDate(updated?.completedOn ?? null);
+    }
+
+    const durationSpan = row.querySelector('[data-stage-duration]');
+    if (durationSpan) {
+      const days = calculateDurationDays(updated?.actualStart ?? null, updated?.completedOn ?? null);
+      if (days) {
+        durationSpan.textContent = `(${days} d)`;
+        durationSpan.classList.remove('d-none');
+      } else {
+        durationSpan.textContent = '';
+        durationSpan.classList.add('d-none');
+      }
+    }
+
+    const triggers = row.querySelectorAll('[data-direct-apply]');
+    triggers.forEach((trigger) => {
+      const triggerStatus = trigger.getAttribute('data-status');
+      if (triggerStatus === 'Completed') {
+        if (updated?.completedOn) {
+          trigger.setAttribute('data-default-date', updated.completedOn);
+        } else {
+          trigger.removeAttribute('data-default-date');
+        }
+      } else if (triggerStatus === 'InProgress') {
+        if (updated?.actualStart) {
+          trigger.setAttribute('data-default-date', updated.actualStart);
+        } else {
+          trigger.removeAttribute('data-default-date');
+        }
+      }
+    });
+  }
+
+  function renderErrors(container, messages) {
+    if (!container) return;
+    const hasErrors = Array.isArray(messages) && messages.length > 0;
+    if (!hasErrors) {
+      container.classList.add('d-none');
+      container.textContent = '';
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'mb-0';
+    messages.forEach((message) => {
+      const item = document.createElement('li');
+      item.textContent = message;
+      list.appendChild(item);
+    });
+    container.replaceChildren(list);
+    container.classList.remove('d-none');
+  }
+
+  function handleWarnings(warnings) {
+    if (!Array.isArray(warnings)) return;
+    warnings.forEach((warning) => {
+      if (warning) {
+        showToast(warning, 'warning');
+      }
+    });
+  }
+
+  function boot() {
+    const modalEl = document.getElementById('stageDirectApplyModal');
+    if (!modalEl) {
+      return;
+    }
+
+    if (typeof bootstrap === 'undefined' || !bootstrap.Modal || !bootstrap.Toast) {
+      return;
+    }
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    const form = modalEl.querySelector('[data-direct-apply-form]');
+    const stageLabel = modalEl.querySelector('[data-direct-apply-stage]');
+    const statusLabelEl = modalEl.querySelector('[data-direct-apply-status]');
+    const dateInput = modalEl.querySelector('input[name="date"]');
+    const noteInput = modalEl.querySelector('textarea[name="note"]');
+    const projectInput = modalEl.querySelector('input[name="projectId"]');
+    const stageInput = modalEl.querySelector('input[name="stageCode"]');
+    const statusInput = modalEl.querySelector('input[name="status"]');
+    const tokenInput = modalEl.querySelector('input[name="__RequestVerificationToken"]');
+    const errorContainer = modalEl.querySelector('[data-direct-apply-errors]');
+    const dateHint = modalEl.querySelector('[data-direct-apply-date-hint]');
+    const submitButton = modalEl.querySelector('[data-direct-apply-submit]');
+
+    function setDateRequired(required) {
+      if (!dateInput) return;
+      dateInput.required = required;
+      if (dateHint) {
+        dateHint.textContent = required ? 'Required.' : 'Optional.';
+      }
+    }
+
+    document.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-direct-apply]');
+      if (!trigger) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const projectId = trigger.getAttribute('data-project') || '';
+      const stageCode = trigger.getAttribute('data-stage') || '';
+      const status = trigger.getAttribute('data-status') || '';
+      const stageName = trigger.getAttribute('data-stage-name') || '';
+      const defaultDate = trigger.getAttribute('data-default-date') || '';
+
+      if (projectInput) projectInput.value = projectId;
+      if (stageInput) stageInput.value = stageCode;
+      if (statusInput) statusInput.value = status;
+      if (stageLabel) stageLabel.textContent = `${stageCode ? stageCode + ' — ' : ''}${stageName}`.trim();
+      if (statusLabelEl) statusLabelEl.textContent = `Change to ${statusLabel(status)}`;
+      if (errorContainer) {
+        errorContainer.classList.add('d-none');
+        errorContainer.textContent = '';
+      }
+      if (noteInput) {
+        noteInput.value = '';
+      }
+
+      const requiresDate = DATE_REQUIRED_STATUSES.has(status);
+      setDateRequired(requiresDate);
+      if (dateInput) {
+        dateInput.value = defaultDate || (requiresDate ? todayIso() : '');
+      }
+
+      if (submitButton) {
+        submitButton.disabled = false;
+      }
+
+      modal.show();
+    });
+
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!projectInput || !stageInput || !statusInput || !tokenInput) {
+        return;
+      }
+
+      if (submitButton) {
+        submitButton.disabled = true;
+      }
+
+      if (errorContainer) {
+        errorContainer.classList.add('d-none');
+        errorContainer.textContent = '';
+      }
+
+      const payload = {
+        projectId: Number.parseInt(projectInput.value, 10),
+        stageCode: stageInput.value,
+        status: statusInput.value,
+        date: dateInput && dateInput.value ? dateInput.value : null,
+        note: noteInput && noteInput.value ? noteInput.value.trim() : null
+      };
+
+      if (!payload.projectId) {
+        payload.projectId = 0;
+      }
+
+      try {
+        const response = await fetch('/Projects/Stages/ApplyChange', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'RequestVerificationToken': tokenInput.value
+          },
+          body: JSON.stringify(payload)
+        });
+
+        if (response.status === 422) {
+          const data = await response.json().catch(() => null);
+          const messages = data?.details || ['Validation failed.'];
+          renderErrors(errorContainer, messages);
+          if (submitButton) submitButton.disabled = false;
+          return;
+        }
+
+        if (response.status === 409) {
+          showToast('Pending request was superseded by this change.', 'warning');
+          modal.hide();
+          if (submitButton) submitButton.disabled = false;
+          return;
+        }
+
+        if (!response.ok) {
+          showToast('Unable to update the stage right now.', 'danger');
+          if (submitButton) submitButton.disabled = false;
+          return;
+        }
+
+        const data = await response.json();
+        if (!data?.ok) {
+          showToast('Unable to update the stage right now.', 'danger');
+          if (submitButton) submitButton.disabled = false;
+          return;
+        }
+
+        updateStageRow(stageInput.value, statusInput.value, data.updated);
+        modal.hide();
+        showToast('Stage updated.', 'success');
+        handleWarnings(data.warnings);
+      } catch (error) {
+        console.error(error);
+        showToast('Unable to update the stage right now.', 'danger');
+      } finally {
+        if (submitButton) submitButton.disabled = false;
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a HoD-only actions dropdown to the project timeline and render a modal for direct apply updates
- wire a dedicated stages.js script to post direct apply requests, refresh the UI, and surface responses
- cover the UI gating and service behaviour with new tests for the timeline partial and StageDirectApplyService

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d851c04fa48329b0d1806a67f35795