### PR TITLE
Prevent duplicate case file numbers when editing or requesting meta updates

### DIFF
--- a/ProjectManagement.Tests/ProjectMetaChangeRequestServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaChangeRequestServiceTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Tests.Fakes;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectMetaChangeRequestServiceTests
+{
+    [Fact]
+    public async Task SubmitAsync_DuplicateCaseFileNumber_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        await db.Projects.AddRangeAsync(
+            new Project
+            {
+                Id = 1,
+                Name = "Existing",
+                CaseFileNumber = "CF-999",
+                CreatedByUserId = "creator"
+            },
+            new Project
+            {
+                Id = 2,
+                Name = "Editable",
+                CreatedByUserId = "creator",
+                LeadPoUserId = "po-user"
+            });
+        await db.SaveChangesAsync();
+
+        var clock = FakeClock.AtUtc(new DateTimeOffset(2024, 10, 1, 0, 0, 0, TimeSpan.Zero));
+        var service = new ProjectMetaChangeRequestService(db, clock);
+
+        var submission = new ProjectMetaChangeRequestSubmission
+        {
+            ProjectId = 2,
+            Name = "Editable",
+            Description = "Updated description",
+            CaseFileNumber = "  CF-999  "
+        };
+
+        var result = await service.SubmitAsync(submission, "po-user", CancellationToken.None);
+
+        Assert.Equal(ProjectMetaChangeRequestSubmissionOutcome.ValidationFailed, result.Outcome);
+        Assert.True(result.Errors.TryGetValue("CaseFileNumber", out var errors));
+        var message = Assert.Single(errors);
+        Assert.Equal(ProjectValidationMessages.DuplicateCaseFileNumber, message);
+        Assert.Equal(0, await db.ProjectMetaChangeRequests.CountAsync());
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/Services/Projects/ProjectMetaChangeRequestService.cs
+++ b/Services/Projects/ProjectMetaChangeRequestService.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectMetaChangeRequestService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public ProjectMetaChangeRequestService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async Task<ProjectMetaChangeRequestSubmissionResult> SubmitAsync(
+        ProjectMetaChangeRequestSubmission submission,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (submission is null)
+        {
+            throw new ArgumentNullException(nameof(submission));
+        }
+
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new ArgumentException("A valid user identifier is required.", nameof(userId));
+        }
+
+        var project = await _db.Projects
+            .SingleOrDefaultAsync(p => p.Id == submission.ProjectId, cancellationToken);
+
+        if (project is null)
+        {
+            return ProjectMetaChangeRequestSubmissionResult.ProjectNotFound();
+        }
+
+        if (!string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return ProjectMetaChangeRequestSubmissionResult.NotProjectOfficer();
+        }
+
+        var trimmedName = string.IsNullOrWhiteSpace(submission.Name)
+            ? project.Name
+            : submission.Name.Trim();
+        var trimmedDescription = string.IsNullOrWhiteSpace(submission.Description)
+            ? null
+            : submission.Description.Trim();
+        var trimmedCaseFileNumber = string.IsNullOrWhiteSpace(submission.CaseFileNumber)
+            ? null
+            : submission.CaseFileNumber.Trim();
+
+        if (!string.IsNullOrEmpty(trimmedCaseFileNumber))
+        {
+            var duplicate = await _db.Projects
+                .AsNoTracking()
+                .AnyAsync(
+                    p => p.Id != project.Id
+                        && p.CaseFileNumber != null
+                        && p.CaseFileNumber == trimmedCaseFileNumber,
+                    cancellationToken);
+
+            if (duplicate)
+            {
+                return ProjectMetaChangeRequestSubmissionResult.ValidationFailed(
+                    new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["CaseFileNumber"] = new[] { ProjectValidationMessages.DuplicateCaseFileNumber }
+                    });
+            }
+        }
+
+        var payload = JsonSerializer.Serialize(new ProjectMetaChangeRequestPayload
+        {
+            Name = trimmedName,
+            Description = trimmedDescription,
+            CaseFileNumber = trimmedCaseFileNumber
+        });
+
+        var request = new ProjectMetaChangeRequest
+        {
+            ProjectId = project.Id,
+            ChangeType = ProjectMetaChangeRequestChangeTypes.Meta,
+            Payload = payload,
+            RequestedByUserId = userId,
+            RequestedOnUtc = _clock.UtcNow,
+            DecisionStatus = ProjectMetaDecisionStatuses.Pending
+        };
+
+        await _db.ProjectMetaChangeRequests.AddAsync(request, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return ProjectMetaChangeRequestSubmissionResult.Success(request.Id);
+    }
+
+    private sealed class ProjectMetaChangeRequestPayload
+    {
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string? CaseFileNumber { get; set; }
+    }
+}
+
+public sealed class ProjectMetaChangeRequestSubmission
+{
+    public int ProjectId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public string? CaseFileNumber { get; set; }
+}
+
+public sealed record ProjectMetaChangeRequestSubmissionResult
+{
+    private static readonly IReadOnlyDictionary<string, string[]> EmptyErrors
+        = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+    private ProjectMetaChangeRequestSubmissionResult(
+        ProjectMetaChangeRequestSubmissionOutcome outcome,
+        int? requestId,
+        IReadOnlyDictionary<string, string[]> errors)
+    {
+        Outcome = outcome;
+        RequestId = requestId;
+        Errors = errors;
+    }
+
+    public ProjectMetaChangeRequestSubmissionOutcome Outcome { get; }
+
+    public int? RequestId { get; }
+
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+
+    public static ProjectMetaChangeRequestSubmissionResult Success(int requestId)
+        => new(ProjectMetaChangeRequestSubmissionOutcome.Success, requestId, EmptyErrors);
+
+    public static ProjectMetaChangeRequestSubmissionResult ProjectNotFound()
+        => new(ProjectMetaChangeRequestSubmissionOutcome.ProjectNotFound, null, EmptyErrors);
+
+    public static ProjectMetaChangeRequestSubmissionResult NotProjectOfficer()
+        => new(ProjectMetaChangeRequestSubmissionOutcome.NotProjectOfficer, null, EmptyErrors);
+
+    public static ProjectMetaChangeRequestSubmissionResult ValidationFailed(
+        IReadOnlyDictionary<string, string[]> errors)
+    {
+        if (errors is null)
+        {
+            throw new ArgumentNullException(nameof(errors));
+        }
+
+        var copy = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in errors)
+        {
+            copy[key] = value;
+        }
+
+        return new(
+            ProjectMetaChangeRequestSubmissionOutcome.ValidationFailed,
+            null,
+            copy);
+    }
+}
+
+public enum ProjectMetaChangeRequestSubmissionOutcome
+{
+    Success,
+    ProjectNotFound,
+    NotProjectOfficer,
+    ValidationFailed
+}
+
+public static class ProjectMetaChangeRequestChangeTypes
+{
+    public const string Meta = "Meta";
+}

--- a/Services/Projects/ProjectValidationMessages.cs
+++ b/Services/Projects/ProjectValidationMessages.cs
@@ -1,0 +1,6 @@
+namespace ProjectManagement.Services.Projects;
+
+public static class ProjectValidationMessages
+{
+    public const string DuplicateCaseFileNumber = "Case file number already exists.";
+}


### PR DESCRIPTION
## Summary
- ensure the meta edit handler trims case file numbers, checks for duplicates, and surfaces the existing validation message instead of persisting invalid updates
- centralize the duplicate case file number validation message and add a project meta change request service that performs the same trimmed duplicate check before queuing a request
- add regression tests covering both the edit handler and the project officer request submission path for duplicate case file numbers

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dba78732208329955c7e4b25590889