### PR TITLE
Keep timeline actions on a single row

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -91,7 +91,7 @@
               @if (canRequestChange)
               {
                 <button type="button"
-                        class="btn btn-link btn-sm pm-primary-action d-none d-lg-inline"
+                        class="btn btn-link btn-sm pm-primary-action"
                         data-stage-request
                         data-stage-request-button
                         data-project="@Model.ProjectId"

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -67,7 +67,7 @@
 
 .pm-item-header {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: start;
 }
@@ -88,14 +88,23 @@
 .pm-item-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 3rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.pm-item-actions > * {
+  flex-shrink: 0;
 }
 
 .pm-primary-action {
   color: var(--bs-body-color);
   text-decoration: none;
   padding: 0;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .pm-primary-action:hover,


### PR DESCRIPTION
## Summary
- allow the timeline header layout to shrink the title column without displacing the action controls
- keep the request link and kebab menu in a no-wrap flex row across breakpoints and leave the request link visible at all sizes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da74c9a9648329a8a9e92a60cfb45f