### PR TITLE
Fix migration snapshot accessibility

### DIFF
--- a/Migrations/20251001050000_ProjectMetaChangeRequests.Designer.cs
+++ b/Migrations/20251001050000_ProjectMetaChangeRequests.Designer.cs
@@ -17,7 +17,7 @@ namespace ProjectManagement.Migrations
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            new ApplicationDbContextModelSnapshot().BuildModel(modelBuilder);
+            new ApplicationDbContextModelSnapshot().PopulateModel(modelBuilder);
 #pragma warning restore 612, 618
         }
     }

--- a/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ProjectManagement.Migrations
+{
+    public partial class ApplicationDbContextModelSnapshot
+    {
+        public void PopulateModel(ModelBuilder modelBuilder)
+        {
+            BuildModel(modelBuilder);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a partial extension of `ApplicationDbContextModelSnapshot` that exposes a public helper to invoke `BuildModel`
- update the `ProjectMetaChangeRequests` migration designer to call the helper method so the build no longer hits a protection-level error

## Testing
- `dotnet build` *(fails: `dotnet` not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe41ab2cc8329bb02e29112cf87f0