### PR TITLE
Hide stage change request card when empty

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -236,59 +236,62 @@
         <div class="col-lg-4 d-flex flex-column gap-3">
             @if (isThisProjectsHod)
             {
-                var decisionTokens = Antiforgery.GetAndStoreTokens(HttpContext);
-                <div class="card" data-stage-requests-card>
-                    <div class="card-header">Stage change requests</div>
-                    <div class="card-body d-flex flex-column gap-3">
-                        <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
-                        <div class="text-muted small @(Model.Timeline.PendingRequests.Any() ? "d-none" : string.Empty)" data-stage-requests-empty>
-                            No pending stage change requests.
-                        </div>
-                        <div class="d-flex flex-column gap-3" data-stage-decision-list>
-                            @foreach (var request in Model.Timeline.PendingRequests)
-                            {
-                                var stageLabel = $"{request.StageCode} — {request.StageName}".Trim(' ', '—');
-                                <div class="border rounded p-3" data-stage-request-item data-request-id="@request.RequestId" data-stage-code="@request.StageCode" data-stage-label="@stageLabel">
-                                    <div class="d-flex justify-content-between align-items-start gap-2">
-                                        <div>
-                                            <div class="fw-semibold">@stageLabel</div>
-                                            <div class="text-muted small">
-                                                Requested by @request.RequestedBy on @request.RequestedOn.ToLocalTime().ToString("dd MMM yyyy")
+                if (Model.Timeline.PendingRequests.Any())
+                {
+                    var decisionTokens = Antiforgery.GetAndStoreTokens(HttpContext);
+                    <div class="card" data-stage-requests-card>
+                        <div class="card-header">Stage change requests</div>
+                        <div class="card-body d-flex flex-column gap-3">
+                            <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
+                            <div class="text-muted small @(Model.Timeline.PendingRequests.Any() ? "d-none" : string.Empty)" data-stage-requests-empty>
+                                No pending stage change requests.
+                            </div>
+                            <div class="d-flex flex-column gap-3" data-stage-decision-list>
+                                @foreach (var request in Model.Timeline.PendingRequests)
+                                {
+                                    var stageLabel = $"{request.StageCode} — {request.StageName}".Trim(' ', '—');
+                                    <div class="border rounded p-3" data-stage-request-item data-request-id="@request.RequestId" data-stage-code="@request.StageCode" data-stage-label="@stageLabel">
+                                        <div class="d-flex justify-content-between align-items-start gap-2">
+                                            <div>
+                                                <div class="fw-semibold">@stageLabel</div>
+                                                <div class="text-muted small">
+                                                    Requested by @request.RequestedBy on @request.RequestedOn.ToLocalTime().ToString("dd MMM yyyy")
+                                                </div>
                                             </div>
+                                            <span class="badge bg-warning text-dark">@StageStatusLabel(request.RequestedStatus)</span>
                                         </div>
-                                        <span class="badge bg-warning text-dark">@StageStatusLabel(request.RequestedStatus)</span>
-                                    </div>
-                                    <dl class="row small mt-3 mb-0">
-                                        <dt class="col-4">Current</dt>
-                                        <dd class="col-8">@StageStatusLabel(request.CurrentStatus)</dd>
-                                        <dt class="col-4">Target</dt>
-                                        <dd class="col-8">
-                                            @StageStatusLabel(request.RequestedStatus)
-                                            @if (request.RequestedDate.HasValue)
+                                        <dl class="row small mt-3 mb-0">
+                                            <dt class="col-4">Current</dt>
+                                            <dd class="col-8">@StageStatusLabel(request.CurrentStatus)</dd>
+                                            <dt class="col-4">Target</dt>
+                                            <dd class="col-8">
+                                                @StageStatusLabel(request.RequestedStatus)
+                                                @if (request.RequestedDate.HasValue)
+                                                {
+                                                    <span>· @request.RequestedDate.Value.ToString("dd MMM yyyy")</span>
+                                                }
+                                            </dd>
+                                            @if (!string.IsNullOrWhiteSpace(request.Note))
                                             {
-                                                <span>· @request.RequestedDate.Value.ToString("dd MMM yyyy")</span>
+                                                <dt class="col-4">PO note</dt>
+                                                <dd class="col-8">@request.Note</dd>
                                             }
-                                        </dd>
-                                        @if (!string.IsNullOrWhiteSpace(request.Note))
-                                        {
-                                            <dt class="col-4">PO note</dt>
-                                            <dd class="col-8">@request.Note</dd>
-                                        }
-                                    </dl>
-                                    <div class="mt-3">
-                                        <label class="form-label mb-1 small" for="decision-note-@request.RequestId">Decision note <span class="text-muted">(optional)</span></label>
-                                        <textarea class="form-control form-control-sm" id="decision-note-@request.RequestId" rows="2" maxlength="1024" data-stage-decision-note></textarea>
+                                        </dl>
+                                        <div class="mt-3">
+                                            <label class="form-label mb-1 small" for="decision-note-@request.RequestId">Decision note <span class="text-muted">(optional)</span></label>
+                                            <textarea class="form-control form-control-sm" id="decision-note-@request.RequestId" rows="2" maxlength="1024" data-stage-decision-note></textarea>
+                                        </div>
+                                        <div class="d-flex gap-2 mt-3">
+                                            <button type="button" class="btn btn-sm btn-success" data-stage-decision="Approve">Approve</button>
+                                            <button type="button" class="btn btn-sm btn-outline-danger" data-stage-decision="Reject">Reject</button>
+                                        </div>
+                                        <div class="text-danger small mt-2 d-none" data-stage-decision-error></div>
                                     </div>
-                                    <div class="d-flex gap-2 mt-3">
-                                        <button type="button" class="btn btn-sm btn-success" data-stage-decision="Approve">Approve</button>
-                                        <button type="button" class="btn btn-sm btn-outline-danger" data-stage-decision="Reject">Reject</button>
-                                    </div>
-                                    <div class="text-danger small mt-2 d-none" data-stage-decision-error></div>
-                                </div>
-                            }
+                                }
+                            </div>
                         </div>
                     </div>
-                </div>
+                }
             }
             <div class="card">
                 <div class="card-header">

--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -402,6 +402,30 @@
     });
   }
 
+  function updateStageRequestsContainer(listElement) {
+    const card = document.querySelector('[data-stage-requests-card]');
+    if (!card) {
+      return;
+    }
+
+    const list = listElement || card.querySelector('[data-stage-decision-list]');
+    const emptyState = card.querySelector('[data-stage-requests-empty]');
+    const hasItems = Boolean(list && list.querySelector('[data-stage-request-item]'));
+
+    if (hasItems) {
+      if (emptyState) {
+        emptyState.classList.add('d-none');
+      }
+      return;
+    }
+
+    if (emptyState) {
+      emptyState.classList.remove('d-none');
+    }
+
+    card.remove();
+  }
+
   function renderErrors(container, messages) {
     if (!container) return;
     const hasErrors = Array.isArray(messages) && messages.length > 0;
@@ -1000,10 +1024,7 @@
             item.remove();
           }
           const list = document.querySelector('[data-stage-decision-list]');
-          const emptyState = document.querySelector('[data-stage-requests-empty]');
-          if (list && !list.querySelector('[data-stage-request-item]') && emptyState) {
-            emptyState.classList.remove('d-none');
-          }
+          updateStageRequestsContainer(list);
           return;
         }
 
@@ -1044,10 +1065,7 @@
           item.remove();
         }
         const list = document.querySelector('[data-stage-decision-list]');
-        const emptyState = document.querySelector('[data-stage-requests-empty]');
-        if (list && !list.querySelector('[data-stage-request-item]') && emptyState) {
-          emptyState.classList.remove('d-none');
-        }
+        updateStageRequestsContainer(list);
       } catch (error) {
         console.error(error);
         showToast('Unable to update the stage right now.', 'danger');
@@ -1068,8 +1086,6 @@
 
     const tokenInput = document.querySelector('[data-stage-decision-token]');
     const token = tokenInput ? tokenInput.value : '';
-    const emptyState = document.querySelector('[data-stage-requests-empty]');
-
     list.addEventListener('click', async (event) => {
       const button = event.target.closest('[data-stage-decision]');
       if (!button) {
@@ -1153,9 +1169,7 @@
             updatePendingBadge(stageCode, null, null);
             enableRequestButton(stageCode);
           }
-          if (!list.querySelector('[data-stage-request-item]') && emptyState) {
-            emptyState.classList.remove('d-none');
-          }
+          updateStageRequestsContainer(list);
           return;
         }
 
@@ -1201,9 +1215,7 @@
 
         item.remove();
         removed = true;
-        if (!list.querySelector('[data-stage-request-item]') && emptyState) {
-          emptyState.classList.remove('d-none');
-        }
+        updateStageRequestsContainer(list);
       } catch (error) {
         console.error(error);
         showToast('Unable to update the stage right now.', 'danger');


### PR DESCRIPTION
## Summary
- only render the HoD stage change request card when there are pending timeline requests
- drop the card from the DOM once the last pending request is decided so the HoD view stays tidy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da74e46dc88329ab797ca4510993f7