### PR TITLE
Fix direct apply force backfill flag selector

### DIFF
--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -294,8 +294,7 @@
     const errorContainer = modalEl.querySelector('[data-direct-apply-errors]');
     const dateHint = modalEl.querySelector('[data-direct-apply-date-hint]');
     const missingPredecessorsContainer = modalEl.querySelector('[data-direct-apply-missing]');
-    const forceCheckbox = modalEl.querySelector('#forceBackfillPredecessors')
-      || modalEl.querySelector('[data-direct-apply-force]');
+    const forceCheckbox = modalEl.querySelector('[data-direct-apply-force]');
     const forceHint = modalEl.querySelector('[data-direct-apply-force-hint]');
     const submitButton = modalEl.querySelector('[data-direct-apply-submit]');
     const noDateWarning = modalEl.querySelector('[data-direct-apply-no-date-warning]');


### PR DESCRIPTION
## Summary
- ensure the direct apply modal payload reads the existing force-complete checkbox so the flag is sent correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9279fcb908329bcf96c6accfba410