### PR TITLE
Add project photo gallery client interactions

### DIFF
--- a/Pages/Projects/Photos/Edit.cshtml
+++ b/Pages/Projects/Photos/Edit.cshtml
@@ -1,13 +1,30 @@
 @page "/Projects/{id:int}/Photos/{photoId:int}/Edit"
 @model ProjectManagement.Pages.Projects.Photos.EditModel
+@using Microsoft.Extensions.Options
+@using ProjectManagement.Services.Projects
+@inject IOptions<ProjectPhotoOptions> PhotoOptions
 @{
     ViewData["Title"] = "Edit Project Photo";
+    var derivativeSettings = PhotoOptions.Value.Derivatives;
+    var coverOptions = derivativeSettings.TryGetValue("xl", out var xlOptions)
+        ? xlOptions
+        : new ProjectPhotoDerivativeOptions { Width = 1600, Height = 1200 };
+    var largeOptions = derivativeSettings.TryGetValue("md", out var mdOptions)
+        ? mdOptions
+        : new ProjectPhotoDerivativeOptions { Width = 1200, Height = 900 };
+    var thumbOptions = derivativeSettings.TryGetValue("sm", out var smOptions)
+        ? smOptions
+        : new ProjectPhotoDerivativeOptions { Width = 800, Height = 600 };
+    var originalPhotoUrl = Url.Page("./View", new { id = Model.Project.Id, photoId = Model.Photo.Id, size = "md" });
+    var editorInitialUrl = Url.Page("./View", new { id = Model.Project.Id, photoId = Model.Photo.Id, size = "xl" });
 }
 
 <h1 class="mb-4">Edit Project Photo</h1>
 
-<div class="mb-4">
-    <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = Model.Photo.Id, size = "md" })" alt="Current project photo" class="img-fluid rounded" style="max-width: 320px;" />
+<div class="mb-4" style="max-width: 320px;">
+    <div class="pm-photo-frame">
+        <img src="@originalPhotoUrl" alt="Current project photo" class="img-fluid" />
+    </div>
 </div>
 
 <form method="post" enctype="multipart/form-data">
@@ -21,6 +38,7 @@
         <label asp-for="Input.File" class="form-label">Replace image (optional)</label>
         <input asp-for="Input.File" class="form-control" type="file" accept="image/*" />
         <span asp-validation-for="Input.File" class="text-danger"></span>
+        <div class="form-text">Select a new file to replace the photo. Minimum size @(coverOptions.Width)×@(coverOptions.Height).</div>
     </div>
 
     <div class="mb-3">
@@ -35,32 +53,59 @@
     </div>
 
     <fieldset class="border rounded p-3 mb-3">
-        <legend class="float-none w-auto fs-6 px-2">Crop (optional)</legend>
-        <div class="row g-3">
-            <div class="col-md-3">
-                <label asp-for="Input.CropX" class="form-label">X</label>
-                <input asp-for="Input.CropX" class="form-control" type="number" />
-                <span asp-validation-for="Input.CropX" class="text-danger"></span>
+        <legend class="float-none w-auto fs-6 px-2">Crop &amp; preview</legend>
+        <p class="text-muted small project-photo-editor__fallback">JavaScript is disabled, so the existing crop will be centred automatically.</p>
+        <div class="project-photo-editor" data-photo-editor data-photo-editor-input="#Input_File" data-photo-editor-initial-url="@editorInitialUrl">
+            <div class="project-photo-editor__canvas">
+                <img data-photo-editor-image alt="Project photo ready for cropping" />
             </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropY" class="form-label">Y</label>
-                <input asp-for="Input.CropY" class="form-control" type="number" />
-                <span asp-validation-for="Input.CropY" class="text-danger"></span>
+            <div class="d-flex flex-column gap-3">
+                <p class="text-muted mb-0 project-photo-editor__placeholder" data-photo-editor-placeholder>Select a new photo or adjust the crop on the existing image.</p>
+                <div class="project-photo-preview-grid" data-photo-editor-previews>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="xl" data-width="@coverOptions.Width" data-height="@coverOptions.Height">
+                            <img alt="Cover preview" />
+                            <span class="pm-photo-cover-badge">Cover</span>
+                        </div>
+                        <div class="project-photo-preview-label">Cover (@coverOptions.Width × @coverOptions.Height)</div>
+                    </div>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="md" data-width="@largeOptions.Width" data-height="@largeOptions.Height">
+                            <img alt="Large preview" />
+                        </div>
+                        <div class="project-photo-preview-label">Large (@largeOptions.Width × @largeOptions.Height)</div>
+                    </div>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="sm" data-width="@thumbOptions.Width" data-height="@thumbOptions.Height">
+                            <img alt="Thumbnail preview" />
+                        </div>
+                        <div class="project-photo-preview-label">Thumbnail (@thumbOptions.Width × @thumbOptions.Height)</div>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropWidth" class="form-label">Width</label>
-                <input asp-for="Input.CropWidth" class="form-control" type="number" min="1" />
-                <span asp-validation-for="Input.CropWidth" class="text-danger"></span>
-            </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropHeight" class="form-label">Height</label>
-                <input asp-for="Input.CropHeight" class="form-control" type="number" min="1" />
-                <span asp-validation-for="Input.CropHeight" class="text-danger"></span>
-            </div>
+
+            <input asp-for="Input.CropX" type="hidden" data-photo-editor-field="x" />
+            <input asp-for="Input.CropY" type="hidden" data-photo-editor-field="y" />
+            <input asp-for="Input.CropWidth" type="hidden" data-photo-editor-field="width" />
+            <input asp-for="Input.CropHeight" type="hidden" data-photo-editor-field="height" />
         </div>
-        <p class="text-muted mt-3 mb-0">Provide crop values to reframe the existing image or apply to the replacement.</p>
+        <noscript>
+            <style>
+                .project-photo-editor { display: none !important; }
+                .project-photo-editor__fallback { display: block !important; }
+            </style>
+        </noscript>
     </fieldset>
 
     <button type="submit" class="btn btn-primary">Save changes</button>
     <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
 </form>
+
+@section Styles {
+    <link rel="stylesheet" href="~/lib/cropperjs/dist/cropper.css" asp-append-version="true" />
+}
+
+@section Scripts {
+    <script src="~/lib/cropperjs/dist/cropper.js" asp-append-version="true"></script>
+    <script src="~/js/widgets/project-photo-gallery.js" asp-append-version="true"></script>
+}

--- a/Pages/Projects/Photos/Reorder.cshtml
+++ b/Pages/Projects/Photos/Reorder.cshtml
@@ -18,47 +18,46 @@
     }
     else
     {
-        <div class="table-responsive">
-            <table class="table align-middle">
-                <thead>
-                    <tr>
-                        <th scope="col">Photo</th>
-                        <th scope="col" style="width: 140px;">Ordinal</th>
-                        <th scope="col">Caption</th>
-                    </tr>
-                </thead>
-                <tbody>
-                @for (var i = 0; i < Model.Input.Items.Count; i++)
-                {
-                    var item = Model.Input.Items[i];
-                    var photo = Model.Photos.FirstOrDefault(p => p.Id == item.PhotoId);
-                    <tr>
-                        <td style="width: 160px;">
-                            <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = item.PhotoId, size = "sm" })" alt="Photo preview" class="img-thumbnail" style="max-width: 128px;" />
-                            <input asp-for="Input.Items[i].PhotoId" type="hidden" />
-                        </td>
-                        <td>
-                            <input asp-for="Input.Items[i].Ordinal" class="form-control" type="number" min="1" />
-                            <span asp-validation-for="Input.Items[i].Ordinal" class="text-danger"></span>
-                        </td>
-                        <td>
-                            @if (photo is not null && !string.IsNullOrWhiteSpace(photo.Caption))
-                            {
-                                <div>@photo.Caption</div>
-                            }
-                            else
-                            {
-                                <span class="text-muted">No caption</span>
-                            }
-                        </td>
-                    </tr>
-                }
-                </tbody>
-            </table>
+        <p class="text-muted">Drag and drop the photo cards to update the display order. The position numbers are used as a fallback when JavaScript is unavailable.</p>
+        <div class="pm-photo-grid" data-photo-reorder>
+        @for (var i = 0; i < Model.Input.Items.Count; i++)
+        {
+            var item = Model.Input.Items[i];
+            var photo = Model.Photos.FirstOrDefault(p => p.Id == item.PhotoId);
+            <div class="pm-photo-grid-item" data-photo-item>
+                <div class="pm-photo-frame">
+                    <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = item.PhotoId, size = "sm" })" alt="Photo preview" />
+                    @if (photo?.IsCover == true)
+                    {
+                        <span class="pm-photo-cover-badge">Cover</span>
+                    }
+                </div>
+                <input asp-for="Input.Items[i].PhotoId" type="hidden" />
+                <div>
+                    <label asp-for="Input.Items[i].Ordinal" class="form-label">Position</label>
+                    <input asp-for="Input.Items[i].Ordinal" class="form-control form-control-sm" type="number" min="1" data-photo-ordinal />
+                    <span asp-validation-for="Input.Items[i].Ordinal" class="text-danger small"></span>
+                </div>
+                <div class="text-muted small">
+                    @if (photo is not null && !string.IsNullOrWhiteSpace(photo.Caption))
+                    {
+                        <span>@photo.Caption</span>
+                    }
+                    else
+                    {
+                        <span>No caption provided.</span>
+                    }
+                </div>
+            </div>
+        }
         </div>
 
-        <button type="submit" class="btn btn-primary">Save order</button>
+        <button type="submit" class="btn btn-primary mt-3">Save order</button>
     }
 
     <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
 </form>
+
+@section Scripts {
+    <script src="~/js/widgets/project-photo-gallery.js" asp-append-version="true"></script>
+}

--- a/Pages/Projects/Photos/Upload.cshtml
+++ b/Pages/Projects/Photos/Upload.cshtml
@@ -1,7 +1,20 @@
 @page "/Projects/{id:int}/Photos/Upload"
 @model ProjectManagement.Pages.Projects.Photos.UploadModel
+@using Microsoft.Extensions.Options
+@using ProjectManagement.Services.Projects
+@inject IOptions<ProjectPhotoOptions> PhotoOptions
 @{
     ViewData["Title"] = "Upload Project Photo";
+    var derivativeSettings = PhotoOptions.Value.Derivatives;
+    var coverOptions = derivativeSettings.TryGetValue("xl", out var xlOptions)
+        ? xlOptions
+        : new ProjectPhotoDerivativeOptions { Width = 1600, Height = 1200 };
+    var largeOptions = derivativeSettings.TryGetValue("md", out var mdOptions)
+        ? mdOptions
+        : new ProjectPhotoDerivativeOptions { Width = 1200, Height = 900 };
+    var thumbOptions = derivativeSettings.TryGetValue("sm", out var smOptions)
+        ? smOptions
+        : new ProjectPhotoDerivativeOptions { Width = 800, Height = 600 };
 }
 
 <h1 class="mb-4">Upload Project Photo</h1>
@@ -15,6 +28,7 @@
         <label asp-for="Input.File" class="form-label">Photo</label>
         <input asp-for="Input.File" class="form-control" type="file" accept="image/*" />
         <span asp-validation-for="Input.File" class="text-danger"></span>
+        <div class="form-text">Supported formats: JPEG, PNG, and WebP. Minimum size @(coverOptions.Width)×@(coverOptions.Height).</div>
     </div>
 
     <div class="mb-3">
@@ -29,31 +43,59 @@
     </div>
 
     <fieldset class="border rounded p-3 mb-3">
-        <legend class="float-none w-auto fs-6 px-2">Crop (optional)</legend>
-        <div class="row g-3">
-            <div class="col-md-3">
-                <label asp-for="Input.CropX" class="form-label">X</label>
-                <input asp-for="Input.CropX" class="form-control" type="number" />
-                <span asp-validation-for="Input.CropX" class="text-danger"></span>
+        <legend class="float-none w-auto fs-6 px-2">Crop &amp; preview</legend>
+        <p class="text-muted small project-photo-editor__fallback">JavaScript is disabled, so the photo will be centre-cropped automatically.</p>
+        <div class="project-photo-editor" data-photo-editor data-photo-editor-input="#Input_File">
+            <div class="project-photo-editor__canvas">
+                <img data-photo-editor-image alt="Selected photo ready for cropping" />
             </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropY" class="form-label">Y</label>
-                <input asp-for="Input.CropY" class="form-control" type="number" />
-                <span asp-validation-for="Input.CropY" class="text-danger"></span>
+            <div class="d-flex flex-column gap-3">
+                <p class="text-muted mb-0 project-photo-editor__placeholder" data-photo-editor-placeholder>Select a photo to enable cropping and preview the derived sizes.</p>
+                <div class="project-photo-preview-grid" data-photo-editor-previews>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="xl" data-width="@coverOptions.Width" data-height="@coverOptions.Height">
+                            <img alt="Cover preview" />
+                            <span class="pm-photo-cover-badge">Cover</span>
+                        </div>
+                        <div class="project-photo-preview-label">Cover (@coverOptions.Width × @coverOptions.Height)</div>
+                    </div>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="md" data-width="@largeOptions.Width" data-height="@largeOptions.Height">
+                            <img alt="Large preview" />
+                        </div>
+                        <div class="project-photo-preview-label">Large (@largeOptions.Width × @largeOptions.Height)</div>
+                    </div>
+                    <div class="project-photo-preview-item">
+                        <div class="project-photo-preview-frame" data-photo-editor-preview="sm" data-width="@thumbOptions.Width" data-height="@thumbOptions.Height">
+                            <img alt="Thumbnail preview" />
+                        </div>
+                        <div class="project-photo-preview-label">Thumbnail (@thumbOptions.Width × @thumbOptions.Height)</div>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropWidth" class="form-label">Width</label>
-                <input asp-for="Input.CropWidth" class="form-control" type="number" min="1" />
-                <span asp-validation-for="Input.CropWidth" class="text-danger"></span>
-            </div>
-            <div class="col-md-3">
-                <label asp-for="Input.CropHeight" class="form-label">Height</label>
-                <input asp-for="Input.CropHeight" class="form-control" type="number" min="1" />
-                <span asp-validation-for="Input.CropHeight" class="text-danger"></span>
-            </div>
+
+            <input asp-for="Input.CropX" type="hidden" data-photo-editor-field="x" />
+            <input asp-for="Input.CropY" type="hidden" data-photo-editor-field="y" />
+            <input asp-for="Input.CropWidth" type="hidden" data-photo-editor-field="width" />
+            <input asp-for="Input.CropHeight" type="hidden" data-photo-editor-field="height" />
         </div>
+        <noscript>
+            <style>
+                .project-photo-editor { display: none !important; }
+                .project-photo-editor__fallback { display: block !important; }
+            </style>
+        </noscript>
     </fieldset>
 
     <button type="submit" class="btn btn-primary">Upload</button>
     <a asp-page="./Index" asp-route-id="@Model.Project.Id" class="btn btn-link">Cancel</a>
 </form>
+
+@section Styles {
+    <link rel="stylesheet" href="~/lib/cropperjs/dist/cropper.css" asp-append-version="true" />
+}
+
+@section Scripts {
+    <script src="~/lib/cropperjs/dist/cropper.js" asp-append-version="true"></script>
+    <script src="~/js/widgets/project-photo-gallery.js" asp-append-version="true"></script>
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -335,3 +335,174 @@ h1, .h1 { font-size: 1.25rem; }
 
 .draggable-handle{cursor:grab}
 
+
+/* ---------- Project photo gallery ---------- */
+.project-photo-editor {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .project-photo-editor {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: flex-start;
+  }
+}
+
+.project-photo-editor__canvas {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background-color: var(--pm-card);
+  border: 1px solid var(--pm-border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-photo-editor__canvas img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.project-photo-editor__placeholder {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.project-photo-editor__fallback {
+  display: none;
+}
+
+.project-photo-editor--unsupported [data-photo-editor-previews] {
+  display: none !important;
+}
+
+.project-photo-editor--unsupported [data-photo-editor-placeholder] {
+  display: block !important;
+}
+
+.project-photo-preview-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .project-photo-preview-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
+.project-photo-preview-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.project-photo-preview-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--pm-border);
+  background-color: var(--pm-card);
+}
+
+.project-photo-preview-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.project-photo-preview-label {
+  font-size: 0.8125rem;
+  color: var(--pm-muted);
+}
+
+.pm-photo-cover-badge {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(45, 108, 223, 0.9);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.pm-photo-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.pm-photo-grid-item {
+  border: 1px solid var(--pm-border);
+  border-radius: 0.75rem;
+  background-color: var(--pm-surface);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.pm-photo-grid-item.is-dragging {
+  opacity: 0.75;
+  border-style: dashed;
+  transform: scale(0.98);
+}
+
+.pm-photo-grid-item:focus-within {
+  box-shadow: var(--pm-shadow);
+}
+
+.pm-photo-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--pm-border);
+  background-color: var(--pm-card);
+}
+
+.pm-photo-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.pm-photo-grid-item .form-label {
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.pm-photo-grid-item .form-control {
+  font-size: 0.875rem;
+}
+.project-photo-editor:not(.is-active) [data-photo-editor-previews] {
+  display: none;
+}
+
+.project-photo-editor:not(.is-active) [data-photo-editor-placeholder] {
+  display: block;
+}
+
+.project-photo-editor.is-active [data-photo-editor-placeholder] {
+  display: none;
+}
+
+.pm-photo-grid-item .pm-photo-cover-badge {
+  position: absolute;
+}

--- a/wwwroot/js/widgets/project-photo-gallery.js
+++ b/wwwroot/js/widgets/project-photo-gallery.js
@@ -1,0 +1,457 @@
+(function () {
+  const ASPECT_RATIO = 4 / 3;
+  const DEFAULT_SIZES = {
+    xl: { width: 1600, height: 1200 },
+    md: { width: 1200, height: 900 },
+    sm: { width: 800, height: 600 }
+  };
+
+  function parseSize(element) {
+    if (!element) {
+      return null;
+    }
+
+    const sizeKey = element.getAttribute('data-photo-editor-preview');
+    const width = Number.parseInt(element.getAttribute('data-width') || '', 10);
+    const height = Number.parseInt(element.getAttribute('data-height') || '', 10);
+
+    if (Number.isNaN(width) || Number.isNaN(height) || width <= 0 || height <= 0) {
+      return DEFAULT_SIZES[sizeKey] || null;
+    }
+
+    return { width, height };
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function formatNumber(value) {
+    return Number.isFinite(value) ? String(Math.round(value)) : '';
+  }
+
+  function initPhotoEditor(editor) {
+    if (!editor) {
+      return;
+    }
+
+    const cropperConstructor = window.Cropper;
+    if (typeof cropperConstructor !== 'function') {
+      editor.classList.add('project-photo-editor--unsupported');
+      return;
+    }
+
+    const inputSelector = editor.getAttribute('data-photo-editor-input');
+    const fileInput = inputSelector ? document.querySelector(inputSelector) : null;
+    const image = editor.querySelector('[data-photo-editor-image]');
+    const selectionPlaceholder = editor.querySelector('[data-photo-editor-placeholder]');
+    const previewGrid = editor.querySelector('[data-photo-editor-previews]');
+
+    if (!fileInput || !image || !previewGrid) {
+      return;
+    }
+
+    const hiddenFields = {
+      x: editor.querySelector('input[data-photo-editor-field="x"]'),
+      y: editor.querySelector('input[data-photo-editor-field="y"]'),
+      width: editor.querySelector('input[data-photo-editor-field="width"]'),
+      height: editor.querySelector('input[data-photo-editor-field="height"]')
+    };
+
+    const previews = Array.from(previewGrid.querySelectorAll('[data-photo-editor-preview]')).map((element) => ({
+      element,
+      image: element.querySelector('img'),
+      size: parseSize(element)
+    })).filter((preview) => preview.image && preview.size);
+
+    let cropper = null;
+    let selection = null;
+    let activeObjectUrl = null;
+    let lastDetail = null;
+    let previewSequence = 0;
+
+    function setActiveState(isActive) {
+      editor.classList.toggle('is-active', !!isActive);
+      if (selectionPlaceholder) {
+        selectionPlaceholder.classList.toggle('d-none', !!isActive);
+      }
+      previewGrid.classList.toggle('d-none', !isActive);
+    }
+
+    function clearPreviews() {
+      previews.forEach((preview) => {
+        if (preview.image) {
+          preview.image.removeAttribute('src');
+        }
+        if (preview.element) {
+          preview.element.classList.remove('is-loaded');
+        }
+      });
+    }
+
+    function resetFields() {
+      Object.values(hiddenFields).forEach((field) => {
+        if (field) {
+          field.value = '';
+        }
+      });
+    }
+
+    function revokeObjectUrl() {
+      if (activeObjectUrl) {
+        URL.revokeObjectURL(activeObjectUrl);
+        activeObjectUrl = null;
+      }
+    }
+
+    function updateHiddenFields(detail, scale) {
+      if (!detail || !scale) {
+        resetFields();
+        return;
+      }
+
+      const { scaleX, scaleY, offsetX, offsetY } = scale;
+      const cropX = clamp((detail.x - offsetX) * scaleX, 0, Number.MAX_SAFE_INTEGER);
+      const cropY = clamp((detail.y - offsetY) * scaleY, 0, Number.MAX_SAFE_INTEGER);
+      const cropWidth = clamp(detail.width * scaleX, 0, Number.MAX_SAFE_INTEGER);
+      const cropHeight = clamp(detail.height * scaleY, 0, Number.MAX_SAFE_INTEGER);
+
+      if (hiddenFields.x) hiddenFields.x.value = formatNumber(cropX);
+      if (hiddenFields.y) hiddenFields.y.value = formatNumber(cropY);
+      if (hiddenFields.width) hiddenFields.width.value = formatNumber(cropWidth);
+      if (hiddenFields.height) hiddenFields.height.value = formatNumber(cropHeight);
+    }
+
+    function computeScale(detail) {
+      if (!cropper || !selection) {
+        return null;
+      }
+
+      const canvasElement = cropper.getCropperCanvas();
+      const cropperImage = cropper.getCropperImage();
+      if (!canvasElement || !cropperImage) {
+        return null;
+      }
+
+      const canvasRect = canvasElement.getBoundingClientRect();
+      const imageRect = cropperImage.getBoundingClientRect();
+      const shadowRoot = cropperImage.$getShadowRoot ? cropperImage.$getShadowRoot() : null;
+      const nativeImage = shadowRoot ? shadowRoot.querySelector('img') : null;
+      const naturalWidth = nativeImage && nativeImage.naturalWidth ? nativeImage.naturalWidth : imageRect.width;
+      const naturalHeight = nativeImage && nativeImage.naturalHeight ? nativeImage.naturalHeight : imageRect.height;
+
+      if (!naturalWidth || !naturalHeight || !imageRect.width || !imageRect.height) {
+        return null;
+      }
+
+      return {
+        scaleX: naturalWidth / imageRect.width,
+        scaleY: naturalHeight / imageRect.height,
+        offsetX: imageRect.left - canvasRect.left,
+        offsetY: imageRect.top - canvasRect.top
+      };
+    }
+
+    function updatePreviews() {
+      if (!selection || previews.length === 0) {
+        clearPreviews();
+        return;
+      }
+
+      const currentSequence = ++previewSequence;
+      previews.forEach((preview) => {
+        const { image: previewImage, element, size } = preview;
+        if (!previewImage || !size) {
+          return;
+        }
+
+        selection.$toCanvas({ width: size.width, height: size.height }).then((canvas) => {
+          if (currentSequence !== previewSequence) {
+            return;
+          }
+
+          if (canvas && canvas.width > 0 && canvas.height > 0) {
+            try {
+              previewImage.src = canvas.toDataURL('image/jpeg', 0.92);
+              element.classList.add('is-loaded');
+            } catch (err) {
+              element.classList.remove('is-loaded');
+            }
+          }
+        }).catch(() => {
+          if (element) {
+            element.classList.remove('is-loaded');
+          }
+        });
+      });
+    }
+
+    function handleSelectionChange(detail) {
+      if (!detail || detail.width <= 0 || detail.height <= 0) {
+        resetFields();
+        clearPreviews();
+        return;
+      }
+
+      lastDetail = detail;
+      const scale = computeScale(detail);
+      updateHiddenFields(detail, scale);
+      updatePreviews();
+    }
+
+    function bindSelectionListeners() {
+      if (!selection) {
+        return;
+      }
+
+      selection.aspectRatio = ASPECT_RATIO;
+      selection.initialAspectRatio = ASPECT_RATIO;
+      selection.initialCoverage = 1;
+      selection.movable = true;
+      selection.resizable = true;
+      selection.zoomable = false;
+      selection.keyboard = true;
+      selection.precise = true;
+      selection.outlined = true;
+
+      selection.addEventListener('change', (event) => {
+        handleSelectionChange(event.detail || null);
+      });
+
+      selection.addEventListener('pointerup', () => {
+        if (lastDetail) {
+          handleSelectionChange(lastDetail);
+        }
+      });
+    }
+
+    function ensureCropperReady() {
+      if (cropper) {
+        return;
+      }
+
+      cropper = new cropperConstructor(image, {
+        viewMode: 1,
+        background: false,
+        autoCropArea: 1,
+        responsive: true
+      });
+
+      selection = cropper.getCropperSelection();
+      bindSelectionListeners();
+
+      if (selection) {
+        const detail = {
+          x: selection.x,
+          y: selection.y,
+          width: selection.width,
+          height: selection.height
+        };
+        handleSelectionChange(detail);
+      } else {
+        setActiveState(false);
+      }
+    }
+
+    function resetEditor() {
+      if (cropper) {
+        const cropperCanvas = cropper.getCropperCanvas();
+        if (cropperCanvas && cropperCanvas.parentNode) {
+          cropperCanvas.parentNode.removeChild(cropperCanvas);
+        }
+        cropper = null;
+        selection = null;
+      }
+
+      revokeObjectUrl();
+      image.removeAttribute('src');
+      image.style.removeProperty('display');
+      lastDetail = null;
+      previewSequence++;
+      resetFields();
+      clearPreviews();
+      setActiveState(false);
+    }
+
+    function setImageSource(source, isObjectUrl) {
+      if (!source) {
+        resetEditor();
+        return;
+      }
+
+      setActiveState(false);
+      if (isObjectUrl) {
+        revokeObjectUrl();
+        activeObjectUrl = source;
+      } else {
+        revokeObjectUrl();
+      }
+
+      if (cropper) {
+        try {
+          cropper.replace(source);
+          selection = cropper.getCropperSelection();
+          window.setTimeout(() => {
+            if (selection) {
+              const detail = {
+                x: selection.x,
+                y: selection.y,
+                width: selection.width,
+                height: selection.height
+              };
+              handleSelectionChange(detail);
+            }
+            setActiveState(true);
+          }, 0);
+        } catch (err) {
+          resetEditor();
+          return;
+        }
+      } else {
+        image.src = source;
+        image.addEventListener('load', () => {
+          ensureCropperReady();
+          if (selection) {
+            const detail = {
+              x: selection.x,
+              y: selection.y,
+              width: selection.width,
+              height: selection.height
+            };
+            handleSelectionChange(detail);
+            setActiveState(true);
+          }
+        }, { once: true });
+      }
+    }
+
+    function handleFileChange() {
+      const [file] = fileInput.files || [];
+      if (!file || !file.type || !file.type.startsWith('image/')) {
+        const initialUrl = editor.getAttribute('data-photo-editor-initial-url');
+        if (initialUrl) {
+          setImageSource(initialUrl, false);
+        } else {
+          resetEditor();
+        }
+        return;
+      }
+
+      const objectUrl = URL.createObjectURL(file);
+      setImageSource(objectUrl, true);
+    }
+
+    window.addEventListener('resize', () => {
+      if (lastDetail) {
+        handleSelectionChange(lastDetail);
+      }
+    });
+
+    fileInput.addEventListener('change', handleFileChange);
+
+    const initialUrl = editor.getAttribute('data-photo-editor-initial-url');
+    if (initialUrl) {
+      setImageSource(initialUrl, false);
+    } else {
+      resetFields();
+      clearPreviews();
+      setActiveState(false);
+    }
+  }
+
+  function getDragAfterElement(container, pointerY) {
+    const siblings = Array.from(container.querySelectorAll('[data-photo-item]:not(.is-dragging)'));
+    let closest = { offset: Number.NEGATIVE_INFINITY, element: null };
+    siblings.forEach((item) => {
+      const box = item.getBoundingClientRect();
+      const offset = pointerY - box.top - (box.height / 2);
+      if (offset < 0 && offset > closest.offset) {
+        closest = { offset, element: item };
+      }
+    });
+    return closest.element;
+  }
+
+  function refreshOrdinals(container) {
+    let index = 0;
+    container.querySelectorAll('[data-photo-item]').forEach((item) => {
+      const ordinalInput = item.querySelector('[data-photo-ordinal]');
+      if (ordinalInput) {
+        index += 1;
+        ordinalInput.value = String(index);
+      }
+    });
+  }
+
+  function initReorder(container) {
+    if (!container) {
+      return;
+    }
+
+    const items = container.querySelectorAll('[data-photo-item]');
+    if (!items.length) {
+      return;
+    }
+
+    let activeItem = null;
+
+    container.addEventListener('dragover', (event) => {
+      if (!activeItem) {
+        return;
+      }
+      event.preventDefault();
+      const afterElement = getDragAfterElement(container, event.clientY);
+      if (!afterElement) {
+        container.appendChild(activeItem);
+      } else if (afterElement !== activeItem) {
+        container.insertBefore(activeItem, afterElement);
+      }
+    });
+
+    container.addEventListener('drop', (event) => {
+      if (!activeItem) {
+        return;
+      }
+      event.preventDefault();
+      const afterElement = getDragAfterElement(container, event.clientY);
+      if (!afterElement) {
+        container.appendChild(activeItem);
+      } else if (afterElement !== activeItem) {
+        container.insertBefore(activeItem, afterElement);
+      }
+      activeItem.classList.remove('is-dragging');
+      activeItem = null;
+      refreshOrdinals(container);
+    });
+
+    container.addEventListener('dragend', () => {
+      if (activeItem) {
+        activeItem.classList.remove('is-dragging');
+        activeItem = null;
+        refreshOrdinals(container);
+      }
+    });
+
+    items.forEach((item) => {
+      item.setAttribute('draggable', 'true');
+      item.addEventListener('dragstart', (event) => {
+        activeItem = item;
+        item.classList.add('is-dragging');
+        if (event.dataTransfer) {
+          event.dataTransfer.effectAllowed = 'move';
+          event.dataTransfer.setData('text/plain', '');
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-photo-editor]').forEach((editor) => {
+      initPhotoEditor(editor);
+    });
+
+    document.querySelectorAll('[data-photo-reorder]').forEach((container) => {
+      initReorder(container);
+    });
+  });
+})();

--- a/wwwroot/lib/cropperjs/dist/cropper.css
+++ b/wwwroot/lib/cropperjs/dist/cropper.css
@@ -1,0 +1,1 @@
+/* Cropper.js v2 uses shadow DOM styling. This file exists so Razor links resolve without 404s. */


### PR DESCRIPTION
## Summary
- add Cropper-based cropping controls and derivative previews to the project photo upload and edit pages with a no-JS fallback
- create a shared gallery widget that manages crop data, previews, and drag-and-drop ordering behaviour
- extend site styling and reorder markup with 4:3 frames, cover badges, and a responsive photo grid

## Testing
- dotnet build *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4906e0d08329be6ee355c817cb8c