### PR TITLE
Add project photo entity and cover photo tracking

### DIFF
--- a/Migrations/20250930203136_AddProjectPhotos.Designer.cs
+++ b/Migrations/20250930203136_AddProjectPhotos.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250930203136_AddProjectPhotos")]
+    partial class AddProjectPhotos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250930203136_AddProjectPhotos.cs
+++ b/Migrations/20250930203136_AddProjectPhotos.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectPhotos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CoverPhotoId",
+                table: "Projects",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CoverPhotoVersion",
+                table: "Projects",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.Sql("UPDATE \"Projects\" SET \"CoverPhotoVersion\" = 1 WHERE \"CoverPhotoVersion\" IS NULL OR \"CoverPhotoVersion\" = 0;");
+
+            migrationBuilder.CreateTable(
+                name: "ProjectPhotos",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    StorageKey = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    OriginalFileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Width = table.Column<int>(type: "integer", nullable: false),
+                    Height = table.Column<int>(type: "integer", nullable: false),
+                    Ordinal = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    Caption = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    IsCover = table.Column<bool>(type: "boolean", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    UpdatedUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: false, defaultValueSql: "now() at time zone 'utc'")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectPhotos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectPhotos_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.Sql("UPDATE \"ProjectPhotos\" SET \"Ordinal\" = 1 WHERE \"Ordinal\" = 0;");
+            migrationBuilder.Sql("UPDATE \"ProjectPhotos\" SET \"Version\" = 1 WHERE \"Version\" = 0;");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_CoverPhotoId",
+                table: "Projects",
+                column: "CoverPhotoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPhotos_ProjectId_Ordinal",
+                table: "ProjectPhotos",
+                columns: new[] { "ProjectId", "Ordinal" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_ProjectPhotos_Cover",
+                table: "ProjectPhotos",
+                column: "ProjectId",
+                unique: true,
+                filter: "\"IsCover\" = TRUE");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_ProjectPhotos_CoverPhotoId",
+                table: "Projects",
+                column: "CoverPhotoId",
+                principalTable: "ProjectPhotos",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_ProjectPhotos_CoverPhotoId",
+                table: "Projects");
+
+            migrationBuilder.DropTable(
+                name: "ProjectPhotos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_CoverPhotoId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "CoverPhotoId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "CoverPhotoVersion",
+                table: "Projects");
+        }
+    }
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using ProjectManagement.Models.Execution;
 
 namespace ProjectManagement.Models
@@ -52,6 +53,7 @@ namespace ProjectManagement.Models
         public ApplicationUser? PlanApprovedByUser { get; set; }
 
         private ICollection<ProjectStage> _projectStages = new List<ProjectStage>();
+        private ICollection<ProjectPhoto> _photos = new List<ProjectPhoto>();
 
         public ICollection<ProjectStage> ProjectStages
         {
@@ -66,5 +68,23 @@ namespace ProjectManagement.Models
             get => ProjectStages;
             set => ProjectStages = value;
         }
+
+        public ICollection<ProjectPhoto> Photos
+        {
+            get => _photos;
+            set => _photos = value ?? new List<ProjectPhoto>();
+        }
+
+        public int? CoverPhotoId { get; set; }
+
+        public int CoverPhotoVersion { get; set; } = 1;
+
+        [NotMapped]
+        public ProjectPhoto? CoverPhoto => CoverPhotoId.HasValue
+            ? Photos.FirstOrDefault(p => p.Id == CoverPhotoId.Value)
+            : null;
+
+        [NotMapped]
+        public int? CurrentCoverPhotoVersion => CoverPhoto?.Version ?? (CoverPhotoId.HasValue ? CoverPhotoVersion : null);
     }
 }

--- a/Models/ProjectPhoto.cs
+++ b/Models/ProjectPhoto.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models
+{
+    public class ProjectPhoto
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int ProjectId { get; set; }
+
+        public Project Project { get; set; } = null!;
+
+        [Required]
+        [MaxLength(260)]
+        public string StorageKey { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(260)]
+        public string OriginalFileName { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(128)]
+        public string ContentType { get; set; } = string.Empty;
+
+        public int Width { get; set; }
+
+        public int Height { get; set; }
+
+        public int Ordinal { get; set; }
+
+        [MaxLength(512)]
+        public string? Caption { get; set; }
+
+        public bool IsCover { get; set; }
+
+        public int Version { get; set; } = 1;
+
+        public DateTime CreatedUtc { get; set; }
+
+        public DateTime UpdatedUtc { get; set; }
+    }
+}

--- a/Pages/Projects/Create.cshtml.cs
+++ b/Pages/Projects/Create.cshtml.cs
@@ -171,7 +171,8 @@ namespace ProjectManagement.Pages.Projects
                 SponsoringUnitId = Input.SponsoringUnitId,
                 SponsoringLineDirectorateId = Input.SponsoringLineDirectorateId,
                 CreatedByUserId = currentUserId,
-                CreatedAt = _clock.UtcNow.UtcDateTime
+                CreatedAt = _clock.UtcNow.UtcDateTime,
+                CoverPhotoVersion = 1
             };
 
             _db.Projects.Add(project);

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -74,6 +74,7 @@ namespace ProjectManagement.Pages.Projects
                 .Include(p => p.PlanApprovedByUser)
                 .Include(p => p.SponsoringUnit)
                 .Include(p => p.SponsoringLineDirectorate)
+                .Include(p => p.Photos)
                 .FirstOrDefaultAsync(p => p.Id == id, ct);
 
             if (project is null)


### PR DESCRIPTION
## Summary
- add a ProjectPhoto aggregate with navigation to Project and cover metadata
- extend Project and the DbContext to track cover photo identifiers, enforce ordering uniqueness, and cascade deletes
- introduce a migration creating the ProjectPhotos table, wiring cover columns on Projects, and ensure new projects initialise cover version

## Testing
- dotnet build
- dotnet test *(fails: existing tests expect a relational provider and MVC services that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3ced63f483298d37a92ca1d5e5ef