### PR TITLE
Adjust project overview cover photo placeholder width

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -199,8 +199,8 @@
                 }
             </div>
             <div class="d-flex flex-column flex-lg-row gap-3">
-                <div>
-                    <div class="ratio ratio-4x3" style="max-width: 360px;">
+                <div class="flex-shrink-0" style="width: min(100%, 360px);">
+                    <div class="ratio ratio-4x3 w-100">
                         @if (coverPhoto != null)
                         {
                             <picture>


### PR DESCRIPTION
## Summary
- set the cover photo container to a fixed width that matches the image dimensions
- ensure the ratio wrapper fills that width so the placeholder stays centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd163c94c8329820337e5743e6aa2