### PR TITLE
Add test coverage for stage rule validation scenarios

### DIFF
--- a/ProjectManagement.Tests/Fakes/FakeClock.cs
+++ b/ProjectManagement.Tests/Fakes/FakeClock.cs
@@ -1,0 +1,35 @@
+using System;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Tests.Fakes;
+
+public sealed class FakeClock : IClock
+{
+    private static readonly TimeZoneInfo IndiaTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");
+
+    private DateTimeOffset _utcNow;
+
+    private FakeClock(DateTimeOffset utcNow)
+    {
+        _utcNow = utcNow;
+    }
+
+    public DateTimeOffset UtcNow => _utcNow;
+
+    public void Set(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+    public static FakeClock AtUtc(DateTimeOffset utcNow) => new(utcNow);
+
+    public static FakeClock ForIst(DateTime localIst)
+    {
+        var unspecified = DateTime.SpecifyKind(localIst, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, IndiaTimeZone);
+        return new FakeClock(new DateTimeOffset(utc, TimeSpan.Zero));
+    }
+
+    public static FakeClock ForIstDate(DateOnly date)
+        => ForIst(date.ToDateTime(TimeOnly.MinValue));
+
+    public static FakeClock ForIstDate(int year, int month, int day, int hour = 0, int minute = 0, int second = 0)
+        => ForIst(new DateTime(year, month, day, hour, minute, second));
+}


### PR DESCRIPTION
## Summary
- add a reusable FakeClock test double to control IST-based dates in stage-related tests
- extend stage validation tests to cover missing completion dates, auto-start suggestions, and HoD warnings
- expand direct apply and request service tests for admin completions, backfills, and duplicate/missing predecessor responses

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e0203af083298189e0a0dfcd95de