### PR TITLE
Add breadcrumbs to lookup management pages

### DIFF
--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Create.cshtml
@@ -1,9 +1,16 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.CreateModel
-@{
+@{ 
     ViewData["Title"] = "Add Line Directorate";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/LineDirectorates/Index">Line Directorates</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Add</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Add Line Directorate</h1>
 
 <form method="post" class="col-md-6">

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Deactivate.cshtml
@@ -1,10 +1,17 @@
 @page "{id:int}"
 @model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.DeactivateModel
-@{
+@{ 
     var actionVerb = Model.Restore ? "Reactivate" : "Deactivate";
     ViewData["Title"] = $"{actionVerb} Line Directorate";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/LineDirectorates/Index">Line Directorates</a></li>
+    <li class="breadcrumb-item active" aria-current="page">@actionVerb</li>
+  </ol>
+</nav>
 <h1 class="mb-4">@ViewData["Title"]</h1>
 
 <div class="col-lg-6">

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Edit.cshtml
@@ -1,9 +1,16 @@
 @page "{id:int}"
 @model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.EditModel
-@{
+@{ 
     ViewData["Title"] = "Edit Line Directorate";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/LineDirectorates/Index">Line Directorates</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Edit</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Edit Line Directorate</h1>
 
 <form method="post" class="col-md-6">

--- a/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/LineDirectorates/Index.cshtml
@@ -1,9 +1,15 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Lookups.LineDirectorates.IndexModel
-@{
+@{ 
     ViewData["Title"] = "Sponsoring Line Directorates";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Line Directorates</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Sponsoring Line Directorates</h1>
 
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Create.cshtml
@@ -1,9 +1,16 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.CreateModel
-@{
+@{ 
     ViewData["Title"] = "Add Sponsoring Unit";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/SponsoringUnits/Index">Sponsoring Units</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Add</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Add Sponsoring Unit</h1>
 
 <form method="post" class="col-md-6">

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Deactivate.cshtml
@@ -1,10 +1,17 @@
 @page "{id:int}"
 @model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.DeactivateModel
-@{
+@{ 
     var actionVerb = Model.Restore ? "Reactivate" : "Deactivate";
     ViewData["Title"] = $"{actionVerb} Sponsoring Unit";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/SponsoringUnits/Index">Sponsoring Units</a></li>
+    <li class="breadcrumb-item active" aria-current="page">@actionVerb</li>
+  </ol>
+</nav>
 <h1 class="mb-4">@ViewData["Title"]</h1>
 
 <div class="col-lg-6">

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Edit.cshtml
@@ -1,9 +1,16 @@
 @page "{id:int}"
 @model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.EditModel
-@{
+@{ 
     ViewData["Title"] = "Edit Sponsoring Unit";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Lookups/SponsoringUnits/Index">Sponsoring Units</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Edit</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Edit Sponsoring Unit</h1>
 
 <form method="post" class="col-md-6">

--- a/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
+++ b/Areas/Admin/Pages/Lookups/SponsoringUnits/Index.cshtml
@@ -1,9 +1,15 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Lookups.SponsoringUnits.IndexModel
-@{
+@{ 
     ViewData["Title"] = "Sponsoring Units";
 }
 
+<nav aria-label="breadcrumb" class="mb-2">
+  <ol class="breadcrumb small mb-0">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Sponsoring Units</li>
+  </ol>
+</nav>
 <h1 class="mb-4">Sponsoring Units</h1>
 
 @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the sponsoring unit lookup pages
- add breadcrumb navigation to the line directorate lookup pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc333baa608329aa84da33e000855a