### PR TITLE
Ensure project stages enforce completion date backfill rule

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -409,27 +409,21 @@ namespace ProjectManagement.Data
                 e.Property(x => x.StageCode).HasMaxLength(16);
             });
 
-        var projectStageCompletedConstraint = "\"Status\" <> 'Completed' OR (\"CompletedOn\" IS NOT NULL AND \"ActualStart\" IS NOT NULL) OR \"RequiresBackfill\" IS TRUE";
-
-        if (Database.IsSqlServer())
-        {
-            projectStageCompletedConstraint = "[Status] <> 'Completed' OR ([CompletedOn] IS NOT NULL AND [ActualStart] IS NOT NULL) OR [RequiresBackfill] = 1";
-        }
-        else if (!Database.IsNpgsql())
-        {
-            projectStageCompletedConstraint = "Status <> 'Completed' OR (CompletedOn IS NOT NULL AND ActualStart IS NOT NULL) OR RequiresBackfill";
-        }
-
         builder.Entity<ProjectStage>(e =>
         {
             e.HasIndex(x => new { x.ProjectId, x.StageCode }).IsUnique();
             e.Property(x => x.StageCode).HasMaxLength(16);
             e.Property(x => x.AutoCompletedFromCode).HasMaxLength(16);
             e.Property(x => x.Status).HasConversion<string>().HasMaxLength(32);
+            e.Property(x => x.ActualStart).HasColumnType("date").IsRequired(false);
+            e.Property(x => x.CompletedOn).HasColumnType("date").IsRequired(false);
+            e.Property(x => x.RequiresBackfill).HasDefaultValue(false).IsRequired();
             e.Property(x => x.ForecastStart).HasColumnType("date");
             e.Property(x => x.ForecastDue).HasColumnType("date");
             e.ToTable("ProjectStages", tb =>
-                tb.HasCheckConstraint("CK_ProjectStages_CompletedHasDate", projectStageCompletedConstraint));
+                tb.HasCheckConstraint(
+                    "CK_ProjectStages_CompletedHasDate",
+                    "\"Status\" <> 'Completed' OR (\"CompletedOn\" IS NOT NULL AND \"ActualStart\" IS NOT NULL) OR \"RequiresBackfill\" IS TRUE"));
         });
 
             builder.Entity<StageShiftLog>(e =>

--- a/Migrations/20250929040000_FixStageDatesAndCheck.Designer.cs
+++ b/Migrations/20250929040000_FixStageDatesAndCheck.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250929040000_FixStageDatesAndCheck")]
+    partial class FixStageDatesAndCheck : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250929040000_FixStageDatesAndCheck.cs
+++ b/Migrations/20250929040000_FixStageDatesAndCheck.cs
@@ -1,0 +1,109 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixStageDatesAndCheck : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "ActualStart",
+                table: "ProjectStages",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: false);
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "CompletedOn",
+                table: "ProjectStages",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: false);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "RequiresBackfill",
+                table: "ProjectStages",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldNullable: false);
+
+            migrationBuilder.Sql(@"
+        UPDATE ""ProjectStages""
+        SET ""RequiresBackfill"" = TRUE
+        WHERE ""Status"" = 'Completed'
+          AND (""ActualStart"" IS NULL OR ""CompletedOn"" IS NULL);
+    ");
+
+            migrationBuilder.Sql(@"
+        DO $$
+        DECLARE r record;
+        BEGIN
+          FOR r IN
+            SELECT conname FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE n.nspname = 'public' AND t.relname = 'ProjectStages'
+              AND conname LIKE 'CK_ProjectStages_CompletedHasDate%'
+          LOOP
+            EXECUTE format('ALTER TABLE ""ProjectStages"" DROP CONSTRAINT %I;', r.conname);
+          END LOOP;
+        END $$;
+    ");
+
+            migrationBuilder.Sql(@"
+        ALTER TABLE ""ProjectStages""
+        ADD CONSTRAINT ""CK_ProjectStages_CompletedHasDate""
+        CHECK (
+          ""Status"" <> 'Completed'
+          OR (""CompletedOn"" IS NOT NULL AND ""ActualStart"" IS NOT NULL)
+          OR ""RequiresBackfill"" IS TRUE
+        );
+    ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"ALTER TABLE ""ProjectStages"" DROP CONSTRAINT IF EXISTS ""CK_ProjectStages_CompletedHasDate"";");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "RequiresBackfill",
+                table: "ProjectStages",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "CompletedOn",
+                table: "ProjectStages",
+                type: "date",
+                nullable: false,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "ActualStart",
+                table: "ProjectStages",
+                type: "date",
+                nullable: false,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true);
+        }
+    }
+}

--- a/Models/Execution/ProjectStage.cs
+++ b/Models/Execution/ProjectStage.cs
@@ -34,5 +34,5 @@ public class ProjectStage
 
     public bool IsAutoCompleted { get; set; }
     public string? AutoCompletedFromCode { get; set; }
-    public bool RequiresBackfill { get; set; }
+    public bool RequiresBackfill { get; set; } = false;
 }


### PR DESCRIPTION
## Summary
- make `ProjectStage.RequiresBackfill` default to `false` and configure the completion dates as nullable fields
- configure a single canonical check constraint for completed stages along with the `RequiresBackfill` default in the model snapshot
- add a migration that normalises existing data, removes prior constraint variants, and recreates the correct constraint

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da2d0688f48329876952348a92c03d