### PR TITLE
Fix project category lookup in request page

### DIFF
--- a/Pages/Projects/Meta/Request.cshtml.cs
+++ b/Pages/Projects/Meta/Request.cshtml.cs
@@ -154,9 +154,7 @@ public sealed class RequestModel : PageModel
             .ThenBy(c => c.Name)
             .ToListAsync(cancellationToken);
 
-        var children = categories
-            .GroupBy(c => c.ParentId)
-            .ToDictionary(g => g.Key, g => g.ToList(), comparer: EqualityComparer<int?>.Default);
+        var children = categories.ToLookup(c => c.ParentId);
 
         var options = new List<SelectListItem>
         {
@@ -165,12 +163,7 @@ public sealed class RequestModel : PageModel
 
         void AddOptions(int? parentId, string prefix)
         {
-            if (!children.TryGetValue(parentId, out var items))
-            {
-                return;
-            }
-
-            foreach (var category in items)
+            foreach (var category in children[parentId])
             {
                 var text = string.IsNullOrEmpty(prefix) ? category.Name : $"{prefix}{category.Name}";
                 options.Add(new SelectListItem(text, category.Id.ToString(), category.Id == selectedCategoryId));


### PR DESCRIPTION
## Summary
- replace the project category grouping in the request page with a null-safe lookup to handle root categories
- update the recursive option builder to iterate the lookup so the hierarchy is still traversed

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe9b8b9208329ba1754261e0c6d0a