### PR TITLE
Fix TempData serializer usage in meta edit page tests

### DIFF
--- a/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
@@ -260,7 +260,7 @@ public sealed class ProjectMetaEditPageTests
             },
             TempData = new TempDataDictionary(
                 new DefaultHttpContext(),
-                new SessionStateTempDataProvider(new TempDataSerializer()))
+                new SessionStateTempDataProvider(new DefaultTempDataSerializer()))
         };
 
         return page;


### PR DESCRIPTION
## Summary
- switch the TempData serializer used in `ProjectMetaEditPageTests` to the concrete `DefaultTempDataSerializer` so the test helper can build a session-backed TempDataDictionary

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf90fa9b083299a3f8aa1d7326605