### PR TITLE
Fix variable shadowing in Program.cs database logging

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -466,10 +466,10 @@ using (var scope = app.Services.CreateScope())
     var db = services.GetRequiredService<ApplicationDbContext>();
     if (app.Environment.IsDevelopment() && db.Database.IsRelational())
     {
-        var connectionString = db.Database.GetConnectionString();
-        if (!string.IsNullOrEmpty(connectionString))
+        var databaseConnectionString = db.Database.GetConnectionString();
+        if (!string.IsNullOrEmpty(databaseConnectionString))
         {
-            await using var conn = new NpgsqlConnection(connectionString);
+            await using var conn = new NpgsqlConnection(databaseConnectionString);
             await conn.OpenAsync();
             await using (var cmd = conn.CreateCommand())
             {


### PR DESCRIPTION
## Summary
- rename the inner database connection string variable in Program.cs to avoid conflicting with the top-level definition

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d95cf085708329a75f926974b07f2e