### PR TITLE
Add utility class for project photo cover column

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -199,7 +199,7 @@
                 }
             </div>
             <div class="d-flex flex-column flex-lg-row gap-3">
-                <div class="flex-shrink-0" style="width: min(100%, 360px);">
+                <div class="flex-shrink-0 project-photo-cover">
                     <div class="ratio ratio-4x3 w-100">
                         @if (coverPhoto != null)
                         {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -144,6 +144,12 @@ body {
     font-size: 1rem;
 }
 
+.project-photo-cover {
+    flex: 0 0 360px;
+    width: 100%;
+    max-width: 360px;
+}
+
 .project-photo-empty {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add a reusable `.project-photo-cover` utility to keep the cover image column sizing consistent
- apply the new helper class on the project overview cover wrapper instead of inline styles

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcd46872d0832998d817ee3cd0524e