### PR TITLE
Improve plan missing badge accessibility

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -1,6 +1,7 @@
 @model ProjectManagement.ViewModels.TimelineVm
 @using System.Globalization
 @using ProjectManagement.Models.Execution
+@using Microsoft.AspNetCore.Mvc.Rendering
 @{
     var isHod = User.IsInRole("HoD");
     var isProjectOfficer = ViewBag?.IsProjectOfficerForProject is bool b && b;
@@ -83,11 +84,15 @@
               </button>
               @if (s.IsPlanMissingDiscrepancy)
               {
+                var planMissingHintId = TagBuilder.CreateSanitizedId($"plan-missing-hint-{s.Code}", "_");
                 <span class="badge bg-warning-subtle text-warning-emphasis badge-plan-missing"
-                      title="Actual dates exist but planned dates are missing"
                       aria-label="Discrepancy: plan missing"
+                      aria-describedby="@planMissingHintId"
                       data-badge="plan-missing">
                   Plan missing
+                </span>
+                <span id="@planMissingHintId" class="badge-plan-missing-hint">
+                  Actual dates exist but planned dates are missing.
                 </span>
               }
               <span class="pm-item-title text-truncate"

--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -90,6 +90,13 @@
   margin-left: 0.25rem;
 }
 
+.badge-plan-missing-hint {
+  font-size: 0.75rem;
+  color: var(--bs-secondary-color);
+  line-height: 1.25;
+  margin-left: 0.25rem;
+}
+
 .pm-item-title {
   font-weight: 600;
   min-width: 0;


### PR DESCRIPTION
## Summary
- add a sanitised descriptive hint to the plan-missing badge so assistive tech always has context
- style the helper hint text so it remains subtle within the timeline header

## Testing
- ❌ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db4ceef3ec8329b7be3165b8342181