### PR TITLE
Remove EOI stage code and clean up schema

### DIFF
--- a/Migrations/20250928041112_RemoveEoiStage_V2_Schema.cs
+++ b/Migrations/20250928041112_RemoveEoiStage_V2_Schema.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250928041112_RemoveEoiStage_V2_Schema")]
+    public partial class RemoveEoiStage_V2_Schema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EoiApplicable",
+                table: "PlanVersions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EoiApplicable",
+                table: "PlanVersions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+    }
+}

--- a/Models/Stages/StageCodes.cs
+++ b/Models/Stages/StageCodes.cs
@@ -5,7 +5,6 @@ namespace ProjectManagement.Models.Stages;
 
 public static class StageCodes
 {
-    public const string EOI = "EOI";
     public const string FS = "FS";
     public const string IPA = "IPA";
     public const string SOW = "SOW";
@@ -40,7 +39,6 @@ public static class StageCodes
     };
     private static readonly Dictionary<string, string> DisplayNames = new(StringComparer.OrdinalIgnoreCase)
     {
-        [EOI] = "Expression of Interest",
         [FS] = "Feasibility Study",
         [IPA] = "In-Principle Approval",
         [SOW] = "SOW Vetting",

--- a/Services/Stages/StageDirectApplyService.cs
+++ b/Services/Stages/StageDirectApplyService.cs
@@ -55,11 +55,6 @@ public sealed class StageDirectApplyService
 
         var normalizedStageCode = stageCode.Trim().ToUpperInvariant();
 
-        if (string.Equals(normalizedStageCode, StageCodes.EOI, StringComparison.OrdinalIgnoreCase))
-        {
-            return DirectApplyResult.StageNotFound();
-        }
-
         var stage = await _db.ProjectStages
             .Include(s => s.Project)
             .SingleOrDefaultAsync(

--- a/Services/Stages/StageRequestService.cs
+++ b/Services/Stages/StageRequestService.cs
@@ -46,11 +46,6 @@ public class StageRequestService
 
         var stageCode = input.StageCode.Trim().ToUpperInvariant();
 
-        if (string.Equals(stageCode, StageCodes.EOI, StringComparison.OrdinalIgnoreCase))
-        {
-            return StageRequestResult.StageNotFound();
-        }
-
         var stage = await _db.ProjectStages
             .Include(s => s.Project)
             .SingleOrDefaultAsync(


### PR DESCRIPTION
## Summary
- remove the remaining EOI stage constant and display name entry
- drop EOI-specific guards from stage request/direct apply services
- add the schema migration that drops the PlanVersions.EoiApplicable column

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b5d369e88329aa9e49f55ff7be0a