### PR TITLE
Add admin dashboard links for sponsoring lookups

### DIFF
--- a/Areas/Admin/Pages/Index.cshtml
+++ b/Areas/Admin/Pages/Index.cshtml
@@ -98,6 +98,16 @@
         <a asp-area="Admin" asp-page="/Categories/Index" class="btn btn-sm btn-outline-primary">Open category manager</a>
       </div>
     </div>
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h5 class="card-title h6 mb-2">Sponsoring lookups</h5>
+        <p class="card-text small text-muted">Manage sponsoring units and line directorates available to project teams.</p>
+        <div class="d-flex flex-wrap gap-2">
+          <a asp-area="Admin" asp-page="/Lookups/SponsoringUnits/Index" class="btn btn-sm btn-outline-primary">Manage sponsoring units</a>
+          <a asp-area="Admin" asp-page="/Lookups/LineDirectorates/Index" class="btn btn-sm btn-outline-primary">Manage line directorates</a>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="col-lg-4">
     <div class="card shadow-sm">


### PR DESCRIPTION
## Summary
- add a new dashboard card that links to sponsoring unit and line directorate lookup screens
- keep the new actions alongside the existing project category management section

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc24f9d2588329a833b854e9ce7154