### PR TITLE
Adjust cropper canvas sizing when active

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -410,6 +410,11 @@ h1, .h1 { font-size: 1.25rem; }
   justify-content: center;
 }
 
+.project-photo-editor.is-active .project-photo-editor__canvas {
+  aspect-ratio: auto;
+  display: block;
+}
+
 .project-photo-editor__canvas img {
   display: block;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- drop the fixed aspect ratio on the project photo editor canvas once a photo is active so the cropper can size itself naturally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcc0b8f7ac8329af55568b134b28e6