### PR TITLE
Improve stage change validation and responses

### DIFF
--- a/Pages/Projects/Stages/ApplyChange.cshtml.cs
+++ b/Pages/Projects/Stages/ApplyChange.cshtml.cs
@@ -87,10 +87,9 @@ public class ApplyChangeModel : PageModel
             });
         }
 
-        var needsDate = string.Equals(statusMatch, "Completed", StringComparison.Ordinal)
-                         || string.Equals(statusMatch, "InProgress", StringComparison.Ordinal);
+        var requiresDate = string.Equals(statusMatch, "InProgress", StringComparison.Ordinal);
 
-        if (needsDate && input.Date is null)
+        if (requiresDate && input.Date is null)
         {
             return ValidationFailure(new[] { "Date is required for the selected status." });
         }

--- a/Pages/Projects/Stages/RequestChange.cshtml.cs
+++ b/Pages/Projects/Stages/RequestChange.cshtml.cs
@@ -57,9 +57,9 @@ public class RequestChangeModel : PageModel
                 {
                     ok = false,
                     error = "validation",
-                    details = string.IsNullOrWhiteSpace(result.Error)
-                        ? Array.Empty<string>()
-                        : new[] { result.Error },
+                    details = result.Errors is { Count: > 0 }
+                        ? result.Errors.ToArray()
+                        : Array.Empty<string>(),
                     missingPredecessors = result.MissingPredecessors is { Count: > 0 }
                         ? result.MissingPredecessors.ToArray()
                         : Array.Empty<string>()

--- a/ProjectManagement.Tests/Stages/StageRequestServiceTests.cs
+++ b/ProjectManagement.Tests/Stages/StageRequestServiceTests.cs
@@ -49,6 +49,7 @@ public class StageRequestServiceTests
         var missing = Assert.IsAssignableFrom<IReadOnlyList<string>>(result.MissingPredecessors);
         Assert.Single(missing);
         Assert.Equal(StageCodes.FS, missing[0]);
+        Assert.Contains("Complete required predecessor stages first.", result.Errors);
 
         var call = Assert.Single(validator.Calls);
         Assert.Equal(1, call.ProjectId);
@@ -89,6 +90,7 @@ public class StageRequestServiceTests
 
         Assert.Equal(StageRequestOutcome.Success, result.Outcome);
         Assert.True(result.RequestId.HasValue);
+        Assert.Empty(result.Errors);
 
         var request = await db.StageChangeRequests.SingleAsync();
         Assert.Equal("po-1", request.RequestedByUserId);

--- a/docs/projects-module.md
+++ b/docs/projects-module.md
@@ -17,6 +17,9 @@ The projects feature brings together procurement data, execution timelines and c
 * `ProjectTimelineReadService` projects a complete timeline view model from `ProjectStages`, combining canonical stage codes (`StageCodes.All`) with per-stage metadata.
 * The same service highlights pending plan approvals and whether any stage still requires backfilling, feeding callouts on the overview screen. Per-user draft state (e.g. whether the current user owns a draft or submission) is sourced from `PlanReadService`.
 * Detailed plan editing uses `PlanReadService` to hydrate both exact date and duration editors. Drafts are scoped to the current user (`OwnerUserId`) so Project Officers and HoDs can work privately in parallel while the service filters out other users’ drafts. `PlanCompareService` produces diffs for the pending submission shown in the HoD review panel.
+* Change-management is coordinated by `StageValidationService`, a shared validator that enforces legal status transitions, prevents future-dated actuals, surfaces unmet predecessor stages (respecting the project’s PNC applicability flag) and recommends the earliest safe auto-start date derived from completed predecessors.
+* Project Officers submit `StageChangeRequest` records through `StageRequestService`. Validation errors are returned with structured error arrays and a list of missing predecessors so the UI can guide users before a HoD review.
+* HoDs can bypass the approval queue via `StageDirectApplyService`, which reuses the validator, can optionally backfill incomplete predecessors, supports admin completions without dates (marking the stage as incomplete data) and emits warnings when the update supersedes a pending request or requires auto-adjustments.
 
 ## Role assignment
 * The overview model builds an `AssignRolesVm` populated from the `HoD` and `Project Officer` role memberships, letting administrators record the responsible officers per project without leaving the page.


### PR DESCRIPTION
## Summary
- surface validation error collections from StageRequestService so the project officer workflow can present detailed guidance
- correct the RequestChange handler and allow HoD direct apply to skip dates when completing stages
- document the shared stage validator and direct-apply flow in the projects module guide

## Testing
- dotnet test *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eaa5563883299ee317fde96ed252