### PR TITLE
Run database migrations on application startup

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -202,6 +202,13 @@ builder.Services.AddRazorPages(options =>
 
 var app = builder.Build();
 
+// Ensure the database schema is up to date before handling requests
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await db.Database.MigrateAsync();
+}
+
 if (runForecastBackfill)
 {
     using var scope = app.Services.CreateScope();


### PR DESCRIPTION
## Summary
- ensure the application runs pending Entity Framework Core migrations during startup so the schema stays current

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0afb261c8329aaa330d23b5e4a0b