### PR TITLE
Adjust timeline spacing

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -21,7 +21,7 @@
 .pm-items {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .pm-item {
@@ -53,14 +53,14 @@
 }
 
 .pm-item-card {
-  padding: 16px 20px;
+  padding: 12px 16px;
   border: 1px solid var(--bs-border-color);
   border-radius: 16px;
   background-color: var(--bs-body-bg);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   border-left: 6px solid var(--bs-gray-300);
 }
 


### PR DESCRIPTION
## Summary
- reduce vertical gaps between timeline items and content cards for tighter layout
- shrink padding within timeline cards to match updated spacing

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68db1ff761e08329a2acbae4e16d090f