### PR TITLE
Fix test temp data setup to avoid inaccessible serializer

### DIFF
--- a/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
@@ -260,7 +260,7 @@ public sealed class ProjectMetaEditPageTests
             },
             TempData = new TempDataDictionary(
                 new DefaultHttpContext(),
-                new SessionStateTempDataProvider(new DefaultTempDataSerializer()))
+                new FakeTempDataProvider())
         };
 
         return page;
@@ -273,6 +273,23 @@ public sealed class ProjectMetaEditPageTests
             .Options;
 
         return new ApplicationDbContext(options);
+    }
+
+    private sealed class FakeTempDataProvider : ITempDataProvider
+    {
+        private IDictionary<string, object?> _data = new Dictionary<string, object?>();
+
+        public IDictionary<string, object?> LoadTempData(HttpContext context)
+        {
+            var result = _data;
+            _data = new Dictionary<string, object?>();
+            return result;
+        }
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+            _data = new Dictionary<string, object?>(values);
+        }
     }
 
     private sealed class FakeUserContext : IUserContext


### PR DESCRIPTION
## Summary
- replace direct usage of DefaultTempDataSerializer with a fake temp data provider in ProjectMetaEditPageTests
- implement a simple in-memory fake ITempDataProvider for tests

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbf9ef90d88329a49dbb02ab9dbee4