### PR TITLE
Add connection hash logging to ApplyChange endpoint

### DIFF
--- a/Pages/Projects/Stages/ApplyChange.cshtml.cs
+++ b/Pages/Projects/Stages/ApplyChange.cshtml.cs
@@ -10,8 +10,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using ProjectManagement.Data;
 using ProjectManagement.Services.Stages;
+using ProjectManagement.Utilities;
 
 namespace ProjectManagement.Pages.Projects.Stages;
 
@@ -31,11 +33,16 @@ public class ApplyChangeModel : PageModel
 
     private readonly ApplicationDbContext _db;
     private readonly StageDirectApplyService _service;
+    private readonly ILogger<ApplyChangeModel> _logger;
 
-    public ApplyChangeModel(ApplicationDbContext db, StageDirectApplyService service)
+    public ApplyChangeModel(
+        ApplicationDbContext db,
+        StageDirectApplyService service,
+        ILogger<ApplyChangeModel> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _service = service ?? throw new ArgumentNullException(nameof(service));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public class ApplyChangeInput
@@ -61,6 +68,9 @@ public class ApplyChangeModel : PageModel
 
     public async Task<IActionResult> OnPostAsync([FromBody] ApplyChangeInput input, CancellationToken ct)
     {
+        var connectionHash = ConnectionStringHasher.Hash(_db.Database.GetConnectionString());
+        _logger.LogInformation("ApplyChange POST received. ConnHash={ConnHash}", connectionHash);
+
         if (!ModelState.IsValid)
         {
             var errs = ModelState.Values


### PR DESCRIPTION
## Summary
- inject a logger into the ApplyChange Razor page handler
- record the database connection hash whenever ApplyChange POST requests arrive

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d97fe121b48329a27b6a4978da5447