### PR TITLE
Adjust timeline rail spacing

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -1,6 +1,6 @@
 .pm-timeline-grid {
   display: grid;
-  grid-template-columns: 56px 1fr;
+  grid-template-columns: 40px 1fr;
   gap: 12px;
   position: relative;
 }
@@ -11,7 +11,7 @@
 
 .pm-rail-line {
   position: absolute;
-  left: 27px;
+  left: 20px;
   top: 0;
   bottom: 0;
   width: 2px;
@@ -32,7 +32,7 @@
 .pm-item::before {
   content: "";
   position: absolute;
-  left: -56px;
+  left: -40px;
   top: 28px;
   width: 12px;
   height: 12px;
@@ -379,16 +379,3 @@
   pointer-events: none;
 }
 
-@media (max-width: 576px) {
-  .pm-timeline-grid {
-    grid-template-columns: 40px 1fr;
-  }
-
-  .pm-rail-line {
-    left: 20px;
-  }
-
-  .pm-item::before {
-    left: -40px;
-  }
-}


### PR DESCRIPTION
## Summary
- adopt the slimmer 40px timeline rail as the default grid width and align markers with updated offsets
- remove redundant small-screen overrides now that the compact rail is standard across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4e8dc1c48329a5d4282861db2bb8