### PR TITLE
Enforce case file uniqueness in meta change flows

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -46,6 +46,7 @@ namespace ProjectManagement.Data
         public DbSet<ProjectPlanSnapshotRow> ProjectPlanSnapshotRows => Set<ProjectPlanSnapshotRow>();
         public DbSet<ProjectStage> ProjectStages => Set<ProjectStage>();
         public DbSet<ProjectComment> ProjectComments => Set<ProjectComment>();
+        public DbSet<ProjectMetaChangeRequest> ProjectMetaChangeRequests => Set<ProjectMetaChangeRequest>();
         public DbSet<ProjectCommentAttachment> ProjectCommentAttachments => Set<ProjectCommentAttachment>();
         public DbSet<ProjectCommentMention> ProjectCommentMentions => Set<ProjectCommentMention>();
         public DbSet<ProjectScheduleSettings> ProjectScheduleSettings => Set<ProjectScheduleSettings>();
@@ -104,6 +105,18 @@ namespace ProjectManagement.Data
                 e.HasOne(x => x.Snapshot)
                     .WithMany(x => x.Rows)
                     .HasForeignKey(x => x.SnapshotId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<ProjectMetaChangeRequest>(e =>
+            {
+                e.Property(x => x.ProposedName).HasMaxLength(100);
+                e.Property(x => x.ProposedCaseFileNumber).HasMaxLength(64);
+                e.Property(x => x.DecisionStatus).HasMaxLength(32).IsRequired();
+                e.Property(x => x.RequestedByUserId).HasMaxLength(64).IsRequired();
+                e.HasOne(x => x.Project)
+                    .WithMany()
+                    .HasForeignKey(x => x.ProjectId)
                     .OnDelete(DeleteBehavior.Cascade);
             });
 

--- a/Models/ProjectMetaChangeRequest.cs
+++ b/Models/ProjectMetaChangeRequest.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace ProjectManagement.Models;
+
+public class ProjectMetaChangeRequest
+{
+    public int Id { get; set; }
+    public int ProjectId { get; set; }
+    public Project Project { get; set; } = default!;
+    public string? ProposedName { get; set; }
+    public string? ProposedDescription { get; set; }
+    public string? ProposedCaseFileNumber { get; set; }
+    public string RequestedByUserId { get; set; } = string.Empty;
+    public DateTime RequestedOnUtc { get; set; }
+    public string DecisionStatus { get; set; } = "Pending";
+    public string? DecisionNote { get; set; }
+    public DateTime? DecidedOnUtc { get; set; }
+    public string? DecidedByUserId { get; set; }
+}

--- a/ProjectManagement.Tests/ProjectMetaChangeRequestServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaChangeRequestServiceTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Tests.Fakes;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class ProjectMetaChangeRequestServiceTests
+{
+    [Fact]
+    public async Task SubmitAsync_FlagsDuplicateCaseFileNumber()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        db.Projects.AddRange(
+            new Project
+            {
+                Name = "Original",
+                CreatedByUserId = "owner",
+                CaseFileNumber = "CF-001"
+            },
+            new Project
+            {
+                Name = "Existing",
+                CreatedByUserId = "owner",
+                CaseFileNumber = "CF-123"
+            });
+        await db.SaveChangesAsync();
+
+        var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
+        var service = new ProjectMetaChangeRequestService(db, clock);
+
+        var project = await db.Projects.FirstAsync(p => p.CaseFileNumber == "CF-001");
+
+        var result = await service.SubmitAsync(new ProjectMetaChangeRequestInput
+        {
+            ProjectId = project.Id,
+            ProposedCaseFileNumber = "  CF-123  ",
+            RequestedByUserId = "po"
+        });
+
+        Assert.Equal(ProjectMetaChangeRequestOutcome.ValidationFailed, result.Outcome);
+        Assert.True(result.Errors.TryGetValue("CaseFileNumber", out var errors));
+        Assert.Contains("Case file number already exists.", errors);
+        Assert.Empty(db.ProjectMetaChangeRequests);
+    }
+
+    [Fact]
+    public async Task DirectEditAsync_FlagsDuplicateCaseFileNumber()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        db.Projects.AddRange(
+            new Project
+            {
+                Name = "Target",
+                CreatedByUserId = "owner",
+                CaseFileNumber = "CF-111"
+            },
+            new Project
+            {
+                Name = "Other",
+                CreatedByUserId = "owner",
+                CaseFileNumber = "CF-222"
+            });
+        await db.SaveChangesAsync();
+
+        var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
+        var service = new ProjectMetaChangeRequestService(db, clock);
+
+        var target = await db.Projects.FirstAsync(p => p.CaseFileNumber == "CF-111");
+
+        var result = await service.DirectEditAsync(new ProjectMetaDirectEditInput
+        {
+            ProjectId = target.Id,
+            CaseFileNumber = "CF-222"
+        });
+
+        Assert.Equal(ProjectMetaDirectEditOutcome.ValidationFailed, result.Outcome);
+        Assert.True(result.Errors.TryGetValue("CaseFileNumber", out var errors));
+        Assert.Contains("Case file number already exists.", errors);
+        Assert.Equal("CF-111", (await db.Projects.FindAsync(target.Id))!.CaseFileNumber);
+    }
+}

--- a/Services/Projects/ProjectMetaChangeRequestService.cs
+++ b/Services/Projects/ProjectMetaChangeRequestService.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Projects;
+
+public class ProjectMetaChangeRequestService
+{
+    private static readonly IReadOnlyDictionary<string, string[]> EmptyErrors =
+        new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public ProjectMetaChangeRequestService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async Task<ProjectMetaChangeRequestResult> SubmitAsync(
+        ProjectMetaChangeRequestInput input,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (string.IsNullOrWhiteSpace(input.RequestedByUserId))
+        {
+            throw new ArgumentException("A valid requester is required.", nameof(input));
+        }
+
+        var project = await _db.Projects
+            .SingleOrDefaultAsync(p => p.Id == input.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            return ProjectMetaChangeRequestResult.ProjectNotFound();
+        }
+
+        var (caseFileNumber, errors) = await ValidateCaseFileNumberAsync(
+            input.ProjectId,
+            input.ProposedCaseFileNumber,
+            cancellationToken);
+
+        if (errors.Count > 0)
+        {
+            return ProjectMetaChangeRequestResult.ValidationFailed(errors);
+        }
+
+        var request = new ProjectMetaChangeRequest
+        {
+            ProjectId = project.Id,
+            ProposedName = string.IsNullOrWhiteSpace(input.ProposedName)
+                ? null
+                : input.ProposedName.Trim(),
+            ProposedDescription = string.IsNullOrWhiteSpace(input.ProposedDescription)
+                ? null
+                : input.ProposedDescription.Trim(),
+            ProposedCaseFileNumber = caseFileNumber,
+            RequestedByUserId = input.RequestedByUserId,
+            RequestedOnUtc = _clock.UtcNow.UtcDateTime,
+            DecisionStatus = "Pending"
+        };
+
+        await _db.ProjectMetaChangeRequests.AddAsync(request, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return ProjectMetaChangeRequestResult.Success(request.Id);
+    }
+
+    public async Task<ProjectMetaDirectEditResult> DirectEditAsync(
+        ProjectMetaDirectEditInput input,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var project = await _db.Projects
+            .SingleOrDefaultAsync(p => p.Id == input.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            return ProjectMetaDirectEditResult.ProjectNotFound();
+        }
+
+        var (caseFileNumber, errors) = await ValidateCaseFileNumberAsync(
+            project.Id,
+            input.CaseFileNumber,
+            cancellationToken);
+
+        if (errors.Count > 0)
+        {
+            return ProjectMetaDirectEditResult.ValidationFailed(errors);
+        }
+
+        project.CaseFileNumber = caseFileNumber;
+
+        if (!string.IsNullOrWhiteSpace(input.Name))
+        {
+            project.Name = input.Name.Trim();
+        }
+
+        if (input.Description is not null)
+        {
+            project.Description = string.IsNullOrWhiteSpace(input.Description)
+                ? null
+                : input.Description.Trim();
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return ProjectMetaDirectEditResult.Success();
+    }
+
+    private async Task<(string? TrimmedCaseFileNumber, IReadOnlyDictionary<string, string[]> Errors)> ValidateCaseFileNumberAsync(
+        int projectId,
+        string? proposedCaseFileNumber,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(proposedCaseFileNumber))
+        {
+            return (null, EmptyErrors);
+        }
+
+        var trimmed = proposedCaseFileNumber.Trim();
+        if (trimmed.Length == 0)
+        {
+            return (null, EmptyErrors);
+        }
+
+        var exists = await _db.Projects
+            .AnyAsync(
+                p => p.CaseFileNumber == trimmed && p.Id != projectId,
+                cancellationToken);
+
+        if (exists)
+        {
+            return (trimmed, new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                ["CaseFileNumber"] = new[] { "Case file number already exists." }
+            });
+        }
+
+        return (trimmed, EmptyErrors);
+    }
+}
+
+public sealed record ProjectMetaChangeRequestInput
+{
+    public int ProjectId { get; init; }
+    public string? ProposedName { get; init; }
+    public string? ProposedDescription { get; init; }
+    public string? ProposedCaseFileNumber { get; init; }
+    public string RequestedByUserId { get; init; } = string.Empty;
+}
+
+public sealed record ProjectMetaDirectEditInput
+{
+    public int ProjectId { get; init; }
+    public string? Name { get; init; }
+    public string? Description { get; init; }
+    public string? CaseFileNumber { get; init; }
+}
+
+public sealed record ProjectMetaChangeRequestResult
+{
+    public ProjectMetaChangeRequestOutcome Outcome { get; init; }
+    public int? RequestId { get; init; }
+    public IReadOnlyDictionary<string, string[]> Errors { get; init; } =
+        new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+    private ProjectMetaChangeRequestResult(
+        ProjectMetaChangeRequestOutcome outcome,
+        int? requestId,
+        IReadOnlyDictionary<string, string[]> errors)
+    {
+        Outcome = outcome;
+        RequestId = requestId;
+        Errors = errors;
+    }
+
+    public static ProjectMetaChangeRequestResult Success(int requestId) =>
+        new(ProjectMetaChangeRequestOutcome.Success, requestId, EmptyErrors);
+
+    public static ProjectMetaChangeRequestResult ValidationFailed(IReadOnlyDictionary<string, string[]> errors) =>
+        new(ProjectMetaChangeRequestOutcome.ValidationFailed, null, errors);
+
+    public static ProjectMetaChangeRequestResult ProjectNotFound() =>
+        new(ProjectMetaChangeRequestOutcome.ProjectNotFound, null, EmptyErrors);
+}
+
+public enum ProjectMetaChangeRequestOutcome
+{
+    Success,
+    ValidationFailed,
+    ProjectNotFound
+}
+
+public sealed record ProjectMetaDirectEditResult
+{
+    public ProjectMetaDirectEditOutcome Outcome { get; init; }
+    public IReadOnlyDictionary<string, string[]> Errors { get; init; } =
+        new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+    private ProjectMetaDirectEditResult(
+        ProjectMetaDirectEditOutcome outcome,
+        IReadOnlyDictionary<string, string[]> errors)
+    {
+        Outcome = outcome;
+        Errors = errors;
+    }
+
+    public static ProjectMetaDirectEditResult Success() =>
+        new(ProjectMetaDirectEditOutcome.Success, EmptyErrors);
+
+    public static ProjectMetaDirectEditResult ValidationFailed(IReadOnlyDictionary<string, string[]> errors) =>
+        new(ProjectMetaDirectEditOutcome.ValidationFailed, errors);
+
+    public static ProjectMetaDirectEditResult ProjectNotFound() =>
+        new(ProjectMetaDirectEditOutcome.ProjectNotFound, EmptyErrors);
+}
+
+public enum ProjectMetaDirectEditOutcome
+{
+    Success,
+    ValidationFailed,
+    ProjectNotFound
+}


### PR DESCRIPTION
## Summary
- add a `ProjectMetaChangeRequest` entity and service that trims proposed case file numbers and blocks duplicates before persisting Project Officer submissions
- reuse the shared validation when HoD/Admin perform direct metadata edits so both paths enforce the same rules
- cover duplicate-case-file scenarios for the submission and direct-edit flows with new unit tests to guard against regression

## Testing
- not run (environment is missing the dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68db7751f75083298ff7242b8d0bb511