### PR TITLE
Fix procurement backfill redirect

### DIFF
--- a/Pages/Projects/Procurement/Edit.cshtml.cs
+++ b/Pages/Projects/Procurement/Edit.cshtml.cs
@@ -33,9 +33,16 @@ namespace ProjectManagement.Pages.Projects.Procurement
         [BindProperty]
         public ProcurementEditInput Input { get; set; } = new();
 
-        public IActionResult OnGet(int id)
+        public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
         {
-            return NotFound();
+            var projectExists = await _db.Projects.AnyAsync(p => p.Id == id, ct);
+            if (!projectExists)
+            {
+                return NotFound();
+            }
+
+            TempData["OpenOffcanvas"] = "procurement";
+            return RedirectToPage("/Projects/Overview", new { id });
         }
 
         public async Task<IActionResult> OnPostAsync(int id, CancellationToken ct)


### PR DESCRIPTION
## Summary
- redirect procurement edit GET requests back to the project overview while opening the procurement offcanvas
- guard against invalid project ids when using backfill links

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3292c04883299e4e5a5a689a77da