### PR TITLE
Add Razor pages for project photo management

### DIFF
--- a/Pages/Projects/Photos/Edit.cshtml
+++ b/Pages/Projects/Photos/Edit.cshtml
@@ -1,0 +1,66 @@
+@page "/Projects/{id:int}/Photos/{photoId:int}/Edit"
+@model ProjectManagement.Pages.Projects.Photos.EditModel
+@{
+    ViewData["Title"] = "Edit Project Photo";
+}
+
+<h1 class="mb-4">Edit Project Photo</h1>
+
+<div class="mb-4">
+    <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = Model.Photo.Id, size = "md" })" alt="Current project photo" class="img-fluid rounded" style="max-width: 320px;" />
+</div>
+
+<form method="post" enctype="multipart/form-data">
+    <input asp-for="Input.ProjectId" type="hidden" />
+    <input asp-for="Input.PhotoId" type="hidden" />
+    <input asp-for="Input.RowVersion" type="hidden" />
+
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+    <div class="mb-3">
+        <label asp-for="Input.File" class="form-label">Replace image (optional)</label>
+        <input asp-for="Input.File" class="form-control" type="file" accept="image/*" />
+        <span asp-validation-for="Input.File" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Input.Caption" class="form-label">Caption</label>
+        <textarea asp-for="Input.Caption" class="form-control" rows="3"></textarea>
+        <span asp-validation-for="Input.Caption" class="text-danger"></span>
+    </div>
+
+    <div class="form-check mb-3">
+        <input asp-for="Input.SetAsCover" class="form-check-input" />
+        <label asp-for="Input.SetAsCover" class="form-check-label">Set as cover photo</label>
+    </div>
+
+    <fieldset class="border rounded p-3 mb-3">
+        <legend class="float-none w-auto fs-6 px-2">Crop (optional)</legend>
+        <div class="row g-3">
+            <div class="col-md-3">
+                <label asp-for="Input.CropX" class="form-label">X</label>
+                <input asp-for="Input.CropX" class="form-control" type="number" />
+                <span asp-validation-for="Input.CropX" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropY" class="form-label">Y</label>
+                <input asp-for="Input.CropY" class="form-control" type="number" />
+                <span asp-validation-for="Input.CropY" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropWidth" class="form-label">Width</label>
+                <input asp-for="Input.CropWidth" class="form-control" type="number" min="1" />
+                <span asp-validation-for="Input.CropWidth" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropHeight" class="form-label">Height</label>
+                <input asp-for="Input.CropHeight" class="form-control" type="number" min="1" />
+                <span asp-validation-for="Input.CropHeight" class="text-danger"></span>
+            </div>
+        </div>
+        <p class="text-muted mt-3 mb-0">Provide crop values to reframe the existing image or apply to the replacement.</p>
+    </fieldset>
+
+    <button type="submit" class="btn btn-primary">Save changes</button>
+    <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
+</form>

--- a/Pages/Projects/Photos/Edit.cshtml.cs
+++ b/Pages/Projects/Photos/Edit.cshtml.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Pages.Projects.Photos;
+
+[Authorize(Roles = "Admin,Project Officer,HoD")]
+[AutoValidateAntiforgeryToken]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IProjectPhotoService _photoService;
+    private readonly ILogger<EditModel> _logger;
+
+    public EditModel(ApplicationDbContext db,
+                     IUserContext userContext,
+                     IProjectPhotoService photoService,
+                     ILogger<EditModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _photoService = photoService ?? throw new ArgumentNullException(nameof(photoService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public EditInput Input { get; set; } = new();
+
+    public Project Project { get; private set; } = null!;
+
+    public ProjectPhoto Photo { get; private set; } = null!;
+
+    public async Task<IActionResult> OnGetAsync(int id, int photoId, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        var photo = project.Photos.SingleOrDefault(p => p.Id == photoId);
+        if (photo is null)
+        {
+            return NotFound();
+        }
+
+        Project = project;
+        Photo = photo;
+        Input = new EditInput
+        {
+            ProjectId = project.Id,
+            PhotoId = photo.Id,
+            RowVersion = Convert.ToBase64String(project.RowVersion),
+            Caption = photo.Caption,
+            SetAsCover = photo.IsCover
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, int photoId, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId || photoId != Input.PhotoId)
+        {
+            return BadRequest();
+        }
+
+        byte[]? rowVersionBytes = ParseRowVersion(Input.RowVersion);
+        if (rowVersionBytes is null)
+        {
+            ModelState.AddModelError(string.Empty, "The form has expired. Please reload and try again.");
+        }
+
+        var crop = BuildCrop(Input);
+        if (crop is null && HasPartialCrop(Input))
+        {
+            ModelState.AddModelError(string.Empty, "Crop requires X, Y, Width, and Height values.");
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        if (rowVersionBytes is not null && !project.RowVersion.SequenceEqual(rowVersionBytes))
+        {
+            ModelState.AddModelError(string.Empty, "The project was updated by someone else. Please reload and try again.");
+        }
+
+        var photo = project.Photos.SingleOrDefault(p => p.Id == photoId);
+        if (photo is null)
+        {
+            return NotFound();
+        }
+
+        Project = project;
+        Photo = photo;
+        Input.RowVersion = Convert.ToBase64String(project.RowVersion);
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var hasChanges = false;
+
+        try
+        {
+            if (Input.File is not null && Input.File.Length > 0)
+            {
+                await using var stream = Input.File.OpenReadStream();
+                if (crop.HasValue)
+                {
+                    var replaced = await _photoService.ReplaceAsync(project.Id,
+                        photo.Id,
+                        stream,
+                        Input.File.FileName,
+                        Input.File.ContentType,
+                        userId,
+                        crop.Value,
+                        cancellationToken);
+                    hasChanges = hasChanges || replaced is not null;
+                }
+                else
+                {
+                    var replaced = await _photoService.ReplaceAsync(project.Id,
+                        photo.Id,
+                        stream,
+                        Input.File.FileName,
+                        Input.File.ContentType,
+                        userId,
+                        cancellationToken);
+                    hasChanges = hasChanges || replaced is not null;
+                }
+            }
+            else if (crop.HasValue)
+            {
+                var updated = await _photoService.UpdateCropAsync(project.Id, photo.Id, crop.Value, userId, cancellationToken);
+                hasChanges = hasChanges || updated is not null;
+            }
+
+            if (!string.Equals(photo.Caption ?? string.Empty, Input.Caption ?? string.Empty, StringComparison.Ordinal))
+            {
+                var updated = await _photoService.UpdateCaptionAsync(project.Id, photo.Id, Input.Caption, userId, cancellationToken);
+                hasChanges = hasChanges || updated is not null;
+            }
+
+            if (Input.SetAsCover && !photo.IsCover)
+            {
+                foreach (var other in project.Photos.Where(p => p.IsCover && p.Id != photo.Id))
+                {
+                    other.IsCover = false;
+                }
+
+                photo.IsCover = true;
+                project.CoverPhotoId = photo.Id;
+                project.CoverPhotoVersion = photo.Version;
+                await _db.SaveChangesAsync(cancellationToken);
+                hasChanges = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error editing photo {PhotoId} for project {ProjectId}", photoId, id);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return Page();
+        }
+
+        if (!hasChanges)
+        {
+            TempData["Flash"] = "No changes were made.";
+            return RedirectToPage("./Index", new { id });
+        }
+
+        TempData["Flash"] = "Photo updated.";
+        return RedirectToPage("./Index", new { id });
+    }
+
+    private bool UserCanManageProject(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        var isAdmin = principal.IsInRole("Admin");
+        if (isAdmin)
+        {
+            return true;
+        }
+
+        var isHoD = principal.IsInRole("HoD");
+        if (isHoD && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[]? ParseRowVersion(string rowVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rowVersion))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Convert.FromBase64String(rowVersion);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static ProjectPhotoCrop? BuildCrop(EditInput input)
+    {
+        if (input.CropX.HasValue && input.CropY.HasValue && input.CropWidth.HasValue && input.CropHeight.HasValue)
+        {
+            return new ProjectPhotoCrop(input.CropX.Value, input.CropY.Value, input.CropWidth.Value, input.CropHeight.Value);
+        }
+
+        return null;
+    }
+
+    private static bool HasPartialCrop(EditInput input)
+    {
+        var values = new[] { input.CropX, input.CropY, input.CropWidth, input.CropHeight };
+        return values.Any(v => v.HasValue) && values.Any(v => !v.HasValue);
+    }
+
+    public class EditInput
+    {
+        public int ProjectId { get; set; }
+
+        public int PhotoId { get; set; }
+
+        public string RowVersion { get; set; } = string.Empty;
+
+        public string? Caption { get; set; }
+
+        public bool SetAsCover { get; set; }
+
+        public IFormFile? File { get; set; }
+
+        public int? CropX { get; set; }
+
+        public int? CropY { get; set; }
+
+        public int? CropWidth { get; set; }
+
+        public int? CropHeight { get; set; }
+    }
+}

--- a/Pages/Projects/Photos/Index.cshtml
+++ b/Pages/Projects/Photos/Index.cshtml
@@ -1,0 +1,80 @@
+@page "/Projects/{id:int}/Photos"
+@model ProjectManagement.Pages.Projects.Photos.IndexModel
+@{
+    ViewData["Title"] = $"Photos – {Model.Project.Name}";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="mb-0">Project Photos</h1>
+        <p class="text-muted mb-0">Manage the images for this project.</p>
+    </div>
+    <div class="d-flex gap-2">
+        <a class="btn btn-outline-secondary" asp-page="./Reorder" asp-route-id="@Model.Project.Id">Reorder</a>
+        <a class="btn btn-primary" asp-page="./Upload" asp-route-id="@Model.Project.Id">Upload Photo</a>
+    </div>
+</div>
+
+@if (!Model.Photos.Any())
+{
+    <div class="alert alert-info">No photos have been uploaded for this project yet.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Preview</th>
+                    <th scope="col">Caption</th>
+                    <th scope="col">Ordinal</th>
+                    <th scope="col">Cover</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var photo in Model.Photos)
+            {
+                <tr>
+                    <td style="width: 140px;">
+                        <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = photo.Id, size = "sm" })" alt="Project photo preview" class="img-thumbnail" style="max-width: 128px;" />
+                    </td>
+                    <td>
+                        @if (!string.IsNullOrWhiteSpace(photo.Caption))
+                        {
+                            <div>@photo.Caption</div>
+                        }
+                        else
+                        {
+                            <span class="text-muted">No caption</span>
+                        }
+                    </td>
+                    <td>@photo.Ordinal</td>
+                    <td>
+                        @if (photo.IsCover)
+                        {
+                            <span class="badge bg-success">Cover</span>
+                        }
+                        else
+                        {
+                            <span class="text-muted">—</span>
+                        }
+                    </td>
+                    <td class="text-end">
+                        <a class="btn btn-sm btn-outline-primary" asp-page="./Edit" asp-route-id="@Model.Project.Id" asp-route-photoId="@photo.Id">Edit</a>
+                        <form method="post" asp-page-handler="Remove" class="d-inline">
+                            <input type="hidden" name="photoId" value="@photo.Id" />
+                            <input type="hidden" name="rowVersion" value="@Model.ProjectRowVersion" />
+                            <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="Are you sure you want to remove this photo?">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+}
+
+<div class="mt-4">
+    <a asp-page="/Projects/Overview" asp-route-id="@Model.Project.Id" class="btn btn-link">Back to project overview</a>
+</div>

--- a/Pages/Projects/Photos/Index.cshtml.cs
+++ b/Pages/Projects/Photos/Index.cshtml.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Pages.Projects.Photos;
+
+[Authorize(Roles = "Admin,Project Officer,HoD")]
+[AutoValidateAntiforgeryToken]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IProjectPhotoService _photoService;
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(ApplicationDbContext db,
+                      IUserContext userContext,
+                      IProjectPhotoService photoService,
+                      ILogger<IndexModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _photoService = photoService ?? throw new ArgumentNullException(nameof(photoService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Project Project { get; private set; } = null!;
+
+    public IReadOnlyList<ProjectPhoto> Photos { get; private set; } = Array.Empty<ProjectPhoto>();
+
+    public string ProjectRowVersion { get; private set; } = string.Empty;
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        Photos = project.Photos
+            .OrderBy(p => p.Ordinal)
+            .ThenBy(p => p.Id)
+            .ToList();
+        ProjectRowVersion = Convert.ToBase64String(project.RowVersion);
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostRemoveAsync(int id, int photoId, string rowVersion, CancellationToken cancellationToken)
+    {
+        if (photoId <= 0)
+        {
+            TempData["Error"] = "Unable to determine the photo to remove.";
+            return RedirectToPage(new { id });
+        }
+
+        byte[]? rowVersionBytes = ParseRowVersion(rowVersion);
+        if (rowVersionBytes is null)
+        {
+            TempData["Error"] = "The form has expired. Please reload and try again.";
+            return RedirectToPage(new { id });
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        if (!project.RowVersion.SequenceEqual(rowVersionBytes))
+        {
+            TempData["Error"] = "The project was updated by someone else. Please reload and try again.";
+            return RedirectToPage(new { id });
+        }
+
+        var wasCover = project.CoverPhotoId == photoId;
+
+        try
+        {
+            var removed = await _photoService.RemoveAsync(project.Id, photoId, userId, cancellationToken);
+            if (!removed)
+            {
+                TempData["Error"] = "Photo could not be removed.";
+                return RedirectToPage(new { id });
+            }
+
+            if (wasCover)
+            {
+                await SetFallbackCoverAsync(project, photoId, cancellationToken);
+            }
+
+            TempData["Flash"] = "Photo removed.";
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            _logger.LogWarning(ex, "Concurrency conflict while removing photo {PhotoId} from project {ProjectId}", photoId, id);
+            TempData["Error"] = "The project was updated by someone else. Please reload and try again.";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error removing photo {PhotoId} from project {ProjectId}", photoId, id);
+            TempData["Error"] = "An unexpected error occurred while removing the photo.";
+        }
+
+        return RedirectToPage(new { id });
+    }
+
+    private bool UserCanManageProject(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        var isAdmin = principal.IsInRole("Admin");
+        if (isAdmin)
+        {
+            return true;
+        }
+
+        var isHoD = principal.IsInRole("HoD");
+        if (isHoD && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[]? ParseRowVersion(string rowVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rowVersion))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Convert.FromBase64String(rowVersion);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private async Task SetFallbackCoverAsync(Project project, int removedPhotoId, CancellationToken cancellationToken)
+    {
+        var nextCover = await _db.ProjectPhotos
+            .Where(p => p.ProjectId == project.Id && p.Id != removedPhotoId)
+            .OrderBy(p => p.Ordinal)
+            .ThenBy(p => p.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (nextCover is null)
+        {
+            return;
+        }
+
+        nextCover.IsCover = true;
+        project.CoverPhotoId = nextCover.Id;
+        project.CoverPhotoVersion = nextCover.Version;
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Pages/Projects/Photos/Reorder.cshtml
+++ b/Pages/Projects/Photos/Reorder.cshtml
@@ -1,0 +1,64 @@
+@page "/Projects/{id:int}/Photos/Reorder"
+@model ProjectManagement.Pages.Projects.Photos.ReorderModel
+@{
+    ViewData["Title"] = "Reorder Project Photos";
+}
+
+<h1 class="mb-4">Reorder Project Photos</h1>
+<p class="text-muted">Set the display order for project photos. Lower numbers appear first.</p>
+
+<form method="post">
+    <input asp-for="Input.ProjectId" type="hidden" />
+    <input asp-for="Input.RowVersion" type="hidden" />
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+    @if (!Model.Photos.Any())
+    {
+        <div class="alert alert-info">No photos available to reorder.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th scope="col">Photo</th>
+                        <th scope="col" style="width: 140px;">Ordinal</th>
+                        <th scope="col">Caption</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @for (var i = 0; i < Model.Input.Items.Count; i++)
+                {
+                    var item = Model.Input.Items[i];
+                    var photo = Model.Photos.FirstOrDefault(p => p.Id == item.PhotoId);
+                    <tr>
+                        <td style="width: 160px;">
+                            <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = item.PhotoId, size = "sm" })" alt="Photo preview" class="img-thumbnail" style="max-width: 128px;" />
+                            <input asp-for="Input.Items[i].PhotoId" type="hidden" />
+                        </td>
+                        <td>
+                            <input asp-for="Input.Items[i].Ordinal" class="form-control" type="number" min="1" />
+                            <span asp-validation-for="Input.Items[i].Ordinal" class="text-danger"></span>
+                        </td>
+                        <td>
+                            @if (photo is not null && !string.IsNullOrWhiteSpace(photo.Caption))
+                            {
+                                <div>@photo.Caption</div>
+                            }
+                            else
+                            {
+                                <span class="text-muted">No caption</span>
+                            }
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Save order</button>
+    }
+
+    <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
+</form>

--- a/Pages/Projects/Photos/Reorder.cshtml.cs
+++ b/Pages/Projects/Photos/Reorder.cshtml.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Pages.Projects.Photos;
+
+[Authorize(Roles = "Admin,Project Officer,HoD")]
+[AutoValidateAntiforgeryToken]
+public class ReorderModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IProjectPhotoService _photoService;
+    private readonly ILogger<ReorderModel> _logger;
+
+    public ReorderModel(ApplicationDbContext db,
+                        IUserContext userContext,
+                        IProjectPhotoService photoService,
+                        ILogger<ReorderModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _photoService = photoService ?? throw new ArgumentNullException(nameof(photoService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public ReorderInput Input { get; set; } = new();
+
+    public Project Project { get; private set; } = null!;
+
+    public IReadOnlyList<ProjectPhoto> Photos { get; private set; } = Array.Empty<ProjectPhoto>();
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        Photos = project.Photos
+            .OrderBy(p => p.Ordinal)
+            .ThenBy(p => p.Id)
+            .ToList();
+
+        Input.ProjectId = project.Id;
+        Input.RowVersion = Convert.ToBase64String(project.RowVersion);
+        Input.Items = Photos
+            .Select(p => new ReorderItem { PhotoId = p.Id, Ordinal = p.Ordinal })
+            .ToList();
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId)
+        {
+            return BadRequest();
+        }
+
+        Input.Items ??= new List<ReorderItem>();
+
+        if (Input.Items.Count == 0)
+        {
+            ModelState.AddModelError(string.Empty, "No photos to reorder.");
+        }
+
+        byte[]? rowVersionBytes = ParseRowVersion(Input.RowVersion);
+        if (rowVersionBytes is null)
+        {
+            ModelState.AddModelError(string.Empty, "The form has expired. Please reload and try again.");
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Photos)
+            .SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        Photos = project.Photos
+            .OrderBy(p => p.Ordinal)
+            .ThenBy(p => p.Id)
+            .ToList();
+        Input.RowVersion = Convert.ToBase64String(project.RowVersion);
+
+        if (rowVersionBytes is not null && !project.RowVersion.SequenceEqual(rowVersionBytes))
+        {
+            ModelState.AddModelError(string.Empty, "The project was updated by someone else. Please reload and try again.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var expectedIds = Photos.Select(p => p.Id).OrderBy(i => i).ToArray();
+        var suppliedIds = Input.Items.Select(i => i.PhotoId).OrderBy(i => i).ToArray();
+        if (!expectedIds.SequenceEqual(suppliedIds))
+        {
+            ModelState.AddModelError(string.Empty, "All project photos must be included in the new order.");
+            return Page();
+        }
+
+        if (Input.Items.Select(i => i.Ordinal).Distinct().Count() != Input.Items.Count)
+        {
+            ModelState.AddModelError(string.Empty, "Each photo must have a unique position.");
+            return Page();
+        }
+
+        if (Input.Items.Any(i => i.Ordinal <= 0))
+        {
+            ModelState.AddModelError(string.Empty, "Ordinals must be positive numbers.");
+            return Page();
+        }
+
+        var orderedPhotoIds = Input.Items
+            .OrderBy(i => i.Ordinal)
+            .ThenBy(i => i.PhotoId)
+            .Select(i => i.PhotoId)
+            .ToList();
+
+        try
+        {
+            await _photoService.ReorderAsync(project.Id, orderedPhotoIds, userId, cancellationToken);
+            TempData["Flash"] = "Photos reordered.";
+            return RedirectToPage("./Index", new { id });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reordering photos for project {ProjectId}", id);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return Page();
+        }
+    }
+
+    private bool UserCanManageProject(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        var isAdmin = principal.IsInRole("Admin");
+        if (isAdmin)
+        {
+            return true;
+        }
+
+        var isHoD = principal.IsInRole("HoD");
+        if (isHoD && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[]? ParseRowVersion(string rowVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rowVersion))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Convert.FromBase64String(rowVersion);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    public class ReorderInput
+    {
+        public int ProjectId { get; set; }
+
+        public string RowVersion { get; set; } = string.Empty;
+
+        public List<ReorderItem> Items { get; set; } = new();
+    }
+
+    public class ReorderItem
+    {
+        public int PhotoId { get; set; }
+
+        public int Ordinal { get; set; }
+    }
+}

--- a/Pages/Projects/Photos/Upload.cshtml
+++ b/Pages/Projects/Photos/Upload.cshtml
@@ -1,0 +1,59 @@
+@page "/Projects/{id:int}/Photos/Upload"
+@model ProjectManagement.Pages.Projects.Photos.UploadModel
+@{
+    ViewData["Title"] = "Upload Project Photo";
+}
+
+<h1 class="mb-4">Upload Project Photo</h1>
+
+<form method="post" enctype="multipart/form-data">
+    <input asp-for="Input.ProjectId" type="hidden" />
+    <input asp-for="Input.RowVersion" type="hidden" />
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+    <div class="mb-3">
+        <label asp-for="Input.File" class="form-label">Photo</label>
+        <input asp-for="Input.File" class="form-control" type="file" accept="image/*" />
+        <span asp-validation-for="Input.File" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Input.Caption" class="form-label">Caption (optional)</label>
+        <textarea asp-for="Input.Caption" class="form-control" rows="3"></textarea>
+        <span asp-validation-for="Input.Caption" class="text-danger"></span>
+    </div>
+
+    <div class="form-check mb-3">
+        <input asp-for="Input.SetAsCover" class="form-check-input" />
+        <label asp-for="Input.SetAsCover" class="form-check-label">Set as cover photo</label>
+    </div>
+
+    <fieldset class="border rounded p-3 mb-3">
+        <legend class="float-none w-auto fs-6 px-2">Crop (optional)</legend>
+        <div class="row g-3">
+            <div class="col-md-3">
+                <label asp-for="Input.CropX" class="form-label">X</label>
+                <input asp-for="Input.CropX" class="form-control" type="number" />
+                <span asp-validation-for="Input.CropX" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropY" class="form-label">Y</label>
+                <input asp-for="Input.CropY" class="form-control" type="number" />
+                <span asp-validation-for="Input.CropY" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropWidth" class="form-label">Width</label>
+                <input asp-for="Input.CropWidth" class="form-control" type="number" min="1" />
+                <span asp-validation-for="Input.CropWidth" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Input.CropHeight" class="form-label">Height</label>
+                <input asp-for="Input.CropHeight" class="form-control" type="number" min="1" />
+                <span asp-validation-for="Input.CropHeight" class="text-danger"></span>
+            </div>
+        </div>
+    </fieldset>
+
+    <button type="submit" class="btn btn-primary">Upload</button>
+    <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
+</form>

--- a/Pages/Projects/Photos/Upload.cshtml.cs
+++ b/Pages/Projects/Photos/Upload.cshtml.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Pages.Projects.Photos;
+
+[Authorize(Roles = "Admin,Project Officer,HoD")]
+[AutoValidateAntiforgeryToken]
+public class UploadModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IProjectPhotoService _photoService;
+    private readonly ILogger<UploadModel> _logger;
+
+    public UploadModel(ApplicationDbContext db,
+                       IUserContext userContext,
+                       IProjectPhotoService photoService,
+                       ILogger<UploadModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _photoService = photoService ?? throw new ArgumentNullException(nameof(photoService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public UploadInput Input { get; set; } = new();
+
+    public Project Project { get; private set; } = null!;
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects.SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        Input.ProjectId = project.Id;
+        Input.RowVersion = Convert.ToBase64String(project.RowVersion);
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId)
+        {
+            return BadRequest();
+        }
+
+        byte[]? rowVersionBytes = ParseRowVersion(Input.RowVersion);
+        if (rowVersionBytes is null)
+        {
+            ModelState.AddModelError(string.Empty, "The form has expired. Please reload and try again.");
+        }
+
+        if (Input.File is null || Input.File.Length == 0)
+        {
+            ModelState.AddModelError("Input.File", "Please select a file to upload.");
+        }
+
+        var crop = BuildCrop(Input);
+        if (crop is null && HasPartialCrop(Input))
+        {
+            ModelState.AddModelError(string.Empty, "Crop requires X, Y, Width, and Height values.");
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Forbid();
+        }
+
+        var project = await _db.Projects.SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanManageProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        Input.RowVersion = Convert.ToBase64String(project.RowVersion);
+
+        if (rowVersionBytes is not null && !project.RowVersion.SequenceEqual(rowVersionBytes))
+        {
+            ModelState.AddModelError(string.Empty, "The project was updated by someone else. Please reload and try again.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        try
+        {
+            await using var stream = Input.File!.OpenReadStream();
+            if (crop.HasValue)
+            {
+                await _photoService.AddAsync(project.Id,
+                    stream,
+                    Input.File.FileName,
+                    Input.File.ContentType,
+                    userId,
+                    Input.SetAsCover,
+                    Input.Caption,
+                    crop.Value,
+                    cancellationToken);
+            }
+            else
+            {
+                await _photoService.AddAsync(project.Id,
+                    stream,
+                    Input.File.FileName,
+                    Input.File.ContentType,
+                    userId,
+                    Input.SetAsCover,
+                    Input.Caption,
+                    cancellationToken);
+            }
+
+            TempData["Flash"] = "Photo uploaded.";
+            return RedirectToPage("./Index", new { id });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error uploading photo for project {ProjectId}", id);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return Page();
+        }
+    }
+
+    private static byte[]? ParseRowVersion(string rowVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rowVersion))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Convert.FromBase64String(rowVersion);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private bool UserCanManageProject(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        var isAdmin = principal.IsInRole("Admin");
+        if (isAdmin)
+        {
+            return true;
+        }
+
+        var isHoD = principal.IsInRole("HoD");
+        if (isHoD && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ProjectPhotoCrop? BuildCrop(UploadInput input)
+    {
+        if (input.CropX.HasValue && input.CropY.HasValue && input.CropWidth.HasValue && input.CropHeight.HasValue)
+        {
+            return new ProjectPhotoCrop(input.CropX.Value, input.CropY.Value, input.CropWidth.Value, input.CropHeight.Value);
+        }
+
+        return null;
+    }
+
+    private static bool HasPartialCrop(UploadInput input)
+    {
+        var values = new[] { input.CropX, input.CropY, input.CropWidth, input.CropHeight };
+        return values.Any(v => v.HasValue) && values.Any(v => !v.HasValue);
+    }
+
+    public class UploadInput
+    {
+        public int ProjectId { get; set; }
+
+        public string RowVersion { get; set; } = string.Empty;
+
+        public IFormFile? File { get; set; }
+
+        public string? Caption { get; set; }
+
+        public bool SetAsCover { get; set; }
+
+        public int? CropX { get; set; }
+
+        public int? CropY { get; set; }
+
+        public int? CropWidth { get; set; }
+
+        public int? CropHeight { get; set; }
+    }
+}

--- a/Pages/Projects/Photos/View.cshtml
+++ b/Pages/Projects/Photos/View.cshtml
@@ -1,0 +1,5 @@
+@page "/Projects/{id:int}/Photos/{photoId:int}/View/{size?}"
+@model ProjectManagement.Pages.Projects.Photos.ViewModel
+@{
+    Layout = null;
+}

--- a/Pages/Projects/Photos/View.cshtml.cs
+++ b/Pages/Projects/Photos/View.cshtml.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Pages.Projects.Photos;
+
+[Authorize]
+public class ViewModel : PageModel
+{
+    private static readonly byte[] PlaceholderImage = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAucB9VHq7eAAAAAASUVORK5CYII=");
+
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IProjectPhotoService _photoService;
+
+    public ViewModel(ApplicationDbContext db, IUserContext userContext, IProjectPhotoService photoService)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _photoService = photoService ?? throw new ArgumentNullException(nameof(photoService));
+    }
+
+    public async Task<IActionResult> OnGetAsync(int id, int photoId, string? size, CancellationToken cancellationToken)
+    {
+        var requestedSize = NormalizeSize(size);
+        if (requestedSize is null)
+        {
+            return NotFound();
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects.SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!CanViewProject(project, userId))
+        {
+            return Forbid();
+        }
+
+        var photo = await _db.ProjectPhotos
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.ProjectId == id && p.Id == photoId, cancellationToken);
+
+        if (photo is null)
+        {
+            return PlaceholderResult(requestedSize);
+        }
+
+        var etag = new EntityTagHeaderValue($"\"pp-{photo.ProjectId}-{photo.Id}-v{photo.Version}-{requestedSize}\"");
+        var cacheHeaders = Response.GetTypedHeaders();
+        cacheHeaders.CacheControl = new CacheControlHeaderValue
+        {
+            Public = true,
+            MaxAge = TimeSpan.FromMinutes(10)
+        };
+        cacheHeaders.ETag = etag;
+        cacheHeaders.LastModified = DateTime.SpecifyKind(photo.UpdatedUtc, DateTimeKind.Utc);
+
+        var ifNoneMatch = Request.GetTypedHeaders().IfNoneMatch;
+        if (ifNoneMatch != null && ifNoneMatch.Any(tag => tag.Equals(etag)))
+        {
+            return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        try
+        {
+            var derivative = await _photoService.OpenDerivativeAsync(id, photoId, requestedSize, cancellationToken);
+            if (derivative is null)
+            {
+                return PlaceholderResult(requestedSize);
+            }
+
+            var result = new FileStreamResult(derivative.Value.Stream, derivative.Value.ContentType)
+            {
+                EnableRangeProcessing = true
+            };
+
+            return result;
+        }
+        catch (Exception)
+        {
+            return PlaceholderResult(requestedSize);
+        }
+    }
+
+    private IActionResult PlaceholderResult(string size)
+    {
+        var etag = new EntityTagHeaderValue($"\"pp-placeholder-{size}\"");
+        var headers = Response.GetTypedHeaders();
+        headers.CacheControl = new CacheControlHeaderValue
+        {
+            Public = true,
+            MaxAge = TimeSpan.FromMinutes(5)
+        };
+        headers.ETag = etag;
+
+        var ifNoneMatch = Request.GetTypedHeaders().IfNoneMatch;
+        if (ifNoneMatch != null && ifNoneMatch.Any(tag => tag.Equals(etag)))
+        {
+            return StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        return File(PlaceholderImage, "image/png");
+    }
+
+    private string? NormalizeSize(string? size)
+    {
+        if (string.IsNullOrWhiteSpace(size))
+        {
+            return "sm";
+        }
+
+        var normalized = size.Trim().ToLowerInvariant();
+        return normalized is "sm" or "md" or "xl" ? normalized : null;
+    }
+
+    private bool CanViewProject(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        if (principal.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        if (principal.IsInRole("HoD") && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (principal.IsInRole("Project Officer"))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a photos index for projects that lists thumbnails, cover status and provides edit/remove actions with cover fallback handling
- implement upload, edit and reorder Razor Pages that enforce admin/HoD/project officer permissions, honour concurrency tokens and delegate to the project photo service
- stream project photo derivatives through a new View page model that applies caching headers, checks access and falls back to placeholders when derivatives are missing

## Testing
- `dotnet build` *(fails: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc43c206588329bf045c3f83600d10