### PR TITLE
Update project photo upload helper text

### DIFF
--- a/Pages/Projects/Photos/Upload.cshtml
+++ b/Pages/Projects/Photos/Upload.cshtml
@@ -2,10 +2,15 @@
 @model ProjectManagement.Pages.Projects.Photos.UploadModel
 @using Microsoft.Extensions.Options
 @using ProjectManagement.Services.Projects
+@using System
+@using System.Collections.Generic
+@using System.Globalization
+@using System.Linq
 @inject IOptions<ProjectPhotoOptions> PhotoOptions
 @{
     ViewData["Title"] = "Upload Project Photo";
-    var derivativeSettings = PhotoOptions.Value.Derivatives;
+    var photoOptions = PhotoOptions.Value;
+    var derivativeSettings = photoOptions.Derivatives;
     var coverOptions = derivativeSettings.TryGetValue("xl", out var xlOptions)
         ? xlOptions
         : new ProjectPhotoDerivativeOptions { Width = 1600, Height = 1200 };
@@ -15,6 +20,57 @@
     var thumbOptions = derivativeSettings.TryGetValue("sm", out var smOptions)
         ? smOptions
         : new ProjectPhotoDerivativeOptions { Width = 800, Height = 600 };
+
+    string FormatContentType(string contentType) => contentType switch
+    {
+        "image/jpeg" => "JPEG",
+        "image/png" => "PNG",
+        "image/webp" => "WebP",
+        _ when contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            => contentType[6..].ToUpperInvariant(),
+        _ => contentType
+    };
+
+    string ToReadableList(IReadOnlyList<string> values) => values.Count switch
+    {
+        0 => string.Empty,
+        1 => values[0],
+        2 => $"{values[0]} and {values[1]}",
+        _ => $"{string.Join(", ", values.Take(values.Count - 1))}, and {values[^1]}"
+    };
+
+    string FormatFileSize(long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return "0 bytes";
+        }
+
+        string[] suffixes = { "bytes", "KB", "MB", "GB" };
+        double value = bytes;
+        var suffixIndex = 0;
+
+        while (value >= 1024 && suffixIndex < suffixes.Length - 1)
+        {
+            value /= 1024;
+            suffixIndex++;
+        }
+
+        return suffixIndex == 0
+            ? $"{bytes} {suffixes[suffixIndex]}"
+            : FormattableString.Invariant($"{value:0.#} {suffixes[suffixIndex]}");
+    }
+
+    var allowedFormats = (photoOptions.AllowedContentTypes?.AsEnumerable() ?? Enumerable.Empty<string>())
+        .Select(FormatContentType)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(format => format)
+        .ToList();
+    var readableFormats = ToReadableList(allowedFormats);
+    var allowedFormatsText = string.IsNullOrEmpty(readableFormats)
+        ? "No formats configured"
+        : readableFormats;
+    var maxFileSizeText = FormatFileSize(photoOptions.MaxFileSizeBytes);
 }
 
 <h1 class="mb-4">Upload Project Photo</h1>
@@ -28,7 +84,11 @@
         <label asp-for="Input.File" class="form-label">Photo</label>
         <input asp-for="Input.File" class="form-control" type="file" accept="image/*" />
         <span asp-validation-for="Input.File" class="text-danger"></span>
-        <div class="form-text">Supported formats: JPEG, PNG, and WebP. Minimum size @(coverOptions.Width)×@(coverOptions.Height).</div>
+        <div class="form-text">
+            Supported formats: @allowedFormatsText.
+            Minimum dimensions: @photoOptions.MinWidth &times; @photoOptions.MinHeight pixels.
+            Maximum file size: @maxFileSizeText.
+        </div>
     </div>
 
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- describe project photo upload constraints in helper text, including minimum dimensions, maximum file size, and supported formats
- render constraint values dynamically from ProjectPhotoOptions so future configuration changes stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9a535b248329887f3896e44c993f