### PR TITLE
Use icon trigger for timeline actions dropdown

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -91,10 +91,11 @@
             @if (showDirectApply)
             {
               <div class="dropdown">
-                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                  Actions
+                <button class="btn btn-sm btn-outline-secondary pm-actions-trigger dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Actions">
+                  <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
+                  <span class="pm-actions-trigger-text">Actions</span>
                 </button>
-                <ul class="dropdown-menu">
+                <ul class="dropdown-menu dropdown-menu-end">
                   <li>
                     <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="InProgress" data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
                       Start stage

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -69,6 +69,38 @@
   font-size: 0.9rem;
 }
 
+.pm-actions-trigger {
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.pm-actions-trigger .bi {
+  font-size: 1.1rem;
+}
+
+.pm-actions-trigger-text {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .pm-actions-trigger {
+    width: auto;
+    min-width: 0;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .pm-actions-trigger-text {
+    display: inline;
+  }
+}
+
 @media (max-width: 576px) {
   .pm-timeline-grid {
     grid-template-columns: 40px 1fr;


### PR DESCRIPTION
## Summary
- replace the timeline actions dropdown button text with an icon-based trigger that keeps an accessible label
- align the dropdown menu to the end to prevent overlap with the timeline content
- add responsive styles so the trigger stays compact while optionally revealing the label on large screens

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da6544fc24832985289a8e76bd779c