### PR TITLE
Fix completion validation to require in-progress stages

### DIFF
--- a/Services/Stages/StageValidationService.cs
+++ b/Services/Stages/StageValidationService.cs
@@ -255,12 +255,14 @@ public sealed class StageValidationService : IStageValidationService
 
     private static bool ValidateCompleteTransition(StageStatus current, out string? error)
     {
-        return current switch
+        if (current == StageStatus.InProgress)
         {
-            StageStatus.NotStarted => true,
-            StageStatus.InProgress => true,
-            _ => (error = $"Changing from {current} to {StageStatus.Completed} is not allowed.", false)
-        };
+            error = null;
+            return true;
+        }
+
+        error = $"Changing from {current} to {StageStatus.Completed} is not allowed.";
+        return false;
     }
 
     private static bool ValidateBlockTransition(StageStatus current, out string? error)


### PR DESCRIPTION
## Summary
- ensure stage completion validation only allows transitions from InProgress
- provide a clear error when attempting to complete from any other status

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8c72e58848329bd549efd0f2b0136