### PR TITLE
Fix timeline card overflow and reduce spacing

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -53,14 +53,14 @@
 }
 
 .pm-item-card {
-  padding: 12px 16px;
+  padding: 10px 14px;
   border: 1px solid var(--bs-border-color);
   border-radius: 16px;
   background-color: var(--bs-body-bg);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   border-left: 6px solid var(--bs-gray-300);
 }
 
@@ -75,14 +75,16 @@
 .pm-item-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
+  gap: 8px;
   align-items: center;
 }
 
 .pm-item-heading {
   display: flex;
   align-items: center;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 6px;
+  row-gap: 4px;
   min-width: 0;
 }
 
@@ -94,7 +96,8 @@
   font-size: 0.75rem;
   color: var(--bs-secondary-color);
   line-height: 1.25;
-  margin-left: 0.25rem;
+  margin-left: 0;
+  flex-basis: 100%;
 }
 
 .pm-item-title {
@@ -156,7 +159,7 @@
 .pm-item-flags {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 4px;
   font-size: 0.8125rem;
   color: var(--bs-gray-600);
 }
@@ -179,7 +182,7 @@
 
 .pm-item-dates {
   display: grid;
-  gap: 12px;
+  gap: 8px;
   color: var(--bs-gray-800);
   font-size: 0.95rem;
 }
@@ -194,10 +197,10 @@
   background-color: var(--bs-gray-100);
   border: 1px solid var(--bs-gray-200);
   border-radius: 12px;
-  padding: 14px 16px;
+  padding: 12px 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   min-height: 100%;
   position: relative;
 }
@@ -248,14 +251,14 @@
 .pm-date-range {
   display: flex;
   align-items: flex-end;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
 .pm-date {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   flex: 1 1 140px;
   min-width: 120px;
 }
@@ -282,13 +285,13 @@
 }
 
 .pm-date-duration {
-  margin-top: 2px;
+  margin-top: 1px;
   color: var(--bs-gray-600);
   font-weight: 500;
 }
 
 .pm-date-meta {
-  margin-top: 2px;
+  margin-top: 1px;
 }
 
 .pm-item-variance {
@@ -300,7 +303,7 @@
 .pm-variance-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 4px;
 }
 
 .pm-chip {


### PR DESCRIPTION
## Summary
- allow project timeline card headings to wrap so the plan-missing hint stays inside the card
- reduce padding and gaps across the timeline card to tighten the layout

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68db5104a6008329b66dafd08854e662