### PR TITLE
Improve backfill banner button contrast

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -104,7 +104,7 @@
         <div>
             <strong>Action needed:</strong> Some earlier stages were auto-completed and need dates or costs.
         </div>
-        <button type="button" class="btn btn-sm btn-outline-warning" data-action="open-backfill">Backfill now</button>
+        <button type="button" class="btn btn-sm btn-warning text-dark" data-action="open-backfill">Backfill now</button>
     </div>
 
     @if (project?.HodUserId == null || project?.LeadPoUserId == null)


### PR DESCRIPTION
## Summary
- update the backfill banner button styling to use the solid warning variant for higher contrast

## Testing
- not run (environment missing dotnet runtime)


------
https://chatgpt.com/codex/tasks/task_e_68db63d9232883298d55a925a55943bd