### PR TITLE
Enforce HoD ownership when editing project metadata

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -45,6 +45,7 @@ namespace ProjectManagement.Data
         public DbSet<ProjectPlanSnapshot> ProjectPlanSnapshots => Set<ProjectPlanSnapshot>();
         public DbSet<ProjectPlanSnapshotRow> ProjectPlanSnapshotRows => Set<ProjectPlanSnapshotRow>();
         public DbSet<ProjectStage> ProjectStages => Set<ProjectStage>();
+        public DbSet<ProjectMetaChangeRequest> ProjectMetaChangeRequests => Set<ProjectMetaChangeRequest>();
         public DbSet<ProjectComment> ProjectComments => Set<ProjectComment>();
         public DbSet<ProjectCommentAttachment> ProjectCommentAttachments => Set<ProjectCommentAttachment>();
         public DbSet<ProjectCommentMention> ProjectCommentMentions => Set<ProjectCommentMention>();

--- a/Models/ProjectMetaChangeRequest.cs
+++ b/Models/ProjectMetaChangeRequest.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace ProjectManagement.Models
+{
+    public class ProjectMetaChangeRequest
+    {
+        public int Id { get; set; }
+
+        public int ProjectId { get; set; }
+
+        public Project? Project { get; set; }
+
+        public string ChangeType { get; set; } = string.Empty;
+
+        public string Payload { get; set; } = string.Empty;
+
+        public string DecisionStatus { get; set; } = "Pending";
+
+        public string? DecisionNote { get; set; }
+
+        public string? RequestedByUserId { get; set; }
+
+        public DateTimeOffset RequestedOnUtc { get; set; } = DateTimeOffset.UtcNow;
+
+        public string? DecidedByUserId { get; set; }
+
+        public DateTimeOffset? DecidedOnUtc { get; set; }
+    }
+}

--- a/Pages/Projects/Meta/Edit.cshtml
+++ b/Pages/Projects/Meta/Edit.cshtml
@@ -1,0 +1,27 @@
+@page "{id:int}"
+@model ProjectManagement.Pages.Projects.Meta.EditModel
+@{
+    ViewData["Title"] = "Edit Project Details";
+}
+
+<h1 class="mb-4">Edit Project Details</h1>
+
+<form method="post">
+    <input asp-for="Input.ProjectId" type="hidden" />
+    <div class="mb-3">
+        <label asp-for="Input.Name" class="form-label"></label>
+        <input asp-for="Input.Name" class="form-control" />
+        <span asp-validation-for="Input.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.Description" class="form-label"></label>
+        <textarea asp-for="Input.Description" class="form-control" rows="4"></textarea>
+        <span asp-validation-for="Input.Description" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.CaseFileNumber" class="form-label"></label>
+        <input asp-for="Input.CaseFileNumber" class="form-control" />
+        <span asp-validation-for="Input.CaseFileNumber" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Save changes</button>
+</form>

--- a/Pages/Projects/Meta/Edit.cshtml.cs
+++ b/Pages/Projects/Meta/Edit.cshtml.cs
@@ -1,0 +1,111 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects.Meta;
+
+[Authorize(Roles = "Admin,HoD")]
+[AutoValidateAntiforgeryToken]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+
+    public EditModel(ApplicationDbContext db, IUserContext userContext)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+    }
+
+    [BindProperty]
+    public MetaEditInput Input { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var project = await _db.Projects
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        Input = new MetaEditInput
+        {
+            ProjectId = project.Id,
+            Name = project.Name,
+            Description = project.Description,
+            CaseFileNumber = project.CaseFileNumber
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId)
+        {
+            return BadRequest();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Forbid();
+        }
+
+        var principal = _userContext.User;
+        var isAdmin = principal.IsInRole("Admin");
+        var isHoD = principal.IsInRole("HoD");
+
+        var project = await _db.Projects
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (isHoD && !isAdmin &&
+            !string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        project.Name = Input.Name.Trim();
+        project.Description = string.IsNullOrWhiteSpace(Input.Description) ? null : Input.Description.Trim();
+        project.CaseFileNumber = string.IsNullOrWhiteSpace(Input.CaseFileNumber) ? null : Input.CaseFileNumber.Trim();
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return RedirectToPage("/Projects/Overview", new { id });
+    }
+
+    public sealed class MetaEditInput
+    {
+        public int ProjectId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [StringLength(1000)]
+        public string? Description { get; set; }
+
+        [StringLength(64)]
+        public string? CaseFileNumber { get; set; }
+    }
+}

--- a/ProjectManagement.Tests/ProjectMetaChangeDecisionServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaChangeDecisionServiceTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Tests.Fakes;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectMetaChangeDecisionServiceTests
+{
+    [Fact]
+    public async Task DecideAsync_UnrelatedHod_ReturnsForbidden()
+    {
+        await using var db = CreateContext();
+        await SeedProjectAsync(db, "hod-owner");
+        await SeedRequestAsync(db, 1);
+
+        var clock = FakeClock.AtUtc(new DateTimeOffset(2024, 10, 1, 8, 0, 0, TimeSpan.Zero));
+        var service = new ProjectMetaChangeDecisionService(db, clock, NullLogger<ProjectMetaChangeDecisionService>.Instance);
+
+        var result = await service.DecideAsync(
+            new ProjectMetaDecisionInput(1, ProjectMetaDecisionAction.Approve, null),
+            new ProjectMetaDecisionUser("hod-stranger", IsAdmin: false, IsHoD: true));
+
+        Assert.Equal(ProjectMetaDecisionOutcome.Forbidden, result.Outcome);
+
+        var request = await db.ProjectMetaChangeRequests.SingleAsync();
+        Assert.Equal(ProjectMetaDecisionStatuses.Pending, request.DecisionStatus);
+    }
+
+    [Fact]
+    public async Task DecideAsync_AssignedHod_Succeeds()
+    {
+        await using var db = CreateContext();
+        await SeedProjectAsync(db, "hod-owner");
+        await SeedRequestAsync(db, 1);
+
+        var clock = FakeClock.AtUtc(new DateTimeOffset(2024, 10, 1, 9, 30, 0, TimeSpan.Zero));
+        var service = new ProjectMetaChangeDecisionService(db, clock, NullLogger<ProjectMetaChangeDecisionService>.Instance);
+
+        var result = await service.DecideAsync(
+            new ProjectMetaDecisionInput(1, ProjectMetaDecisionAction.Approve, "looks good"),
+            new ProjectMetaDecisionUser("hod-owner", IsAdmin: false, IsHoD: true));
+
+        Assert.Equal(ProjectMetaDecisionOutcome.Success, result.Outcome);
+
+        var request = await db.ProjectMetaChangeRequests.SingleAsync();
+        Assert.Equal(ProjectMetaDecisionStatuses.Approved, request.DecisionStatus);
+        Assert.Equal("looks good", request.DecisionNote);
+        Assert.Equal("hod-owner", request.DecidedByUserId);
+        Assert.Equal(clock.UtcNow, request.DecidedOnUtc);
+    }
+
+    [Fact]
+    public async Task DecideAsync_AdminBypassesHodAssignment()
+    {
+        await using var db = CreateContext();
+        await SeedProjectAsync(db, "hod-owner");
+        await SeedRequestAsync(db, 1);
+
+        var clock = FakeClock.AtUtc(new DateTimeOffset(2024, 10, 2, 10, 0, 0, TimeSpan.Zero));
+        var service = new ProjectMetaChangeDecisionService(db, clock, NullLogger<ProjectMetaChangeDecisionService>.Instance);
+
+        var result = await service.DecideAsync(
+            new ProjectMetaDecisionInput(1, ProjectMetaDecisionAction.Reject, "missing info"),
+            new ProjectMetaDecisionUser("admin-user", IsAdmin: true, IsHoD: false));
+
+        Assert.Equal(ProjectMetaDecisionOutcome.Success, result.Outcome);
+
+        var request = await db.ProjectMetaChangeRequests.SingleAsync();
+        Assert.Equal(ProjectMetaDecisionStatuses.Rejected, request.DecisionStatus);
+        Assert.Equal("missing info", request.DecisionNote);
+        Assert.Equal("admin-user", request.DecidedByUserId);
+    }
+
+    private static async Task SeedProjectAsync(ApplicationDbContext db, string hodUserId)
+    {
+        await db.Projects.AddAsync(new Project
+        {
+            Id = 1,
+            Name = "Project",
+            CreatedByUserId = "creator",
+            HodUserId = hodUserId
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedRequestAsync(ApplicationDbContext db, int projectId)
+    {
+        await db.ProjectMetaChangeRequests.AddAsync(new ProjectMetaChangeRequest
+        {
+            Id = 1,
+            ProjectId = projectId,
+            ChangeType = "Name",
+            Payload = "{}",
+            DecisionStatus = ProjectMetaDecisionStatuses.Pending
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Pages.Projects.Meta;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectMetaEditPageTests
+{
+    [Fact]
+    public async Task OnPostAsync_UnrelatedHod_ReturnsForbid()
+    {
+        await using var db = CreateContext();
+        await db.Projects.AddAsync(new Project
+        {
+            Id = 1,
+            Name = "Test",
+            CreatedByUserId = "creator",
+            HodUserId = "hod-assigned"
+        });
+        await db.SaveChangesAsync();
+
+        var userContext = new FakeUserContext("hod-other", isHoD: true);
+        var page = CreatePage(db, userContext);
+        page.Input = new EditModel.MetaEditInput
+        {
+            ProjectId = 1,
+            Name = "Updated"
+        };
+
+        var result = await page.OnPostAsync(1, CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_AssignedHod_Succeeds()
+    {
+        await using var db = CreateContext();
+        await db.Projects.AddAsync(new Project
+        {
+            Id = 5,
+            Name = "Original",
+            CreatedByUserId = "creator",
+            HodUserId = "hod-5"
+        });
+        await db.SaveChangesAsync();
+
+        var userContext = new FakeUserContext("hod-5", isHoD: true);
+        var page = CreatePage(db, userContext);
+        page.Input = new EditModel.MetaEditInput
+        {
+            ProjectId = 5,
+            Name = "Updated Name",
+            Description = "Desc"
+        };
+
+        var result = await page.OnPostAsync(5, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("/Projects/Overview", redirect.PageName);
+
+        var project = await db.Projects.SingleAsync(p => p.Id == 5);
+        Assert.Equal("Updated Name", project.Name);
+        Assert.Equal("Desc", project.Description);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_AdminBypassesAssignment()
+    {
+        await using var db = CreateContext();
+        await db.Projects.AddAsync(new Project
+        {
+            Id = 8,
+            Name = "Project",
+            CreatedByUserId = "creator",
+            HodUserId = "hod-8"
+        });
+        await db.SaveChangesAsync();
+
+        var userContext = new FakeUserContext("admin-user", isAdmin: true);
+        var page = CreatePage(db, userContext);
+        page.Input = new EditModel.MetaEditInput
+        {
+            ProjectId = 8,
+            Name = "Admin Updated"
+        };
+
+        var result = await page.OnPostAsync(8, CancellationToken.None);
+
+        Assert.IsType<RedirectToPageResult>(result);
+        var project = await db.Projects.SingleAsync(p => p.Id == 8);
+        Assert.Equal("Admin Updated", project.Name);
+    }
+
+    private static EditModel CreatePage(ApplicationDbContext db, IUserContext userContext)
+    {
+        var page = new EditModel(db, userContext)
+        {
+            PageContext = new PageContext
+            {
+                HttpContext = new DefaultHttpContext()
+            },
+            TempData = new TempDataDictionary(new DefaultHttpContext(), new SessionStateTempDataProvider())
+        };
+
+        return page;
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class FakeUserContext : IUserContext
+    {
+        public FakeUserContext(string userId, bool isAdmin = false, bool isHoD = false)
+        {
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId)
+            };
+
+            if (isAdmin)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, "Admin"));
+            }
+
+            if (isHoD)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, "HoD"));
+            }
+
+            UserId = userId;
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        }
+
+        public ClaimsPrincipal User { get; }
+
+        public string? UserId { get; }
+    }
+}

--- a/Services/Projects/ProjectMetaChangeDecisionService.cs
+++ b/Services/Projects/ProjectMetaChangeDecisionService.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectMetaChangeDecisionService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+    private readonly ILogger<ProjectMetaChangeDecisionService> _logger;
+
+    public ProjectMetaChangeDecisionService(
+        ApplicationDbContext db,
+        IClock clock,
+        ILogger<ProjectMetaChangeDecisionService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ProjectMetaDecisionResult> DecideAsync(
+        ProjectMetaDecisionInput input,
+        ProjectMetaDecisionUser user,
+        CancellationToken cancellationToken = default)
+    {
+        if (input is null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        if (string.IsNullOrWhiteSpace(user.UserId))
+        {
+            return ProjectMetaDecisionResult.Forbidden();
+        }
+
+        var request = await _db.ProjectMetaChangeRequests
+            .SingleOrDefaultAsync(r => r.Id == input.RequestId, cancellationToken);
+
+        if (request is null)
+        {
+            _logger.LogWarning(
+                "Project meta change request {RequestId} was not found.",
+                input.RequestId);
+            return ProjectMetaDecisionResult.RequestNotFound();
+        }
+
+        var project = await _db.Projects
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == request.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            _logger.LogWarning(
+                "Project meta change request {RequestId} references missing project {ProjectId}.",
+                input.RequestId,
+                request.ProjectId);
+            return ProjectMetaDecisionResult.RequestNotFound();
+        }
+
+        if (user.IsHoD && !user.IsAdmin &&
+            !string.Equals(project.HodUserId, user.UserId, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to decide meta change request {RequestId} for project {ProjectId} but is not the assigned HoD.",
+                user.UserId,
+                input.RequestId,
+                request.ProjectId);
+            return ProjectMetaDecisionResult.Forbidden();
+        }
+
+        if (!string.Equals(request.DecisionStatus, ProjectMetaDecisionStatuses.Pending, StringComparison.Ordinal))
+        {
+            _logger.LogInformation(
+                "Project meta change request {RequestId} has already been decided with status {Status}.",
+                input.RequestId,
+                request.DecisionStatus);
+            return ProjectMetaDecisionResult.AlreadyDecided();
+        }
+
+        request.DecisionStatus = input.Action == ProjectMetaDecisionAction.Approve
+            ? ProjectMetaDecisionStatuses.Approved
+            : ProjectMetaDecisionStatuses.Rejected;
+        request.DecisionNote = string.IsNullOrWhiteSpace(input.Note) ? null : input.Note.Trim();
+        request.DecidedByUserId = user.UserId;
+        request.DecidedOnUtc = _clock.UtcNow;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Project meta change request {RequestId} marked as {Status} by {UserId}.",
+            input.RequestId,
+            request.DecisionStatus,
+            user.UserId);
+
+        return ProjectMetaDecisionResult.Success();
+    }
+}
+
+public readonly record struct ProjectMetaDecisionUser(string UserId, bool IsAdmin, bool IsHoD);
+
+public sealed record ProjectMetaDecisionInput(int RequestId, ProjectMetaDecisionAction Action, string? Note);
+
+public enum ProjectMetaDecisionAction
+{
+    Approve,
+    Reject
+}
+
+public static class ProjectMetaDecisionStatuses
+{
+    public const string Pending = "Pending";
+    public const string Approved = "Approved";
+    public const string Rejected = "Rejected";
+}
+
+public enum ProjectMetaDecisionOutcome
+{
+    Success,
+    Forbidden,
+    RequestNotFound,
+    AlreadyDecided
+}
+
+public sealed record ProjectMetaDecisionResult(ProjectMetaDecisionOutcome Outcome, string? Error = null)
+{
+    public static ProjectMetaDecisionResult Success() => new(ProjectMetaDecisionOutcome.Success);
+
+    public static ProjectMetaDecisionResult Forbidden() => new(ProjectMetaDecisionOutcome.Forbidden);
+
+    public static ProjectMetaDecisionResult RequestNotFound() => new(ProjectMetaDecisionOutcome.RequestNotFound);
+
+    public static ProjectMetaDecisionResult AlreadyDecided() => new(ProjectMetaDecisionOutcome.AlreadyDecided);
+}


### PR DESCRIPTION
## Summary
- add a dedicated project meta edit page that loads the project from the main DbSet and forbids HoDs who are not assigned
- create a meta change decision service that mirrors the HoD ownership checks before approving or rejecting change requests
- extend the data model and tests to cover the new meta change requests and ensure admins can still override the HoD restriction

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68db774f1fa88329b8dc75ec015fc341