### PR TITLE
Fix stage change endpoints and antiforgery token

### DIFF
--- a/Pages/Projects/Stages/ApplyChange.cshtml
+++ b/Pages/Projects/Stages/ApplyChange.cshtml
@@ -1,0 +1,5 @@
+@page
+@model ProjectManagement.Pages.Projects.Stages.ApplyChangeModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Stages/DecideChange.cshtml
+++ b/Pages/Projects/Stages/DecideChange.cshtml
@@ -1,0 +1,5 @@
+@page
+@model ProjectManagement.Pages.Projects.Stages.DecideChangeModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/_StageDirectApplyModal.cshtml
+++ b/Pages/Projects/_StageDirectApplyModal.cshtml
@@ -1,6 +1,8 @@
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
 @{
     Layout = null;
     var isHod = User.IsInRole("HoD");
+    var directApplyTokens = Antiforgery.GetAndStoreTokens(HttpContext);
 }
 
 <div class="modal fade" id="stageDirectApplyModal" tabindex="-1" aria-labelledby="stageDirectApplyLabel" aria-hidden="true" data-actor-hod="@isHod.ToString().ToLowerInvariant()">
@@ -15,7 +17,7 @@
                     <input type="hidden" name="projectId" />
                     <input type="hidden" name="stageCode" />
                     <input type="hidden" name="status" />
-                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="__RequestVerificationToken" value="@directApplyTokens.RequestToken" />
 
                     <div class="alert alert-warning d-none" role="alert" data-direct-apply-missing></div>
 


### PR DESCRIPTION
## Summary
- add Razor Page shells alongside the ApplyChange and DecideChange handlers so their routes resolve
- inject the antiforgery service into the direct stage apply modal and render the hidden verification token for AJAX requests

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f54d37f4832997e01ad21fabb77b