### PR TITLE
Add force completion option to HoD direct apply modal

### DIFF
--- a/Pages/Projects/_StageDirectApplyModal.cshtml
+++ b/Pages/Projects/_StageDirectApplyModal.cshtml
@@ -16,6 +16,8 @@
                     <input type="hidden" name="status" />
                     @Html.AntiForgeryToken()
 
+                    <div class="alert alert-warning d-none" role="alert" data-direct-apply-missing></div>
+
                     <div class="mb-3">
                         <div class="fw-semibold" data-direct-apply-stage></div>
                         <div class="text-muted" data-direct-apply-status></div>
@@ -27,6 +29,12 @@
                         <label class="form-label" for="directApplyDate">Effective date</label>
                         <input type="date" class="form-control" id="directApplyDate" name="date" />
                         <div class="form-text" data-direct-apply-date-hint>Optional.</div>
+                    </div>
+
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" value="true" id="directApplyForce" name="forceBackfillPredecessors" data-direct-apply-force />
+                        <label class="form-check-label" for="directApplyForce">Force complete predecessors (may leave dates blank)</label>
+                        <div class="form-text" data-direct-apply-force-hint>Tick to auto-complete any remaining predecessors when required.</div>
                     </div>
 
                     <div class="mb-0">

--- a/ProjectManagement.Tests/StageDirectApplyModalUiTests.cs
+++ b/ProjectManagement.Tests/StageDirectApplyModalUiTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageDirectApplyModalUiTests
+{
+    private static readonly IServiceProvider Services = BuildServiceProvider();
+
+    [Fact]
+    public async Task RendersForceCompleteCheckbox()
+    {
+        var html = await RenderAsync();
+        Assert.Contains("Force complete predecessors (may leave dates blank)", html, StringComparison.Ordinal);
+    }
+
+    private static async Task<string> RenderAsync()
+    {
+        using var scope = Services.CreateScope();
+        var provider = scope.ServiceProvider;
+        var viewEngine = provider.GetRequiredService<IRazorViewEngine>();
+        var tempDataProvider = provider.GetRequiredService<ITempDataProvider>();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = provider
+        };
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: "/Pages/Projects/_StageDirectApplyModal.cshtml", isMainPage: false);
+
+        if (!viewResult.Success)
+        {
+            throw new InvalidOperationException("Unable to locate _StageDirectApplyModal partial view.");
+        }
+
+        await using var writer = new StringWriter();
+        var viewData = new ViewDataDictionary<object>(new EmptyModelMetadataProvider(), new ModelStateDictionary());
+        var tempData = new TempDataDictionary(httpContext, tempDataProvider);
+        var viewContext = new ViewContext(actionContext, viewResult.View, viewData, tempData, writer, new HtmlHelperOptions());
+
+        await viewResult.View.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    private static IServiceProvider BuildServiceProvider()
+    {
+        var contentRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var webRoot = Path.Combine(contentRoot, "wwwroot");
+
+        var environment = new TestWebHostEnvironment
+        {
+            ApplicationName = typeof(Program).Assembly.GetName().Name!,
+            ContentRootPath = contentRoot,
+            WebRootPath = webRoot,
+            ContentRootFileProvider = new PhysicalFileProvider(contentRoot),
+            WebRootFileProvider = Directory.Exists(webRoot) ? new PhysicalFileProvider(webRoot) : new NullFileProvider(),
+            EnvironmentName = Environments.Development
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IWebHostEnvironment>(environment);
+        services.AddSingleton<IHostEnvironment>(environment);
+        services.AddLogging();
+        services.AddRouting();
+        services.AddRazorPages();
+        services.AddControllersWithViews();
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary
- add a force-complete predecessors checkbox and warning area to the HoD direct apply modal
- update the modal script to send the new flag, allow completed stages without dates, and surface missing predecessor details
- add a UI smoke test to confirm the checkbox renders in the modal

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8d69ae1548329be5a3514e9161ae6