### PR TITLE
Add Plan missing discrepancy badge to project timeline

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -81,6 +81,15 @@
                       aria-label="Backfill required for @s.Name">
                 Backfill required
               </button>
+              @if (s.IsPlanMissingDiscrepancy)
+              {
+                <span class="badge bg-warning-subtle text-warning-emphasis badge-plan-missing"
+                      title="Actual dates exist but planned dates are missing"
+                      aria-label="Discrepancy: plan missing"
+                      data-badge="plan-missing">
+                  Plan missing
+                </span>
+              }
               <span class="pm-item-title text-truncate"
                     title="@s.Name"
                     data-stage-name>
@@ -286,7 +295,7 @@
                   </span>
               }
             </div>
-            <div class="pm-variance-hint small text-muted@(s.PlannedStart.HasValue || s.PlannedEnd.HasValue ? " d-none" : string.Empty)" data-stage-plan-hint>
+            <div class="pm-variance-hint small text-muted@(s.HasPlanDates || s.IsPlanMissingDiscrepancy ? " d-none" : string.Empty)" data-stage-plan-hint>
               No plan dates
             </div>
           </div>

--- a/ViewModels/TimelineVm.cs
+++ b/ViewModels/TimelineVm.cs
@@ -67,4 +67,8 @@ public sealed class TimelineItemVm
     public bool NeedsFinish => Status == StageStatus.Completed && CompletedOn is null;
     public bool IsIncompleteData => NeedsStart || NeedsFinish;
     public bool IsOverdue => Status != StageStatus.Completed && PlannedEnd.HasValue && Today > PlannedEnd.Value;
+
+    public bool HasPlanDates => PlannedStart.HasValue && PlannedEnd.HasValue;
+    public bool HasActualDates => ActualStart.HasValue || CompletedOn.HasValue;
+    public bool IsPlanMissingDiscrepancy => HasActualDates && !HasPlanDates;
 }

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -86,6 +86,10 @@
   min-width: 0;
 }
 
+.badge-plan-missing {
+  margin-left: 0.25rem;
+}
+
 .pm-item-title {
   font-weight: 600;
   min-width: 0;


### PR DESCRIPTION
## Summary
- add computed timeline item flags that describe plan and actual date availability
- render a Plan missing badge in the timeline header when actual dates exist without plan dates
- hide the No plan dates hint when the badge is shown and style the new badge spacing

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db4424389c832998c7643c34e93e09