### PR TITLE
Fix Razor block syntax for project overview photo empty state

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -242,10 +242,8 @@
                     }
                     else if (coverPhoto is null)
                     {
-                        @{
-                            var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
-                            var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
-                        }
+                        var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
+                        var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
                         <div class="project-photo-empty border rounded bg-light-subtle text-center"
                              role="region"
                              aria-labelledby="@emptyStateHeadingId"


### PR DESCRIPTION
## Summary
- remove unnecessary `@{ }` block from the empty-photo state logic on the project overview page
- keep the identifier declarations directly inside the existing Razor code block to avoid RZ1010

## Testing
- (not run)

------
https://chatgpt.com/codex/tasks/task_e_68dca66f2e44832992deff59a6956466