### PR TITLE
Adjust calendar month locale

### DIFF
--- a/wwwroot/js/calendar.js
+++ b/wwwroot/js/calendar.js
@@ -40,7 +40,7 @@
     return `${dt.getFullYear()}-${pad(dt.getMonth()+1)}-${pad(dt.getDate())}`;
   };
 
-  const monthFormatter = new Intl.DateTimeFormat('en-GB', { month: 'short' });
+  const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
   const formatDisplayDate = (date) => {
     const d = date instanceof Date ? date : new Date(date);
     return `${pad(d.getDate())} ${monthFormatter.format(d)} ${d.getFullYear()}`;


### PR DESCRIPTION
## Summary
- update the calendar month formatter to use the en-US locale so months use three-letter abbreviations

## Testing
- `dotnet run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db634cec148329a3f88728bb4d1137