### PR TITLE
Allow blob URLs in CSP for image previews

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -252,7 +252,7 @@ app.Use(async (ctx, next) =>
         "default-src 'self'; " +
         "base-uri 'self'; " +
         "frame-ancestors 'none'; " +
-        "img-src 'self' data:; " +
+        "img-src 'self' data: blob:; " +
         "script-src 'self'; " +
         "style-src 'self'; " +
         "font-src 'self' data:; " +


### PR DESCRIPTION
## Summary
- update the Content Security Policy to permit `blob:` image sources so client-side previews load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcb450669883299ba95dc122d42846