### PR TITLE
Add sponsoring lookup infrastructure to project metadata flows

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -56,6 +56,8 @@ namespace ProjectManagement.Data
         public DbSet<Status> Statuses => Set<Status>();
         public DbSet<Workflow> Workflows => Set<Workflow>();
         public DbSet<WorkflowStatus> WorkflowStatuses => Set<WorkflowStatus>();
+        public DbSet<SponsoringUnit> SponsoringUnits => Set<SponsoringUnit>();
+        public DbSet<LineDirectorate> LineDirectorates => Set<LineDirectorate>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -75,6 +77,14 @@ namespace ProjectManagement.Data
                 e.HasOne(x => x.Category)
                     .WithMany(x => x.Projects)
                     .HasForeignKey(x => x.CategoryId)
+                    .OnDelete(DeleteBehavior.Restrict);
+                e.HasOne(x => x.SponsoringUnit)
+                    .WithMany(x => x.Projects)
+                    .HasForeignKey(x => x.SponsoringUnitId)
+                    .OnDelete(DeleteBehavior.Restrict);
+                e.HasOne(x => x.SponsoringLineDirectorate)
+                    .WithMany(x => x.Projects)
+                    .HasForeignKey(x => x.SponsoringLineDirectorateId)
                     .OnDelete(DeleteBehavior.Restrict);
                 e.Property(x => x.PlanApprovedByUserId).HasMaxLength(450);
                 e.HasOne(x => x.PlanApprovedByUser)
@@ -162,6 +172,54 @@ namespace ProjectManagement.Data
                     .WithMany(x => x.Children)
                     .HasForeignKey(x => x.ParentId)
                     .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<SponsoringUnit>(e =>
+            {
+                e.Property(x => x.Name).HasMaxLength(200).IsRequired();
+                e.HasIndex(x => x.Name).IsUnique();
+                e.Property(x => x.IsActive).HasDefaultValue(true);
+                e.Property(x => x.SortOrder).HasDefaultValue(0);
+
+                if (Database.IsSqlServer())
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("GETUTCDATE()");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("GETUTCDATE()");
+                }
+                else if (Database.IsNpgsql())
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("now() at time zone 'utc'");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("now() at time zone 'utc'");
+                }
+                else
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                }
+            });
+
+            builder.Entity<LineDirectorate>(e =>
+            {
+                e.Property(x => x.Name).HasMaxLength(200).IsRequired();
+                e.HasIndex(x => x.Name).IsUnique();
+                e.Property(x => x.IsActive).HasDefaultValue(true);
+                e.Property(x => x.SortOrder).HasDefaultValue(0);
+
+                if (Database.IsSqlServer())
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("GETUTCDATE()");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("GETUTCDATE()");
+                }
+                else if (Database.IsNpgsql())
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("now() at time zone 'utc'");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("now() at time zone 'utc'");
+                }
+                else
+                {
+                    e.Property(x => x.CreatedUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                    e.Property(x => x.UpdatedUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                }
             });
 
             builder.Entity<ProjectMetaChangeRequest>(e =>

--- a/Data/Migrations/20250312000000_AddSponsoringLookups.cs
+++ b/Data/Migrations/20250312000000_AddSponsoringLookups.cs
@@ -1,0 +1,230 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Data.Migrations
+{
+    public partial class AddSponsoringLookups : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var isSqlServer = migrationBuilder.ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer";
+            var isNpgsql = migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL";
+            var timestampDefault = isSqlServer
+                ? "GETUTCDATE()"
+                : isNpgsql
+                    ? "now() at time zone 'utc'"
+                    : "CURRENT_TIMESTAMP";
+
+            if (isSqlServer)
+            {
+                migrationBuilder.CreateTable(
+                    name: "LineDirectorates",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "int", nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(type: "int", nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_LineDirectorates", x => x.Id);
+                    });
+
+                migrationBuilder.CreateTable(
+                    name: "SponsoringUnits",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "int", nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(type: "int", nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_SponsoringUnits", x => x.Id);
+                    });
+            }
+            else if (isNpgsql)
+            {
+                migrationBuilder.CreateTable(
+                    name: "LineDirectorates",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "integer", nullable: false)
+                            .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                        Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_LineDirectorates", x => x.Id);
+                    });
+
+                migrationBuilder.CreateTable(
+                    name: "SponsoringUnits",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "integer", nullable: false)
+                            .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                        Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_SponsoringUnits", x => x.Id);
+                    });
+            }
+            else
+            {
+                migrationBuilder.CreateTable(
+                    name: "LineDirectorates",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        Name = table.Column<string>(maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_LineDirectorates", x => x.Id);
+                    });
+
+                migrationBuilder.CreateTable(
+                    name: "SponsoringUnits",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        Name = table.Column<string>(maxLength: 200, nullable: false),
+                        IsActive = table.Column<bool>(nullable: false, defaultValue: true),
+                        SortOrder = table.Column<int>(nullable: false, defaultValue: 0),
+                        CreatedUtc = table.Column<DateTime>(nullable: false, defaultValueSql: timestampDefault),
+                        UpdatedUtc = table.Column<DateTime>(nullable: false, defaultValueSql: timestampDefault)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_SponsoringUnits", x => x.Id);
+                    });
+            }
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineDirectorates_Name",
+                table: "LineDirectorates",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SponsoringUnits_Name",
+                table: "SponsoringUnits",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SponsoringLineDirectorateId",
+                table: "Projects",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SponsoringUnitId",
+                table: "Projects",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OriginalSponsoringLineDirectorateId",
+                table: "ProjectMetaChangeRequests",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OriginalSponsoringUnitId",
+                table: "ProjectMetaChangeRequests",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_SponsoringLineDirectorateId",
+                table: "Projects",
+                column: "SponsoringLineDirectorateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_SponsoringUnitId",
+                table: "Projects",
+                column: "SponsoringUnitId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_LineDirectorates_SponsoringLineDirectorateId",
+                table: "Projects",
+                column: "SponsoringLineDirectorateId",
+                principalTable: "LineDirectorates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_SponsoringUnits_SponsoringUnitId",
+                table: "Projects",
+                column: "SponsoringUnitId",
+                principalTable: "SponsoringUnits",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_LineDirectorates_SponsoringLineDirectorateId",
+                table: "Projects");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_SponsoringUnits_SponsoringUnitId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_SponsoringLineDirectorateId",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_SponsoringUnitId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "SponsoringLineDirectorateId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "SponsoringUnitId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "OriginalSponsoringLineDirectorateId",
+                table: "ProjectMetaChangeRequests");
+
+            migrationBuilder.DropColumn(
+                name: "OriginalSponsoringUnitId",
+                table: "ProjectMetaChangeRequests");
+
+            migrationBuilder.DropTable(
+                name: "LineDirectorates");
+
+            migrationBuilder.DropTable(
+                name: "SponsoringUnits");
+        }
+    }
+}

--- a/Models/LineDirectorate.cs
+++ b/Models/LineDirectorate.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class LineDirectorate
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public bool IsActive { get; set; } = true;
+
+    public int SortOrder { get; set; }
+
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdatedUtc { get; set; } = DateTime.UtcNow;
+
+    public ICollection<Project> Projects { get; set; } = new List<Project>();
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -34,6 +34,12 @@ namespace ProjectManagement.Models
         public int? CategoryId { get; set; }
         public ProjectCategory? Category { get; set; }
 
+        public int? SponsoringUnitId { get; set; }
+        public SponsoringUnit? SponsoringUnit { get; set; }
+
+        public int? SponsoringLineDirectorateId { get; set; }
+        public LineDirectorate? SponsoringLineDirectorate { get; set; }
+
         // Assignments
         public string? HodUserId { get; set; }
         public ApplicationUser? HodUser { get; set; }

--- a/Models/ProjectMetaChangeRequest.cs
+++ b/Models/ProjectMetaChangeRequest.cs
@@ -37,5 +37,9 @@ namespace ProjectManagement.Models
         public string? OriginalCaseFileNumber { get; set; }
 
         public byte[]? OriginalRowVersion { get; set; }
+
+        public int? OriginalSponsoringUnitId { get; set; }
+
+        public int? OriginalSponsoringLineDirectorateId { get; set; }
     }
 }

--- a/Models/SponsoringUnit.cs
+++ b/Models/SponsoringUnit.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class SponsoringUnit
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public bool IsActive { get; set; } = true;
+
+    public int SortOrder { get; set; }
+
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdatedUtc { get; set; } = DateTime.UtcNow;
+
+    public ICollection<Project> Projects { get; set; } = new List<Project>();
+}

--- a/Services/Projects/ProjectMetaChangeDrift.cs
+++ b/Services/Projects/ProjectMetaChangeDrift.cs
@@ -11,6 +11,8 @@ public static class ProjectMetaChangeDriftFields
     public const string Description = nameof(Project.Description);
     public const string CaseFileNumber = nameof(Project.CaseFileNumber);
     public const string Category = nameof(Project.CategoryId);
+    public const string SponsoringUnit = nameof(Project.SponsoringUnitId);
+    public const string SponsoringLineDirectorate = nameof(Project.SponsoringLineDirectorateId);
     public const string ProjectRecord = "ProjectRecord";
 }
 
@@ -52,6 +54,16 @@ public static class ProjectMetaChangeDriftDetector
         if (request.OriginalCategoryId != project.CategoryId)
         {
             fields.Add(ProjectMetaChangeDriftFields.Category);
+        }
+
+        if (request.OriginalSponsoringUnitId != project.SponsoringUnitId)
+        {
+            fields.Add(ProjectMetaChangeDriftFields.SponsoringUnit);
+        }
+
+        if (request.OriginalSponsoringLineDirectorateId != project.SponsoringLineDirectorateId)
+        {
+            fields.Add(ProjectMetaChangeDriftFields.SponsoringLineDirectorate);
         }
 
         if (request.OriginalRowVersion is { Length: > 0 }

--- a/Services/Projects/ProjectMetaChangeRequestPayload.cs
+++ b/Services/Projects/ProjectMetaChangeRequestPayload.cs
@@ -15,4 +15,10 @@ public sealed class ProjectMetaChangeRequestPayload
 
     [JsonPropertyName("categoryId")]
     public int? CategoryId { get; set; }
+
+    [JsonPropertyName("sponsoringUnitId")]
+    public int? SponsoringUnitId { get; set; }
+
+    [JsonPropertyName("sponsoringLineDirectorateId")]
+    public int? SponsoringLineDirectorateId { get; set; }
 }

--- a/Services/Projects/ProjectValidationMessages.cs
+++ b/Services/Projects/ProjectValidationMessages.cs
@@ -6,5 +6,9 @@ public static class ProjectValidationMessages
 
     public const string InactiveCategory = "Selected category is no longer active.";
 
+    public const string InactiveSponsoringUnit = "Selected sponsoring unit is no longer active.";
+
+    public const string InactiveLineDirectorate = "Selected line directorate is no longer active.";
+
     public const string PendingMetaChangeRequest = "A meta change request is already pending for this project.";
 }


### PR DESCRIPTION
## Summary
- add SponsoringUnit and LineDirectorate entities with EF configuration and schema migration
- extend project meta change request payloads, services, and drift detection to track sponsoring lookups
- add migration wiring the new lookup tables and foreign keys into projects and change requests

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc05eec1308329bf5076148721da0a