### PR TITLE
Align local database configuration and logging

### DIFF
--- a/Pages/Projects/Stages/ApplyChange.cshtml.cs
+++ b/Pages/Projects/Stages/ApplyChange.cshtml.cs
@@ -68,8 +68,9 @@ public class ApplyChangeModel : PageModel
 
     public async Task<IActionResult> OnPostAsync([FromBody] ApplyChangeInput input, CancellationToken ct)
     {
-        var connectionHash = ConnectionStringHasher.Hash(_db.Database.GetConnectionString());
-        _logger.LogInformation("ApplyChange POST received. ConnHash={ConnHash}", connectionHash);
+        _logger.LogInformation(
+            "ApplyChange POST ConnHash={ConnHash}",
+            ConnectionStringHasher.Hash(_db.Database.GetConnectionString()));
 
         if (!ModelState.IsValid)
         {

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -9,20 +9,11 @@
     }
   },
   "profiles": {
-    "http": {
+    "ProjectManagement": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5249",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7130;http://localhost:5249",
+      "applicationUrl": "http://localhost:7130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=ProjectManagement;Username=postgres;Password=postgres;Include Error Detail=true"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=ProjectManagement;Username=postgres;Password=postgres;Include Error Detail=true"
   },
   "DetailedErrors": true,
   "Logging": {


### PR DESCRIPTION
## Summary
- add explicit connection-hash logging to the stage apply endpoint so GET/POST database mismatches are obvious
- update the development connection string and launch profile to share a single, consistent local configuration

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d9847ce91883299889bf53c1694e32