### PR TITLE
Add stage backfill workflow and distinguish timeline backfill types

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -25,6 +25,8 @@
     var completedStages = Model.Timeline.CompletedCount;
     var totalStages = Model.Timeline.TotalStages;
     var progressMax = totalStages == 0 ? 1 : totalStages;
+    var scheduleBackfillStage = Model.Timeline.Items.FirstOrDefault(i => i.BackfillKind == TimelineBackfillKind.Schedule);
+    var hasProcurementBackfill = Model.Timeline.Items.Any(i => i.BackfillKind == TimelineBackfillKind.Procurement);
     ViewData["Title"] = pageTitle;
 }
 
@@ -71,6 +73,13 @@
     {
         <div id="open-procurement" data-open="1"></div>
     }
+    @if (string.Equals(Request.Query["oc"], "backfill", StringComparison.Ordinal))
+    {
+        var stageCode = (string?)Request.Query["stage"];
+        var startDate = (string?)Request.Query["start"];
+        var finishDate = (string?)Request.Query["finish"];
+        <div id="open-stage-backfill" data-open="1" data-stage="@stageCode" data-start="@startDate" data-finish="@finishDate"></div>
+    }
     @if (TempData["OpenOffcanvas"] as string == "assign-roles")
     {
         <div id="open-assign-roles" data-open="1"></div>
@@ -102,9 +111,21 @@
     {
         <div class="alert alert-warning d-flex align-items-center justify-content-between" role="alert">
             <div>
-                <strong>Action needed:</strong> Some earlier stages were auto-completed and need dates or costs.
+                <strong>Action needed:</strong> Some earlier stages need actual dates or procurement details.
             </div>
-            <a class="btn btn-sm btn-outline-warning" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.Project!.Id">Backfill now</a>
+            <div class="d-flex flex-wrap gap-2">
+                @if (hasProcurementBackfill)
+                {
+                    <a class="btn btn-sm btn-outline-warning" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.Project!.Id">Procurement backfill</a>
+                }
+                @if (scheduleBackfillStage is not null)
+                {
+                    <a class="btn btn-sm btn-outline-warning"
+                       asp-page="/Projects/Stages/Backfill"
+                       asp-route-projectId="@Model.Project!.Id"
+                       asp-route-stageCode="@scheduleBackfillStage.Code">Stage dates backfill</a>
+                }
+            </div>
         </div>
     }
 
@@ -312,7 +333,7 @@
                                     }
                                     @if (Model.HasBackfill)
                                     {
-                                        <span class="badge text-bg-secondary" title="Resolve procurement backfill to proceed">Backfill required</span>
+                                        <span class="badge text-bg-secondary" title="Resolve outstanding backfill to proceed">Backfill required</span>
                                     }
                                     @if (project?.PlanApprovedAt is DateTimeOffset approvedAt)
                                     {
@@ -404,6 +425,8 @@
             <partial name="Projects/Procurement/_EditFormBody" model="Model.ProcurementEdit" />
         </div>
     </div>
+
+    <partial name="Projects/Stages/_StageBackfillOffcanvas" model="Model.Project.Id" />
 
     <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasPlanReview" aria-labelledby="offcanvasPlanReviewLabel">
         <div class="offcanvas-header">

--- a/Pages/Projects/Stages/Backfill.cshtml
+++ b/Pages/Projects/Stages/Backfill.cshtml
@@ -1,0 +1,5 @@
+@page
+@model ProjectManagement.Pages.Projects.Stages.BackfillModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Stages/Backfill.cshtml.cs
+++ b/Pages/Projects/Stages/Backfill.cshtml.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services.Stages;
+
+namespace ProjectManagement.Pages.Projects.Stages;
+
+[Authorize(Roles = "Admin,HoD")]
+[AutoValidateAntiforgeryToken]
+public sealed class BackfillModel : PageModel
+{
+    private const string BackfillNote = "Schedule backfill";
+
+    private readonly ApplicationDbContext _db;
+    private readonly StageDirectApplyService _directApply;
+    private readonly ILogger<BackfillModel> _logger;
+
+    public BackfillModel(ApplicationDbContext db, StageDirectApplyService directApply, ILogger<BackfillModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _directApply = directApply ?? throw new ArgumentNullException(nameof(directApply));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public StageBackfillInput Input { get; set; } = new();
+
+    public sealed class StageBackfillInput
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [Required]
+        [StringLength(32)]
+        public string StageCode { get; set; } = string.Empty;
+
+        public DateOnly? ActualStart { get; set; }
+        public DateOnly? CompletedOn { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(int projectId, string? stageCode, CancellationToken ct)
+    {
+        if (projectId <= 0 || string.IsNullOrWhiteSpace(stageCode))
+        {
+            return NotFound();
+        }
+
+        var projectExists = await _db.Projects.AsNoTracking().AnyAsync(p => p.Id == projectId, ct);
+        if (!projectExists)
+        {
+            return NotFound();
+        }
+
+        var normalizedStage = stageCode.Trim().ToUpperInvariant();
+        if (!StageCodes.All.Contains(normalizedStage, StringComparer.OrdinalIgnoreCase))
+        {
+            return RedirectToPage("/Projects/Overview", new { id = projectId });
+        }
+
+        var redirectValues = new
+        {
+            id = projectId,
+            oc = "backfill",
+            stage = normalizedStage
+        };
+
+        return RedirectToPage("/Projects/Overview", redirectValues);
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            var errors = ModelState.Values
+                .SelectMany(v => v.Errors)
+                .Select(e => string.IsNullOrWhiteSpace(e.ErrorMessage) ? "Invalid value." : e.ErrorMessage)
+                .ToArray();
+
+            return RedirectWithError(errors);
+        }
+
+        var normalizedStage = Input.StageCode.Trim().ToUpperInvariant();
+        Input.StageCode = normalizedStage;
+        if (!StageCodes.All.Contains(normalizedStage, StringComparer.OrdinalIgnoreCase))
+        {
+            return RedirectWithError(new[] { "Stage not recognised." });
+        }
+
+        var stage = await _db.ProjectStages
+            .AsNoTracking()
+            .SingleOrDefaultAsync(s => s.ProjectId == Input.ProjectId && s.StageCode == normalizedStage, ct);
+
+        if (stage is null)
+        {
+            var projectExists = await _db.Projects.AsNoTracking().AnyAsync(p => p.Id == Input.ProjectId, ct);
+            if (!projectExists)
+            {
+                return NotFound();
+            }
+
+            return RedirectWithError(new[] { "Stage not found for this project." });
+        }
+
+        var targetStart = Input.ActualStart ?? stage.ActualStart;
+        var targetCompletion = Input.CompletedOn ?? stage.CompletedOn;
+
+        var validationErrors = new List<string>();
+        if (targetStart is null)
+        {
+            validationErrors.Add("Actual start date is required.");
+        }
+
+        if (targetCompletion is null)
+        {
+            validationErrors.Add("Completion date is required.");
+        }
+
+        if (targetStart.HasValue && targetCompletion.HasValue && targetCompletion.Value < targetStart.Value)
+        {
+            validationErrors.Add("Completion date cannot be before the actual start date.");
+        }
+
+        if (validationErrors.Count > 0)
+        {
+            return RedirectWithError(validationErrors, targetStart, targetCompletion);
+        }
+
+        var userId = User?.FindFirstValue(ClaimTypes.NameIdentifier) ?? User?.Identity?.Name;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            var needsStartUpdate = !stage.ActualStart.HasValue || (Input.ActualStart.HasValue && Input.ActualStart.Value != stage.ActualStart.Value);
+            var needsCompletionUpdate = !stage.CompletedOn.HasValue || (Input.CompletedOn.HasValue && Input.CompletedOn.Value != stage.CompletedOn.Value);
+
+            if (needsStartUpdate)
+            {
+                await _directApply.ApplyAsync(
+                    Input.ProjectId,
+                    normalizedStage,
+                    "Reopen",
+                    targetStart,
+                    BackfillNote,
+                    userId,
+                    forceBackfillPredecessors: false,
+                    ct);
+            }
+
+            if (needsCompletionUpdate || needsStartUpdate)
+            {
+                await _directApply.ApplyAsync(
+                    Input.ProjectId,
+                    normalizedStage,
+                    "Completed",
+                    targetCompletion,
+                    BackfillNote,
+                    userId,
+                    forceBackfillPredecessors: false,
+                    ct);
+            }
+
+            TempData["Flash"] = "Stage actuals updated.";
+            return RedirectToPage("/Projects/Overview", new { id = Input.ProjectId });
+        }
+        catch (StageDirectApplyNotFoundException)
+        {
+            return RedirectWithError(new[] { "Stage could not be updated." }, targetStart, targetCompletion);
+        }
+        catch (StageDirectApplyNotHeadOfDepartmentException)
+        {
+            TempData["Error"] = "Only the assigned Head of Department can update this stage.";
+            return RedirectToPage("/Projects/Overview", new { id = Input.ProjectId });
+        }
+        catch (StageDirectApplyValidationException ex)
+        {
+            var details = ex.Details?.Where(d => !string.IsNullOrWhiteSpace(d)).ToArray() ?? Array.Empty<string>();
+            return RedirectWithError(details.Length > 0 ? details : new[] { "Unable to update stage." }, targetStart, targetCompletion);
+        }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogError(ex, "Stage backfill failed for project {ProjectId} stage {StageCode}.", Input.ProjectId, normalizedStage);
+            return RedirectWithError(new[] { "Could not save stage updates." }, targetStart, targetCompletion);
+        }
+    }
+
+    private RedirectToPageResult RedirectWithError(IEnumerable<string> errors, DateOnly? start = null, DateOnly? completion = null)
+    {
+        var message = string.Join(" ", errors.Where(e => !string.IsNullOrWhiteSpace(e)));
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            TempData["Error"] = message;
+        }
+
+        return RedirectToPage(
+            "/Projects/Overview",
+            new
+            {
+                id = Input.ProjectId,
+                oc = "backfill",
+                stage = string.IsNullOrWhiteSpace(Input.StageCode) ? null : Input.StageCode,
+                start = start?.ToString("yyyy-MM-dd"),
+                finish = completion?.ToString("yyyy-MM-dd")
+            });
+    }
+}

--- a/Pages/Projects/Stages/_StageBackfillOffcanvas.cshtml
+++ b/Pages/Projects/Stages/_StageBackfillOffcanvas.cshtml
@@ -1,0 +1,42 @@
+@model int
+@{
+    Layout = null;
+}
+
+<div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasStageBackfill" aria-labelledby="offcanvasStageBackfillLabel">
+    <div class="offcanvas-header">
+        <div>
+            <h5 id="offcanvasStageBackfillLabel" class="mb-0">Backfill stage dates</h5>
+            <div class="text-muted small" data-stage-backfill-subtitle></div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <form method="post" asp-page="/Projects/Stages/Backfill" data-stage-backfill-form>
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="Input.ProjectId" value="@Model" />
+            <input type="hidden" name="Input.StageCode" data-stage-backfill-stage />
+
+            <div class="mb-3">
+                <label class="form-label" for="stageBackfillActualStart">Actual start date</label>
+                <input type="date" class="form-control" id="stageBackfillActualStart" name="Input.ActualStart" data-stage-backfill-start />
+                <div class="form-text">Required. The date work on this stage actually began.</div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="stageBackfillCompletedOn">Completion date</label>
+                <input type="date" class="form-control" id="stageBackfillCompletedOn" name="Input.CompletedOn" data-stage-backfill-finish />
+                <div class="form-text">Required. The date this stage actually finished.</div>
+            </div>
+
+            <div class="alert alert-info d-none" role="status" data-stage-backfill-warning>
+                Actual start will be restored before marking the stage as completed.
+            </div>
+
+            <div class="d-flex justify-content-end gap-2">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                <button type="submit" class="btn btn-primary">Save dates</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,6 +1,7 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
 @using ProjectManagement.Models.Execution
+@using ProjectManagement.ViewModels
 @{ 
     var showDirectApply = User.IsInRole("HoD");
     var canRequestChange = ViewBag?.IsProjectOfficerForProject is bool b && b;
@@ -35,7 +36,13 @@
         StageStatus.InProgress => "pm-item is-active",
         _                      => "pm-item"
       };
-      <div class="@itemClass" data-stage-row="@s.Code">
+      <div class="@itemClass"
+           data-stage-row="@s.Code"
+           data-stage-name-value="@s.Name"
+           data-stage-actual-start="@s.ActualStart?.ToString("yyyy-MM-dd")"
+           data-stage-completed="@s.CompletedOn?.ToString("yyyy-MM-dd")"
+           data-stage-backfill-kind="@s.BackfillKind"
+           data-stage-status-value="@s.Status">
         <div class="pm-item-header d-flex flex-wrap justify-content-between align-items-start gap-2">
           <div class="d-flex flex-wrap align-items-center gap-2">
             <span class="pm-item-title" data-stage-name="@s.Name">@s.Name</span>
@@ -63,10 +70,25 @@
             {
               <span class="badge bg-danger-subtle text-danger border border-danger-subtle">Overdue</span>
             }
-            @if (s.RequiresBackfill)
+            @switch (s.BackfillKind)
             {
-              <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
-              <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
+              case TimelineBackfillKind.Procurement:
+              {
+                <span class="ms-2 text-warning" title="Procurement details missing">⚠︎</span>
+                <a class="ms-1 small"
+                   asp-page="/Projects/Procurement/Edit"
+                   asp-route-id="@Model.ProjectId">Backfill procurement…</a>
+                break;
+              }
+              case TimelineBackfillKind.Schedule:
+              {
+                <span class="ms-2 text-warning" title="Actual dates missing">⚠︎</span>
+                <a class="ms-1 small"
+                   asp-page="/Projects/Stages/Backfill"
+                   asp-route-projectId="@Model.ProjectId"
+                   asp-route-stageCode="@s.Code">Backfill dates…</a>
+                break;
+              }
             }
           </div>
           <div class="d-flex align-items-center gap-2">

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -13,7 +13,7 @@ public sealed class TimelineVm
     public IReadOnlyList<TimelineItemVm> Items { get; init; } = Array.Empty<TimelineItemVm>();
     public IReadOnlyList<TimelineStageRequestVm> PendingRequests { get; init; } = Array.Empty<TimelineStageRequestVm>();
 
-    public bool HasBackfill => Items.Any(i => i.RequiresBackfill);
+    public bool HasBackfill => Items.Any(i => i.BackfillKind != TimelineBackfillKind.None);
     public bool PlanPendingApproval { get; init; }
     public bool HasDraft { get; init; }
     public DateTimeOffset? LatestApprovalAt { get; init; }
@@ -47,6 +47,7 @@ public sealed class TimelineItemVm
     public bool IsAutoCompleted { get; init; }
     public string? AutoCompletedFromCode { get; init; }
     public bool RequiresBackfill { get; init; }
+    public TimelineBackfillKind BackfillKind { get; init; }
     public bool HasPendingRequest { get; init; }
     public string? PendingStatus { get; init; }
     public DateOnly? PendingDate { get; init; }
@@ -66,4 +67,11 @@ public sealed class TimelineItemVm
     public bool NeedsFinish => Status == StageStatus.Completed && CompletedOn is null;
     public bool IsIncompleteData => NeedsStart || NeedsFinish;
     public bool IsOverdue => Status != StageStatus.Completed && PlannedEnd.HasValue && Today > PlannedEnd.Value;
+}
+
+public enum TimelineBackfillKind
+{
+    None = 0,
+    Procurement = 1,
+    Schedule = 2
 }

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -19,6 +19,100 @@
         }
     }
 
+    const stageBackfill = document.getElementById('offcanvasStageBackfill');
+    if (stageBackfill) {
+        const form = stageBackfill.querySelector('[data-stage-backfill-form]');
+        const stageInput = stageBackfill.querySelector('[data-stage-backfill-stage]');
+        const startInput = stageBackfill.querySelector('[data-stage-backfill-start]');
+        const finishInput = stageBackfill.querySelector('[data-stage-backfill-finish]');
+        const subtitle = stageBackfill.querySelector('[data-stage-backfill-subtitle]');
+        const warning = stageBackfill.querySelector('[data-stage-backfill-warning]');
+
+        function findStageRow(stageCode) {
+            if (!stageCode) {
+                return null;
+            }
+
+            let escaped = stageCode;
+            if (window.CSS && typeof window.CSS.escape === 'function') {
+                escaped = window.CSS.escape(stageCode);
+            } else {
+                escaped = stageCode.replace(/"/g, '\\"');
+            }
+            return document.querySelector(`[data-stage-row="${escaped}"]`);
+        }
+
+        function populateStageBackfill(stageCode, startValue, finishValue) {
+            if (!stageInput || !form) {
+                return;
+            }
+
+            stageInput.value = stageCode || '';
+
+            const row = findStageRow(stageCode);
+            const stageName = row?.dataset.stageNameValue || stageCode || '';
+            if (subtitle) {
+                subtitle.textContent = stageName ? `For ${stageName}` : '';
+            }
+
+            const defaultStart = row?.dataset.stageActualStart || '';
+            const defaultFinish = row?.dataset.stageCompleted || '';
+
+            if (startInput) {
+                startInput.value = startValue || defaultStart || '';
+            }
+
+            if (finishInput) {
+                finishInput.value = finishValue || defaultFinish || '';
+            }
+
+            if (warning) {
+                if (row?.dataset.stageCompleted && !row.dataset.stageActualStart) {
+                    warning.classList.remove('d-none');
+                } else {
+                    warning.classList.add('d-none');
+                }
+            }
+        }
+
+        stageBackfill.addEventListener('shown.bs.offcanvas', function () {
+            if (startInput && !startInput.value) {
+                startInput.focus();
+                return;
+            }
+
+            if (finishInput) {
+                finishInput.focus();
+            }
+        });
+
+        stageBackfill.addEventListener('hidden.bs.offcanvas', function () {
+            if (form) {
+                form.reset();
+            }
+
+            if (subtitle) {
+                subtitle.textContent = '';
+            }
+
+            if (warning) {
+                warning.classList.add('d-none');
+            }
+        });
+
+        const backfillMarker = document.getElementById('open-stage-backfill');
+        if (backfillMarker && backfillMarker.dataset.open === '1') {
+            populateStageBackfill(
+                backfillMarker.dataset.stage || '',
+                backfillMarker.dataset.start || '',
+                backfillMarker.dataset.finish || ''
+            );
+
+            const instance = bootstrap.Offcanvas.getOrCreateInstance(stageBackfill);
+            instance.show();
+        }
+    }
+
     const assignRoles = document.getElementById('offcanvasAssignRoles');
     if (assignRoles) {
         assignRoles.addEventListener('shown.bs.offcanvas', function () {


### PR DESCRIPTION
## Summary
- add a backfill kind indicator to project timeline items so procurement and schedule gaps are distinguished in the UI
- introduce a stage backfill off-canvas and Razor page that lets HoDs record actual start/completion dates via StageDirectApplyService
- update the overview page and scripts so backfill actions deep-link to the correct workflow and new `oc=backfill` marker auto-opens the stage form

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3db4cc288329ac9f147b23e96b74