### PR TITLE
Add project officer stage request UI

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -312,6 +312,7 @@
                             Another plan is already awaiting approval. You can keep editing your draft, but submitting is disabled until the review is complete.
                         </div>
                     }
+                    @{ ViewBag.IsProjectOfficerForProject = isThisProjectsPo; }
                     <partial name="_ProjectTimeline" model="Model.Timeline" />
                 </div>
             </div>
@@ -319,6 +320,7 @@
     </div>
 
     <partial name="_StageDirectApplyModal" />
+    <partial name="Projects/Stages/_StageRequestModal" />
 
     <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasProcurement" aria-labelledby="offcanvasProcurementLabel">
         <div class="offcanvas-header">

--- a/Pages/Projects/Stages/_StageRequestModal.cshtml
+++ b/Pages/Projects/Stages/_StageRequestModal.cshtml
@@ -1,0 +1,56 @@
+@{
+    Layout = null;
+}
+
+<div class="modal fade" id="stageRequestModal" tabindex="-1" aria-labelledby="stageRequestLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" data-stage-request-form novalidate>
+                <div class="modal-header">
+                    <h5 class="modal-title" id="stageRequestLabel">Request stage change</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="projectId" />
+                    <input type="hidden" name="stageCode" />
+                    @Html.AntiForgeryToken()
+
+                    <div class="mb-3">
+                        <div class="fw-semibold" data-stage-request-stage></div>
+                        <div class="text-muted" data-stage-request-status></div>
+                    </div>
+
+                    <div class="alert alert-danger d-none" role="alert" data-stage-request-errors></div>
+                    <div class="alert alert-warning d-none" role="alert" data-stage-request-conflict>A pending request already exists…</div>
+                    <div class="alert alert-warning d-none" role="alert" data-stage-request-missing></div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="stageRequestTarget">Target status</label>
+                        <select class="form-select" id="stageRequestTarget" name="status" data-stage-request-target>
+                            <option value="NotStarted">Not started</option>
+                            <option value="InProgress">In progress</option>
+                            <option value="Completed">Completed</option>
+                            <option value="Skipped">Skipped</option>
+                            <option value="Blocked">Blocked</option>
+                        </select>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label" for="stageRequestDate">Requested date</label>
+                        <input type="date" class="form-control" id="stageRequestDate" name="date" data-stage-request-date />
+                        <div class="form-text" data-stage-request-date-hint>Optional.</div>
+                    </div>
+
+                    <div class="mb-0">
+                        <label class="form-label" for="stageRequestNote">Note <span class="text-muted">(optional)</span></label>
+                        <textarea class="form-control" id="stageRequestNote" name="note" rows="3" maxlength="1024" data-stage-request-note></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary" data-stage-request-submit>Submit request</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,8 +1,9 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
 @using ProjectManagement.Models.Execution
-@{
+@{ 
     var showDirectApply = User.IsInRole("HoD");
+    var canRequestChange = ViewBag?.IsProjectOfficerForProject is bool b && b;
 }
 @functions{
     string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
@@ -42,15 +43,17 @@
             {
               <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle">Incomplete data</span>
             }
-            @if (s.HasPendingRequest)
-            {
-              <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
-                Pending: @s.PendingStatus@if (s.PendingDate.HasValue)
-                {
-                  <text> · @D(s.PendingDate)</text>
-                }
-              </span>
-            }
+            <span data-stage-pending>
+              @if (s.HasPendingRequest)
+              {
+                <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
+                  Pending: @s.PendingStatus@if (s.PendingDate.HasValue)
+                  {
+                    <text> · @D(s.PendingDate)</text>
+                  }
+                </span>
+              }
+            </span>
             @if (s.IsOverdue)
             {
               <span class="badge bg-danger-subtle text-danger border border-danger-subtle">Overdue</span>
@@ -61,41 +64,57 @@
               <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
             }
           </div>
-          @if (showDirectApply)
-          {
-            <div class="dropdown">
-              <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                Actions
+          <div class="d-flex align-items-center gap-2">
+            @if (canRequestChange)
+            {
+              <button type="button"
+                      class="btn btn-sm btn-outline-primary"
+                      data-stage-request
+                      data-stage-request-button
+                      data-project="@Model.ProjectId"
+                      data-stage="@s.Code"
+                      data-stage-name="@s.Name"
+                      data-current-status="@s.Status"
+                      @(s.HasPendingRequest ? "disabled" : null)>
+                Request change
               </button>
-              <ul class="dropdown-menu">
-                <li>
-                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="InProgress" data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
-                    Start stage
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Completed" data-default-date="@s.CompletedOn?.ToString("yyyy-MM-dd")">
-                    Mark completed
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Blocked">
-                    Block
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Skipped">
-                    Skip
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Reopen">
-                    Reopen
-                  </button>
-                </li>
-              </ul>
-            </div>
-          }
+            }
+            @if (showDirectApply)
+            {
+              <div class="dropdown">
+                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  Actions
+                </button>
+                <ul class="dropdown-menu">
+                  <li>
+                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="InProgress" data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
+                      Start stage
+                    </button>
+                  </li>
+                  <li>
+                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Completed" data-default-date="@s.CompletedOn?.ToString("yyyy-MM-dd")">
+                      Mark completed
+                    </button>
+                  </li>
+                  <li>
+                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Blocked">
+                      Block
+                    </button>
+                  </li>
+                  <li>
+                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Skipped">
+                      Skip
+                    </button>
+                  </li>
+                  <li>
+                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Reopen">
+                      Reopen
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            }
+          </div>
         </div>
         <div class="pm-item-meta">
           <div>Planned: <span data-stage-planned-start>@D(s.PlannedStart)</span> — <span data-stage-planned-end>@D(s.PlannedEnd)</span></div>


### PR DESCRIPTION
## Summary
- expose a request change action for project officers in the project timeline and hide it from other roles
- add a stage change request modal that collects target status, date, and notes with validation and conflict messaging
- extend the stages JavaScript to submit requests, render pending badges inline, and disable further submissions once pending

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8d88f1eb48329a766340fc6d776a6