### PR TITLE
Expose timeline badges for pending and incomplete stages

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -38,6 +38,23 @@
             {
               <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
             }
+            @if (s.IsIncompleteData)
+            {
+              <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle">Incomplete data</span>
+            }
+            @if (s.HasPendingRequest)
+            {
+              <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
+                Pending: @s.PendingStatus@if (s.PendingDate.HasValue)
+                {
+                  <text> · @D(s.PendingDate)</text>
+                }
+              </span>
+            }
+            @if (s.IsOverdue)
+            {
+              <span class="badge bg-danger-subtle text-danger border border-danger-subtle">Overdue</span>
+            }
             @if (s.RequiresBackfill)
             {
               <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -32,10 +32,20 @@ public sealed class TimelineItemVm
     public bool IsAutoCompleted { get; init; }
     public string? AutoCompletedFromCode { get; init; }
     public bool RequiresBackfill { get; init; }
+    public bool HasPendingRequest { get; init; }
+    public string? PendingStatus { get; init; }
+    public DateOnly? PendingDate { get; init; }
+
+    public DateOnly Today { get; init; }
 
     public int SortOrder { get; init; }
     public int? PlannedDurationDays =>
         (PlannedStart.HasValue && PlannedEnd.HasValue) ? (PlannedEnd.Value.DayNumber - PlannedStart.Value.DayNumber + 1) : null;
     public int? ActualDurationDays =>
         (ActualStart.HasValue && CompletedOn.HasValue) ? (CompletedOn.Value.DayNumber - ActualStart.Value.DayNumber + 1) : null;
+
+    public bool NeedsStart => (Status is StageStatus.InProgress or StageStatus.Completed) && ActualStart is null;
+    public bool NeedsFinish => Status == StageStatus.Completed && CompletedOn is null;
+    public bool IsIncompleteData => NeedsStart || NeedsFinish;
+    public bool IsOverdue => Status != StageStatus.Completed && PlannedEnd.HasValue && Today > PlannedEnd.Value;
 }


### PR DESCRIPTION
## Summary
- pull pending stage change requests and IST current date into the timeline read model
- add derived pending/incomplete/overdue flags on timeline items
- render badges for incomplete data, pending requests, and overdue stages in the timeline partial

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ceef61b083299fd5d359d9485fed