### PR TITLE
Fix direct apply force completion checkbox wiring

### DIFF
--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -414,7 +414,7 @@
         status: statusInput.value,
         date: dateInput && dateInput.value ? dateInput.value : null,
         note: noteInput && noteInput.value ? noteInput.value.trim() : null,
-        forceBackfillPredecessors: !!document.querySelector('#forceBackfillPredecessors')?.checked
+        forceBackfillPredecessors: !!(forceCheckbox?.checked)
       };
 
       if (!payload.projectId) {
@@ -488,11 +488,7 @@
         }
         renderMissingPredecessors(missingPredecessorsContainer, []);
         setForceHintHighlighted(false);
-        const modalForceCheckbox = document.querySelector('#forceBackfillPredecessors');
-        if (modalForceCheckbox) {
-          modalForceCheckbox.checked = false;
-        }
-        if (forceCheckbox && forceCheckbox !== modalForceCheckbox) {
+        if (forceCheckbox) {
           forceCheckbox.checked = false;
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the direct apply payload reads the force-complete checkbox via the modal-scoped reference
- reset the modal's force checkbox using the cached element instead of querying by a mismatched id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d925691170832991c22931e2795432