### PR TITLE
Add illustrated empty state for project photo card

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -242,7 +242,33 @@
                     }
                     else if (coverPhoto is null)
                     {
-                        <p class="text-muted mb-0">No project photos have been uploaded yet.</p>
+                        @{
+                            var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
+                            var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
+                        }
+                        <div class="project-photo-empty border rounded bg-light-subtle text-center"
+                             role="region"
+                             aria-labelledby="@emptyStateHeadingId"
+                             aria-describedby="@emptyStateDescriptionId">
+                            <div class="project-photo-empty-body">
+                                <span class="project-photo-empty-icon" aria-hidden="true">
+                                    <i class="bi bi-images"></i>
+                                </span>
+                                <h3 id="@emptyStateHeadingId" class="h6 fw-semibold mb-2">No photos yet</h3>
+                                <p id="@emptyStateDescriptionId" class="mb-3 text-muted">
+                                    Add a cover or gallery photo to help everyone recognise this project at a glance.
+                                </p>
+                                @if (canManagePhotos)
+                                {
+                                    <a class="btn btn-sm btn-primary"
+                                       asp-page="/Projects/Photos/Index"
+                                       asp-route-id="@Model.Project!.Id"
+                                       aria-label="Upload the first project photo">
+                                        Upload photo
+                                    </a>
+                                }
+                            </div>
+                        </div>
                     }
                 </div>
             </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -144,6 +144,54 @@ body {
     font-size: 1rem;
 }
 
+.project-photo-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 220px;
+    height: 100%;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.project-photo-empty-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .5rem;
+    max-width: 20rem;
+    width: 100%;
+    word-break: break-word;
+}
+
+.project-photo-empty-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    background-color: rgba(45, 108, 223, .12);
+    color: var(--pm-primary);
+    font-size: 1.75rem;
+    margin-bottom: .25rem;
+}
+
+.project-photo-empty .btn {
+    white-space: nowrap;
+}
+
+@media (max-width: 576px) {
+    .project-photo-empty {
+        min-height: 180px;
+        padding: 1.25rem;
+    }
+
+    .project-photo-empty-body {
+        gap: .4rem;
+    }
+}
+
 /* Responsive behaviour */
 @media (max-width: 992px) {
   .hero {


### PR DESCRIPTION
## Summary
- add an illustrated empty state with accessible messaging for projects that lack photos
- style the project photo card empty state for centered layout and responsive behaviour

## Testing
- not run (markup and style changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dca47276248329a72cd7c7273711e4