### PR TITLE
Refine project timeline stage actions and layout

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -296,7 +296,26 @@
                         <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center gap-3 justify-content-lg-between">
                             <div class="d-flex flex-wrap align-items-center gap-2">
                                 <h5 class="mb-0">Timeline</h5>
+                                @{ 
+                                    string? viewerRole = null;
+                                    if (isHoD && isThisProjectsPo)
+                                    {
+                                        viewerRole = "Head of Department & Project Officer";
+                                    }
+                                    else if (isHoD)
+                                    {
+                                        viewerRole = "Head of Department";
+                                    }
+                                    else if (isThisProjectsPo)
+                                    {
+                                        viewerRole = "Project Officer";
+                                    }
+                                }
                                 <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-2 mt-2 mt-lg-0">
+                                    @if (!string.IsNullOrEmpty(viewerRole))
+                                    {
+                                        <span class="text-muted small" data-role-indicator title="Current permissions for timeline actions">Viewing as @viewerRole</span>
+                                    }
                                     @if (pendingOwnedByCurrentUser)
                                     {
                                         <span class="badge text-bg-warning">Submitted for approval</span>

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,23 +1,52 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
 @using ProjectManagement.Models.Execution
-@{ 
-    var showDirectApply = User.IsInRole("HoD");
-    var canRequestChange = ViewBag?.IsProjectOfficerForProject is bool b && b;
+@{
+    var isHod = User.IsInRole("HoD");
+    var isProjectOfficer = ViewBag?.IsProjectOfficerForProject is bool b && b;
+    var canRequestChange = isProjectOfficer || isHod;
 }
 @functions{
     string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
-    string StatusChip(StageStatus s) =>
-        s switch
-        {
-            StageStatus.Completed  => "badge bg-success",
-            StageStatus.InProgress => "badge bg-primary",
-            _                      => "badge bg-secondary"
-        };
-    string VarianceLabel(string name, int value)
+
+    string StatusPillClass(StageStatus s) => s switch
     {
-        var sign = value > 0 ? "+" : "−";
-        return $"{name} {sign}{Math.Abs(value)}d";
+        StageStatus.Completed  => "pm-pill pm-pill-success",
+        StageStatus.InProgress => "pm-pill pm-pill-primary",
+        _                      => "pm-pill pm-pill-muted"
+    };
+
+    string StatusLabel(StageStatus status) => status switch
+    {
+        StageStatus.Completed  => "Completed",
+        StageStatus.InProgress => "In progress",
+        _                      => "Not started"
+    };
+
+    (string text, string description, string cssClass) VarianceToken(string name, int value)
+    {
+        var magnitude = Math.Abs(value);
+        var cssClass = value switch
+        {
+            < 0 => "pm-chip pm-chip-early",
+            > 0 => "pm-chip pm-chip-late",
+            _   => "pm-chip pm-chip-on-time"
+        };
+
+        if (value == 0)
+        {
+            return ($"{name} on time", $"{name} on time", cssClass);
+        }
+
+        var text = value > 0
+            ? $"{name} +{magnitude}d"
+            : $"{name} −{magnitude}d";
+
+        var description = value > 0
+            ? $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} late"
+            : $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} early";
+
+        return (text, description, cssClass);
     }
 }
 <link rel="stylesheet" href="~/css/projects/timeline.css" />
@@ -36,113 +65,240 @@
         _                      => "pm-item"
       };
       <div class="@itemClass" data-stage-row="@s.Code" data-requires-backfill="@(s.RequiresBackfill ? "true" : "false")">
-        <div class="pm-item-header d-flex flex-wrap justify-content-between align-items-start gap-2">
-          <div class="d-flex flex-wrap align-items-center gap-2">
-            <span class="pm-item-title" data-stage-name="@s.Name">@s.Name</span>
-            <span class="@StatusChip(s.Status)" data-stage-status>@s.Status</span>
-            @if (s.IsAutoCompleted)
-            {
-              <span class="badge bg-warning-subtle text-warning border border-warning-subtle" title="Auto-completed when a later stage was completed.">inferred</span>
-            }
-            @{
-              var showIncomplete = s.IsIncompleteData || s.RequiresBackfill;
-            }
-            <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle@(showIncomplete ? string.Empty : " d-none")" data-stage-incomplete>
-              Incomplete data
-            </span>
-            <span data-stage-pending>
-              @if (s.HasPendingRequest)
-              {
-                <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
-                  Pending: @s.PendingStatus@if (s.PendingDate.HasValue)
-                  {
-                    <text> · @D(s.PendingDate)</text>
-                  }
-                </span>
-              }
-            </span>
-            @if (s.IsOverdue)
-            {
-              <span class="badge bg-danger-subtle text-danger border border-danger-subtle">Overdue</span>
-            }
-            <span class="ms-2 text-warning@(s.RequiresBackfill ? string.Empty : " d-none")" title="Additional data required" data-stage-backfill-indicator>⚠︎</span>
-            <button type="button"
-                    class="btn btn-link btn-sm px-0 align-baseline ms-1@(s.RequiresBackfill ? string.Empty : " d-none")"
-                    data-action="open-backfill"
-                    data-stage-backfill-button>
-              Backfill…
-            </button>
-          </div>
-          <div class="d-flex align-items-center gap-2">
-            @if (canRequestChange)
-            {
+        <div class="pm-item-card">
+          <div class="pm-item-header">
+            <div class="pm-item-heading">
+              <span class="@StatusPillClass(s.Status)"
+                    data-stage-status
+                    data-stage-status-pill
+                    aria-label="Stage status: @StatusLabel(s.Status)">
+                @StatusLabel(s.Status)
+              </span>
               <button type="button"
-                      class="btn btn-sm btn-outline-primary"
-                      data-stage-request
-                      data-stage-request-button
-                      data-project="@Model.ProjectId"
-                      data-stage="@s.Code"
-                      data-stage-name="@s.Name"
-                      data-current-status="@s.Status"
-                      @(s.HasPendingRequest ? "disabled" : null)>
-                Request change
+                      class="pm-pill pm-pill-warning@(s.RequiresBackfill ? string.Empty : " d-none")"
+                      data-action="open-backfill"
+                      data-stage-backfill-pill
+                      aria-label="Backfill required for @s.Name">
+                Backfill required
               </button>
-            }
-            @if (showDirectApply)
-            {
-              <div class="dropdown">
-                <button class="btn btn-sm btn-outline-secondary pm-actions-trigger dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Actions">
-                  <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
-                  <span class="pm-actions-trigger-text">Actions</span>
+              <span class="pm-item-title text-truncate"
+                    title="@s.Name"
+                    data-stage-name>
+                @s.Name
+              </span>
+            </div>
+            <div class="pm-item-actions">
+              @if (canRequestChange)
+              {
+                <button type="button"
+                        class="btn btn-link btn-sm pm-primary-action d-none d-lg-inline"
+                        data-stage-request
+                        data-stage-request-button
+                        data-project="@Model.ProjectId"
+                        data-stage="@s.Code"
+                        data-stage-name="@s.Name"
+                        data-current-status="@s.Status"
+                        @(s.HasPendingRequest ? "disabled" : null)>
+                  Request
                 </button>
-                <ul class="dropdown-menu dropdown-menu-end">
-                  <li>
-                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="InProgress" data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
-                      Start stage
-                    </button>
-                  </li>
-                  <li>
-                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Completed" data-default-date="@s.CompletedOn?.ToString("yyyy-MM-dd")">
-                      Mark completed
-                    </button>
-                  </li>
-                  <li>
-                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Blocked">
-                      Block
-                    </button>
-                  </li>
-                  <li>
-                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Skipped">
-                      Skip
-                    </button>
-                  </li>
-                  <li>
-                    <button class="dropdown-item" type="button" data-direct-apply data-project="@Model.ProjectId" data-stage="@s.Code" data-stage-name="@s.Name" data-status="Reopen">
-                      Reopen
-                    </button>
-                  </li>
+              }
+              <div class="dropdown">
+                <button class="btn pm-kebab" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Stage actions for @s.Name">
+                  <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end" data-stage-action-menu>
+                  @if (isHod && s.HasPendingRequest && s.PendingRequestId is int requestId)
+                  {
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-stage-decision-inline
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-request-id="@requestId"
+                              data-decision="Approve">
+                        Approve
+                      </button>
+                    </li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-stage-decision-inline
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-request-id="@requestId"
+                              data-decision="Reject">
+                        Reject
+                      </button>
+                    </li>
+                    <li><hr class="dropdown-divider" /></li>
+                  }
+                  @if (isHod)
+                  {
+                    <li class="dropdown-header">Mark as…</li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-direct-apply
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-status="InProgress"
+                              data-default-date="@s.ActualStart?.ToString("yyyy-MM-dd")">
+                        In progress
+                      </button>
+                    </li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-direct-apply
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-status="Completed"
+                              data-default-date="@s.CompletedOn?.ToString("yyyy-MM-dd")">
+                        Completed
+                      </button>
+                    </li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-direct-apply
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-status="Blocked">
+                        Blocked
+                      </button>
+                    </li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-direct-apply
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-status="Skipped">
+                        Skipped
+                      </button>
+                    </li>
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-direct-apply
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-status="Reopen">
+                        Reopen
+                      </button>
+                    </li>
+                    @if (canRequestChange)
+                    {
+                      <li><hr class="dropdown-divider" /></li>
+                    }
+                  }
+                  @if (canRequestChange)
+                  {
+                    <li>
+                      <button class="dropdown-item"
+                              type="button"
+                              data-stage-request
+                              data-stage-request-button
+                              data-project="@Model.ProjectId"
+                              data-stage="@s.Code"
+                              data-stage-name="@s.Name"
+                              data-current-status="@s.Status"
+                              @(s.HasPendingRequest ? "disabled" : null)>
+                        Request change
+                      </button>
+                    </li>
+                  }
                 </ul>
               </div>
-            }
+            </div>
           </div>
-        </div>
-        <div class="pm-item-meta">
-          <div>Planned: <span data-stage-planned-start>@D(s.PlannedStart)</span> — <span data-stage-planned-end>@D(s.PlannedEnd)</span></div>
-          <div>
-            Actual: <span data-stage-actual-start>@D(s.ActualStart)</span> — <span data-stage-completed>@D(s.CompletedOn)</span>
-            <span class="text-muted ms-2@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
-              @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
+          <div class="pm-item-flags">
+            @if (s.IsAutoCompleted)
+            {
+              <span class="pm-flag" title="Auto-completed when a later stage finished." data-stage-autocomplete>Inferred</span>
+            }
+            <span class="pm-flag@(s.IsIncompleteData || s.RequiresBackfill ? string.Empty : " d-none")" data-stage-incomplete>
+              Incomplete data
+            </span>
+            <span class="pm-flag pm-flag-danger@(s.IsOverdue ? string.Empty : " d-none")" data-stage-overdue>Overdue</span>
+            <span class="pm-flag pm-flag-warning@(s.HasPendingRequest ? string.Empty : " d-none")" data-stage-pending>
+              @if (s.HasPendingRequest)
+              {
+                  <text>Pending: @s.PendingStatus</text>
+                  @if (s.PendingDate.HasValue)
+                  {
+                      <text> · @D(s.PendingDate)</text>
+                  }
+              }
             </span>
           </div>
-          <div class="pm-item-variance d-flex flex-wrap gap-1 mt-1">
-            @if (s.StartVarianceDays is int startVar && startVar != 0)
-            {
-              <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle" data-stage-start-variance>@VarianceLabel("Start", startVar)</span>
-            }
-            @if (s.FinishVarianceDays is int finishVar && finishVar != 0)
-            {
-              <span class="badge bg-secondary-subtle text-body-secondary border border-secondary-subtle" data-stage-finish-variance>@VarianceLabel("Finish", finishVar)</span>
-            }
+          <div class="pm-item-dates">
+            <div class="pm-date-row">
+              <span class="pm-date-label">Planned</span>
+              <div class="pm-date-values">
+                <span data-stage-planned-start>@D(s.PlannedStart)</span>
+                <span class="pm-date-sep">–</span>
+                <span data-stage-planned-end>@D(s.PlannedEnd)</span>
+              </div>
+            </div>
+            <div class="pm-date-row">
+              <span class="pm-date-label">Actual</span>
+              <div class="pm-date-values">
+                <span data-stage-actual-start>@D(s.ActualStart)</span>
+                <span class="pm-date-sep">–</span>
+                <span data-stage-completed>@D(s.CompletedOn)</span>
+                <span class="pm-date-duration@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
+                  @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
+                </span>
+              </div>
+            </div>
+            <div class="pm-date-hint small text-muted@(s.NeedsStart || s.NeedsFinish ? string.Empty : " d-none")" data-stage-date-hint>
+              @if (s.NeedsStart && s.NeedsFinish)
+              {
+                  <text>Actual start and finish missing</text>
+              }
+              else if (s.NeedsStart)
+              {
+                  <text>Actual start missing</text>
+              }
+              else if (s.NeedsFinish)
+              {
+                  <text>Actual finish missing</text>
+              }
+            </div>
+          </div>
+          <div class="pm-item-variance">
+            <div class="pm-variance-chips">
+              @if (s.PlannedStart.HasValue && s.ActualStart.HasValue && s.StartVarianceDays is int startVar)
+              {
+                  var variance = VarianceToken("Start", startVar);
+                  <span class="@variance.cssClass"
+                        data-stage-start-variance
+                        aria-label="@variance.description"
+                        title="@variance.description">
+                    @variance.text
+                  </span>
+              }
+              @if (s.PlannedEnd.HasValue && s.CompletedOn.HasValue && s.FinishVarianceDays is int finishVar)
+              {
+                  var variance = VarianceToken("Finish", finishVar);
+                  <span class="@variance.cssClass"
+                        data-stage-finish-variance
+                        aria-label="@variance.description"
+                        title="@variance.description">
+                    @variance.text
+                  </span>
+              }
+            </div>
+            <div class="pm-variance-hint small text-muted@(s.PlannedStart.HasValue || s.PlannedEnd.HasValue ? " d-none" : string.Empty)" data-stage-plan-hint>
+              No plan dates
+            </div>
           </div>
         </div>
       </div>

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -125,21 +125,13 @@ public sealed class ProjectTimelineReadService
             int? startVarianceDays = null;
             if (plannedStart.HasValue && actualStart.HasValue)
             {
-                var diff = actualStart.Value.DayNumber - plannedStart.Value.DayNumber;
-                if (diff != 0)
-                {
-                    startVarianceDays = diff;
-                }
+                startVarianceDays = actualStart.Value.DayNumber - plannedStart.Value.DayNumber;
             }
 
             int? finishVarianceDays = null;
             if (plannedEnd.HasValue && actualEnd.HasValue)
             {
-                var diff = actualEnd.Value.DayNumber - plannedEnd.Value.DayNumber;
-                if (diff != 0)
-                {
-                    finishVarianceDays = diff;
-                }
+                finishVarianceDays = actualEnd.Value.DayNumber - plannedEnd.Value.DayNumber;
             }
 
             items.Add(new TimelineItemVm
@@ -160,7 +152,8 @@ public sealed class ProjectTimelineReadService
                 PendingStatus = pendingRequest?.RequestedStatus,
                 PendingDate = pendingRequest?.RequestedDate,
                 StartVarianceDays = startVarianceDays,
-                FinishVarianceDays = finishVarianceDays
+                FinishVarianceDays = finishVarianceDays,
+                PendingRequestId = pendingRequest?.Id
             });
         }
 

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -50,6 +50,7 @@ public sealed class TimelineItemVm
     public bool HasPendingRequest { get; init; }
     public string? PendingStatus { get; init; }
     public DateOnly? PendingDate { get; init; }
+    public int? PendingRequestId { get; init; }
 
     public int? StartVarianceDays { get; init; }
     public int? FinishVarianceDays { get; init; }

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -21,7 +21,7 @@
 .pm-items {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 0;
 }
 
 .pm-item {
@@ -33,7 +33,7 @@
   content: "";
   position: absolute;
   left: -56px;
-  top: 6px;
+  top: 12px;
   width: 12px;
   height: 12px;
   border-radius: 50%;
@@ -52,53 +52,226 @@
   box-shadow: 0 0 0 2px rgba(25, 135, 84, 0.25);
 }
 
-.pm-item-header {
+.pm-item-card {
+  padding: 12px 0;
+  border-top: 1px solid var(--bs-border-color);
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pm-item:first-child .pm-item-card {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.pm-item-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: start;
+}
+
+.pm-item-heading {
+  display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .pm-item-title {
   font-weight: 600;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
-.pm-item-meta {
-  margin-top: 4px;
-  color: var(--bs-gray-600);
-  font-size: 0.9rem;
+.pm-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 3rem;
 }
 
-.pm-actions-trigger {
-  width: var(--pm-btn-icon);
-  min-width: var(--pm-btn-icon);
-  height: var(--pm-btn-icon);
+.pm-primary-action {
+  color: var(--bs-body-color);
+  text-decoration: none;
+  padding: 0;
+}
+
+.pm-primary-action:hover,
+.pm-primary-action:focus {
+  text-decoration: underline;
+}
+
+.pm-kebab {
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
-  padding: 0;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  background-color: transparent;
+  color: inherit;
+}
+
+.pm-kebab:hover,
+.pm-kebab:focus {
+  background-color: var(--bs-gray-100);
+  border-color: var(--bs-gray-300);
+}
+
+.pm-kebab:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.pm-item-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.8125rem;
+  color: var(--bs-gray-600);
+}
+
+.pm-flag {
+  background-color: var(--bs-gray-100);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.pm-flag-danger {
+  color: var(--bs-danger);
+  background-color: rgba(var(--bs-danger-rgb), 0.1);
+}
+
+.pm-flag-warning {
+  color: var(--bs-warning);
+  background-color: rgba(var(--bs-warning-rgb), 0.12);
+}
+
+.pm-item-dates {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--bs-gray-700);
+  font-size: 0.9rem;
+}
+
+.pm-date-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.pm-date-label {
+  font-weight: 500;
+  color: var(--bs-gray-600);
+}
+
+.pm-date-values {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.pm-date-duration {
+  color: var(--bs-gray-600);
+}
+
+.pm-date-hint {
+  padding-left: 80px;
+}
+
+.pm-item-variance {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pm-variance-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pm-chip {
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+
+.pm-chip-early {
+  background-color: rgba(var(--bs-success-rgb), 0.12);
+  color: var(--bs-success);
+  border-color: rgba(var(--bs-success-rgb), 0.25);
+}
+
+.pm-chip-late {
+  background-color: rgba(var(--bs-danger-rgb), 0.12);
+  color: var(--bs-danger);
+  border-color: rgba(var(--bs-danger-rgb), 0.25);
+}
+
+.pm-chip-on-time {
+  background-color: var(--bs-gray-100);
+  color: var(--bs-gray-700);
+  border-color: var(--bs-gray-300);
+}
+
+.pm-variance-hint {
+  padding-left: 80px;
+}
+
+.pm-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  text-transform: none;
   white-space: nowrap;
 }
 
-.pm-actions-trigger .bi {
-  font-size: 1.1rem;
+.pm-pill-muted {
+  background-color: var(--bs-gray-200);
+  color: var(--bs-gray-700);
+  border-color: var(--bs-gray-200);
 }
 
-.pm-actions-trigger-text {
-  display: none;
+.pm-pill-primary {
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  color: var(--bs-primary);
+  border-color: rgba(var(--bs-primary-rgb), 0.25);
 }
 
-@media (min-width: 992px) {
-  .pm-actions-trigger {
-    width: auto;
-    min-width: 0;
-    padding: 0.25rem 0.5rem;
-  }
+.pm-pill-success {
+  background-color: rgba(var(--bs-success-rgb), 0.12);
+  color: var(--bs-success);
+  border-color: rgba(var(--bs-success-rgb), 0.25);
+}
 
-  .pm-actions-trigger-text {
-    display: inline;
-  }
+.pm-pill-warning {
+  background-color: rgba(var(--bs-warning-rgb), 0.18);
+  color: var(--bs-warning);
+  border-color: rgba(var(--bs-warning-rgb), 0.3);
+}
+
+.pm-pill:disabled {
+  opacity: 0.6;
+}
+
+.pm-item[data-loading="true"] .pm-item-card {
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- redesign the project timeline stage rows with compact status/backfill pills, aligned date blocks, drift indicators, and an icon-only actions menu
- refresh timeline styling to keep rows dense, reserve an actions column, and support the new pill and chip treatments with loading feedback
- enhance timeline interactions by adding inline HoD approve/reject controls, row loading states, and updated data wiring for pending request identifiers and variance chips
- surface the viewer role on the overview timeline header to clarify which actions are available

## Testing
- `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da6c31fba483298f7545e95c1be7cd