### PR TITLE
Keep timeline actions aligned across breakpoints

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -91,7 +91,7 @@
               @if (canRequestChange)
               {
                 <button type="button"
-                        class="btn btn-link btn-sm pm-primary-action d-none d-lg-inline"
+                        class="btn btn-link btn-sm pm-primary-action"
                         data-stage-request
                         data-stage-request-button
                         data-project="@Model.ProjectId"

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -67,9 +67,9 @@
 
 .pm-item-header {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
-  align-items: start;
+  align-items: center;
 }
 
 .pm-item-heading {
@@ -86,11 +86,16 @@
 }
 
 .pm-item-actions {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   min-width: 3rem;
   flex-wrap: nowrap;
+}
+
+.pm-item-actions > * {
+  flex: 0 0 auto;
 }
 
 .pm-primary-action {


### PR DESCRIPTION
## Summary
- update the timeline header grid and action alignment so the request and kebab controls remain on a single row
- remove the large-screen-only utility from the request action so it stays visible at every viewport size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da78dfc0ac83298ea80e41b833e0d8