### PR TITLE
Adjust timeline marker alignment

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -32,7 +32,7 @@
 .pm-item::before {
   content: "";
   position: absolute;
-  left: -24px;
+  left: -27px;
   top: 28px;
   width: 12px;
   height: 12px;


### PR DESCRIPTION
## Summary
- shift the timeline stage marker slightly left so its center aligns with the rail
- ensure active and completed stage markers inherit the updated positioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5df867d4832989c0666508bd6906