### PR TITLE
Allow AutoBackfill stage change logs

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -338,19 +338,19 @@ namespace ProjectManagement.Data
                 {
                     e.ToTable(tb =>
                         tb.HasCheckConstraint("CK_StageChangeLogs_Action",
-                            "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')"));
+                            "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')"));
                 }
                 else if (Database.IsNpgsql())
                 {
                     e.ToTable(tb =>
                         tb.HasCheckConstraint("CK_StageChangeLogs_Action",
-                            "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')"));
+                            "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')"));
                 }
                 else
                 {
                     e.ToTable(tb =>
                         tb.HasCheckConstraint("CK_StageChangeLogs_Action",
-                            "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')"));
+                            "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')"));
                 }
             });
 

--- a/Migrations/20250214000000_AddAutoBackfillStageChangeLogAction.cs
+++ b/Migrations/20250214000000_AddAutoBackfillStageChangeLogAction.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250214000000_AddAutoBackfillStageChangeLogAction")]
+    public partial class AddAutoBackfillStageChangeLogAction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_StageChangeLogs_Action",
+                table: "StageChangeLogs");
+
+            if (migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+            else if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+            else
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_StageChangeLogs_Action",
+                table: "StageChangeLogs");
+
+            if (migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')");
+            }
+            else if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')");
+            }
+            else
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')");
+            }
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1477,7 +1477,7 @@ namespace ProjectManagement.Migrations
 
                     b.ToTable("StageChangeLogs", t =>
                         {
-                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded')");
+                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
                         });
                 });
 

--- a/ProjectManagement.Tests/StageDirectApplyServiceTests.cs
+++ b/ProjectManagement.Tests/StageDirectApplyServiceTests.cs
@@ -155,10 +155,11 @@ public class StageDirectApplyServiceTests
             .Where(l => l.StageCode == StageCodes.IPA || l.StageCode == StageCodes.SOW)
             .ToListAsync();
 
-        Assert.Contains(logs, l => l.StageCode == StageCodes.IPA &&
-            string.Equals(l.Action, "AutoBackfill", StringComparison.OrdinalIgnoreCase) &&
-            l.Note != null &&
-            l.Note.Contains("Auto-backfilled (no dates) due to completion of", StringComparison.Ordinal));
+        var autoBackfillLogs = logs.Where(l => l.StageCode == StageCodes.IPA &&
+            string.Equals(l.Action, "AutoBackfill", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.Single(autoBackfillLogs);
+        Assert.NotNull(autoBackfillLogs[0].Note);
+        Assert.Contains("Auto-backfilled (no dates) due to completion of", autoBackfillLogs[0].Note!, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow the StageChangeLog check constraint to accept the AutoBackfill action across supported providers
- add a migration to update the database constraint and refresh the model snapshot
- extend the StageDirectApplyService test to assert the AutoBackfill log is persisted when forcing predecessor backfill

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da2ca9ecf48329ba601762b94a1b22