### PR TITLE
Add HoD stage change approvals to overview

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1,9 +1,11 @@
 @page "{id:int}"
 @using System
 @using ProjectManagement.Models
+@using ProjectManagement.Models.Execution
 @using ProjectManagement.Models.Plans
 @using ProjectManagement.ViewModels
 @model ProjectManagement.Pages.Projects.OverviewModel
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
 @{
     var project = Model.Project;
     var pageTitle = project?.Name ?? "Project";
@@ -24,6 +26,23 @@
     var totalStages = Model.Timeline.TotalStages;
     var progressMax = totalStages == 0 ? 1 : totalStages;
     ViewData["Title"] = pageTitle;
+}
+
+@functions
+{
+    private static string StageStatusLabel(string? status) => status switch
+    {
+        "Completed" => "Completed",
+        "InProgress" => "In progress",
+        "Blocked" => "Blocked",
+        "Skipped" => "Skipped",
+        "NotStarted" => "Not started",
+        null => "Unknown",
+        _ when string.IsNullOrWhiteSpace(status) => "Unknown",
+        _ => status!
+    };
+
+    private static string StageStatusLabel(StageStatus status) => StageStatusLabel(status.ToString());
 }
 
 <div class="container-xxl">
@@ -216,6 +235,62 @@
             </div>
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">
+            @if (isThisProjectsHod)
+            {
+                var decisionTokens = Antiforgery.GetAndStoreTokens(HttpContext);
+                <div class="card" data-stage-requests-card>
+                    <div class="card-header">Stage change requests</div>
+                    <div class="card-body d-flex flex-column gap-3">
+                        <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
+                        <div class="text-muted small @(Model.Timeline.PendingRequests.Any() ? "d-none" : string.Empty)" data-stage-requests-empty>
+                            No pending stage change requests.
+                        </div>
+                        <div class="d-flex flex-column gap-3" data-stage-decision-list>
+                            @foreach (var request in Model.Timeline.PendingRequests)
+                            {
+                                var stageLabel = $"{request.StageCode} — {request.StageName}".Trim(' ', '—');
+                                <div class="border rounded p-3" data-stage-request-item data-request-id="@request.RequestId" data-stage-code="@request.StageCode" data-stage-label="@stageLabel">
+                                    <div class="d-flex justify-content-between align-items-start gap-2">
+                                        <div>
+                                            <div class="fw-semibold">@stageLabel</div>
+                                            <div class="text-muted small">
+                                                Requested by @request.RequestedBy on @request.RequestedOn.ToLocalTime().ToString("dd MMM yyyy")
+                                            </div>
+                                        </div>
+                                        <span class="badge bg-warning text-dark">@StageStatusLabel(request.RequestedStatus)</span>
+                                    </div>
+                                    <dl class="row small mt-3 mb-0">
+                                        <dt class="col-4">Current</dt>
+                                        <dd class="col-8">@StageStatusLabel(request.CurrentStatus)</dd>
+                                        <dt class="col-4">Target</dt>
+                                        <dd class="col-8">
+                                            @StageStatusLabel(request.RequestedStatus)
+                                            @if (request.RequestedDate.HasValue)
+                                            {
+                                                <span>· @request.RequestedDate.Value.ToString("dd MMM yyyy")</span>
+                                            }
+                                        </dd>
+                                        @if (!string.IsNullOrWhiteSpace(request.Note))
+                                        {
+                                            <dt class="col-4">PO note</dt>
+                                            <dd class="col-8">@request.Note</dd>
+                                        }
+                                    </dl>
+                                    <div class="mt-3">
+                                        <label class="form-label mb-1 small" for="decision-note-@request.RequestId">Decision note <span class="text-muted">(optional)</span></label>
+                                        <textarea class="form-control form-control-sm" id="decision-note-@request.RequestId" rows="2" maxlength="1024" data-stage-decision-note></textarea>
+                                    </div>
+                                    <div class="d-flex gap-2 mt-3">
+                                        <button type="button" class="btn btn-sm btn-success" data-stage-decision="Approve">Approve</button>
+                                        <button type="button" class="btn btn-sm btn-outline-danger" data-stage-decision="Reject">Reject</button>
+                                    </div>
+                                    <div class="text-danger small mt-2 d-none" data-stage-decision-error></div>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
             <div class="card">
                 <div class="card-header">
                     <div class="d-flex flex-column gap-2">

--- a/Pages/Projects/Stages/DecideChange.cshtml.cs
+++ b/Pages/Projects/Stages/DecideChange.cshtml.cs
@@ -49,7 +49,17 @@ public class DecideChangeModel : PageModel
 
         return result.Outcome switch
         {
-            StageDecisionOutcome.Success => HttpContext.SetSuccess(),
+            StageDecisionOutcome.Success => HttpContext.SetSuccess(new
+            {
+                ok = true,
+                updated = result.Stage is null ? null : new
+                {
+                    status = result.Stage.Status.ToString(),
+                    actualStart = result.Stage.ActualStart?.ToString("yyyy-MM-dd"),
+                    completedOn = result.Stage.CompletedOn?.ToString("yyyy-MM-dd")
+                },
+                warnings = result.Warnings
+            }),
             StageDecisionOutcome.NotHeadOfDepartment => Forbid(),
             StageDecisionOutcome.RequestNotFound => HttpContext.SetStatusCode(
                 StatusCodes.Status404NotFound,

--- a/ProjectManagement.Tests/StageDecisionServiceTests.cs
+++ b/ProjectManagement.Tests/StageDecisionServiceTests.cs
@@ -42,6 +42,10 @@ public sealed class StageDecisionServiceTests
 
         Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
         Assert.Empty(result.Warnings);
+        Assert.NotNull(result.Stage);
+        Assert.Equal(StageStatus.InProgress, result.Stage!.Status);
+        Assert.Equal(new DateOnly(2024, 1, 15), result.Stage!.ActualStart);
+        Assert.Null(result.Stage!.CompletedOn);
 
         var stage = await db.ProjectStages.SingleAsync(s => s.StageCode == StageCodes.IPA);
         Assert.Equal(StageStatus.InProgress, stage.Status);
@@ -99,6 +103,10 @@ public sealed class StageDecisionServiceTests
             "hod-9");
 
         Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
+        Assert.NotNull(result.Stage);
+        Assert.Equal(StageStatus.NotStarted, result.Stage!.Status);
+        Assert.Null(result.Stage!.ActualStart);
+        Assert.Null(result.Stage!.CompletedOn);
 
         var stage = await db.ProjectStages.SingleAsync(s => s.StageCode == StageCodes.IPA);
         Assert.Equal(StageStatus.NotStarted, stage.Status);
@@ -151,6 +159,10 @@ public sealed class StageDecisionServiceTests
 
         Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
         Assert.Contains(result.Warnings, w => w.Contains("Completion date was earlier"));
+        Assert.NotNull(result.Stage);
+        Assert.Equal(StageStatus.Completed, result.Stage!.Status);
+        Assert.Equal(new DateOnly(2024, 3, 10), result.Stage!.CompletedOn);
+        Assert.Equal(new DateOnly(2024, 3, 10), result.Stage!.ActualStart);
 
         var stage = await db.ProjectStages.SingleAsync(s => s.StageCode == StageCodes.IPA);
         Assert.Equal(StageStatus.Completed, stage.Status);
@@ -193,6 +205,10 @@ public sealed class StageDecisionServiceTests
 
         Assert.Equal(StageDecisionOutcome.Success, result.Outcome);
         Assert.Contains(result.Warnings, w => w.Contains(StageCodes.IPA));
+        Assert.NotNull(result.Stage);
+        Assert.Equal(StageStatus.InProgress, result.Stage!.Status);
+        Assert.Equal(new DateOnly(2024, 4, 14), result.Stage!.ActualStart);
+        Assert.Null(result.Stage!.CompletedOn);
 
         var persistedRequest = await db.StageChangeRequests.SingleAsync(r => r.Id == request.Id);
         Assert.Contains(StageCodes.IPA, persistedRequest.DecisionNote);

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
 
 namespace ProjectManagement.ViewModels;
 
@@ -10,12 +11,26 @@ public sealed class TimelineVm
     public int TotalStages { get; init; }
     public int CompletedCount { get; init; }
     public IReadOnlyList<TimelineItemVm> Items { get; init; } = Array.Empty<TimelineItemVm>();
+    public IReadOnlyList<TimelineStageRequestVm> PendingRequests { get; init; } = Array.Empty<TimelineStageRequestVm>();
 
     public bool HasBackfill => Items.Any(i => i.RequiresBackfill);
     public bool PlanPendingApproval { get; init; }
     public bool HasDraft { get; init; }
     public DateTimeOffset? LatestApprovalAt { get; init; }
     public string? LatestApprovalBy { get; init; }
+}
+
+public sealed class TimelineStageRequestVm
+{
+    public int RequestId { get; init; }
+    public string StageCode { get; init; } = string.Empty;
+    public string StageName { get; init; } = string.Empty;
+    public StageStatus CurrentStatus { get; init; } = StageStatus.NotStarted;
+    public string RequestedStatus { get; init; } = string.Empty;
+    public DateOnly? RequestedDate { get; init; }
+    public string? Note { get; init; }
+    public string RequestedBy { get; init; } = string.Empty;
+    public DateTimeOffset RequestedOn { get; init; }
 }
 
 public sealed class TimelineItemVm


### PR DESCRIPTION
## Summary
- surface pending stage change requests in the timeline view model, including requester names
- add a Head of Department review card on the project overview with approve/reject actions
- return updated stage snapshots from the decision endpoint and update the front-end workflow and tests

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d926d05c9c8329b6577130547544e1