### PR TITLE
Fix audit logging and pagination issues in lookup pages

### DIFF
--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml.cs
@@ -63,14 +63,14 @@ public class CreateModel : PageModel
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         await _audit.LogAsync(
             "Lookups.LineDirectorateCreated",
-            new Dictionary<string, string?>
+            userId: userId,
+            userName: User.Identity?.Name,
+            data: new Dictionary<string, string?>
             {
                 ["LineDirectorateId"] = entity.Id.ToString(),
                 ["Name"] = entity.Name,
                 ["SortOrder"] = entity.SortOrder.ToString()
-            },
-            userId: userId,
-            userName: User.Identity?.Name);
+            });
 
         TempData["StatusMessage"] = $"Created '{entity.Name}'.";
         return RedirectToPage("./Index");

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml.cs
@@ -74,13 +74,13 @@ public class DeactivateModel : PageModel
 
                 await _audit.LogAsync(
                     "Lookups.LineDirectorateReactivated",
-                    new Dictionary<string, string?>
+                    userId: userId,
+                    userName: User.Identity?.Name,
+                    data: new Dictionary<string, string?>
                     {
                         ["LineDirectorateId"] = entity.Id.ToString(),
                         ["Name"] = entity.Name
-                    },
-                    userId: userId,
-                    userName: User.Identity?.Name);
+                    });
             }
 
             TempData["StatusMessage"] = $"Reactivated '{entity.Name}'.";
@@ -95,13 +95,13 @@ public class DeactivateModel : PageModel
 
                 await _audit.LogAsync(
                     "Lookups.LineDirectorateDeactivated",
-                    new Dictionary<string, string?>
+                    userId: userId,
+                    userName: User.Identity?.Name,
+                    data: new Dictionary<string, string?>
                     {
                         ["LineDirectorateId"] = entity.Id.ToString(),
                         ["Name"] = entity.Name
-                    },
-                    userId: userId,
-                    userName: User.Identity?.Name);
+                    });
             }
 
             TempData["StatusMessage"] = $"Deactivated '{entity.Name}'.";

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml.cs
@@ -80,16 +80,16 @@ public class EditModel : PageModel
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         await _audit.LogAsync(
             "Lookups.LineDirectorateUpdated",
-            new Dictionary<string, string?>
+            userId: userId,
+            userName: User.Identity?.Name,
+            data: new Dictionary<string, string?>
             {
                 ["LineDirectorateId"] = entity.Id.ToString(),
                 ["NameBefore"] = originalName,
                 ["NameAfter"] = entity.Name,
                 ["SortOrderBefore"] = originalSortOrder.ToString(),
                 ["SortOrderAfter"] = entity.SortOrder.ToString()
-            },
-            userId: userId,
-            userName: User.Identity?.Name);
+            });
 
         TempData["StatusMessage"] = $"Updated '{entity.Name}'.";
         return RedirectToPage("./Index");

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
@@ -88,12 +88,12 @@ else
 
     <nav aria-label="Pagination" class="mt-3">
         <ul class="pagination">
-            <li class="page-item @(Model.Page <= 1 ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.Page - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
             </li>
-            <li class="page-item disabled"><span class="page-link">Page @Model.Page of @Model.TotalPages</span></li>
-            <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.Page + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+            <li class="page-item disabled"><span class="page-link">Page @Model.PageNumber of @Model.TotalPages</span></li>
+            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
             </li>
         </ul>
     </nav>

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
@@ -30,8 +30,8 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string Status { get; set; } = "active";
 
-    [BindProperty(SupportsGet = true)]
-    public int Page { get; set; } = 1;
+    [BindProperty(SupportsGet = true, Name = "page")]
+    public int PageNumber { get; set; } = 1;
 
     public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
 
@@ -67,17 +67,17 @@ public class IndexModel : PageModel
         TotalCount = await query.CountAsync();
         TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
 
-        if (Page < 1)
+        if (PageNumber < 1)
         {
-            Page = 1;
+            PageNumber = 1;
         }
-        else if (Page > TotalPages)
+        else if (PageNumber > TotalPages)
         {
-            Page = TotalPages;
+            PageNumber = TotalPages;
         }
 
         Items = await query
-            .Skip((Page - 1) * PageSize)
+            .Skip((PageNumber - 1) * PageSize)
             .Take(PageSize)
             .Select(l => new Row
             {

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml.cs
@@ -68,14 +68,14 @@ public class CreateModel : PageModel
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         await _audit.LogAsync(
             "Lookups.SponsoringUnitCreated",
-            new Dictionary<string, string?>
+            userId: userId,
+            userName: User.Identity?.Name,
+            data: new Dictionary<string, string?>
             {
                 ["SponsoringUnitId"] = unit.Id.ToString(),
                 ["Name"] = unit.Name,
                 ["SortOrder"] = unit.SortOrder.ToString()
-            },
-            userId: userId,
-            userName: User.Identity?.Name);
+            });
 
         TempData["StatusMessage"] = $"Created '{unit.Name}'.";
         return RedirectToPage("./Index");

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml.cs
@@ -75,13 +75,13 @@ public class DeactivateModel : PageModel
 
                 await _audit.LogAsync(
                     "Lookups.SponsoringUnitReactivated",
-                    new Dictionary<string, string?>
+                    userId: userId,
+                    userName: User.Identity?.Name,
+                    data: new Dictionary<string, string?>
                     {
                         ["SponsoringUnitId"] = unit.Id.ToString(),
                         ["Name"] = unit.Name
-                    },
-                    userId: userId,
-                    userName: User.Identity?.Name);
+                    });
             }
 
             TempData["StatusMessage"] = $"Reactivated '{unit.Name}'.";
@@ -96,13 +96,13 @@ public class DeactivateModel : PageModel
 
                 await _audit.LogAsync(
                     "Lookups.SponsoringUnitDeactivated",
-                    new Dictionary<string, string?>
+                    userId: userId,
+                    userName: User.Identity?.Name,
+                    data: new Dictionary<string, string?>
                     {
                         ["SponsoringUnitId"] = unit.Id.ToString(),
                         ["Name"] = unit.Name
-                    },
-                    userId: userId,
-                    userName: User.Identity?.Name);
+                    });
             }
 
             TempData["StatusMessage"] = $"Deactivated '{unit.Name}'.";

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml.cs
@@ -84,16 +84,16 @@ public class EditModel : PageModel
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         await _audit.LogAsync(
             "Lookups.SponsoringUnitUpdated",
-            new Dictionary<string, string?>
+            userId: userId,
+            userName: User.Identity?.Name,
+            data: new Dictionary<string, string?>
             {
                 ["SponsoringUnitId"] = unit.Id.ToString(),
                 ["NameBefore"] = originalName,
                 ["NameAfter"] = unit.Name,
                 ["SortOrderBefore"] = originalSort.ToString(),
                 ["SortOrderAfter"] = unit.SortOrder.ToString()
-            },
-            userId: userId,
-            userName: User.Identity?.Name);
+            });
 
         TempData["StatusMessage"] = $"Updated '{unit.Name}'.";
         return RedirectToPage("./Index");

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
@@ -88,12 +88,12 @@ else
 
     <nav aria-label="Pagination" class="mt-3">
         <ul class="pagination">
-            <li class="page-item @(Model.Page <= 1 ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.Page - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
             </li>
-            <li class="page-item disabled"><span class="page-link">Page @Model.Page of @Model.TotalPages</span></li>
-            <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.Page + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+            <li class="page-item disabled"><span class="page-link">Page @Model.PageNumber of @Model.TotalPages</span></li>
+            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-route-page="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
             </li>
         </ul>
     </nav>

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
@@ -30,8 +30,8 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string Status { get; set; } = "active";
 
-    [BindProperty(SupportsGet = true)]
-    public int Page { get; set; } = 1;
+    [BindProperty(SupportsGet = true, Name = "page")]
+    public int PageNumber { get; set; } = 1;
 
     public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
 
@@ -68,17 +68,17 @@ public class IndexModel : PageModel
         TotalCount = await query.CountAsync();
         TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
 
-        if (Page < 1)
+        if (PageNumber < 1)
         {
-            Page = 1;
+            PageNumber = 1;
         }
-        else if (Page > TotalPages)
+        else if (PageNumber > TotalPages)
         {
-            Page = TotalPages;
+            PageNumber = TotalPages;
         }
 
         Items = await query
-            .Skip((Page - 1) * PageSize)
+            .Skip((PageNumber - 1) * PageSize)
             .Take(PageSize)
             .Select(u => new Row
             {


### PR DESCRIPTION
## Summary
- update admin lookup audit logging calls to pass structured data via the named parameter expected by IAuditService
- rename the Razor Page paging property to PageNumber to avoid conflicts with PageModel.Page and update the corresponding views

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1b4cbaec83298ac9eac21447589a