### PR TITLE
Fix tuple handling in project photo services and tests

### DIFF
--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -186,7 +186,8 @@ public sealed class ProjectPhotoPageTests
         var headers = page.Response.GetTypedHeaders();
         Assert.Equal(TimeSpan.FromDays(7), headers.CacheControl?.MaxAge);
         Assert.Equal("Accept", page.Response.Headers[HeaderNames.Vary]);
-        Assert.Contains("webp", headers.ETag?.Tag);
+        Assert.NotNull(headers.ETag);
+        Assert.Contains("webp", headers.ETag!.Tag.Value, StringComparison.OrdinalIgnoreCase);
         Assert.True(photoService.OpenDerivativeCalled);
         Assert.True(photoService.PreferWebpRequested);
     }

--- a/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
@@ -262,7 +262,7 @@ public sealed class ProjectPhotoServiceTests
 
             Assert.NotNull(derivative);
             Assert.True(File.Exists(service.GetDerivativePath(photo, "xl", preferWebp: true)));
-            derivative!.Stream.Dispose();
+            derivative!.Value.Stream.Dispose();
         }
         finally
         {

--- a/Services/Projects/ProjectPhotoService.cs
+++ b/Services/Projects/ProjectPhotoService.cs
@@ -240,12 +240,12 @@ namespace ProjectManagement.Services.Projects
                 return null;
             }
 
-            foreach (var candidate in EnumerateDerivativeCandidates(photo, sizeKey, preferWebp))
+            foreach (var (path, contentType) in EnumerateDerivativeCandidates(photo, sizeKey, preferWebp))
             {
-                if (File.Exists(candidate.Path))
+                if (File.Exists(path))
                 {
-                    var stream = new FileStream(candidate.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
-                    return (stream, candidate.ContentType);
+                    var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    return (stream, contentType);
                 }
             }
 


### PR DESCRIPTION
## Summary
- adjust tuple access in project photo service to avoid using tuple field names directly
- update tests to reference tuple values safely and assert on ETag strings without nullable StringSegment issues

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcb6d0a268832986f7db55ed2217c1