### PR TITLE
Add variance chips for project timeline stages

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -14,6 +14,11 @@
             StageStatus.InProgress => "badge bg-primary",
             _                      => "badge bg-secondary"
         };
+    string VarianceLabel(string name, int value)
+    {
+        var sign = value > 0 ? "+" : "−";
+        return $"{name} {sign}{Math.Abs(value)}d";
+    }
 }
 <link rel="stylesheet" href="~/css/projects/timeline.css" />
 
@@ -123,6 +128,16 @@
             <span class="text-muted ms-2@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
               @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
             </span>
+          </div>
+          <div class="pm-item-variance d-flex flex-wrap gap-1 mt-1">
+            @if (s.StartVarianceDays is int startVar && startVar != 0)
+            {
+              <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle" data-stage-start-variance>@VarianceLabel("Start", startVar)</span>
+            }
+            @if (s.FinishVarianceDays is int finishVar && finishVar != 0)
+            {
+              <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle" data-stage-finish-variance>@VarianceLabel("Finish", finishVar)</span>
+            }
           </div>
         </div>
       </div>

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -59,15 +59,41 @@ public sealed class ProjectTimelineReadService
         {
             var r = rows.FirstOrDefault(x => x.StageCode == code);
             pendingLookup.TryGetValue(code, out var pendingRequest);
+
+            var plannedStart = r?.PlannedStart;
+            var actualStart = r?.ActualStart;
+            var plannedEnd = r?.PlannedDue;
+            var actualEnd = r?.CompletedOn;
+
+            int? startVarianceDays = null;
+            if (plannedStart.HasValue && actualStart.HasValue)
+            {
+                var diff = actualStart.Value.DayNumber - plannedStart.Value.DayNumber;
+                if (diff != 0)
+                {
+                    startVarianceDays = diff;
+                }
+            }
+
+            int? finishVarianceDays = null;
+            if (plannedEnd.HasValue && actualEnd.HasValue)
+            {
+                var diff = actualEnd.Value.DayNumber - plannedEnd.Value.DayNumber;
+                if (diff != 0)
+                {
+                    finishVarianceDays = diff;
+                }
+            }
+
             items.Add(new TimelineItemVm
             {
                 Code = code,
                 Name = StageCodes.DisplayNameOf(code),
                 Status = r?.Status ?? StageStatus.NotStarted,
-                PlannedStart = r?.PlannedStart,
-                PlannedEnd = r?.PlannedDue,
-                ActualStart = r?.ActualStart,
-                CompletedOn = r?.CompletedOn,
+                PlannedStart = plannedStart,
+                PlannedEnd = plannedEnd,
+                ActualStart = actualStart,
+                CompletedOn = actualEnd,
                 IsAutoCompleted = r?.IsAutoCompleted ?? false,
                 AutoCompletedFromCode = r?.AutoCompletedFromCode,
                 RequiresBackfill = r?.RequiresBackfill ?? false,
@@ -75,7 +101,9 @@ public sealed class ProjectTimelineReadService
                 Today = today,
                 HasPendingRequest = pendingRequest is not null,
                 PendingStatus = pendingRequest?.RequestedStatus,
-                PendingDate = pendingRequest?.RequestedDate
+                PendingDate = pendingRequest?.RequestedDate,
+                StartVarianceDays = startVarianceDays,
+                FinishVarianceDays = finishVarianceDays
             });
         }
 

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -36,6 +36,9 @@ public sealed class TimelineItemVm
     public string? PendingStatus { get; init; }
     public DateOnly? PendingDate { get; init; }
 
+    public int? StartVarianceDays { get; init; }
+    public int? FinishVarianceDays { get; init; }
+
     public DateOnly Today { get; init; }
 
     public int SortOrder { get; init; }


### PR DESCRIPTION
## Summary
- derive start and finish variance days for project timeline items when both planned and actual dates are available
- surface start and finish variance badges in the project timeline partial view so late/early stages are visible

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8dd80b9ac8329835d13e54e59c02b