### PR TITLE
Deactivate EOI stage in phase 1

### DIFF
--- a/Migrations/20250928120000_RemoveEoiStage_V1_Deactivate.cs
+++ b/Migrations/20250928120000_RemoveEoiStage_V1_Deactivate.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveEoiStage_V1_Deactivate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var isSqlServer = migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer";
+
+            if (isSqlServer)
+            {
+                migrationBuilder.Sql(@"DELETE FROM StageChangeLogs WHERE StageCode = 'EOI';
+DELETE FROM StageChangeRequests WHERE StageCode = 'EOI';
+DELETE FROM ProjectStages WHERE StageCode = 'EOI';
+DELETE FROM StagePlans WHERE StageCode = 'EOI';");
+            }
+            else
+            {
+                migrationBuilder.Sql(@"DELETE FROM \"StageChangeLogs\" WHERE \"StageCode\" = 'EOI';
+DELETE FROM \"StageChangeRequests\" WHERE \"StageCode\" = 'EOI';
+DELETE FROM \"ProjectStages\" WHERE \"StageCode\" = 'EOI';
+DELETE FROM \"StagePlans\" WHERE \"StageCode\" = 'EOI';");
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/Models/Stages/StageCodes.cs
+++ b/Models/Stages/StageCodes.cs
@@ -23,7 +23,6 @@ public static class StageCodes
 
     public static readonly string[] All =
     {
-        EOI,
         FS,
         IPA,
         SOW,

--- a/ProjectManagement.Tests/PlanDraftAndApprovalServiceTests.cs
+++ b/ProjectManagement.Tests/PlanDraftAndApprovalServiceTests.cs
@@ -30,8 +30,8 @@ public class PlanDraftAndApprovalServiceTests
         db.StageTemplates.Add(new StageTemplate
         {
             Version = PlanConstants.StageTemplateVersion,
-            Code = StageCodes.EOI,
-            Name = "Expression of Interest",
+            Code = StageCodes.FS,
+            Name = "Feasibility Study",
             Sequence = 10
         });
 
@@ -65,7 +65,7 @@ public class PlanDraftAndApprovalServiceTests
         Assert.NotEqual("other", draft.CreatedByUserId);
         Assert.Equal(2, draft.VersionNo);
         Assert.Single(draft.StagePlans);
-        Assert.Equal(StageCodes.EOI, draft.StagePlans[0].StageCode);
+        Assert.Equal(StageCodes.FS, draft.StagePlans[0].StageCode);
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class PlanDraftAndApprovalServiceTests
         db.StageTemplates.Add(new StageTemplate
         {
             Version = PlanConstants.StageTemplateVersion,
-            Code = StageCodes.EOI,
-            Name = "Expression of Interest",
+            Code = StageCodes.FS,
+            Name = "Feasibility Study",
             Sequence = 10
         });
 
@@ -125,8 +125,8 @@ public class PlanDraftAndApprovalServiceTests
         db.StageTemplates.Add(new StageTemplate
         {
             Version = PlanConstants.StageTemplateVersion,
-            Code = StageCodes.EOI,
-            Name = "Expression of Interest",
+            Code = StageCodes.FS,
+            Name = "Feasibility Study",
             Sequence = 10
         });
 
@@ -150,7 +150,7 @@ public class PlanDraftAndApprovalServiceTests
 
         orphan.StagePlans.Add(new StagePlan
         {
-            StageCode = StageCodes.EOI,
+            StageCode = StageCodes.FS,
             PlannedStart = new DateOnly(2024, 1, 1),
             PlannedDue = new DateOnly(2024, 1, 5)
         });
@@ -246,7 +246,7 @@ public class PlanDraftAndApprovalServiceTests
 
         plan.StagePlans.Add(new StagePlan
         {
-            StageCode = StageCodes.EOI,
+            StageCode = StageCodes.FS,
             PlannedStart = DateOnly.FromDateTime(DateTime.Today),
             PlannedDue = DateOnly.FromDateTime(DateTime.Today.AddDays(5))
         });
@@ -288,7 +288,7 @@ public class PlanDraftAndApprovalServiceTests
 
         draft.StagePlans.Add(new StagePlan
         {
-            StageCode = StageCodes.EOI,
+            StageCode = StageCodes.FS,
             PlannedStart = new DateOnly(2024, 1, 1),
             PlannedDue = new DateOnly(2024, 1, 10)
         });

--- a/ProjectManagement.Tests/PlanDraftDeletionIntegrationTests.cs
+++ b/ProjectManagement.Tests/PlanDraftDeletionIntegrationTests.cs
@@ -54,7 +54,7 @@ public class PlanDraftDeletionIntegrationTests
 
         plan.StagePlans.Add(new StagePlan
         {
-            StageCode = StageCodes.EOI,
+            StageCode = StageCodes.FS,
             PlannedStart = new DateOnly(2024, 1, 5),
             PlannedDue = new DateOnly(2024, 1, 12)
         });

--- a/Services/Stages/StageDirectApplyService.cs
+++ b/Services/Stages/StageDirectApplyService.cs
@@ -55,6 +55,11 @@ public sealed class StageDirectApplyService
 
         var normalizedStageCode = stageCode.Trim().ToUpperInvariant();
 
+        if (string.Equals(normalizedStageCode, StageCodes.EOI, StringComparison.OrdinalIgnoreCase))
+        {
+            return DirectApplyResult.StageNotFound();
+        }
+
         var stage = await _db.ProjectStages
             .Include(s => s.Project)
             .SingleOrDefaultAsync(

--- a/Services/Stages/StageRequestService.cs
+++ b/Services/Stages/StageRequestService.cs
@@ -46,6 +46,11 @@ public class StageRequestService
 
         var stageCode = input.StageCode.Trim().ToUpperInvariant();
 
+        if (string.Equals(stageCode, StageCodes.EOI, StringComparison.OrdinalIgnoreCase))
+        {
+            return StageRequestResult.StageNotFound();
+        }
+
         var stage = await _db.ProjectStages
             .Include(s => s.Project)
             .SingleOrDefaultAsync(


### PR DESCRIPTION
## Summary
- add a RemoveEoiStage_V1_Deactivate data cleanup migration to purge lingering EOI records
- stop including EOI in the ordered stage list and guard request/direct apply flows against it
- refresh affected plan draft tests to use Feasibility Study as the initial stage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b03cdc4c8329987149722cef7057