### PR TITLE
Allow minor crop ratio tolerance and add regression test

### DIFF
--- a/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
@@ -158,6 +158,34 @@ public sealed class ProjectPhotoServiceTests
     }
 
     [Fact]
+    public async Task AddAsync_AcceptsCropWithinAspectTolerance()
+    {
+        await using var db = CreateContext();
+        await SeedProjectAsync(db, 13);
+
+        await using var stream = await CreateImageStreamAsync(1600, 1200);
+
+        var root = CreateTempRoot();
+        SetUploadRoot(root);
+        try
+        {
+            var options = CreateOptions();
+            var service = CreateService(db, options);
+
+            var crop = new ProjectPhotoCrop(0, 0, 867, 650);
+            var photo = await service.AddAsync(13, stream, "tolerant.png", "image/png", "user", false, null, crop, CancellationToken.None);
+
+            Assert.Equal(867, photo.Width);
+            Assert.Equal(650, photo.Height);
+        }
+        finally
+        {
+            ResetUploadRoot();
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
     public async Task UpdateCropAsync_ReusesOriginalAndBumpsVersion()
     {
         await using var db = CreateContext();

--- a/Services/Projects/ProjectPhotoService.cs
+++ b/Services/Projects/ProjectPhotoService.cs
@@ -709,7 +709,7 @@ namespace ProjectManagement.Services.Projects
                 throw new InvalidOperationException("Crop rectangle must be within the image bounds.");
             }
 
-            if (crop.Width * 3 != crop.Height * 4)
+            if (Math.Abs(crop.Width * 3 - crop.Height * 4) > 1)
             {
                 throw new InvalidOperationException("Crop rectangle must maintain a 4:3 aspect ratio.");
             }


### PR DESCRIPTION
## Summary
- allow a one-pixel tolerance when validating 4:3 project photo crops
- add a regression test to ensure tolerant crops are accepted

## Testing
- dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc39bb9cc8329bd808fe2b1ca61c5