### PR TITLE
Prevent timeline action controls from wrapping

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -88,14 +88,17 @@
 .pm-item-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 3rem;
+  flex-wrap: nowrap;
 }
 
 .pm-primary-action {
   color: var(--bs-body-color);
   text-decoration: none;
   padding: 0;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .pm-primary-action:hover,


### PR DESCRIPTION
## Summary
- prevent the timeline request link and kebab menu from wrapping onto multiple lines
- ensure the primary action button label never breaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da74c9a9648329a8a9e92a60cfb45f