### PR TITLE
Handle stale stage updates in direct apply modal

### DIFF
--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -468,7 +468,17 @@
         }
 
         if (response.status === 409) {
-          showToast('Blocked: plan version is awaiting HoD review.', 'warning');
+          const conflict = await response.json().catch(() => null);
+          if (conflict?.error === 'stale') {
+            showToast('Timeline changed since this page was loaded. Refreshing…', 'warning');
+            setTimeout(() => {
+              window.location.reload();
+            }, 1500);
+          } else if (conflict?.error === 'plan-pending') {
+            showToast('Blocked: plan version is awaiting HoD review.', 'warning');
+          } else {
+            showToast('Unable to update the stage right now.', 'danger');
+          }
           resetControls();
           return;
         }


### PR DESCRIPTION
## Summary
- return a 409 conflict with a specific error when a stage disappears while applying a change
- have the direct-apply modal surface the stale-data state and automatically reload the page

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d973ca6ad88329a55c56e6138a9bb9