### PR TITLE
Lock cropper aspect ratio for project photo gallery

### DIFF
--- a/wwwroot/js/widgets/project-photo-gallery.js
+++ b/wwwroot/js/widgets/project-photo-gallery.js
@@ -365,7 +365,9 @@
         viewMode: 1,
         background: false,
         autoCropArea: 1,
-        responsive: true
+        responsive: true,
+        aspectRatio: ASPECT_RATIO,
+        initialAspectRatio: ASPECT_RATIO
       });
 
       isModernCropper = cropper && typeof cropper.getCropperSelection === 'function' && typeof cropper.getCropperCanvas === 'function' && typeof cropper.getCropperImage === 'function';
@@ -388,6 +390,9 @@
         }
       } else {
         selection = null;
+        if (cropper && typeof cropper.setAspectRatio === 'function') {
+          cropper.setAspectRatio(ASPECT_RATIO);
+        }
         if (legacyListenerCleanup) {
           legacyListenerCleanup();
         }


### PR DESCRIPTION
## Summary
- set the cropper constructor options to start with a 4:3 aspect ratio
- ensure the legacy cropper API enforces the aspect ratio when resizing

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcc02fd5ec8329af110d6c02271c68