### PR TITLE
Improve timeline panel readability and stage request handling

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -237,58 +237,61 @@
             @if (isThisProjectsHod)
             {
                 var decisionTokens = Antiforgery.GetAndStoreTokens(HttpContext);
-                <div class="card" data-stage-requests-card>
-                    <div class="card-header">Stage change requests</div>
-                    <div class="card-body d-flex flex-column gap-3">
-                        <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
-                        <div class="text-muted small @(Model.Timeline.PendingRequests.Any() ? "d-none" : string.Empty)" data-stage-requests-empty>
-                            No pending stage change requests.
-                        </div>
-                        <div class="d-flex flex-column gap-3" data-stage-decision-list>
-                            @foreach (var request in Model.Timeline.PendingRequests)
-                            {
-                                var stageLabel = $"{request.StageCode} — {request.StageName}".Trim(' ', '—');
-                                <div class="border rounded p-3" data-stage-request-item data-request-id="@request.RequestId" data-stage-code="@request.StageCode" data-stage-label="@stageLabel">
-                                    <div class="d-flex justify-content-between align-items-start gap-2">
-                                        <div>
-                                            <div class="fw-semibold">@stageLabel</div>
-                                            <div class="text-muted small">
-                                                Requested by @request.RequestedBy on @request.RequestedOn.ToLocalTime().ToString("dd MMM yyyy")
+                <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
+                if (Model.Timeline.PendingRequests.Any())
+                {
+                    <div class="card" data-stage-requests-card>
+                        <div class="card-header">Stage change requests</div>
+                        <div class="card-body d-flex flex-column gap-3">
+                            <div class="text-muted small d-none" data-stage-requests-empty>
+                                No pending stage change requests.
+                            </div>
+                            <div class="d-flex flex-column gap-3" data-stage-decision-list>
+                                @foreach (var request in Model.Timeline.PendingRequests)
+                                {
+                                    var stageLabel = $"{request.StageCode} — {request.StageName}".Trim(' ', '—');
+                                    <div class="border rounded p-3" data-stage-request-item data-request-id="@request.RequestId" data-stage-code="@request.StageCode" data-stage-label="@stageLabel">
+                                        <div class="d-flex justify-content-between align-items-start gap-2">
+                                            <div>
+                                                <div class="fw-semibold">@stageLabel</div>
+                                                <div class="text-muted small">
+                                                    Requested by @request.RequestedBy on @request.RequestedOn.ToLocalTime().ToString("dd MMM yyyy")
+                                                </div>
                                             </div>
+                                            <span class="badge bg-warning text-dark">@StageStatusLabel(request.RequestedStatus)</span>
                                         </div>
-                                        <span class="badge bg-warning text-dark">@StageStatusLabel(request.RequestedStatus)</span>
-                                    </div>
-                                    <dl class="row small mt-3 mb-0">
-                                        <dt class="col-4">Current</dt>
-                                        <dd class="col-8">@StageStatusLabel(request.CurrentStatus)</dd>
-                                        <dt class="col-4">Target</dt>
-                                        <dd class="col-8">
-                                            @StageStatusLabel(request.RequestedStatus)
-                                            @if (request.RequestedDate.HasValue)
+                                        <dl class="row small mt-3 mb-0">
+                                            <dt class="col-4">Current</dt>
+                                            <dd class="col-8">@StageStatusLabel(request.CurrentStatus)</dd>
+                                            <dt class="col-4">Target</dt>
+                                            <dd class="col-8">
+                                                @StageStatusLabel(request.RequestedStatus)
+                                                @if (request.RequestedDate.HasValue)
+                                                {
+                                                    <span>· @request.RequestedDate.Value.ToString("dd MMM yyyy")</span>
+                                                }
+                                            </dd>
+                                            @if (!string.IsNullOrWhiteSpace(request.Note))
                                             {
-                                                <span>· @request.RequestedDate.Value.ToString("dd MMM yyyy")</span>
+                                                <dt class="col-4">PO note</dt>
+                                                <dd class="col-8">@request.Note</dd>
                                             }
-                                        </dd>
-                                        @if (!string.IsNullOrWhiteSpace(request.Note))
-                                        {
-                                            <dt class="col-4">PO note</dt>
-                                            <dd class="col-8">@request.Note</dd>
-                                        }
-                                    </dl>
-                                    <div class="mt-3">
-                                        <label class="form-label mb-1 small" for="decision-note-@request.RequestId">Decision note <span class="text-muted">(optional)</span></label>
-                                        <textarea class="form-control form-control-sm" id="decision-note-@request.RequestId" rows="2" maxlength="1024" data-stage-decision-note></textarea>
+                                        </dl>
+                                        <div class="mt-3">
+                                            <label class="form-label mb-1 small" for="decision-note-@request.RequestId">Decision note <span class="text-muted">(optional)</span></label>
+                                            <textarea class="form-control form-control-sm" id="decision-note-@request.RequestId" rows="2" maxlength="1024" data-stage-decision-note></textarea>
+                                        </div>
+                                        <div class="d-flex gap-2 mt-3">
+                                            <button type="button" class="btn btn-sm btn-success" data-stage-decision="Approve">Approve</button>
+                                            <button type="button" class="btn btn-sm btn-outline-danger" data-stage-decision="Reject">Reject</button>
+                                        </div>
+                                        <div class="text-danger small mt-2 d-none" data-stage-decision-error></div>
                                     </div>
-                                    <div class="d-flex gap-2 mt-3">
-                                        <button type="button" class="btn btn-sm btn-success" data-stage-decision="Approve">Approve</button>
-                                        <button type="button" class="btn btn-sm btn-outline-danger" data-stage-decision="Reject">Reject</button>
-                                    </div>
-                                    <div class="text-danger small mt-2 d-none" data-stage-decision-error></div>
-                                </div>
-                            }
+                                }
+                            </div>
                         </div>
                     </div>
-                </div>
+                }
             }
             <div class="card">
                 <div class="card-header">

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -21,7 +21,7 @@
 .pm-items {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 12px;
 }
 
 .pm-item {
@@ -53,21 +53,43 @@
 }
 
 .pm-item-card {
-  padding: 12px 0;
-  border-top: 1px solid var(--bs-border-color);
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+  padding: 16px 20px 16px 24px;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.75rem;
+  background-color: var(--bs-gray-100);
+  box-shadow: 0 1px 1px rgba(15, 23, 42, 0.04);
+  overflow: hidden;
 }
 
-.pm-item:first-child .pm-item-card {
-  border-top: 0;
-  padding-top: 0;
+.pm-item-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 4px;
+  background: transparent;
+}
+
+.pm-item.is-active .pm-item-card::before {
+  background: rgba(var(--bs-primary-rgb), 0.45);
+}
+
+.pm-item.is-complete .pm-item-card::before {
+  background: rgba(var(--bs-success-rgb), 0.45);
+}
+
+.pm-item:not(.is-active):not(.is-complete) .pm-item-card::before {
+  background: rgba(var(--bs-secondary-rgb), 0.35);
 }
 
 .pm-item-header {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: start;
 }
@@ -88,6 +110,7 @@
 .pm-item-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   min-width: 3rem;
   flex-wrap: nowrap;
@@ -104,6 +127,10 @@
 .pm-primary-action:hover,
 .pm-primary-action:focus {
   text-decoration: underline;
+}
+
+.pm-item-actions .dropdown {
+  flex-shrink: 0;
 }
 
 .pm-kebab {
@@ -193,6 +220,13 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.pm-item-card > * + .pm-item-dates,
+.pm-item-card > * + .pm-item-variance {
+  border-top: 1px solid var(--bs-border-color);
+  padding-top: 12px;
+  margin-top: 4px;
 }
 
 .pm-variance-chips {

--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -402,6 +402,18 @@
     });
   }
 
+  function handleStageRequestsCleared() {
+    const emptyState = document.querySelector('[data-stage-requests-empty]');
+    if (emptyState) {
+      emptyState.classList.remove('d-none');
+    }
+
+    const card = document.querySelector('[data-stage-requests-card]');
+    if (card && !card.querySelector('[data-stage-request-item]')) {
+      card.remove();
+    }
+  }
+
   function renderErrors(container, messages) {
     if (!container) return;
     const hasErrors = Array.isArray(messages) && messages.length > 0;
@@ -1000,9 +1012,8 @@
             item.remove();
           }
           const list = document.querySelector('[data-stage-decision-list]');
-          const emptyState = document.querySelector('[data-stage-requests-empty]');
-          if (list && !list.querySelector('[data-stage-request-item]') && emptyState) {
-            emptyState.classList.remove('d-none');
+          if (list && !list.querySelector('[data-stage-request-item]')) {
+            handleStageRequestsCleared();
           }
           return;
         }
@@ -1044,9 +1055,8 @@
           item.remove();
         }
         const list = document.querySelector('[data-stage-decision-list]');
-        const emptyState = document.querySelector('[data-stage-requests-empty]');
-        if (list && !list.querySelector('[data-stage-request-item]') && emptyState) {
-          emptyState.classList.remove('d-none');
+        if (list && !list.querySelector('[data-stage-request-item]')) {
+          handleStageRequestsCleared();
         }
       } catch (error) {
         console.error(error);
@@ -1068,7 +1078,6 @@
 
     const tokenInput = document.querySelector('[data-stage-decision-token]');
     const token = tokenInput ? tokenInput.value : '';
-    const emptyState = document.querySelector('[data-stage-requests-empty]');
 
     list.addEventListener('click', async (event) => {
       const button = event.target.closest('[data-stage-decision]');
@@ -1153,8 +1162,8 @@
             updatePendingBadge(stageCode, null, null);
             enableRequestButton(stageCode);
           }
-          if (!list.querySelector('[data-stage-request-item]') && emptyState) {
-            emptyState.classList.remove('d-none');
+          if (!list.querySelector('[data-stage-request-item]')) {
+            handleStageRequestsCleared();
           }
           return;
         }
@@ -1201,8 +1210,8 @@
 
         item.remove();
         removed = true;
-        if (!list.querySelector('[data-stage-request-item]') && emptyState) {
-          emptyState.classList.remove('d-none');
+        if (!list.querySelector('[data-stage-request-item]')) {
+          handleStageRequestsCleared();
         }
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Summary
- hide the Head of Department stage request card when there are no pending items while keeping the antiforgery token available for inline actions
- update the stages script to remove the request card once the final item is resolved and reuse a helper to show the empty state
- restyle the project timeline cards for better readability and prevent the action controls from wrapping onto multiple rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da73bb69dc8329ba9e1303f52722ec