### PR TITLE
Fix tuple access in project photo service

### DIFF
--- a/Services/Projects/ProjectPhotoService.cs
+++ b/Services/Projects/ProjectPhotoService.cs
@@ -310,11 +310,11 @@ namespace ProjectManagement.Services.Projects
                 : fallbackCandidates.Concat(Enumerable.Repeat(webpCandidate, 1));
 
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var candidate in ordered)
+            foreach (var (path, contentType) in ordered)
             {
-                if (seen.Add(candidate.Path))
+                if (seen.Add(path))
                 {
-                    yield return candidate;
+                    yield return (path, contentType);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- adjust tuple handling in `ProjectPhotoService` so that iteration uses deconstruction instead of named fields which are lost after concatenation

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb7bc3b9c832984bb40c4bb07700a