### PR TITLE
Polish project timeline interactions and procurement summary

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -295,108 +295,122 @@
             }
             <div class="card">
                 <div class="card-header">
-                    <div class="d-flex flex-column gap-2">
-                        <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center gap-3 justify-content-lg-between">
-                            <div class="d-flex flex-wrap align-items-center gap-2">
-                                <h5 class="mb-0">Timeline</h5>
-                                @{ 
-                                    string? viewerRole = null;
-                                    if (isHoD && isThisProjectsPo)
-                                    {
-                                        viewerRole = "Head of Department & Project Officer";
-                                    }
-                                    else if (isHoD)
-                                    {
-                                        viewerRole = "Head of Department";
-                                    }
-                                    else if (isThisProjectsPo)
-                                    {
-                                        viewerRole = "Project Officer";
-                                    }
-                                }
-                                <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-2 mt-2 mt-lg-0">
-                                    @if (!string.IsNullOrEmpty(viewerRole))
-                                    {
-                                        <span class="text-muted small" data-role-indicator title="Current permissions for timeline actions">Viewing as @viewerRole</span>
-                                    }
-                                    @if (pendingOwnedByCurrentUser)
-                                    {
-                                        <span class="badge text-bg-warning">Submitted for approval</span>
-                                    }
-                                    else if (Model.Timeline.PlanPendingApproval)
-                                    {
-                                        <span class="badge text-bg-warning">Another submission pending</span>
-                                    }
-                                    else if (hasMyDraft)
-                                    {
-                                        <span class="badge text-bg-secondary">Draft saved (not submitted)</span>
-                                    }
-                                    <span class="badge text-bg-secondary@(Model.HasBackfill ? string.Empty : " d-none")"
-                                          title="Resolve procurement backfill to proceed"
-                                          data-backfill-summary>
-                                        Backfill required
-                                    </span>
-                                    @if (project?.PlanApprovedAt is DateTimeOffset approvedAt)
-                                    {
-                                        <span class="badge text-bg-success">Approved on @approvedAt.ToLocalTime().ToString("dd MMM yyyy")</span>
-                                    }
+                    @{
+                        string? viewerRole = null;
+                        if (isHoD && isThisProjectsPo)
+                        {
+                            viewerRole = "Head of Department & Project Officer";
+                        }
+                        else if (isHoD)
+                        {
+                            viewerRole = "Head of Department";
+                        }
+                        else if (isThisProjectsPo)
+                        {
+                            viewerRole = "Project Officer";
+                        }
+                    }
+                    <div class="pm-timeline-header">
+                        <div class="pm-timeline-header-main">
+                            <div class="pm-timeline-title">
+                                <div class="d-flex align-items-center gap-2">
+                                    <h5 class="mb-0">Timeline</h5>
+                                    <button type="button"
+                                            class="pm-status-legend"
+                                            data-bs-toggle="tooltip"
+                                            data-bs-placement="top"
+                                            title="Stage status">
+                                        <span aria-hidden="true">●</span>
+                                        <span class="visually-hidden">Stage status indicator</span>
+                                    </button>
                                 </div>
-                                @if (hasMyDraft && !pendingOwnedByCurrentUser)
+                                @if (!string.IsNullOrEmpty(viewerRole))
                                 {
-                                    <div class="d-flex flex-wrap align-items-center gap-2">
-                                        <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
-                                                type="button"
-                                                data-bs-toggle="offcanvas"
-                                                data-bs-target="#offcanvasPlanEdit"
-                                                aria-controls="offcanvasPlanEdit">
-                                            <span>Your draft saved</span>
-                                            @if (planState.LastSavedOn is DateTimeOffset savedOn)
-                                            {
-                                                <span class="text-muted">@savedOn.ToLocalTime().ToString("dd MMM HH:mm")</span>
-                                            }
-                                            <span class="fw-semibold">Continue editing</span>
-                                        </button>
-                                        <button class="btn btn-sm btn-outline-secondary"
-                                                type="button"
-                                                data-bs-toggle="modal"
-                                                data-bs-target="#discardDraftModal">
-                                            Discard draft
-                                        </button>
+                                    <div class="text-muted small mt-1"
+                                         data-role-indicator
+                                         title="Current permissions for timeline actions">
+                                        Viewing as @viewerRole
                                     </div>
                                 }
                             </div>
-                            <div class="d-flex flex-wrap align-items-center gap-2 justify-content-lg-end">
-                                @if (planState.HasPendingSubmission && isHoD)
+                            <div class="pm-timeline-badges d-flex flex-wrap align-items-center gap-2 mt-2">
+                                @if (pendingOwnedByCurrentUser)
                                 {
-                                    <button class="btn btn-sm btn-outline-primary"
-                                            type="button"
-                                            data-bs-toggle="offcanvas"
-                                            data-bs-target="#offcanvasPlanReview"
-                                            aria-controls="offcanvasPlanReview">
-                                        Review &amp; approve
-                                    </button>
+                                    <span class="badge text-bg-warning">Submitted for approval</span>
                                 }
-                                @if (canEditTimeline && !(hasMyDraft && !pendingOwnedByCurrentUser))
+                                else if (Model.Timeline.PlanPendingApproval)
                                 {
-                                    <button class="btn btn-sm btn-outline-primary"
+                                    <span class="badge text-bg-warning">Another submission pending</span>
+                                }
+                                else if (hasMyDraft)
+                                {
+                                    <span class="badge text-bg-secondary">Draft saved (not submitted)</span>
+                                }
+                                <span class="badge text-bg-secondary@(Model.HasBackfill ? string.Empty : " d-none")"
+                                      title="Resolve procurement backfill to proceed"
+                                      data-backfill-summary>
+                                    Backfill required
+                                </span>
+                                @if (project?.PlanApprovedAt is DateTimeOffset approvedAt)
+                                {
+                                    <span class="badge text-bg-success">Approved on @approvedAt.ToLocalTime().ToString("dd MMM yyyy")</span>
+                                }
+                            </div>
+                            @if (hasMyDraft && !pendingOwnedByCurrentUser)
+                            {
+                                <div class="pm-timeline-draft d-flex flex-wrap align-items-center gap-2 mt-2">
+                                    <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
                                             type="button"
                                             data-bs-toggle="offcanvas"
                                             data-bs-target="#offcanvasPlanEdit"
                                             aria-controls="offcanvasPlanEdit">
-                                        Edit timeline
+                                        <span>Your draft saved</span>
+                                        @if (planState.LastSavedOn is DateTimeOffset savedOn)
+                                        {
+                                            <span class="text-muted">@savedOn.ToLocalTime().ToString("dd MMM HH:mm")</span>
+                                        }
+                                        <span class="fw-semibold">Continue editing</span>
                                     </button>
-                                }
-                            </div>
+                                    <button class="btn btn-sm btn-outline-secondary"
+                                            type="button"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#discardDraftModal">
+                                        Discard draft
+                                    </button>
+                                </div>
+                            }
                         </div>
-                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
-                            <div class="d-flex align-items-center gap-2">
-                                <progress class="pm-progress pm-progress-slim pm-progress-fixed-180"
-                                          value="@completedStages"
-                                          max="@progressMax"
-                                          aria-label="Stages completed">
-                                </progress>
-                                <span class="text-muted small">@completedStages of @totalStages</span>
-                            </div>
+                        <div class="pm-timeline-header-actions">
+                            @if (planState.HasPendingSubmission && isHoD)
+                            {
+                                <button class="btn btn-sm btn-outline-primary w-100"
+                                        type="button"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#offcanvasPlanReview"
+                                        aria-controls="offcanvasPlanReview">
+                                    Review &amp; approve
+                                </button>
+                            }
+                            @if (canEditTimeline && !(hasMyDraft && !pendingOwnedByCurrentUser))
+                            {
+                                <button class="btn btn-sm btn-outline-primary w-100"
+                                        type="button"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#offcanvasPlanEdit"
+                                        aria-controls="offcanvasPlanEdit">
+                                    Edit timeline
+                                </button>
+                            }
+                        </div>
+                    </div>
+                    <div class="pm-timeline-progress mt-3">
+                        <progress class="pm-progress pm-progress-slim"
+                                  value="@completedStages"
+                                  max="@progressMax"
+                                  aria-label="Stages completed">
+                        </progress>
+                        <div class="pm-progress-caption text-muted small mt-1">
+                            @completedStages of @totalStages completed
                         </div>
                     </div>
                 </div>

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -5,23 +5,26 @@
     {
         var culture = CultureInfo.GetCultureInfo("en-IN");
         var abs = System.Math.Abs(value);
+        var sign = value < 0 ? "−" : string.Empty;
 
         if (abs >= 1_00_00_000m)
         {
-            return $"₹ {(value / 1_00_00_000m).ToString("0.##", culture)} Cr";
+            return $"{sign}{(abs / 1_00_00_000m).ToString("0.##", culture)} Cr";
         }
 
         if (abs >= 1_00_000m)
         {
-            return $"₹ {(value / 1_00_000m).ToString("0.##", culture)} Lakh";
+            return $"{sign}{(abs / 1_00_000m).ToString("0.##", culture)} Lakh";
         }
 
-        return value.ToString("C2", culture);
+        return value.ToString("N2", culture);
     }
 
     string Money(decimal? value) => value.HasValue ? ShortInr(value.Value) : "—";
     string FullInr(decimal? value) => value.HasValue ? value.Value.ToString("C2", CultureInfo.GetCultureInfo("en-IN")) : "—";
-    string DateDmy(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
+    string DateDmy(DateOnly? d) => d.HasValue
+        ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture).Replace(' ', '\u00A0')
+        : "—";
 }
 
 <div class="card">
@@ -39,36 +42,47 @@
   </div>
 
   <div class="card-body">
-    <div class="row g-3">
-      <div class="col-md-6">
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">IPA Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.IpaCost)">@Money(Model.IpaCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">AON Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.AonCost)">@Money(Model.AonCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">Benchmark Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.BenchmarkCost)">@Money(Model.BenchmarkCost)</span>
-        </div>
-      </div>
+    <div class="table-responsive">
+      <table class="table table-sm table-borderless align-middle mb-3">
+        <thead>
+          <tr>
+            <th scope="col" class="text-muted text-uppercase small">Metric</th>
+            <th scope="col" class="text-muted text-uppercase small text-end">₹</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row" class="text-muted">IPA Cost</th>
+            <td class="text-end fw-semibold@(Model.IpaCost.HasValue ? string.Empty : " text-muted")"
+                title="@(Model.IpaCost.HasValue ? FullInr(Model.IpaCost) : null)">@Money(Model.IpaCost)</td>
+          </tr>
+          <tr>
+            <th scope="row" class="text-muted">AON Cost</th>
+            <td class="text-end fw-semibold@(Model.AonCost.HasValue ? string.Empty : " text-muted")"
+                title="@(Model.AonCost.HasValue ? FullInr(Model.AonCost) : null)">@Money(Model.AonCost)</td>
+          </tr>
+          <tr>
+            <th scope="row" class="text-muted">Benchmark Cost</th>
+            <td class="text-end fw-semibold@(Model.BenchmarkCost.HasValue ? string.Empty : " text-muted")"
+                title="@(Model.BenchmarkCost.HasValue ? FullInr(Model.BenchmarkCost) : null)">@Money(Model.BenchmarkCost)</td>
+          </tr>
+          <tr>
+            <th scope="row" class="text-muted">L1 Cost</th>
+            <td class="text-end fw-semibold@(Model.L1Cost.HasValue ? string.Empty : " text-muted")"
+                title="@(Model.L1Cost.HasValue ? FullInr(Model.L1Cost) : null)">@Money(Model.L1Cost)</td>
+          </tr>
+          <tr>
+            <th scope="row" class="text-muted">PNC Cost</th>
+            <td class="text-end fw-semibold@(Model.PncCost.HasValue ? string.Empty : " text-muted")"
+                title="@(Model.PncCost.HasValue ? FullInr(Model.PncCost) : null)">@Money(Model.PncCost)</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-      <div class="col-md-6">
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">L1 Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.L1Cost)">@Money(Model.L1Cost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">PNC Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.PncCost)">@Money(Model.PncCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">Supply Order Date</span>
-          <span class="fw-semibold">@DateDmy(Model.SupplyOrderDate)</span>
-        </div>
-      </div>
+    <div class="d-flex justify-content-between align-items-baseline">
+      <span class="text-muted">Supply Order Date</span>
+      <span class="fw-semibold@(Model.SupplyOrderDate.HasValue ? string.Empty : " text-muted")">@DateDmy(Model.SupplyOrderDate)</span>
     </div>
 
     <div class="mt-2 small text-muted">

--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -7,7 +7,9 @@
     var canRequestChange = isProjectOfficer || isHod;
 }
 @functions {
-    string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
+    string D(DateOnly? d) => d.HasValue
+        ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture).Replace(' ', '\u00A0')
+        : "—";
 
     string StatusPillClass(StageStatus s) => s switch
     {
@@ -23,30 +25,23 @@
         _                      => "Not started"
     };
 
-    (string text, string description, string cssClass) VarianceToken(string name, int value)
+    (string label, string value, string description, string cssClass) VarianceToken(string name, int value)
     {
         var magnitude = Math.Abs(value);
 
-        var cssClass = value < 0
-            ? "pm-chip pm-chip-early"
-            : value > 0
-                ? "pm-chip pm-chip-late"
-                : "pm-chip pm-chip-on-time";
-
         if (value == 0)
         {
-            return ($"{name} on time", $"{name} on time", cssClass);
+            return (name, "on time", $"{name} on time", "pm-variance-value is-on-time");
         }
 
-        var text = value > 0
-            ? $"{name} +{magnitude}d"
-            : $"{name} −{magnitude}d";
-
+        var magnitudeText = magnitude.ToString(CultureInfo.InvariantCulture);
+        var text = value > 0 ? $"+{magnitudeText}d" : $"−{magnitudeText}d";
         var description = value > 0
-            ? $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} late"
-            : $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} early";
+            ? $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} later than plan."
+            : $"{name} {magnitude} day{(magnitude == 1 ? string.Empty : "s")} earlier than plan.";
+        var cssClass = value > 0 ? "pm-variance-value is-late" : "pm-variance-value is-early";
 
-        return (text, description, cssClass);
+        return (name, text, description, cssClass);
     }
 }
 <link rel="stylesheet" href="~/css/projects/timeline.css" />
@@ -89,7 +84,7 @@
             </div>
             <div class="pm-item-actions">
               <div class="dropdown">
-                <button class="btn pm-kebab" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Stage actions for @s.Name">
+                <button class="btn pm-kebab" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Actions for @s.Name">
                   <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-end" data-stage-action-menu>
@@ -226,7 +221,7 @@
           </div>
           <div class="pm-item-dates">
             <div class="pm-date-row">
-              <span class="pm-date-label">Planned</span>
+              <span class="pm-date-label pm-date-label-muted">Planned</span>
               <div class="pm-date-values">
                 <span data-stage-planned-start>@D(s.PlannedStart)</span>
                 <span class="pm-date-sep">–</span>
@@ -260,25 +255,39 @@
             </div>
           </div>
           <div class="pm-item-variance">
-            <div class="pm-variance-chips">
+            <div class="pm-variance-line@(s.PlannedStart.HasValue && s.ActualStart.HasValue || s.PlannedEnd.HasValue && s.CompletedOn.HasValue ? string.Empty : " d-none")" data-stage-variance-line>
               @if (s.PlannedStart.HasValue && s.ActualStart.HasValue && s.StartVarianceDays is int startVar)
               {
                   var variance = VarianceToken("Start", startVar);
-                  <span class="@variance.cssClass"
-                        data-stage-start-variance
-                        aria-label="@variance.description"
-                        title="@variance.description">
-                    @variance.text
+                  <span class="pm-variance-segment">
+                    <span class="pm-variance-label">@variance.label</span>
+                    <span class="@variance.cssClass"
+                          data-stage-start-variance
+                          aria-label="@variance.description"
+                          title="@variance.description"
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="top">
+                      @variance.value
+                    </span>
                   </span>
+              }
+              @if (s.PlannedStart.HasValue && s.ActualStart.HasValue && s.PlannedEnd.HasValue && s.CompletedOn.HasValue)
+              {
+                  <span class="pm-variance-sep" aria-hidden="true">·</span>
               }
               @if (s.PlannedEnd.HasValue && s.CompletedOn.HasValue && s.FinishVarianceDays is int finishVar)
               {
                   var variance = VarianceToken("Finish", finishVar);
-                  <span class="@variance.cssClass"
-                        data-stage-finish-variance
-                        aria-label="@variance.description"
-                        title="@variance.description">
-                    @variance.text
+                  <span class="pm-variance-segment">
+                    <span class="pm-variance-label">@variance.label</span>
+                    <span class="@variance.cssClass"
+                          data-stage-finish-variance
+                          aria-label="@variance.description"
+                          title="@variance.description"
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="top">
+                      @variance.value
+                    </span>
                   </span>
               }
             </div>

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -21,7 +21,7 @@
 .pm-items {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 12px;
 }
 
 .pm-item {
@@ -33,7 +33,7 @@
   content: "";
   position: absolute;
   left: -56px;
-  top: 12px;
+  top: 18px;
   width: 12px;
   height: 12px;
   border-radius: 50%;
@@ -53,11 +53,12 @@
 }
 
 .pm-item-card {
-  padding: 12px 0;
+  padding: 16px 0;
   border-top: 1px solid var(--bs-border-color);
   display: flex;
   flex-direction: column;
   gap: 8px;
+  transition: background-color .2s ease, opacity .18s ease, transform .18s ease;
 }
 
 .pm-item:first-child .pm-item-card {
@@ -67,7 +68,7 @@
 
 .pm-item-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) 40px;
   gap: 12px;
   align-items: center;
 }
@@ -77,12 +78,16 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
+  flex-wrap: nowrap;
 }
 
 .pm-item-title {
   font-weight: 600;
   min-width: 0;
   flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .pm-item-actions {
@@ -90,7 +95,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  min-width: 3rem;
+  min-width: 40px;
   flex-wrap: nowrap;
 }
 
@@ -130,9 +135,17 @@
   border-color: var(--bs-gray-300);
 }
 
-.pm-kebab:focus-visible {
+.pm-kebab:focus-visible,
+.pm-status-legend:focus-visible,
+.pm-pill:focus-visible {
   outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+  box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.35);
+}
+
+.dropdown-item:focus-visible {
+  outline: 0;
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  color: var(--bs-primary);
 }
 
 .pm-item-flags {
@@ -280,6 +293,121 @@
 .pm-item[data-loading="true"] .pm-item-card {
   opacity: 0.6;
   pointer-events: none;
+  transform: translateY(4px);
+}
+
+.pm-item-card:hover {
+  background-color: var(--bs-gray-100);
+}
+
+.pm-date-label-muted {
+  color: var(--bs-gray-500);
+  font-weight: 500;
+}
+
+.pm-variance-line {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  color: var(--bs-gray-600);
+}
+
+.pm-variance-segment {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.pm-variance-label {
+  color: var(--bs-gray-600);
+  font-weight: 500;
+}
+
+.pm-variance-sep {
+  color: var(--bs-gray-500);
+}
+
+.pm-variance-value {
+  font-weight: 600;
+  font-feature-settings: "tnum";
+}
+
+.pm-variance-value.is-early {
+  color: var(--bs-success);
+}
+
+.pm-variance-value.is-late {
+  color: var(--bs-danger);
+}
+
+.pm-variance-value.is-on-time {
+  color: var(--bs-gray-600);
+}
+
+.pm-timeline-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pm-timeline-header-main {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pm-timeline-header-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.pm-timeline-progress {
+  display: flex;
+  flex-direction: column;
+}
+
+.pm-progress-caption {
+  font-feature-settings: "tnum";
+}
+
+.pm-status-legend {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0 6px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--bs-success);
+  background-color: transparent;
+  cursor: help;
+}
+
+.pm-status-legend:hover,
+.pm-status-legend:focus {
+  background-color: rgba(var(--bs-success-rgb), 0.12);
+  border-color: rgba(var(--bs-success-rgb), 0.2);
+}
+
+@media (min-width: 992px) {
+  .pm-timeline-header {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .pm-timeline-header-main {
+    flex: 1 1 auto;
+  }
+
+  .pm-timeline-header-actions {
+    flex: 0 0 220px;
+    max-width: 220px;
+  }
 }
 
 @media (max-width: 576px) {

--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -181,19 +181,19 @@
     const magnitude = Math.abs(value);
     if (value === 0) {
       return {
-        text: `${name} on time`,
-        title: `${name} on time`,
-        cssClass: 'pm-chip pm-chip-on-time'
+        value: 'on time',
+        title: `${name} on time.`,
+        cssClass: 'pm-variance-value is-on-time'
       };
     }
 
     const sign = value > 0 ? '+' : '−';
-    const direction = value > 0 ? 'late' : 'early';
+    const direction = value > 0 ? 'later' : 'earlier';
     const plural = magnitude === 1 ? '' : 's';
     return {
-      text: `${name} ${sign}${magnitude}d`,
-      title: `${name} ${magnitude} day${plural} ${direction}`,
-      cssClass: value > 0 ? 'pm-chip pm-chip-late' : 'pm-chip pm-chip-early'
+      value: `${sign}${magnitude}d`,
+      title: `${name} ${magnitude} day${plural} ${direction} than plan.`,
+      cssClass: value > 0 ? 'pm-variance-value is-late' : 'pm-variance-value is-early'
     };
   }
 
@@ -316,33 +316,61 @@
       }
     }
 
+    const varianceLine = row.querySelector('[data-stage-variance-line]');
+
+    let hasStartVariance = false;
     const startChip = row.querySelector('[data-stage-start-variance]');
     if (startChip) {
+      const startSegment = startChip.closest('.pm-variance-segment');
       if (startVariance === null || startVariance === undefined || Number.isNaN(startVariance)) {
         startChip.classList.add('d-none');
         startChip.textContent = '';
+        if (startSegment) {
+          startSegment.classList.add('d-none');
+        }
       } else {
         const details = describeVariance('Start', startVariance);
-        startChip.textContent = details.text;
+        startChip.textContent = details.value;
         startChip.className = details.cssClass;
         startChip.setAttribute('title', details.title);
         startChip.setAttribute('aria-label', details.title);
         startChip.classList.remove('d-none');
+        if (startSegment) {
+          startSegment.classList.remove('d-none');
+        }
+        hasStartVariance = true;
       }
     }
 
+    let hasFinishVariance = false;
     const finishChip = row.querySelector('[data-stage-finish-variance]');
     if (finishChip) {
+      const finishSegment = finishChip.closest('.pm-variance-segment');
       if (finishVariance === null || finishVariance === undefined || Number.isNaN(finishVariance)) {
         finishChip.classList.add('d-none');
         finishChip.textContent = '';
+        if (finishSegment) {
+          finishSegment.classList.add('d-none');
+        }
       } else {
         const details = describeVariance('Finish', finishVariance);
-        finishChip.textContent = details.text;
+        finishChip.textContent = details.value;
         finishChip.className = details.cssClass;
         finishChip.setAttribute('title', details.title);
         finishChip.setAttribute('aria-label', details.title);
         finishChip.classList.remove('d-none');
+        if (finishSegment) {
+          finishSegment.classList.remove('d-none');
+        }
+        hasFinishVariance = true;
+      }
+    }
+
+    if (varianceLine) {
+      varianceLine.classList.toggle('d-none', !(hasStartVariance || hasFinishVariance));
+      const varianceSeparator = varianceLine.querySelector('.pm-variance-sep');
+      if (varianceSeparator) {
+        varianceSeparator.classList.toggle('d-none', !(hasStartVariance && hasFinishVariance));
       }
     }
 


### PR DESCRIPTION
## Summary
- restructure the project timeline header with a fixed actions column, viewer context, and a stage status legend
- restyle stage rows by simplifying variance chips, tightening date styling, and updating focus handling in CSS/JS
- tidy the procurement at-a-glance card with a tabular currency layout and muted placeholders

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da9e5013308329a95e406c8fc7351f