### PR TITLE
Fix stage validation start transition errors

### DIFF
--- a/Services/Stages/StageValidationService.cs
+++ b/Services/Stages/StageValidationService.cs
@@ -246,11 +246,27 @@ public sealed class StageValidationService : IStageValidationService
             StageStatus.NotStarted => true,
             StageStatus.Blocked => true,
             StageStatus.Skipped => true,
-            StageStatus.Completed => targetDate.HasValue
-                ? true
-                : (error = "Reopening to InProgress requires an actual start date.", false),
-            _ => (error = $"Changing from {current} to {StageStatus.InProgress} is not allowed.", false)
+            StageStatus.Completed => ValidateCompletedToInProgress(targetDate, out error),
+            _ => DenyTransition(current, StageStatus.InProgress, out error)
         };
+    }
+
+    private static bool ValidateCompletedToInProgress(DateOnly? targetDate, out string? error)
+    {
+        if (targetDate.HasValue)
+        {
+            error = null;
+            return true;
+        }
+
+        error = "Reopening to InProgress requires an actual start date.";
+        return false;
+    }
+
+    private static bool DenyTransition(StageStatus current, StageStatus target, out string? error)
+    {
+        error = $"Changing from {current} to {target} is not allowed.";
+        return false;
     }
 
     private static bool ValidateCompleteTransition(StageStatus current, out string? error)


### PR DESCRIPTION
## Summary
- fix the validation logic when reopening a completed stage to InProgress so it enforces the start date requirement without compile errors
- add helpers to provide consistent error messaging for disallowed transitions

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8c8df3ae48329befa550b490e7971