### PR TITLE
Use Bootstrap emphasis tokens for warning pill

### DIFF
--- a/wwwroot/css/projects/timeline.css
+++ b/wwwroot/css/projects/timeline.css
@@ -368,9 +368,9 @@
 }
 
 .pm-pill-warning {
-  background-color: rgba(var(--bs-warning-rgb), 0.18);
-  color: var(--bs-warning);
-  border-color: rgba(var(--bs-warning-rgb), 0.3);
+  background-color: var(--bs-warning-bg-subtle);
+  color: var(--bs-warning-text-emphasis);
+  border-color: var(--bs-warning-border-subtle);
 }
 
 .pm-pill:disabled {


### PR DESCRIPTION
## Summary
- switch the project timeline warning pill to the Bootstrap warning emphasis variables for better contrast
- verified the warning pill button markup retains the expected hover and focus behavior for accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5e0a78148329b25b22efeb4f726f