### PR TITLE
Add JPEG fallbacks for project photos and update view handling

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -35,6 +35,14 @@
     var coverSm = coverPhoto != null ? photoUrl(coverPhoto, "sm", coverVersion) : null;
     var coverMd = coverPhoto != null ? photoUrl(coverPhoto, "md", coverVersion) : null;
     var coverXl = coverPhoto != null ? photoUrl(coverPhoto, "xl", coverVersion) : null;
+    var coverSrcSet = coverPhoto != null
+        ? string.Join(", ", new[]
+        {
+            $"{coverSm} 800w",
+            $"{coverMd} 1200w",
+            $"{coverXl} 1600w"
+        })
+        : null;
     ViewData["Title"] = pageTitle;
 }
 
@@ -195,13 +203,18 @@
                     <div class="ratio ratio-4x3" style="max-width: 360px;">
                         @if (coverPhoto != null)
                         {
-                            <img class="w-100 h-100 object-fit-cover rounded border"
-                                 width="360"
-                                 height="270"
-                                 src="@coverMd"
-                                 srcset="@coverSm 800w, @coverMd 1200w, @coverXl 1600w"
-                                 sizes="(min-width: 992px) 360px, 100vw"
-                                 alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
+                            <picture>
+                                <source type="image/webp"
+                                        srcset="@coverSrcSet"
+                                        sizes="(min-width: 992px) 360px, 100vw" />
+                                <img class="w-100 h-100 object-fit-cover rounded border"
+                                     width="360"
+                                     height="270"
+                                     src="@coverMd"
+                                     srcset="@coverSrcSet"
+                                     sizes="(min-width: 992px) 360px, 100vw"
+                                     alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
+                            </picture>
                         }
                         else
                         {
@@ -223,14 +236,24 @@
                             {
                                 var thumbUrl = photoUrl(photo, "sm", photo.Version);
                                 var largeUrl = photoUrl(photo, "xl", photo.Version);
+                                var thumbSrcSet = string.Join(", ", new[]
+                                {
+                                    $"{thumbUrl} 1x",
+                                    $"{largeUrl} 2x"
+                                });
                                 <a class="text-decoration-none" href="@largeUrl" target="_blank" rel="noopener">
                                     <div class="ratio ratio-4x3" style="width: 140px;">
-                                        <img class="w-100 h-100 object-fit-cover rounded border"
-                                             loading="lazy"
-                                             width="140"
-                                             height="105"
-                                             src="@thumbUrl"
-                                             alt="@(string.IsNullOrWhiteSpace(photo.Caption) ? $"{project?.Name} photo" : photo.Caption)" />
+                                        <picture>
+                                            <source type="image/webp"
+                                                    srcset="@thumbSrcSet" />
+                                            <img class="w-100 h-100 object-fit-cover rounded border"
+                                                 loading="lazy"
+                                                 width="140"
+                                                 height="105"
+                                                 src="@thumbUrl"
+                                                 srcset="@thumbSrcSet"
+                                                 alt="@(string.IsNullOrWhiteSpace(photo.Caption) ? $"{project?.Name} photo" : photo.Caption)" />
+                                        </picture>
                                     </div>
                                     @if (!string.IsNullOrWhiteSpace(photo.Caption))
                                     {

--- a/Pages/Projects/Photos/Index.cshtml
+++ b/Pages/Projects/Photos/Index.cshtml
@@ -43,7 +43,23 @@ else
                     : $"photo in position {photo.Ordinal}";
                 <tr>
                     <td style="width: 140px;">
-                        <img src="@Url.Page("./View", new { id = Model.Project.Id, photoId = photo.Id, size = "sm" })" alt="Project photo preview" class="img-thumbnail" style="max-width: 128px;" />
+                        @{ 
+                            var previewSm = Url.Page("./View", new { id = Model.Project.Id, photoId = photo.Id, size = "sm" });
+                            var previewMd = Url.Page("./View", new { id = Model.Project.Id, photoId = photo.Id, size = "md" });
+                            var previewSrcSet = string.Join(", ", new[]
+                            {
+                                $"{previewSm} 1x",
+                                $"{previewMd} 2x"
+                            });
+                        }
+                        <picture>
+                            <source type="image/webp" srcset="@previewSrcSet" />
+                            <img src="@previewSm"
+                                 srcset="@previewSrcSet"
+                                 alt="Project photo preview"
+                                 class="img-thumbnail"
+                                 style="max-width: 128px;" />
+                        </picture>
                     </td>
                     <td>
                         @if (!string.IsNullOrWhiteSpace(photo.Caption))

--- a/Services/Projects/IProjectPhotoService.cs
+++ b/Services/Projects/IProjectPhotoService.cs
@@ -52,9 +52,13 @@ namespace ProjectManagement.Services.Projects
 
         Task ReorderAsync(int projectId, IReadOnlyList<int> orderedPhotoIds, string userId, CancellationToken cancellationToken);
 
-        Task<(Stream Stream, string ContentType)?> OpenDerivativeAsync(int projectId, int photoId, string sizeKey, CancellationToken cancellationToken);
+        Task<(Stream Stream, string ContentType)?> OpenDerivativeAsync(int projectId,
+                                                                      int photoId,
+                                                                      string sizeKey,
+                                                                      bool preferWebp,
+                                                                      CancellationToken cancellationToken);
 
-        string GetDerivativePath(ProjectPhoto photo, string sizeKey);
+        string GetDerivativePath(ProjectPhoto photo, string sizeKey, bool preferWebp);
     }
 
     public readonly record struct ProjectPhotoCrop(int X, int Y, int Width, int Height);


### PR DESCRIPTION
## Summary
- generate both WebP and JPEG/PNG derivatives for each project photo size
- adjust the photo delivery endpoint to negotiate WebP via the Accept header and emit Vary: Accept
- update project photo Razor views to serve WebP via <picture> fallbacks while keeping legacy support

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb38a30f0832993b184de0f38de42