### PR TITLE
Remove inline request action from timeline header

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -88,20 +88,6 @@
               </span>
             </div>
             <div class="pm-item-actions">
-              @if (canRequestChange)
-              {
-                <button type="button"
-                        class="btn btn-link btn-sm pm-primary-action"
-                        data-stage-request
-                        data-stage-request-button
-                        data-project="@Model.ProjectId"
-                        data-stage="@s.Code"
-                        data-stage-name="@s.Name"
-                        data-current-status="@s.Status"
-                        @(s.HasPendingRequest ? "disabled" : null)>
-                  Request
-                </button>
-              }
               <div class="dropdown">
                 <button class="btn pm-kebab" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Stage actions for @s.Name">
                   <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- remove the inline Request button from the project timeline item header so only the menu affordance remains

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da99badecc8329bfecb5260f5725d0