### PR TITLE
Adjust mobile timeline action button sizing

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -70,9 +70,9 @@
 }
 
 .pm-actions-trigger {
-  width: 2.5rem;
-  min-width: 2.5rem;
-  height: 2.5rem;
+  width: var(--pm-btn-icon);
+  min-width: var(--pm-btn-icon);
+  height: var(--pm-btn-icon);
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- allow the timeline actions trigger button to use the shared icon sizing token on small screens
- keep the large-screen media query so the padded text label still appears correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da691452248329a314c67efcf4bd18