### PR TITLE
Keep timeline actions aligned across breakpoints

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -91,7 +91,7 @@
               @if (canRequestChange)
               {
                 <button type="button"
-                        class="btn btn-link btn-sm pm-primary-action d-none d-lg-inline"
+                        class="btn btn-link btn-sm pm-primary-action"
                         data-stage-request
                         data-stage-request-button
                         data-project="@Model.ProjectId"

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -67,9 +67,9 @@
 
 .pm-item-header {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
-  align-items: start;
+  align-items: center;
 }
 
 .pm-item-heading {
@@ -86,11 +86,17 @@
 }
 
 .pm-item-actions {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   align-items: center;
+  justify-content: end;
   gap: 8px;
   min-width: 3rem;
-  flex-wrap: nowrap;
+}
+
+.pm-item-actions > * {
+  min-width: 0;
 }
 
 .pm-primary-action {


### PR DESCRIPTION
## Summary
- adjust the timeline action container to use a grid-based layout so the request button and kebab stay on a single row

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da78dfc0ac83298ea80e41b833e0d8