### PR TITLE
Fix admin lookup paging parameter name

### DIFF
--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
@@ -25,7 +25,7 @@
                 <option value="all" selected="@(string.Equals(Model.Status, "all", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">All</option>
             </select>
         </div>
-        <input type="hidden" name="page" value="1" />
+        <input type="hidden" name="pageNumber" value="1" />
         <div class="col-12">
             <button type="submit" class="btn btn-outline-primary">Apply</button>
         </div>
@@ -73,7 +73,7 @@ else
                                 <form method="post" asp-page-handler="Move" asp-route-id="@item.Id" asp-route-offset="-1" class="d-inline">
                                     <input type="hidden" name="q" value="@Model.Q" />
                                     <input type="hidden" name="status" value="@Model.Status" />
-                                    <input type="hidden" name="page" value="@Model.PageNumber" />
+                                    <input type="hidden" name="pageNumber" value="@Model.PageNumber" />
                                     <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move up">
                                         <span aria-hidden="true">↑</span>
                                         <span class="visually-hidden">Move @item.Name up</span>
@@ -82,7 +82,7 @@ else
                                 <form method="post" asp-page-handler="Move" asp-route-id="@item.Id" asp-route-offset="1" class="d-inline">
                                     <input type="hidden" name="q" value="@Model.Q" />
                                     <input type="hidden" name="status" value="@Model.Status" />
-                                    <input type="hidden" name="page" value="@Model.PageNumber" />
+                                    <input type="hidden" name="pageNumber" value="@Model.PageNumber" />
                                     <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move down">
                                         <span aria-hidden="true">↓</span>
                                         <span class="visually-hidden">Move @item.Name down</span>
@@ -111,11 +111,11 @@ else
     <nav aria-label="Pagination" class="mt-3">
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+                <a class="page-link" asp-route-pageNumber="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
             </li>
             <li class="page-item disabled"><span class="page-link">Page @Model.PageNumber of @Model.TotalPages</span></li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+                <a class="page-link" asp-route-pageNumber="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
             </li>
         </ul>
     </nav>

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml.cs
@@ -30,7 +30,7 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string Status { get; set; } = "active";
 
-    [BindProperty(SupportsGet = true, Name = "page")]
+    [BindProperty(SupportsGet = true, Name = "pageNumber")]
     public int PageNumber { get; set; } = 1;
 
     public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
@@ -95,7 +95,7 @@ public class IndexModel : PageModel
         if (offset == 0)
         {
             StatusMessage = "No changes made.";
-            return RedirectToPage(new { q = Q, status = Status, page = PageNumber });
+            return RedirectToPage(new { q = Q, status = Status, pageNumber = PageNumber });
         }
 
         var lineDirectorate = await _db.LineDirectorates.SingleOrDefaultAsync(l => l.Id == id);
@@ -113,7 +113,7 @@ public class IndexModel : PageModel
         if (index < 0)
         {
             StatusMessage = "Unable to reorder line directorates.";
-            return RedirectToPage(new { q = Q, status = Status, page = PageNumber });
+            return RedirectToPage(new { q = Q, status = Status, pageNumber = PageNumber });
         }
 
         var targetIndex = Math.Clamp(index + offset, 0, siblings.Count - 1);
@@ -122,7 +122,7 @@ public class IndexModel : PageModel
             StatusMessage = offset < 0
                 ? $"'{lineDirectorate.Name}' is already at the top."
                 : $"'{lineDirectorate.Name}' is already at the bottom.";
-            return RedirectToPage(new { q = Q, status = Status, page = PageNumber });
+            return RedirectToPage(new { q = Q, status = Status, pageNumber = PageNumber });
         }
 
         var moving = siblings[index];
@@ -143,7 +143,7 @@ public class IndexModel : PageModel
             ? $"Moved '{lineDirectorate.Name}' up."
             : $"Moved '{lineDirectorate.Name}' down.";
 
-        return RedirectToPage(new { q = Q, status = Status, page = PageNumber });
+        return RedirectToPage(new { q = Q, status = Status, pageNumber = PageNumber });
     }
 
     public sealed class Row

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
@@ -25,7 +25,7 @@
                 <option value="all" selected="@(string.Equals(Model.Status, "all", StringComparison.OrdinalIgnoreCase) ? "selected" : null)">All</option>
             </select>
         </div>
-        <input type="hidden" name="page" value="1" />
+        <input type="hidden" name="pageNumber" value="1" />
         <div class="col-12">
             <button type="submit" class="btn btn-outline-primary">Apply</button>
         </div>
@@ -81,7 +81,7 @@ else
                             <form method="post" asp-page-handler="Move" class="d-inline">
                                 <input type="hidden" name="id" value="@item.Id" />
                                 <input type="hidden" name="offset" value="-1" />
-                                <input type="hidden" name="page" value="@Model.PageNumber" />
+                                <input type="hidden" name="pageNumber" value="@Model.PageNumber" />
                                 <input type="hidden" name="q" value="@Model.Q" />
                                 <input type="hidden" name="status" value="@Model.Status" />
                                 <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move up">↑</button>
@@ -89,7 +89,7 @@ else
                             <form method="post" asp-page-handler="Move" class="d-inline">
                                 <input type="hidden" name="id" value="@item.Id" />
                                 <input type="hidden" name="offset" value="1" />
-                                <input type="hidden" name="page" value="@Model.PageNumber" />
+                                <input type="hidden" name="pageNumber" value="@Model.PageNumber" />
                                 <input type="hidden" name="q" value="@Model.Q" />
                                 <input type="hidden" name="status" value="@Model.Status" />
                                 <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move down">↓</button>
@@ -105,11 +105,11 @@ else
     <nav aria-label="Pagination" class="mt-3">
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
+                <a class="page-link" asp-route-pageNumber="@(Model.PageNumber - 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Previous</a>
             </li>
             <li class="page-item disabled"><span class="page-link">Page @Model.PageNumber of @Model.TotalPages</span></li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : string.Empty)">
-                <a class="page-link" asp-route-page="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
+                <a class="page-link" asp-route-pageNumber="@(Model.PageNumber + 1)" asp-route-q="@Model.Q" asp-route-status="@Model.Status">Next</a>
             </li>
         </ul>
     </nav>

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml.cs
@@ -30,7 +30,7 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string Status { get; set; } = "active";
 
-    [BindProperty(SupportsGet = true, Name = "page")]
+    [BindProperty(SupportsGet = true, Name = "pageNumber")]
     public int PageNumber { get; set; } = 1;
 
     public IReadOnlyList<Row> Items { get; private set; } = Array.Empty<Row>();
@@ -96,7 +96,7 @@ public class IndexModel : PageModel
         if (offset == 0)
         {
             StatusMessage = "No changes made.";
-            return RedirectToPage(new { page = Math.Max(1, PageNumber), q = Q, status = Status });
+            return RedirectToPage(new { pageNumber = Math.Max(1, PageNumber), q = Q, status = Status });
         }
 
         var units = await _db.SponsoringUnits
@@ -114,7 +114,7 @@ public class IndexModel : PageModel
         if (targetIndex == currentIndex)
         {
             StatusMessage = offset < 0 ? "Already at the top." : "Already at the bottom.";
-            return RedirectToPage(new { page = Math.Max(1, PageNumber), q = Q, status = Status });
+            return RedirectToPage(new { pageNumber = Math.Max(1, PageNumber), q = Q, status = Status });
         }
 
         var unit = units[currentIndex];
@@ -144,7 +144,7 @@ public class IndexModel : PageModel
             StatusMessage = "No changes made.";
         }
 
-        return RedirectToPage(new { page = Math.Max(1, PageNumber), q = Q, status = Status });
+        return RedirectToPage(new { pageNumber = Math.Max(1, PageNumber), q = Q, status = Status });
     }
 
     public sealed class Row


### PR DESCRIPTION
## Summary
- rename the admin lookup pagination query parameter to pageNumber to avoid using the reserved `page` key
- update Razor pages and handlers to persist the renamed parameter during filtering, pagination, and reorder redirects

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d552bd48329aac78f5a73371634