### PR TITLE
Fix GetConnectionString usage in DecideChange page

### DIFF
--- a/Pages/Projects/Stages/DecideChange.cshtml.cs
+++ b/Pages/Projects/Stages/DecideChange.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Helpers;
 using ProjectManagement.Data;


### PR DESCRIPTION
## Summary
- add the EF Core namespace import to expose DatabaseFacade.GetConnectionString

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d95bf771b48329bc00ddebe7a434a7