### PR TITLE
Add sponsoring lookup management and project UI

### DIFF
--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml
@@ -1,0 +1,29 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.CreateModel
+@{
+    ViewData["Title"] = "Add Line Directorate";
+}
+
+<h1 class="mb-4">Add Line Directorate</h1>
+
+<form method="post" class="col-md-6">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Input.Name" class="form-label"></label>
+        <input asp-for="Input.Name" class="form-control" />
+        <span asp-validation-for="Input.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SortOrder" class="form-label"></label>
+        <input asp-for="Input.SortOrder" class="form-control" type="number" />
+        <span asp-validation-for="Input.SortOrder" class="text-danger"></span>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates;
+
+[Authorize(Roles = "Admin")]
+public class CreateModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public CreateModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var trimmedName = Input.Name.Trim();
+        var exists = await _db.LineDirectorates.AnyAsync(l => l.Name == trimmedName);
+
+        if (exists)
+        {
+            ModelState.AddModelError("Input.Name", "A line directorate with this name already exists.");
+            return Page();
+        }
+
+        var now = DateTime.UtcNow;
+        var entity = new ProjectManagement.Models.LineDirectorate
+        {
+            Name = trimmedName,
+            SortOrder = Input.SortOrder,
+            IsActive = true,
+            CreatedUtc = now,
+            UpdatedUtc = now
+        };
+
+        _db.LineDirectorates.Add(entity);
+        await _db.SaveChangesAsync();
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await _audit.LogAsync(
+            "Lookups.LineDirectorateCreated",
+            new Dictionary<string, string?>
+            {
+                ["LineDirectorateId"] = entity.Id.ToString(),
+                ["Name"] = entity.Name,
+                ["SortOrder"] = entity.SortOrder.ToString()
+            },
+            userId: userId,
+            userName: User.Identity?.Name);
+
+        TempData["StatusMessage"] = $"Created '{entity.Name}'.";
+        return RedirectToPage("./Index");
+    }
+
+    public sealed class InputModel
+    {
+        [Required]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Range(0, 1000)]
+        public int SortOrder { get; set; }
+    }
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml
@@ -1,0 +1,41 @@
+@page "{id:int}"
+@model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.DeactivateModel
+@{
+    var actionVerb = Model.Restore ? "Reactivate" : "Deactivate";
+    ViewData["Title"] = $"{actionVerb} Line Directorate";
+}
+
+<h1 class="mb-4">@ViewData["Title"]</h1>
+
+<div class="col-lg-6">
+    <div class="alert alert-warning">
+        <p class="mb-2"><strong>@Model.Name</strong></p>
+        @if (Model.Restore)
+        {
+            <p class="mb-0">This line directorate will be selectable again once reactivated.</p>
+        }
+        else if (Model.ProjectCount > 0)
+        {
+            <p class="mb-0">This line directorate is referenced by <strong>@Model.ProjectCount</strong> project(s). Remove the assignments before deactivation.</p>
+        }
+        else
+        {
+            <p class="mb-0">Deactivated line directorates cannot be selected on project forms.</p>
+        }
+    </div>
+
+    <form method="post" class="d-flex gap-2">
+        <button type="submit" class="btn btn-@(Model.Restore ? "success" : "danger")">@actionVerb</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </form>
+</div>
+
+@if (!ModelState.IsValid)
+{
+    <div class="text-danger mt-3">
+        @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
+        {
+            <div>@error.ErrorMessage</div>
+        }
+    </div>
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates;
+
+[Authorize(Roles = "Admin")]
+public class DeactivateModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public DeactivateModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty(SupportsGet = true)]
+    public int Id { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public bool Restore { get; set; }
+
+    public string Name { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; }
+    public int ProjectCount { get; private set; }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var entity = await LoadAsync();
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var entity = await _db.LineDirectorates.FirstOrDefaultAsync(l => l.Id == Id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        ProjectCount = await _db.Projects.CountAsync(p => p.SponsoringLineDirectorateId == Id);
+
+        if (!Restore && ProjectCount > 0)
+        {
+            Name = entity.Name;
+            IsActive = entity.IsActive;
+            ModelState.AddModelError(string.Empty, "Cannot deactivate while the line directorate is assigned to existing projects.");
+            return Page();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (Restore)
+        {
+            if (!entity.IsActive)
+            {
+                entity.IsActive = true;
+                entity.UpdatedUtc = DateTime.UtcNow;
+                await _db.SaveChangesAsync();
+
+                await _audit.LogAsync(
+                    "Lookups.LineDirectorateReactivated",
+                    new Dictionary<string, string?>
+                    {
+                        ["LineDirectorateId"] = entity.Id.ToString(),
+                        ["Name"] = entity.Name
+                    },
+                    userId: userId,
+                    userName: User.Identity?.Name);
+            }
+
+            TempData["StatusMessage"] = $"Reactivated '{entity.Name}'.";
+        }
+        else
+        {
+            if (entity.IsActive)
+            {
+                entity.IsActive = false;
+                entity.UpdatedUtc = DateTime.UtcNow;
+                await _db.SaveChangesAsync();
+
+                await _audit.LogAsync(
+                    "Lookups.LineDirectorateDeactivated",
+                    new Dictionary<string, string?>
+                    {
+                        ["LineDirectorateId"] = entity.Id.ToString(),
+                        ["Name"] = entity.Name
+                    },
+                    userId: userId,
+                    userName: User.Identity?.Name);
+            }
+
+            TempData["StatusMessage"] = $"Deactivated '{entity.Name}'.";
+        }
+
+        return RedirectToPage("./Index");
+    }
+
+    private async Task<ProjectManagement.Models.LineDirectorate?> LoadAsync()
+    {
+        var entity = await _db.LineDirectorates
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l => l.Id == Id);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        Name = entity.Name;
+        IsActive = entity.IsActive;
+        ProjectCount = await _db.Projects.CountAsync(p => p.SponsoringLineDirectorateId == Id);
+        return entity;
+    }
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml
@@ -1,0 +1,30 @@
+@page "{id:int}"
+@model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.EditModel
+@{
+    ViewData["Title"] = "Edit Line Directorate";
+}
+
+<h1 class="mb-4">Edit Line Directorate</h1>
+
+<form method="post" class="col-md-6">
+    <input asp-for="Input.Id" type="hidden" />
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Input.Name" class="form-label"></label>
+        <input asp-for="Input.Name" class="form-control" />
+        <span asp-validation-for="Input.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SortOrder" class="form-label"></label>
+        <input asp-for="Input.SortOrder" class="form-control" type="number" />
+        <span asp-validation-for="Input.SortOrder" class="text-danger"></span>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Save changes</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates;
+
+[Authorize(Roles = "Admin")]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public EditModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var entity = await _db.LineDirectorates.FindAsync(id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        Input = new InputModel
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            SortOrder = entity.SortOrder
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var entity = await _db.LineDirectorates.FindAsync(Input.Id);
+        if (entity is null)
+        {
+            return NotFound();
+        }
+
+        var trimmedName = Input.Name.Trim();
+        var duplicate = await _db.LineDirectorates
+            .AnyAsync(l => l.Id != Input.Id && l.Name == trimmedName);
+
+        if (duplicate)
+        {
+            ModelState.AddModelError("Input.Name", "A line directorate with this name already exists.");
+            return Page();
+        }
+
+        var originalName = entity.Name;
+        var originalSortOrder = entity.SortOrder;
+
+        entity.Name = trimmedName;
+        entity.SortOrder = Input.SortOrder;
+        entity.UpdatedUtc = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await _audit.LogAsync(
+            "Lookups.LineDirectorateUpdated",
+            new Dictionary<string, string?>
+            {
+                ["LineDirectorateId"] = entity.Id.ToString(),
+                ["NameBefore"] = originalName,
+                ["NameAfter"] = entity.Name,
+                ["SortOrderBefore"] = originalSortOrder.ToString(),
+                ["SortOrderAfter"] = entity.SortOrder.ToString()
+            },
+            userId: userId,
+            userName: User.Identity?.Name);
+
+        TempData["StatusMessage"] = $"Updated '{entity.Name}'.";
+        return RedirectToPage("./Index");
+    }
+
+    public sealed class InputModel
+    {
+        [HiddenInput]
+        public int Id { get; set; }
+
+        [Required]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Range(0, 1000)]
+        public int SortOrder { get; set; }
+    }
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
@@ -1,0 +1,100 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.IndexModel
+@{
+    ViewData["Title"] = "Sponsoring Line Directorates";
+}
+
+<h1 class="mb-4">Sponsoring Line Directorates</h1>
+
+@if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+{
+    <div class="alert alert-success">@Model.StatusMessage</div>
+}
+
+<div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+    <form method="get" class="row row-cols-lg-auto g-2 align-items-end">
+        <div class="col-12">
+            <label asp-for="Q" class="form-label">Search</label>
+            <input asp-for="Q" class="form-control" />
+        </div>
+        <div class="col-12">
+            <label class="form-label" for="line-status">Status</label>
+            <select id="line-status" name="status" class="form-select">
+                <option value="active" selected="@(string.Equals(Model.Status, "active", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Active</option>
+                <option value="inactive" selected="@(string.Equals(Model.Status, "inactive", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Inactive</option>
+                <option value="all" selected="@(string.Equals(Model.Status, "all", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">All</option>
+            </select>
+        </div>
+        <input type="hidden" name="page" value="1" />
+        <div class="col-12">
+            <button type="submit" class="btn btn-outline-primary">Apply</button>
+        </div>
+    </form>
+    <a class="btn btn-primary" asp-page="./Create">Add line directorate</a>
+</div>
+
+@if (!Model.Items.Any())
+{
+    <div class="alert alert-info">No line directorates found.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Sort Order</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Referenced</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var item in Model.Items)
+            {
+                <tr>
+                    <td>@item.Name</td>
+                    <td>@item.SortOrder</td>
+                    <td>
+                        @if (item.IsActive)
+                        {
+                            <span class="badge text-bg-success">Active</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary">Inactive</span>
+                        }
+                    </td>
+                    <td>@item.ProjectCount</td>
+                    <td class="text-end">
+                        <div class="btn-group">
+                            <a class="btn btn-sm btn-outline-secondary" asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
+                            @if (item.IsActive)
+                            {
+                                <a class="btn btn-sm btn-outline-danger" asp-page="./Deactivate" asp-route-id="@item.Id">Deactivate</a>
+                            }
+                            else
+                            {
+                                <a class="btn btn-sm btn-outline-success" asp-page="./Deactivate" asp-route-id="@item.Id" asp-route-restore="true">Reactivate</a>
+                            }
+                        </div>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+
+    <nav aria-label="Pagination" class="mt-3">
+        <ul class="pagination">
+            <li class="page-item @(Model.Page <= 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.Page - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+            </li>
+            <li class="page-item disabled"><span class="page-link">Page @Model.Page of @Model.TotalPages</span></li>
+            <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.Page + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+
+    public IndexModel(ApplicationDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    private const int PageSize = 20;
+
+    [BindProperty(SupportsGet = true)]
+    [Display(Name = "Search")]
+    public string? Q { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string Status { get; set; } = "active";
+
+    [BindProperty(SupportsGet = true)]
+    public int Page { get; set; } = 1;
+
+    public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
+
+    public int TotalCount { get; private set; }
+
+    public int TotalPages { get; private set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        var query = _db.LineDirectorates.AsNoTracking();
+
+        var statusFilter = (Status ?? "active").Trim().ToLowerInvariant();
+        query = statusFilter switch
+        {
+            "inactive" => query.Where(l => !l.IsActive),
+            "all" => query,
+            _ => query.Where(l => l.IsActive)
+        };
+
+        if (!string.IsNullOrWhiteSpace(Q))
+        {
+            var term = Q.Trim();
+            query = query.Where(l => EF.Functions.ILike(l.Name, $"%{term}%"));
+        }
+
+        query = query
+            .OrderBy(l => l.SortOrder)
+            .ThenBy(l => l.Name);
+
+        TotalCount = await query.CountAsync();
+        TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
+
+        if (Page < 1)
+        {
+            Page = 1;
+        }
+        else if (Page > TotalPages)
+        {
+            Page = TotalPages;
+        }
+
+        Items = await query
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .Select(l => new Row
+            {
+                Id = l.Id,
+                Name = l.Name,
+                SortOrder = l.SortOrder,
+                IsActive = l.IsActive,
+                ProjectCount = l.Projects.Count
+            })
+            .ToListAsync();
+    }
+
+    public sealed class Row
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public int SortOrder { get; init; }
+        public bool IsActive { get; init; }
+        public int ProjectCount { get; init; }
+    }
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml
@@ -1,0 +1,29 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.CreateModel
+@{
+    ViewData["Title"] = "Add Sponsoring Unit";
+}
+
+<h1 class="mb-4">Add Sponsoring Unit</h1>
+
+<form method="post" class="col-md-6">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Input.Name" class="form-label"></label>
+        <input asp-for="Input.Name" class="form-control" />
+        <span asp-validation-for="Input.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SortOrder" class="form-label"></label>
+        <input asp-for="Input.SortOrder" class="form-control" type="number" />
+        <span asp-validation-for="Input.SortOrder" class="text-danger"></span>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits;
+
+[Authorize(Roles = "Admin")]
+public class CreateModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public CreateModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var trimmedName = Input.Name.Trim();
+
+        var exists = await _db.SponsoringUnits
+            .AnyAsync(u => u.Name == trimmedName);
+
+        if (exists)
+        {
+            ModelState.AddModelError("Input.Name", "A sponsoring unit with this name already exists.");
+            return Page();
+        }
+
+        var now = DateTime.UtcNow;
+        var unit = new ProjectManagement.Models.SponsoringUnit
+        {
+            Name = trimmedName,
+            SortOrder = Input.SortOrder,
+            IsActive = true,
+            CreatedUtc = now,
+            UpdatedUtc = now
+        };
+
+        _db.SponsoringUnits.Add(unit);
+        await _db.SaveChangesAsync();
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await _audit.LogAsync(
+            "Lookups.SponsoringUnitCreated",
+            new Dictionary<string, string?>
+            {
+                ["SponsoringUnitId"] = unit.Id.ToString(),
+                ["Name"] = unit.Name,
+                ["SortOrder"] = unit.SortOrder.ToString()
+            },
+            userId: userId,
+            userName: User.Identity?.Name);
+
+        TempData["StatusMessage"] = $"Created '{unit.Name}'.";
+        return RedirectToPage("./Index");
+    }
+
+    public sealed class InputModel
+    {
+        [Required]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Range(0, 1000)]
+        public int SortOrder { get; set; }
+    }
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml
@@ -1,0 +1,41 @@
+@page "{id:int}"
+@model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.DeactivateModel
+@{
+    var actionVerb = Model.Restore ? "Reactivate" : "Deactivate";
+    ViewData["Title"] = $"{actionVerb} Sponsoring Unit";
+}
+
+<h1 class="mb-4">@ViewData["Title"]</h1>
+
+<div class="col-lg-6">
+    <div class="alert alert-warning">
+        <p class="mb-2"><strong>@Model.Name</strong></p>
+        @if (Model.Restore)
+        {
+            <p class="mb-0">This unit will be available for selection once reactivated.</p>
+        }
+        else if (Model.ProjectCount > 0)
+        {
+            <p class="mb-0">This unit is referenced by <strong>@Model.ProjectCount</strong> project(s). Active assignments must be cleared before deactivation.</p>
+        }
+        else
+        {
+            <p class="mb-0">Deactivated units cannot be selected when creating or editing projects.</p>
+        }
+    </div>
+
+    <form method="post" class="d-flex gap-2">
+        <button type="submit" class="btn btn-@(Model.Restore ? "success" : "danger")">@actionVerb</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </form>
+</div>
+
+@if (!ModelState.IsValid)
+{
+    <div class="text-danger mt-3">
+        @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
+        {
+            <div>@error.ErrorMessage</div>
+        }
+    </div>
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits;
+
+[Authorize(Roles = "Admin")]
+public class DeactivateModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public DeactivateModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty(SupportsGet = true)]
+    public int Id { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public bool Restore { get; set; }
+
+    public string Name { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; }
+    public int ProjectCount { get; private set; }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var unit = await LoadAsync();
+        if (unit is null)
+        {
+            return NotFound();
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var unit = await _db.SponsoringUnits
+            .FirstOrDefaultAsync(u => u.Id == Id);
+
+        if (unit is null)
+        {
+            return NotFound();
+        }
+
+        ProjectCount = await _db.Projects.CountAsync(p => p.SponsoringUnitId == Id);
+
+        if (!Restore && ProjectCount > 0)
+        {
+            IsActive = unit.IsActive;
+            Name = unit.Name;
+            ModelState.AddModelError(string.Empty, "Cannot deactivate while the unit is assigned to existing projects.");
+            return Page();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (Restore)
+        {
+            if (!unit.IsActive)
+            {
+                unit.IsActive = true;
+                unit.UpdatedUtc = DateTime.UtcNow;
+                await _db.SaveChangesAsync();
+
+                await _audit.LogAsync(
+                    "Lookups.SponsoringUnitReactivated",
+                    new Dictionary<string, string?>
+                    {
+                        ["SponsoringUnitId"] = unit.Id.ToString(),
+                        ["Name"] = unit.Name
+                    },
+                    userId: userId,
+                    userName: User.Identity?.Name);
+            }
+
+            TempData["StatusMessage"] = $"Reactivated '{unit.Name}'.";
+        }
+        else
+        {
+            if (unit.IsActive)
+            {
+                unit.IsActive = false;
+                unit.UpdatedUtc = DateTime.UtcNow;
+                await _db.SaveChangesAsync();
+
+                await _audit.LogAsync(
+                    "Lookups.SponsoringUnitDeactivated",
+                    new Dictionary<string, string?>
+                    {
+                        ["SponsoringUnitId"] = unit.Id.ToString(),
+                        ["Name"] = unit.Name
+                    },
+                    userId: userId,
+                    userName: User.Identity?.Name);
+            }
+
+            TempData["StatusMessage"] = $"Deactivated '{unit.Name}'.";
+        }
+
+        return RedirectToPage("./Index");
+    }
+
+    private async Task<ProjectManagement.Models.SponsoringUnit?> LoadAsync()
+    {
+        var unit = await _db.SponsoringUnits
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == Id);
+
+        if (unit is null)
+        {
+            return null;
+        }
+
+        Name = unit.Name;
+        IsActive = unit.IsActive;
+        ProjectCount = await _db.Projects.CountAsync(p => p.SponsoringUnitId == Id);
+
+        return unit;
+    }
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml
@@ -1,0 +1,30 @@
+@page "{id:int}"
+@model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.EditModel
+@{
+    ViewData["Title"] = "Edit Sponsoring Unit";
+}
+
+<h1 class="mb-4">Edit Sponsoring Unit</h1>
+
+<form method="post" class="col-md-6">
+    <input asp-for="Input.Id" type="hidden" />
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Input.Name" class="form-label"></label>
+        <input asp-for="Input.Name" class="form-control" />
+        <span asp-validation-for="Input.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SortOrder" class="form-label"></label>
+        <input asp-for="Input.SortOrder" class="form-control" type="number" />
+        <span asp-validation-for="Input.SortOrder" class="text-danger"></span>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Save changes</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits;
+
+[Authorize(Roles = "Admin")]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+
+    public EditModel(ApplicationDbContext db, IAuditService audit)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var unit = await _db.SponsoringUnits.FindAsync(id);
+        if (unit is null)
+        {
+            return NotFound();
+        }
+
+        Input = new InputModel
+        {
+            Id = unit.Id,
+            Name = unit.Name,
+            SortOrder = unit.SortOrder
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var unit = await _db.SponsoringUnits.FindAsync(Input.Id);
+        if (unit is null)
+        {
+            return NotFound();
+        }
+
+        var trimmedName = Input.Name.Trim();
+
+        var duplicate = await _db.SponsoringUnits
+            .AnyAsync(u => u.Id != Input.Id && u.Name == trimmedName);
+
+        if (duplicate)
+        {
+            ModelState.AddModelError("Input.Name", "A sponsoring unit with this name already exists.");
+            return Page();
+        }
+
+        var originalName = unit.Name;
+        var originalSort = unit.SortOrder;
+
+        unit.Name = trimmedName;
+        unit.SortOrder = Input.SortOrder;
+        unit.UpdatedUtc = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await _audit.LogAsync(
+            "Lookups.SponsoringUnitUpdated",
+            new Dictionary<string, string?>
+            {
+                ["SponsoringUnitId"] = unit.Id.ToString(),
+                ["NameBefore"] = originalName,
+                ["NameAfter"] = unit.Name,
+                ["SortOrderBefore"] = originalSort.ToString(),
+                ["SortOrderAfter"] = unit.SortOrder.ToString()
+            },
+            userId: userId,
+            userName: User.Identity?.Name);
+
+        TempData["StatusMessage"] = $"Updated '{unit.Name}'.";
+        return RedirectToPage("./Index");
+    }
+
+    public sealed class InputModel
+    {
+        [HiddenInput]
+        public int Id { get; set; }
+
+        [Required]
+        [StringLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [Range(0, 1000)]
+        public int SortOrder { get; set; }
+    }
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
@@ -1,0 +1,100 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.IndexModel
+@{
+    ViewData["Title"] = "Sponsoring Units";
+}
+
+<h1 class="mb-4">Sponsoring Units</h1>
+
+@if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+{
+    <div class="alert alert-success">@Model.StatusMessage</div>
+}
+
+<div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+    <form method="get" class="row row-cols-lg-auto g-2 align-items-end">
+        <div class="col-12">
+            <label asp-for="Q" class="form-label">Search</label>
+            <input asp-for="Q" class="form-control" />
+        </div>
+        <div class="col-12">
+            <label class="form-label" for="status-filter">Status</label>
+            <select id="status-filter" name="status" class="form-select">
+                <option value="active" selected="@(string.Equals(Model.Status, "active", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Active</option>
+                <option value="inactive" selected="@(string.Equals(Model.Status, "inactive", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">Inactive</option>
+                <option value="all" selected="@(string.Equals(Model.Status, "all", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">All</option>
+            </select>
+        </div>
+        <input type="hidden" name="page" value="1" />
+        <div class="col-12">
+            <button type="submit" class="btn btn-outline-primary">Apply</button>
+        </div>
+    </form>
+    <a class="btn btn-primary" asp-page="./Create">Add sponsoring unit</a>
+</div>
+
+@if (!Model.Items.Any())
+{
+    <div class="alert alert-info">No sponsoring units found.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Sort Order</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Referenced</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var item in Model.Items)
+            {
+                <tr>
+                    <td>@item.Name</td>
+                    <td>@item.SortOrder</td>
+                    <td>
+                        @if (item.IsActive)
+                        {
+                            <span class="badge text-bg-success">Active</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary">Inactive</span>
+                        }
+                    </td>
+                    <td>@item.ProjectCount</td>
+                    <td class="text-end">
+                        <div class="btn-group">
+                            <a class="btn btn-sm btn-outline-secondary" asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
+                            @if (item.IsActive)
+                            {
+                                <a class="btn btn-sm btn-outline-danger" asp-page="./Deactivate" asp-route-id="@item.Id">Deactivate</a>
+                            }
+                            else
+                            {
+                                <a class="btn btn-sm btn-outline-success" asp-page="./Deactivate" asp-route-id="@item.Id" asp-route-restore="true">Reactivate</a>
+                            }
+                        </div>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+
+    <nav aria-label="Pagination" class="mt-3">
+        <ul class="pagination">
+            <li class="page-item @(Model.Page <= 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.Page - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+            </li>
+            <li class="page-item disabled"><span class="page-link">Page @Model.Page of @Model.TotalPages</span></li>
+            <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.Page + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+
+    public IndexModel(ApplicationDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    private const int PageSize = 20;
+
+    [BindProperty(SupportsGet = true)]
+    [Display(Name = "Search")]
+    public string? Q { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string Status { get; set; } = "active";
+
+    [BindProperty(SupportsGet = true)]
+    public int Page { get; set; } = 1;
+
+    public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
+
+    public int TotalCount { get; private set; }
+
+    public int TotalPages { get; private set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        var query = _db.SponsoringUnits
+            .AsNoTracking();
+
+        var statusFilter = (Status ?? "active").Trim().ToLowerInvariant();
+        query = statusFilter switch
+        {
+            "inactive" => query.Where(u => !u.IsActive),
+            "all" => query,
+            _ => query.Where(u => u.IsActive)
+        };
+
+        if (!string.IsNullOrWhiteSpace(Q))
+        {
+            var term = Q.Trim();
+            query = query.Where(u => EF.Functions.ILike(u.Name, $"%{term}%"));
+        }
+
+        query = query
+            .OrderBy(u => u.SortOrder)
+            .ThenBy(u => u.Name);
+
+        TotalCount = await query.CountAsync();
+        TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
+
+        if (Page < 1)
+        {
+            Page = 1;
+        }
+        else if (Page > TotalPages)
+        {
+            Page = TotalPages;
+        }
+
+        Items = await query
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .Select(u => new Row
+            {
+                Id = u.Id,
+                Name = u.Name,
+                SortOrder = u.SortOrder,
+                IsActive = u.IsActive,
+                ProjectCount = u.Projects.Count
+            })
+            .ToListAsync();
+    }
+
+    public sealed class Row
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public int SortOrder { get; init; }
+        public bool IsActive { get; init; }
+        public int ProjectCount { get; init; }
+    }
+}

--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -57,6 +57,19 @@
                         <div class="form-text">Appears when the category has active children.</div>
                     </div>
                 </div>
+                <div class="row g-3 mt-0">
+                    <div class="col-md-6">
+                        <label asp-for="Input.SponsoringUnitId" class="form-label">Sponsoring Unit</label>
+                        <select asp-for="Input.SponsoringUnitId" class="form-select js-async-select" asp-items="Model.SponsoringUnitOptions" data-source="/api/lookups/sponsoring-units" data-search-placeholder="Search sponsoring units"></select>
+                        <div class="form-text">Optional; can be set later.</div>
+                        <span asp-validation-for="Input.SponsoringUnitId" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.SponsoringLineDirectorateId" class="form-label">Sponsoring Line Dte</label>
+                        <select asp-for="Input.SponsoringLineDirectorateId" class="form-select js-async-select" asp-items="Model.LineDirectorateOptions" data-source="/api/lookups/line-directorates" data-search-placeholder="Search line directorates"></select>
+                        <span asp-validation-for="Input.SponsoringLineDirectorateId" class="text-danger"></span>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -108,5 +121,6 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/widgets/async-select.js" asp-append-version="true" defer></script>
     <script src="~/js/projects/create.js" asp-append-version="true"></script>
 }

--- a/Pages/Projects/Meta/Edit.cshtml
+++ b/Pages/Projects/Meta/Edit.cshtml
@@ -26,9 +26,24 @@
         <span asp-validation-for="Input.CategoryId" class="text-danger"></span>
     </div>
     <div class="mb-3">
+        <label asp-for="Input.SponsoringUnitId" class="form-label">Sponsoring Unit</label>
+        <select asp-for="Input.SponsoringUnitId" class="form-select js-async-select" asp-items="Model.SponsoringUnitOptions" data-source="/api/lookups/sponsoring-units" data-search-placeholder="Search sponsoring units"></select>
+        <span asp-validation-for="Input.SponsoringUnitId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SponsoringLineDirectorateId" class="form-label">Sponsoring Line Dte</label>
+        <select asp-for="Input.SponsoringLineDirectorateId" class="form-select js-async-select" asp-items="Model.LineDirectorateOptions" data-source="/api/lookups/line-directorates" data-search-placeholder="Search line directorates"></select>
+        <span asp-validation-for="Input.SponsoringLineDirectorateId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
         <label asp-for="Input.CaseFileNumber" class="form-label"></label>
         <input asp-for="Input.CaseFileNumber" class="form-control" />
         <span asp-validation-for="Input.CaseFileNumber" class="text-danger"></span>
     </div>
     <button type="submit" class="btn btn-primary">Save changes</button>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/widgets/async-select.js" asp-append-version="true" defer></script>
+}

--- a/Pages/Projects/Meta/Request.cshtml
+++ b/Pages/Projects/Meta/Request.cshtml
@@ -26,6 +26,16 @@
         <span asp-validation-for="Input.CategoryId" class="text-danger"></span>
     </div>
     <div class="mb-3">
+        <label asp-for="Input.SponsoringUnitId" class="form-label">Sponsoring Unit</label>
+        <select asp-for="Input.SponsoringUnitId" class="form-select js-async-select" asp-items="Model.SponsoringUnitOptions" data-source="/api/lookups/sponsoring-units" data-search-placeholder="Search sponsoring units"></select>
+        <span asp-validation-for="Input.SponsoringUnitId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.SponsoringLineDirectorateId" class="form-label">Sponsoring Line Dte</label>
+        <select asp-for="Input.SponsoringLineDirectorateId" class="form-select js-async-select" asp-items="Model.LineDirectorateOptions" data-source="/api/lookups/line-directorates" data-search-placeholder="Search line directorates"></select>
+        <span asp-validation-for="Input.SponsoringLineDirectorateId" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
         <label asp-for="Input.CaseFileNumber" class="form-label"></label>
         <input asp-for="Input.CaseFileNumber" class="form-control" />
         <span asp-validation-for="Input.CaseFileNumber" class="text-danger"></span>
@@ -38,3 +48,8 @@
     <button type="submit" class="btn btn-primary">Send request</button>
     <a asp-page="/Projects/Overview" asp-route-id="@Model.Input.ProjectId" class="btn btn-link">Cancel</a>
 </form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/widgets/async-select.js" asp-append-version="true" defer></script>
+}

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -203,6 +203,12 @@
                             }
                         </dd>
 
+                        <dt class="col-sm-4">Sponsoring Unit</dt>
+                        <dd class="col-sm-8">@(Model.Project?.SponsoringUnit?.Name ?? "—")</dd>
+
+                        <dt class="col-sm-4">Sponsoring Line Dte</dt>
+                        <dd class="col-sm-8">@(Model.Project?.SponsoringLineDirectorate?.Name ?? "—")</dd>
+
                         <dt class="col-sm-4">Head of Department</dt>
                         <dd class="col-sm-8">@DisplayUser(project?.HodUser)</dd>
 
@@ -339,6 +345,32 @@
                                     <div>
                                         <span class="fw-semibold">@metaRequest.Category.ProposedValue</span>
                                         @if (metaRequest.Category.HasChanged)
+                                        {
+                                            <span class="badge text-bg-warning ms-1">Changed</span>
+                                        }
+                                    </div>
+                                </div>
+                                <div>
+                                    <div class="fw-semibold">Sponsoring Unit</div>
+                                    <div class="text-muted small">Current</div>
+                                    <div>@metaRequest.SponsoringUnit.CurrentValue</div>
+                                    <div class="text-muted small mt-1">Proposed</div>
+                                    <div>
+                                        <span class="fw-semibold">@metaRequest.SponsoringUnit.ProposedValue</span>
+                                        @if (metaRequest.SponsoringUnit.HasChanged)
+                                        {
+                                            <span class="badge text-bg-warning ms-1">Changed</span>
+                                        }
+                                    </div>
+                                </div>
+                                <div>
+                                    <div class="fw-semibold">Sponsoring Line Dte</div>
+                                    <div class="text-muted small">Current</div>
+                                    <div>@metaRequest.SponsoringLineDirectorate.CurrentValue</div>
+                                    <div class="text-muted small mt-1">Proposed</div>
+                                    <div>
+                                        <span class="fw-semibold">@metaRequest.SponsoringLineDirectorate.ProposedValue</span>
+                                        @if (metaRequest.SponsoringLineDirectorate.HasChanged)
                                         {
                                             <span class="badge text-bg-warning ms-1">Changed</span>
                                         }

--- a/ViewModels/ProjectMetaChangeRequestVm.cs
+++ b/ViewModels/ProjectMetaChangeRequestVm.cs
@@ -35,6 +35,10 @@ public sealed class ProjectMetaChangeRequestVm
 
     public ProjectMetaChangeFieldVm Category { get; init; } = new("", "", false);
 
+    public ProjectMetaChangeFieldVm SponsoringUnit { get; init; } = new("", "", false);
+
+    public ProjectMetaChangeFieldVm SponsoringLineDirectorate { get; init; } = new("", "", false);
+
     public bool HasDrift { get; init; }
 
     public IReadOnlyList<ProjectMetaChangeDriftVm> Drift { get; init; } = Array.Empty<ProjectMetaChangeDriftVm>();

--- a/wwwroot/js/widgets/async-select.js
+++ b/wwwroot/js/widgets/async-select.js
@@ -1,0 +1,134 @@
+(function () {
+  const initialized = new WeakSet();
+
+  function buildSearch(select) {
+    if (!select || initialized.has(select)) {
+      return;
+    }
+
+    const source = select.dataset.source;
+    if (!source) {
+      return;
+    }
+
+    const cache = new Map();
+    Array.from(select.options).forEach((option) => {
+      if (option.value) {
+        cache.set(option.value, option.textContent ?? option.value);
+      }
+    });
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'async-select-wrapper';
+
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.className = 'form-control form-control-sm mb-2';
+    search.placeholder = select.getAttribute('data-search-placeholder') ?? 'Search…';
+    search.setAttribute('aria-label', 'Search options');
+
+    const parent = select.parentNode;
+    if (!parent) {
+      return;
+    }
+
+    parent.insertBefore(wrapper, select);
+    wrapper.appendChild(search);
+    wrapper.appendChild(select);
+
+    initialized.add(select);
+
+    let debounceHandle;
+    let lastQuery = '';
+
+    async function loadOptions(query) {
+      const trimmed = query.trim();
+      if (trimmed === lastQuery) {
+        return;
+      }
+      lastQuery = trimmed;
+
+      const params = new URLSearchParams();
+      if (trimmed.length > 0) {
+        params.set('q', trimmed);
+      }
+      params.set('page', '1');
+      params.set('pageSize', select.dataset.pageSize ?? '20');
+
+      let response;
+      try {
+        response = await fetch(`${source}?${params.toString()}`, { credentials: 'same-origin' });
+      } catch (err) {
+        return;
+      }
+
+      if (!response.ok) {
+        return;
+      }
+
+      let payload;
+      try {
+        payload = await response.json();
+      } catch (err) {
+        return;
+      }
+
+      if (!payload || !Array.isArray(payload.items)) {
+        return;
+      }
+
+      const currentValue = select.value;
+      const placeholder = Array.from(select.options).find((opt) => opt.value === '');
+      const fragment = document.createDocumentFragment();
+
+      if (placeholder) {
+        fragment.appendChild(new Option(placeholder.textContent ?? '— (none) —', ''));
+      } else {
+        fragment.appendChild(new Option('— (none) —', ''));
+      }
+
+      const values = new Set();
+      for (const item of payload.items) {
+        if (item && Object.prototype.hasOwnProperty.call(item, 'id') && Object.prototype.hasOwnProperty.call(item, 'name')) {
+          const value = String(item.id);
+          const text = String(item.name);
+          cache.set(value, text);
+          values.add(value);
+          fragment.appendChild(new Option(text, value));
+        }
+      }
+
+      if (currentValue && !values.has(currentValue)) {
+        const knownText = cache.get(currentValue) ?? currentValue;
+        fragment.appendChild(new Option(knownText, currentValue));
+      }
+
+      select.innerHTML = '';
+      select.appendChild(fragment);
+      select.value = currentValue;
+    }
+
+    function handleInput(event) {
+      const value = event.target.value;
+      if (debounceHandle) {
+        clearTimeout(debounceHandle);
+      }
+      debounceHandle = window.setTimeout(() => {
+        loadOptions(value);
+      }, 250);
+    }
+
+    search.addEventListener('input', handleInput);
+
+    select.addEventListener('focus', () => {
+      if (!select.dataset.asyncSelectBootstrapped) {
+        loadOptions('');
+        select.dataset.asyncSelectBootstrapped = '1';
+      }
+    }, { once: true });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('select.js-async-select').forEach(buildSearch);
+  });
+})();


### PR DESCRIPTION
## Summary
- expose sponsoring unit and line directorate selectors across project create, direct edit, request, and overview flows with validation and diff support
- add authenticated lookup APIs with a reusable async-select widget to progressively enhance dropdowns
- provide admin Razor Pages to create, edit, list, and deactivate sponsoring units and line directorates with audit logging

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0f8ea3348329bd084c08fe4ac090