### PR TITLE
Add dedicated procurement backfill workflow

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -336,7 +336,7 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Note).HasMaxLength(1024);
                 e.HasIndex(x => new { x.ProjectId, x.StageCode, x.At });
 
-                const string allowedStageLogActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')";
+                const string allowedStageLogActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')";
 
                 if (Database.IsSqlServer())
                 {

--- a/Features/Backfill/BackfillViewModel.cs
+++ b/Features/Backfill/BackfillViewModel.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.Features.Backfill;
+
+public sealed class BackfillViewModel
+{
+    public static readonly BackfillViewModel Empty = new()
+    {
+        ProjectId = 0,
+        Today = DateOnly.FromDateTime(DateTime.UtcNow.Date)
+    };
+
+    public int ProjectId { get; init; }
+
+    public DateOnly Today { get; init; }
+
+    public IReadOnlyList<BackfillStageViewModel> Stages { get; init; } = Array.Empty<BackfillStageViewModel>();
+
+    public bool HasStages => Stages.Count > 0;
+}
+
+public sealed class BackfillStageViewModel
+{
+    public string StageCode { get; init; } = string.Empty;
+
+    public string StageName { get; init; } = string.Empty;
+
+    public DateOnly? ActualStart { get; init; }
+
+    public DateOnly? CompletedOn { get; init; }
+
+    public bool IsAutoCompleted { get; init; }
+
+    public string? AutoCompletedFromCode { get; init; }
+
+    public string? AutoCompletedFromName =>
+        string.IsNullOrWhiteSpace(AutoCompletedFromCode)
+            ? null
+            : StageCodes.DisplayNameOf(AutoCompletedFromCode);
+}

--- a/Migrations/20250301090000_AddBackfillStageChangeLogAction.cs
+++ b/Migrations/20250301090000_AddBackfillStageChangeLogAction.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250301090000_AddBackfillStageChangeLogAction")]
+    public partial class AddBackfillStageChangeLogAction : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_StageChangeLogs_Action",
+                table: "StageChangeLogs");
+
+            if (migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')");
+            }
+            else if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')");
+            }
+            else
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')");
+            }
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_StageChangeLogs_Action",
+                table: "StageChangeLogs");
+
+            if (migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "[Action] IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+            else if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+            else
+            {
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_StageChangeLogs_Action",
+                    table: "StageChangeLogs",
+                    sql: "Action IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+            }
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1479,7 +1479,7 @@ namespace ProjectManagement.Migrations
 
                     b.ToTable("StageChangeLogs", t =>
                         {
-                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill')");
+                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')");
                         });
                 });
 

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -104,7 +104,7 @@
             <div>
                 <strong>Action needed:</strong> Some earlier stages were auto-completed and need dates or costs.
             </div>
-            <a class="btn btn-sm btn-outline-warning" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.Project!.Id">Backfill now</a>
+            <button type="button" class="btn btn-sm btn-outline-warning" data-action="open-backfill">Backfill now</button>
         </div>
     }
 
@@ -392,6 +392,7 @@
         </div>
     </div>
 
+    <partial name="Projects/_BackfillModal" model="Model.Backfill" />
     <partial name="_StageDirectApplyModal" />
     <partial name="Projects/Stages/_StageRequestModal" />
 

--- a/Pages/Projects/Stages/BackfillApply.cshtml
+++ b/Pages/Projects/Stages/BackfillApply.cshtml
@@ -1,0 +1,5 @@
+@page
+@model ProjectManagement.Pages.Projects.Stages.BackfillApplyModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Stages/BackfillApply.cshtml.cs
+++ b/Pages/Projects/Stages/BackfillApply.cshtml.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Services.Stages;
+
+namespace ProjectManagement.Pages.Projects.Stages;
+
+[Authorize(Roles = "Admin,HoD,Project Officer")]
+[AutoValidateAntiforgeryToken]
+public class BackfillApplyModel : PageModel
+{
+    private readonly StageBackfillService _backfillService;
+    private readonly ILogger<BackfillApplyModel> _logger;
+
+    public BackfillApplyModel(StageBackfillService backfillService, ILogger<BackfillApplyModel> logger)
+    {
+        _backfillService = backfillService ?? throw new ArgumentNullException(nameof(backfillService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public class BackfillStageInput
+    {
+        [Required]
+        [StringLength(32)]
+        public string StageCode { get; set; } = string.Empty;
+
+        public DateOnly? ActualStart { get; set; }
+
+        public DateOnly? CompletedOn { get; set; }
+    }
+
+    public class BackfillApplyInput
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [MinLength(1)]
+        public List<BackfillStageInput> Stages { get; set; } = new();
+    }
+
+    public async Task<IActionResult> OnPostAsync([FromBody] BackfillApplyInput input, CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "BackfillApply POST ProjectId={ProjectId}",
+            input?.ProjectId);
+
+        if (!ModelState.IsValid)
+        {
+            var details = ModelState.Values
+                .SelectMany(v => v.Errors)
+                .Select(e => string.IsNullOrWhiteSpace(e.ErrorMessage) ? "Invalid value." : e.ErrorMessage)
+                .ToArray();
+
+            return ValidationFailure(details);
+        }
+
+        if (input.ProjectId <= 0)
+        {
+            return ValidationFailure(new[] { "ProjectId must be greater than zero." });
+        }
+
+        if (input.Stages is null || input.Stages.Count == 0)
+        {
+            return ValidationFailure(new[] { "At least one stage update must be provided." });
+        }
+
+        var userId = User?.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? User?.Identity?.Name
+            ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            var updates = input.Stages
+                .Where(stage => !string.IsNullOrWhiteSpace(stage.StageCode))
+                .Select(stage => new StageBackfillUpdate(stage.StageCode, stage.ActualStart, stage.CompletedOn))
+                .ToArray();
+
+            if (updates.Length == 0)
+            {
+                return ValidationFailure(new[] { "At least one stage update must be provided." });
+            }
+
+            var result = await _backfillService.ApplyAsync(input.ProjectId, updates, userId, ct);
+
+            return new JsonResult(new
+            {
+                ok = true,
+                updated = new
+                {
+                    count = result.UpdatedCount,
+                    stages = result.StageCodes
+                }
+            });
+        }
+        catch (StageBackfillValidationException ex)
+        {
+            return ValidationFailure(ex.Details);
+        }
+        catch (StageBackfillConflictException ex)
+        {
+            return StatusCode(StatusCodes.Status409Conflict, new
+            {
+                ok = false,
+                error = "conflict",
+                stages = ex.ConflictingStages,
+                message = "One or more stages no longer require backfill."
+            });
+        }
+        catch (StageBackfillNotFoundException)
+        {
+            return NotFound(new
+            {
+                ok = false,
+                error = "not-found"
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to apply backfill for project {ProjectId}.", input.ProjectId);
+            return StatusCode(StatusCodes.Status500InternalServerError, new
+            {
+                ok = false,
+                error = "server-error"
+            });
+        }
+    }
+
+    private static UnprocessableEntityObjectResult ValidationFailure(IEnumerable<string> details)
+    {
+        var clean = details?
+            .Where(d => !string.IsNullOrWhiteSpace(d))
+            .ToArray() ?? Array.Empty<string>();
+
+        return new UnprocessableEntityObjectResult(new
+        {
+            ok = false,
+            error = "validation",
+            details = clean
+        });
+    }
+}

--- a/Pages/Projects/_BackfillForm.cshtml
+++ b/Pages/Projects/_BackfillForm.cshtml
@@ -1,0 +1,51 @@
+@model ProjectManagement.Features.Backfill.BackfillViewModel
+@{
+    var todayIso = Model?.Today.ToString("yyyy-MM-dd");
+}
+
+<div class="d-flex flex-column gap-3" data-backfill-stage-list>
+@if (Model?.Stages is { Count: > 0 } stages)
+{
+    foreach (var stage in stages)
+    {
+        var startValue = stage.ActualStart?.ToString("yyyy-MM-dd");
+        var completedValue = stage.CompletedOn?.ToString("yyyy-MM-dd");
+        <section class="border rounded p-3" data-backfill-row data-stage-code="@stage.StageCode">
+            <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                <div>
+                    <div class="fw-semibold">@stage.StageName</div>
+                    <div class="text-muted small">@stage.StageCode</div>
+                </div>
+                @if (stage.IsAutoCompleted && !string.IsNullOrWhiteSpace(stage.AutoCompletedFromName))
+                {
+                    <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
+                        Auto-completed after @stage.AutoCompletedFromName (@stage.AutoCompletedFromCode)
+                    </span>
+                }
+            </div>
+            <div class="row g-3 mt-2">
+                <div class="col-md-6">
+                    <label class="form-label" for="backfill-start-@stage.StageCode">Actual start date</label>
+                    <input type="date"
+                           class="form-control"
+                           id="backfill-start-@stage.StageCode"
+                           data-backfill-start
+                           value="@startValue"
+                           max="@todayIso"
+                           required />
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="backfill-completed-@stage.StageCode">Completed on</label>
+                    <input type="date"
+                           class="form-control"
+                           id="backfill-completed-@stage.StageCode"
+                           data-backfill-completed
+                           value="@completedValue"
+                           max="@todayIso"
+                           required />
+                </div>
+            </div>
+        </section>
+    }
+}
+</div>

--- a/Pages/Projects/_BackfillModal.cshtml
+++ b/Pages/Projects/_BackfillModal.cshtml
@@ -1,0 +1,49 @@
+@model ProjectManagement.Features.Backfill.BackfillViewModel
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
+@{
+    Layout = null;
+    var tokens = Antiforgery.GetAndStoreTokens(Context);
+    var hasStages = Model?.HasStages ?? false;
+}
+
+<div class="modal fade"
+     id="backfillModal"
+     tabindex="-1"
+     aria-labelledby="backfillModalLabel"
+     aria-hidden="true"
+     data-backfill-empty="@(!hasStages).ToString().ToLowerInvariant()">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="backfillModalLabel">Backfill missing stage details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form data-backfill-form novalidate>
+                    <input type="hidden" name="projectId" value="@Model?.ProjectId" data-backfill-project />
+                    <input type="hidden" name="__RequestVerificationToken" value="@tokens.RequestToken" data-backfill-token />
+
+                    <div class="alert alert-danger d-none" role="alert" data-backfill-errors></div>
+
+                    @if (hasStages)
+                    {
+                        <p class="text-muted small">
+                            Enter the actual start and completion dates for stages that were auto-completed without full data.
+                        </p>
+                        @await Html.PartialAsync("_BackfillForm", Model)
+                    }
+                    else
+                    {
+                        <div class="alert alert-success mb-0" role="status" data-backfill-empty-message>
+                            All procurement stages have complete data.
+                        </div>
+                    }
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="submitBackfillBtn" @(hasStages ? null : "disabled")>Save</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -66,7 +66,7 @@
             @if (s.RequiresBackfill)
             {
               <span class="ms-2 text-warning" title="Additional data required">⚠︎</span>
-              <a class="ms-1 small" asp-page="/Projects/Procurement/Edit" asp-route-id="@Model.ProjectId">Backfill…</a>
+              <button type="button" class="btn btn-link btn-sm px-0 align-baseline ms-1" data-action="open-backfill">Backfill…</button>
             }
           </div>
           <div class="d-flex align-items-center gap-2">

--- a/Program.cs
+++ b/Program.cs
@@ -153,6 +153,7 @@ builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<IStageValidationService, StageValidationService>();
 builder.Services.AddScoped<StageRequestService>();
 builder.Services.AddScoped<StageDirectApplyService>();
+builder.Services.AddScoped<StageBackfillService>();
 builder.Services.AddScoped<StageDecisionService>();
 builder.Services.AddScoped<PlanSnapshotService>();
 builder.Services.AddScoped<PlanCompareService>();

--- a/ProjectManagement.Tests/StageBackfillServiceTests.cs
+++ b/ProjectManagement.Tests/StageBackfillServiceTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services.Stages;
+using ProjectManagement.Tests.Fakes;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class StageBackfillServiceTests
+{
+    [Fact]
+    public async Task ApplyAsync_WhenValid_UpdatesStageAndLogs()
+    {
+        var clock = FakeClock.ForIstDate(new DateOnly(2024, 12, 5));
+        await using var db = CreateContext();
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = StageStatus.Completed,
+            RequiresBackfill = true
+        });
+        await db.SaveChangesAsync();
+
+        var service = new StageBackfillService(db, clock);
+
+        var result = await service.ApplyAsync(
+            projectId: 1,
+            updates: new[]
+            {
+                new StageBackfillUpdate(StageCodes.IPA, new DateOnly(2024, 11, 20), new DateOnly(2024, 11, 25))
+            },
+            userId: "user-1",
+            ct: CancellationToken.None);
+
+        Assert.Equal(1, result.UpdatedCount);
+        Assert.Contains(StageCodes.IPA, result.StageCodes);
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(new DateOnly(2024, 11, 20), stage.ActualStart);
+        Assert.Equal(new DateOnly(2024, 11, 25), stage.CompletedOn);
+        Assert.False(stage.RequiresBackfill);
+
+        var log = await db.StageChangeLogs.SingleAsync();
+        Assert.Equal("Backfill", log.Action);
+        Assert.Equal(new DateOnly(2024, 11, 20), log.ToActualStart);
+        Assert.Equal(new DateOnly(2024, 11, 25), log.ToCompletedOn);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenStageDoesNotRequireBackfill_ThrowsConflict()
+    {
+        var clock = FakeClock.ForIstDate(new DateOnly(2025, 1, 10));
+        await using var db = CreateContext();
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = StageStatus.Completed,
+            ActualStart = new DateOnly(2024, 11, 1),
+            CompletedOn = new DateOnly(2024, 11, 5),
+            RequiresBackfill = false
+        });
+        await db.SaveChangesAsync();
+
+        var service = new StageBackfillService(db, clock);
+
+        var ex = await Assert.ThrowsAsync<StageBackfillConflictException>(() => service.ApplyAsync(
+            projectId: 1,
+            updates: new[]
+            {
+                new StageBackfillUpdate(StageCodes.IPA, new DateOnly(2024, 10, 1), new DateOnly(2024, 10, 5))
+            },
+            userId: "user-1",
+            ct: CancellationToken.None));
+
+        Assert.Contains(StageCodes.IPA, ex.ConflictingStages);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenDatesMissing_ThrowsValidation()
+    {
+        var clock = FakeClock.ForIstDate(new DateOnly(2025, 2, 1));
+        await using var db = CreateContext();
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.SOW,
+            SortOrder = 2,
+            Status = StageStatus.Completed,
+            RequiresBackfill = true
+        });
+        await db.SaveChangesAsync();
+
+        var service = new StageBackfillService(db, clock);
+
+        var ex = await Assert.ThrowsAsync<StageBackfillValidationException>(() => service.ApplyAsync(
+            projectId: 1,
+            updates: new[]
+            {
+                new StageBackfillUpdate(StageCodes.SOW, null, null)
+            },
+            userId: "user-1",
+            ct: CancellationToken.None));
+
+        Assert.Contains(ex.Details, detail => detail.Contains(StageCodes.SOW, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenStageMissing_ThrowsNotFound()
+    {
+        var clock = FakeClock.ForIstDate(new DateOnly(2025, 3, 15));
+        await using var db = CreateContext();
+        var service = new StageBackfillService(db, clock);
+
+        await Assert.ThrowsAsync<StageBackfillNotFoundException>(() => service.ApplyAsync(
+            projectId: 1,
+            updates: new[]
+            {
+                new StageBackfillUpdate(StageCodes.PNC, new DateOnly(2025, 1, 2), new DateOnly(2025, 1, 5))
+            },
+            userId: "user-1",
+            ct: CancellationToken.None));
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/Services/Stages/StageBackfillService.cs
+++ b/Services/Stages/StageBackfillService.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Stages;
+
+public sealed class StageBackfillService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public StageBackfillService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async Task<StageBackfillResult> ApplyAsync(
+        int projectId,
+        IReadOnlyCollection<StageBackfillUpdate> updates,
+        string userId,
+        CancellationToken ct = default)
+    {
+        if (projectId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(projectId));
+        }
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new ArgumentException("A valid user identifier is required.", nameof(userId));
+        }
+
+        if (updates is null || updates.Count == 0)
+        {
+            throw new StageBackfillValidationException(new[]
+            {
+                "At least one stage update is required."
+            });
+        }
+
+        var distinctUpdates = updates
+            .Where(u => u is not null && !string.IsNullOrWhiteSpace(u.StageCode))
+            .GroupBy(u => u.StageCode!, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var item = group.Last();
+                return new StageBackfillUpdate(
+                    group.Key,
+                    item.ActualStart,
+                    item.CompletedOn);
+            })
+            .ToArray();
+
+        if (distinctUpdates.Length == 0)
+        {
+            throw new StageBackfillValidationException(new[]
+            {
+                "At least one stage update is required."
+            });
+        }
+
+        var stageCodes = distinctUpdates.Select(u => u.StageCode).ToArray();
+
+        var stageLookup = await _db.ProjectStages
+            .Where(s => s.ProjectId == projectId && stageCodes.Contains(s.StageCode))
+            .ToDictionaryAsync(s => s.StageCode!, StringComparer.OrdinalIgnoreCase, ct);
+
+        if (stageLookup.Count != stageCodes.Length)
+        {
+            var missing = stageCodes
+                .Where(code => !stageLookup.ContainsKey(code))
+                .ToArray();
+
+            throw new StageBackfillNotFoundException(missing);
+        }
+
+        var today = DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime.Date);
+        var validationErrors = new List<string>();
+        var conflicts = new List<string>();
+
+        foreach (var update in distinctUpdates)
+        {
+            var stage = stageLookup[update.StageCode];
+
+            if (stage.Status != StageStatus.Completed)
+            {
+                conflicts.Add(update.StageCode);
+                continue;
+            }
+
+            if (!RequiresBackfill(stage))
+            {
+                conflicts.Add(update.StageCode);
+                continue;
+            }
+
+            var start = update.ActualStart ?? stage.ActualStart;
+            var completed = update.CompletedOn ?? stage.CompletedOn;
+
+            if (start is null)
+            {
+                validationErrors.Add($"Stage {update.StageCode}: actual start date is required.");
+            }
+            else if (start > today)
+            {
+                validationErrors.Add($"Stage {update.StageCode}: actual start date cannot be in the future.");
+            }
+
+            if (completed is null)
+            {
+                validationErrors.Add($"Stage {update.StageCode}: completion date is required.");
+            }
+            else if (completed > today)
+            {
+                validationErrors.Add($"Stage {update.StageCode}: completion date cannot be in the future.");
+            }
+
+            if (start is not null && completed is not null && start > completed)
+            {
+                validationErrors.Add($"Stage {update.StageCode}: completion date must be on or after the start date.");
+            }
+        }
+
+        if (validationErrors.Count > 0)
+        {
+            throw new StageBackfillValidationException(validationErrors);
+        }
+
+        if (conflicts.Count > 0)
+        {
+            throw new StageBackfillConflictException(conflicts.ToArray());
+        }
+
+        var now = _clock.UtcNow;
+        var updatedCodes = new List<string>(distinctUpdates.Length);
+
+        foreach (var update in distinctUpdates)
+        {
+            var stage = stageLookup[update.StageCode];
+            var originalActualStart = stage.ActualStart;
+            var originalCompletedOn = stage.CompletedOn;
+
+            var resolvedStart = update.ActualStart ?? stage.ActualStart!;
+            var resolvedCompleted = update.CompletedOn ?? stage.CompletedOn!;
+
+            stage.ActualStart = resolvedStart;
+            stage.CompletedOn = resolvedCompleted;
+            stage.RequiresBackfill = false;
+
+            var log = new StageChangeLog
+            {
+                ProjectId = stage.ProjectId,
+                StageCode = stage.StageCode,
+                Action = StageBackfillLogAction,
+                FromStatus = stage.Status.ToString(),
+                ToStatus = stage.Status.ToString(),
+                FromActualStart = originalActualStart,
+                ToActualStart = resolvedStart,
+                FromCompletedOn = originalCompletedOn,
+                ToCompletedOn = resolvedCompleted,
+                UserId = userId,
+                At = now,
+                Note = "Dates supplied via backfill workflow."
+            };
+
+            await _db.StageChangeLogs.AddAsync(log, ct);
+            updatedCodes.Add(stage.StageCode);
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        return new StageBackfillResult(updatedCodes.Count, updatedCodes.ToArray());
+    }
+
+    private static bool RequiresBackfill(ProjectStage stage)
+        => stage.RequiresBackfill || !stage.ActualStart.HasValue || !stage.CompletedOn.HasValue;
+
+    private const string StageBackfillLogAction = "Backfill";
+}
+
+public sealed record StageBackfillUpdate(string StageCode, DateOnly? ActualStart, DateOnly? CompletedOn);
+
+public sealed record StageBackfillResult(int UpdatedCount, IReadOnlyList<string> StageCodes);
+
+public sealed class StageBackfillValidationException : Exception
+{
+    public StageBackfillValidationException(IReadOnlyList<string> details)
+        : base("Validation failed for backfill input.")
+    {
+        Details = details ?? Array.Empty<string>();
+    }
+
+    public IReadOnlyList<string> Details { get; }
+}
+
+public sealed class StageBackfillConflictException : Exception
+{
+    public StageBackfillConflictException(IReadOnlyList<string> conflictingStages)
+        : base("One or more stages cannot be backfilled.")
+    {
+        ConflictingStages = conflictingStages ?? Array.Empty<string>();
+    }
+
+    public IReadOnlyList<string> ConflictingStages { get; }
+}
+
+public sealed class StageBackfillNotFoundException : Exception
+{
+    public StageBackfillNotFoundException(IReadOnlyList<string> missingStageCodes)
+        : base("Stage backfill target not found.")
+    {
+        MissingStageCodes = missingStageCodes ?? Array.Empty<string>();
+    }
+
+    public IReadOnlyList<string> MissingStageCodes { get; }
+}


### PR DESCRIPTION
## Summary
- replace procurement query trigger with a dedicated backfill modal in the project overview
- add a stage backfill service, Razor page endpoint, and migration to support “Backfill” stage change logs
- update client scripts, view models, and tests to drive the new backfill flow

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3b55a6888329b4a74ef042f579ee