### PR TITLE
Handle null backfill payload and update temp data provider

### DIFF
--- a/Pages/Projects/Stages/BackfillApply.cshtml.cs
+++ b/Pages/Projects/Stages/BackfillApply.cshtml.cs
@@ -53,6 +53,11 @@ public class BackfillApplyModel : PageModel
             "BackfillApply POST ProjectId={ProjectId}",
             input?.ProjectId);
 
+        if (input is null)
+        {
+            return ValidationFailure(new[] { "A request body is required." });
+        }
+
         if (!ModelState.IsValid)
         {
             var details = ModelState.Values

--- a/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
@@ -257,7 +258,9 @@ public sealed class ProjectMetaEditPageTests
             {
                 HttpContext = new DefaultHttpContext()
             },
-            TempData = new TempDataDictionary(new DefaultHttpContext(), new SessionStateTempDataProvider())
+            TempData = new TempDataDictionary(
+                new DefaultHttpContext(),
+                new SessionStateTempDataProvider(new TempDataSerializer()))
         };
 
         return page;


### PR DESCRIPTION
## Summary
- guard the backfill apply endpoint against missing request bodies before evaluating validation state
- update the project meta edit page tests to construct the session state temp data provider with the required serializer

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf816db5c8329b962f9782a55048d