### PR TITLE
Allow admin stage completions without dates

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -541,7 +541,7 @@ namespace ProjectManagement.Migrations
 
                     b.ToTable("ProjectStages", null, t =>
                         {
-                            t.HasCheckConstraint("CK_ProjectStages_CompletedHasDate", "\"Status\" <> 'Completed' OR (\"CompletedOn\" IS NOT NULL AND \"ActualStart\" IS NOT NULL)");
+                        t.HasCheckConstraint("CK_ProjectStages_CompletedHasDate", "\"Status\" <> 'Completed' OR (\"CompletedOn\" IS NOT NULL AND \"ActualStart\" IS NOT NULL) OR \"RequiresBackfill\" IS TRUE");
                         });
                 });
 

--- a/Pages/Projects/Stages/ApplyChange.cshtml.cs
+++ b/Pages/Projects/Stages/ApplyChange.cshtml.cs
@@ -173,6 +173,14 @@ public class ApplyChangeModel : PageModel
         {
             return ValidationFailure(ex.Details, ex.MissingPredecessors);
         }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogError(ex, "Failed to apply direct stage change for project {ProjectId} stage {StageCode}.", input.ProjectId, input.StageCode);
+            return ValidationFailure(new[]
+            {
+                "Could not save stage update. The database may not allow blank dates for admin completion."
+            });
+        }
         catch (OperationCanceledException)
         {
             throw;

--- a/Program.cs
+++ b/Program.cs
@@ -520,6 +520,23 @@ using (var scope = app.Services.CreateScope())
             ALTER TABLE "ProjectStages"
             ALTER COLUMN "RequiresBackfill" SET DEFAULT FALSE;
         """);
+        await db.Database.ExecuteSqlRawAsync("""
+            ALTER TABLE "ProjectStages"
+            ALTER COLUMN "ActualStart" DROP NOT NULL;
+        """);
+        await db.Database.ExecuteSqlRawAsync("""
+            ALTER TABLE "ProjectStages"
+            ALTER COLUMN "CompletedOn" DROP NOT NULL;
+        """);
+        await db.Database.ExecuteSqlRawAsync("""
+            ALTER TABLE "ProjectStages"
+            DROP CONSTRAINT IF EXISTS "CK_ProjectStages_CompletedHasDate";
+        """);
+        await db.Database.ExecuteSqlRawAsync("""
+            ALTER TABLE "ProjectStages"
+            ADD CONSTRAINT "CK_ProjectStages_CompletedHasDate"
+            CHECK ("Status" <> 'Completed' OR ("CompletedOn" IS NOT NULL AND "ActualStart" IS NOT NULL) OR "RequiresBackfill" IS TRUE);
+        """);
         var migrations = await db.Database.GetAppliedMigrationsAsync();
         if (!migrations.Contains("20250909153316_UseXminForTodoItem"))
         {


### PR DESCRIPTION
## Summary
- update the ProjectStages check constraint to allow completed stages flagged for backfill to store blank dates
- ensure the startup schema sync relaxes ActualStart/CompletedOn nullability and reapplies the updated constraint
- catch DbUpdateException during direct apply so the UI surfaces a clear validation error instead of a 500

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9fe3344c48329b9d6b4a4711e7bff