### PR TITLE
Improve project timeline date labelling

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -239,9 +239,15 @@
                 <span class="pm-date-badge">Planned</span>
               </div>
               <div class="pm-date-range">
-                <span data-stage-planned-start>@D(s.PlannedStart)</span>
-                <span class="pm-date-sep">–</span>
-                <span data-stage-planned-end>@D(s.PlannedEnd)</span>
+                <div class="pm-date pm-date-start">
+                  <span class="pm-date-label">Start</span>
+                  <span class="pm-date-value" data-stage-planned-start>@D(s.PlannedStart)</span>
+                </div>
+                <div class="pm-date-range-sep" aria-hidden="true">–</div>
+                <div class="pm-date pm-date-finish">
+                  <span class="pm-date-label">Finish</span>
+                  <span class="pm-date-value" data-stage-planned-end>@D(s.PlannedEnd)</span>
+                </div>
               </div>
             </div>
             <div class="pm-date-block is-actual">
@@ -249,12 +255,18 @@
                 <span class="pm-date-badge">Actual</span>
               </div>
               <div class="pm-date-range">
-                <span data-stage-actual-start>@D(s.ActualStart)</span>
-                <span class="pm-date-sep">–</span>
-                <span data-stage-completed>@D(s.CompletedOn)</span>
-                <span class="pm-date-duration@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
-                  @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
-                </span>
+                <div class="pm-date pm-date-start">
+                  <span class="pm-date-label">Start</span>
+                  <span class="pm-date-value" data-stage-actual-start>@D(s.ActualStart)</span>
+                </div>
+                <div class="pm-date-range-sep" aria-hidden="true">–</div>
+                <div class="pm-date pm-date-finish">
+                  <span class="pm-date-label">Finish</span>
+                  <span class="pm-date-value" data-stage-completed>@D(s.CompletedOn)</span>
+                  <span class="pm-date-duration@(s.ActualDurationDays.HasValue ? string.Empty : " d-none")" data-stage-duration>
+                    @(s.ActualDurationDays.HasValue ? $"({s.ActualDurationDays} d)" : string.Empty)
+                  </span>
+                </div>
               </div>
               <div class="pm-date-meta small text-muted@(s.NeedsStart || s.NeedsFinish ? string.Empty : " d-none")" data-stage-date-hint>
                 @if (s.NeedsStart && s.NeedsFinish)

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -240,18 +240,44 @@
 
 .pm-date-range {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
+  align-items: flex-end;
+  gap: 12px;
   flex-wrap: wrap;
-  font-weight: 600;
 }
 
-.pm-date-range span {
+.pm-date {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 140px;
+  min-width: 120px;
+}
+
+.pm-date-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bs-gray-600);
+}
+
+.pm-date-value {
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
+.pm-date-range-sep {
+  font-weight: 600;
+  align-self: center;
+  color: var(--bs-gray-500);
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .pm-date-duration {
+  margin-top: 2px;
   color: var(--bs-gray-600);
+  font-weight: 500;
 }
 
 .pm-date-meta {


### PR DESCRIPTION
## Summary
- add explicit start and finish wrappers to planned and actual dates in the project timeline partial
- adjust timeline styling so the labelled date layout remains responsive while keeping existing JavaScript selectors intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4cb1995083299b18afb1ef9b5cda