### PR TITLE
Fix test references after plan edit refactor

### DIFF
--- a/ProjectManagement.Tests/EditPlanPncOptionalityTests.cs
+++ b/ProjectManagement.Tests/EditPlanPncOptionalityTests.cs
@@ -19,6 +19,7 @@ using ProjectManagement.Pages.Projects.Timeline;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Plans;
 using ProjectManagement.Services.Stages;
+using ProjectManagement.ViewModels;
 using Xunit;
 
 namespace ProjectManagement.Tests;

--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectManagement.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/ProjectManagement.Tests/ProjectTimelineUiTests.cs
+++ b/ProjectManagement.Tests/ProjectTimelineUiTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary
- import the plan edit view model types in the plan optionality tests
- add the missing ViewContext namespace for the timeline UI tests
- reference the ASP.NET Core shared framework from the test project

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a9154be8832984c7ab13b6fa95bd