### PR TITLE
Ensure quick parser advances to future Mondays

### DIFF
--- a/Helpers/TodoQuickParser.cs
+++ b/Helpers/TodoQuickParser.cs
@@ -74,6 +74,10 @@ namespace ProjectManagement.Helpers
         {
             var now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, Ist).Date;
             int daysToMon = ((int)DayOfWeek.Monday - (int)now.DayOfWeek + 7) % 7;
+            if (daysToMon == 0)
+            {
+                daysToMon = 7;
+            }
             var mon = now.AddDays(daysToMon);
             return mon;
         }


### PR DESCRIPTION
## Summary
- adjust TodoQuickParser to treat Monday tokens as the next future Monday instead of today

## Testing
- not run (dotnet CLI unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d966ac2a888329a1d5b6d34060a5db