### PR TITLE
Enhance project overview gallery

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -281,40 +281,85 @@
 
                         @if (additionalPhotos.Any())
                         {
-                            <div>
-                                <h3 class="h6 mb-2">Gallery</h3>
-                                <div class="d-flex flex-wrap gap-3">
-                                    @foreach (var photo in additionalPhotos)
+                            var previewPhotos = additionalPhotos.Take(4).ToList();
+                            var remainingPhotos = Math.Max(0, additionalPhotos.Count - previewPhotos.Count);
+                            var galleryModalId = $"project-gallery-modal-{Model.Project!.Id}";
+                            var galleryModalModel = new ProjectPhotoLightboxViewModel(
+                                Model.Project!.Id,
+                                project?.Name ?? "Project",
+                                Model.Photos,
+                                coverPhoto?.Id,
+                                Model.CoverPhotoVersion ?? coverPhoto?.Version,
+                                galleryModalId);
+
+                            <div class="project-gallery" data-gallery data-gallery-project="@Model.Project!.Id" data-gallery-modal-id="@galleryModalId">
+                                <div class="project-gallery__header">
+                                    <h3 class="h6 mb-2">Gallery</h3>
+                                    <p class="text-muted small mb-0">Browse project highlights without leaving the page.</p>
+                                </div>
+                                <div class="project-gallery__grid" role="list">
+                                    @for (var i = 0; i < previewPhotos.Count; i++)
                                     {
+                                        var photo = previewPhotos[i];
                                         var thumbUrl = photoUrl(photo, "sm", photo.Version);
+                                        var mediumUrl = photoUrl(photo, "md", photo.Version);
                                         var largeUrl = photoUrl(photo, "xl", photo.Version);
                                         var thumbSrcSet = string.Join(", ", new[]
                                         {
                                             $"{thumbUrl} 1x",
+                                            $"{mediumUrl} 1.5x",
                                             $"{largeUrl} 2x"
                                         });
-                                        <a class="text-decoration-none" href="@largeUrl" target="_blank" rel="noopener">
-                                            <div class="ratio ratio-4x3" style="width: 140px;">
+                                        var captionText = string.IsNullOrWhiteSpace(photo.Caption) ? null : photo.Caption;
+                                        var altText = captionText ?? $"{project?.Name ?? "Project"} photo";
+                                        var itemClasses = "project-gallery__item" + (i == 0 ? " project-gallery__item--featured" : string.Empty);
+                                        <a class="@itemClasses"
+                                           role="listitem"
+                                           href="@largeUrl"
+                                           data-gallery-trigger
+                                           data-gallery-photo-id="@photo.Id"
+                                           data-gallery-full="@largeUrl"
+                                           data-gallery-srcset="@thumbSrcSet"
+                                           data-gallery-caption="@captionText"
+                                           data-gallery-alt="@altText"
+                                           aria-label="View photo @(i + 1) of @additionalPhotos.Count@(captionText is null ? string.Empty : $": {captionText}")">
+                                            <div class="project-gallery__media">
                                                 <picture>
-                                                    <source type="image/webp"
-                                                            srcset="@thumbSrcSet" />
-                                                    <img class="w-100 h-100 object-fit-cover rounded border"
+                                                    <source type="image/webp" srcset="@thumbSrcSet" />
+                                                    <img class="project-gallery__img"
                                                          loading="lazy"
-                                                         width="140"
-                                                         height="105"
+                                                         width="320"
+                                                         height="240"
                                                          src="@thumbUrl"
                                                          srcset="@thumbSrcSet"
-                                                         alt="@(string.IsNullOrWhiteSpace(photo.Caption) ? $"{project?.Name} photo" : photo.Caption)" />
+                                                         alt="@altText" />
                                                 </picture>
                                             </div>
-                                            @if (!string.IsNullOrWhiteSpace(photo.Caption))
-                                            {
-                                                <small class="d-block text-muted text-truncate mt-1" title="@photo.Caption">@photo.Caption</small>
-                                            }
+                                            <div class="project-gallery__overlay" aria-hidden="true">
+                                                <span class="project-gallery__overlay-text">@(captionText ?? "View photo")</span>
+                                            </div>
                                         </a>
                                     }
+
+                                    <a class="project-gallery__item project-gallery__item--cta"
+                                       role="listitem"
+                                       href="@Url.Page("/Projects/Photos/Index", new { id = Model.Project!.Id })"
+                                       data-gallery-open
+                                       aria-controls="@galleryModalId"
+                                       aria-label="View the full project photo gallery">
+                                        <div class="project-gallery__cta-body">
+                                            <span class="project-gallery__cta-icon" aria-hidden="true">&#128247;</span>
+                                            <span class="project-gallery__cta-text">View gallery</span>
+                                            @if (remainingPhotos > 0)
+                                            {
+                                                <span class="project-gallery__cta-meta">+@remainingPhotos more</span>
+                                            }
+                                        </div>
+                                    </a>
                                 </div>
                             </div>
+
+                            <partial name="_ProjectPhotoLightbox" model="galleryModalModel" />
                         }
                     </div>
                 </div>
@@ -760,6 +805,7 @@
 <partial name="_PlanDiscardDraftModal" model="Model.Project.Id" />
 
 @section Scripts {
+    <script type="module" src="~/js/gallery-lightbox.js" asp-append-version="true"></script>
     <script src="~/js/projects/overview.js" asp-append-version="true"></script>
     <script src="~/js/projects/plan-edit.js" asp-append-version="true"></script>
     <script src="~/js/projects/stages.js" asp-append-version="true"></script>

--- a/Pages/Shared/_ProjectPhotoLightbox.cshtml
+++ b/Pages/Shared/_ProjectPhotoLightbox.cshtml
@@ -1,0 +1,97 @@
+@using System.Linq
+@using System.Text.Encodings.Web
+@using System.Text.Json
+@using ProjectManagement.Models
+@model ProjectManagement.ViewModels.ProjectPhotoLightboxViewModel
+@{
+    if (Model.Photos.Count == 0)
+    {
+        return;
+    }
+
+    var modalId = Model.ModalId;
+    var labelId = $"{modalId}-title";
+    var captionId = $"{modalId}-caption";
+    var counterId = $"{modalId}-counter";
+    var options = new JsonSerializerOptions
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    var payload = Model.Photos
+        .Select((photo, index) =>
+        {
+            var version = Model.GetVersion(photo);
+            var caption = string.IsNullOrWhiteSpace(photo.Caption) ? null : photo.Caption;
+            var alt = caption ?? $"{Model.ProjectName} photo";
+            var thumb = new
+            {
+                src = Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "sm", v = version }),
+                srcSet = string.Join(", ", new[]
+                {
+                    Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "sm", v = version }) + " 1x",
+                    Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "md", v = version }) + " 2x"
+                })
+            };
+            var stage = new
+            {
+                src = Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "xl", v = version }),
+                srcSet = string.Join(", ", new[]
+                {
+                    Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "md", v = version }) + " 1x",
+                    Url.Page("/Projects/Photos/View", new { id = Model.ProjectId, photoId = photo.Id, size = "xl", v = version }) + " 2x"
+                }),
+                sizes = "(min-width: 992px) 960px, 100vw"
+            };
+
+            return new
+            {
+                id = photo.Id,
+                index,
+                caption,
+                alt,
+                thumb,
+                stage
+            };
+        })
+        .ToList();
+
+    var json = JsonSerializer.Serialize(payload, options);
+}
+
+<div class="modal fade project-gallery-modal" id="@modalId" tabindex="-1" aria-labelledby="@labelId" aria-describedby="@captionId" aria-hidden="true" data-gallery-modal>
+    <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title fs-5" id="@labelId">Photo gallery</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close gallery"></button>
+            </div>
+            <div class="modal-body">
+                <div class="project-gallery-modal__content" data-gallery-lightbox>
+                    <div class="project-gallery-modal__stage">
+                        <picture data-gallery-picture>
+                            <img data-gallery-image class="project-gallery-modal__image" alt="" />
+                        </picture>
+                        <div class="project-gallery-modal__stage-controls">
+                            <button type="button" class="btn btn-outline-light project-gallery-modal__control" data-gallery-prev aria-controls="@captionId" aria-label="Previous photo">
+                                <span aria-hidden="true">&larr;</span>
+                            </button>
+                            <button type="button" class="btn btn-outline-light project-gallery-modal__control" data-gallery-next aria-controls="@captionId" aria-label="Next photo">
+                                <span aria-hidden="true">&rarr;</span>
+                            </button>
+                        </div>
+                        <div class="project-gallery-modal__counter" id="@counterId" data-gallery-counter aria-live="polite"></div>
+                    </div>
+                    <div class="project-gallery-modal__meta">
+                        <p class="project-gallery-modal__caption" id="@captionId" data-gallery-caption aria-live="polite"></p>
+                        <div class="project-gallery-modal__thumbnails" data-gallery-thumbnails role="list"></div>
+                        <div class="project-gallery-modal__fallback">
+                            <p class="mb-0">JavaScript is disabled. <a class="link-primary" asp-page="/Projects/Photos/Index" asp-route-id="@Model.ProjectId">View all project photos</a>.</p>
+                        </div>
+                    </div>
+                </div>
+                <script type="application/json" data-gallery-data>@Html.Raw(json)</script>
+            </div>
+        </div>
+    </div>
+</div>

--- a/ViewModels/ProjectPhotoLightboxViewModel.cs
+++ b/ViewModels/ProjectPhotoLightboxViewModel.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels
+{
+    public class ProjectPhotoLightboxViewModel
+    {
+        public ProjectPhotoLightboxViewModel(
+            int projectId,
+            string projectName,
+            IReadOnlyList<ProjectPhoto> photos,
+            int? coverPhotoId,
+            int? coverPhotoVersion,
+            string modalId)
+        {
+            ProjectId = projectId;
+            ProjectName = projectName;
+            Photos = photos ?? Array.Empty<ProjectPhoto>();
+            CoverPhotoId = coverPhotoId;
+            CoverPhotoVersion = coverPhotoVersion;
+            ModalId = string.IsNullOrWhiteSpace(modalId) ? $"project-gallery-modal-{projectId}" : modalId;
+        }
+
+        public int ProjectId { get; }
+
+        public string ProjectName { get; }
+
+        public IReadOnlyList<ProjectPhoto> Photos { get; }
+
+        public int? CoverPhotoId { get; }
+
+        public int? CoverPhotoVersion { get; }
+
+        public string ModalId { get; }
+
+        public int GetVersion(ProjectPhoto photo)
+        {
+            if (photo is null)
+            {
+                throw new ArgumentNullException(nameof(photo));
+            }
+
+            if (CoverPhotoId.HasValue && photo.Id == CoverPhotoId.Value && CoverPhotoVersion.HasValue)
+            {
+                return CoverPhotoVersion.Value;
+            }
+
+            return photo.Version;
+        }
+    }
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -194,6 +194,278 @@ body {
     white-space: nowrap;
 }
 
+/* ---------- Project gallery ---------- */
+.project-gallery {
+    border: 1px solid var(--pm-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    background-color: var(--pm-card);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .4);
+}
+
+.project-gallery__header {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    margin-bottom: 1rem;
+}
+
+.project-gallery__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.project-gallery__item {
+    position: relative;
+    display: block;
+    color: inherit;
+    text-decoration: none;
+    border-radius: .875rem;
+    overflow: hidden;
+    background-color: var(--pm-surface);
+    transition: transform .18s ease;
+}
+
+.project-gallery__item:focus-visible {
+    outline: 3px solid var(--pm-primary);
+    outline-offset: 2px;
+}
+
+.project-gallery__item:hover:not(.project-gallery__item--cta) {
+    transform: translateY(-2px);
+}
+
+.project-gallery__item--featured {
+    min-height: 100%;
+}
+
+.project-gallery__item--featured .project-gallery__media {
+    aspect-ratio: 16 / 9;
+}
+
+.project-gallery__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    background-color: var(--bs-secondary-bg, #f1f3f5);
+}
+
+.project-gallery__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform .2s ease;
+}
+
+.project-gallery__item:hover .project-gallery__img,
+.project-gallery__item:focus-visible .project-gallery__img {
+    transform: scale(1.02);
+}
+
+.project-gallery__overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: .65rem .85rem;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, .7) 100%);
+    color: #fff;
+    font-size: .875rem;
+    transform: translateY(100%);
+    opacity: 0;
+    transition: transform .2s ease, opacity .2s ease;
+}
+
+.project-gallery__item:hover .project-gallery__overlay,
+.project-gallery__item:focus-visible .project-gallery__overlay {
+    transform: translateY(0);
+    opacity: 1;
+}
+
+.project-gallery__overlay-text {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.project-gallery__item--cta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    border: 2px dashed var(--pm-border);
+    background: rgba(45, 108, 223, .08);
+    padding: 1.25rem;
+    min-height: 100%;
+    color: var(--pm-primary);
+}
+
+.project-gallery__item--cta:hover,
+.project-gallery__item--cta:focus-visible {
+    border-color: var(--pm-primary);
+    background: rgba(45, 108, 223, .12);
+}
+
+.project-gallery__cta-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .35rem;
+    color: inherit;
+}
+
+.project-gallery__cta-icon {
+    font-size: 1.75rem;
+    line-height: 1;
+}
+
+.project-gallery__cta-text {
+    font-weight: 600;
+}
+
+.project-gallery__cta-meta {
+    font-size: .85rem;
+    color: var(--pm-muted);
+}
+
+@media (min-width: 768px) {
+    .project-gallery__item--featured {
+        grid-column: span 2;
+    }
+}
+
+@media (min-width: 992px) {
+    .project-gallery__grid {
+        grid-template-columns: repeat(3, minmax(220px, 1fr));
+    }
+}
+
+.project-gallery-modal__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.project-gallery-modal__stage {
+    position: relative;
+    background: #0b1120;
+    border-radius: 1rem;
+    padding: clamp(.5rem, 2vw, 1.25rem);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.project-gallery-modal__image {
+    max-width: 100%;
+    max-height: 70vh;
+    width: 100%;
+    border-radius: .75rem;
+    object-fit: contain;
+    background-color: #000;
+}
+
+.project-gallery-modal__stage-controls {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    display: flex;
+    justify-content: space-between;
+    padding: 0 1rem;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.project-gallery-modal__control {
+    pointer-events: auto;
+    border-radius: 999px;
+    min-width: 2.75rem;
+}
+
+.project-gallery-modal__counter {
+    margin-top: 1rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.project-gallery-modal__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.project-gallery-modal__caption {
+    font-size: 1rem;
+    min-height: 1.5em;
+}
+
+.project-gallery-modal__thumbnails {
+    display: grid;
+    gap: .75rem;
+    grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
+}
+
+.project-gallery-modal__thumb {
+    border: 2px solid transparent;
+    border-radius: .5rem;
+    overflow: hidden;
+    padding: 0;
+    background: none;
+    transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.project-gallery-modal__thumb-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.project-gallery-modal__thumb:hover,
+.project-gallery-modal__thumb:focus-visible {
+    border-color: var(--pm-primary);
+    outline: none;
+}
+
+.project-gallery-modal__thumb.is-active {
+    border-color: var(--pm-primary);
+    box-shadow: 0 0 0 2px rgba(45, 108, 223, .25);
+}
+
+.project-gallery-modal__fallback {
+    font-size: .875rem;
+    color: var(--pm-muted);
+}
+
+@media (max-width: 767.98px) {
+    .project-gallery-modal__stage-controls {
+        position: static;
+        transform: none;
+        margin-top: .75rem;
+        gap: .75rem;
+        justify-content: center;
+    }
+}
+
+@media (min-width: 992px) {
+    .project-gallery-modal__content {
+        flex-direction: row;
+    }
+
+    .project-gallery-modal__stage {
+        flex: 1 1 65%;
+    }
+
+    .project-gallery-modal__meta {
+        flex: 1 1 35%;
+    }
+}
+
 @media (max-width: 576px) {
     .project-photo-empty {
         min-height: 180px;

--- a/wwwroot/js/gallery-lightbox.js
+++ b/wwwroot/js/gallery-lightbox.js
@@ -1,0 +1,233 @@
+function initGallery(gallery) {
+  const modalId = gallery.getAttribute('data-gallery-modal-id');
+  const Modal = window.bootstrap?.Modal;
+  if (!modalId || !Modal) {
+    return;
+  }
+
+  const modalEl = document.getElementById(modalId);
+  if (!modalEl) {
+    return;
+  }
+
+  const dataEl = modalEl.querySelector('[data-gallery-data]');
+  if (!dataEl) {
+    return;
+  }
+
+  let photos = [];
+  try {
+    photos = JSON.parse(dataEl.textContent ?? '[]');
+  } catch (error) {
+    console.error('Failed to parse gallery data', error);
+    return;
+  }
+
+  if (!Array.isArray(photos) || photos.length === 0) {
+    return;
+  }
+
+  const modalInstance = typeof Modal.getOrCreateInstance === 'function'
+    ? Modal.getOrCreateInstance(modalEl)
+    : new Modal(modalEl);
+
+  const imgEl = modalEl.querySelector('[data-gallery-image]');
+  const captionEl = modalEl.querySelector('[data-gallery-caption]');
+  const counterEl = modalEl.querySelector('[data-gallery-counter]');
+  const thumbContainer = modalEl.querySelector('[data-gallery-thumbnails]');
+  const prevBtn = modalEl.querySelector('[data-gallery-prev]');
+  const nextBtn = modalEl.querySelector('[data-gallery-next]');
+  const fallbackEl = modalEl.querySelector('.project-gallery-modal__fallback');
+
+  let currentIndex = 0;
+
+  const updateThumbState = () => {
+    if (!thumbContainer) {
+      return;
+    }
+
+    const buttons = thumbContainer.querySelectorAll('[data-gallery-thumb]');
+    buttons.forEach((button, idx) => {
+      if (idx === currentIndex) {
+        button.classList.add('is-active');
+        button.setAttribute('aria-current', 'true');
+      } else {
+        button.classList.remove('is-active');
+        button.removeAttribute('aria-current');
+      }
+    });
+  };
+
+  const updateNavState = () => {
+    if (prevBtn) {
+      prevBtn.disabled = currentIndex <= 0;
+    }
+    if (nextBtn) {
+      nextBtn.disabled = currentIndex >= photos.length - 1;
+    }
+  };
+
+  const updateStage = (index) => {
+    const nextIndex = Math.min(Math.max(index, 0), photos.length - 1);
+    const photo = photos[nextIndex];
+    if (!photo || !imgEl) {
+      return;
+    }
+
+    currentIndex = nextIndex;
+    const { stage, caption, alt } = photo;
+    if (stage) {
+      if (stage.src) {
+        imgEl.src = stage.src;
+      }
+      if (stage.srcSet) {
+        imgEl.srcset = stage.srcSet;
+      } else {
+        imgEl.removeAttribute('srcset');
+      }
+      if (stage.sizes) {
+        imgEl.sizes = stage.sizes;
+      } else {
+        imgEl.removeAttribute('sizes');
+      }
+    }
+
+    imgEl.alt = alt ?? '';
+
+    if (captionEl) {
+      captionEl.textContent = caption ?? '';
+    }
+
+    if (counterEl) {
+      counterEl.textContent = `${currentIndex + 1} of ${photos.length}`;
+    }
+
+    updateThumbState();
+    updateNavState();
+  };
+
+  const handlePrev = () => {
+    if (currentIndex > 0) {
+      updateStage(currentIndex - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentIndex < photos.length - 1) {
+      updateStage(currentIndex + 1);
+    }
+  };
+
+  const handleKey = (event) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      handlePrev();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      handleNext();
+    }
+  };
+
+  if (prevBtn) {
+    prevBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      handlePrev();
+    });
+  }
+
+  if (nextBtn) {
+    nextBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      handleNext();
+    });
+  }
+
+  if (thumbContainer) {
+    thumbContainer.innerHTML = '';
+    photos.forEach((photo, idx) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'project-gallery-modal__thumb';
+      button.setAttribute('data-gallery-thumb', '');
+      button.setAttribute('role', 'listitem');
+      button.setAttribute('aria-label', photo.caption ? `View photo: ${photo.caption}` : 'View photo');
+
+      const thumbImage = document.createElement('img');
+      thumbImage.className = 'project-gallery-modal__thumb-img';
+      if (photo.thumb?.src) {
+        thumbImage.src = photo.thumb.src;
+      }
+      if (photo.thumb?.srcSet) {
+        thumbImage.srcset = photo.thumb.srcSet;
+      }
+      thumbImage.alt = photo.caption ? `Thumbnail: ${photo.caption}` : 'Photo thumbnail';
+
+      button.appendChild(thumbImage);
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        updateStage(idx);
+      });
+
+      thumbContainer.appendChild(button);
+    });
+  }
+
+  if (fallbackEl) {
+    fallbackEl.hidden = true;
+  }
+
+  const openModalAt = (photoId) => {
+    const index = photos.findIndex((item) => item.id === photoId);
+    updateStage(index >= 0 ? index : 0);
+    modalInstance.show();
+  };
+
+  const triggers = gallery.querySelectorAll('[data-gallery-trigger]');
+  triggers.forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      if (!photos.length) {
+        return;
+      }
+      const id = Number.parseInt(trigger.getAttribute('data-gallery-photo-id') ?? '', 10);
+      if (Number.isNaN(id)) {
+        return;
+      }
+      event.preventDefault();
+      openModalAt(id);
+    });
+  });
+
+  const openers = gallery.querySelectorAll('[data-gallery-open]');
+  openers.forEach((opener) => {
+    opener.addEventListener('click', (event) => {
+      if (!photos.length) {
+        return;
+      }
+      event.preventDefault();
+      openModalAt(photos[0].id);
+    });
+  });
+
+  modalEl.addEventListener('shown.bs.modal', () => {
+    document.addEventListener('keydown', handleKey);
+    const initialFocus = (!prevBtn || prevBtn.disabled) ? nextBtn : prevBtn;
+    if (initialFocus) {
+      initialFocus.focus();
+    }
+  });
+
+  modalEl.addEventListener('hidden.bs.modal', () => {
+    document.removeEventListener('keydown', handleKey);
+  });
+}
+
+function boot() {
+  const galleries = document.querySelectorAll('[data-gallery]');
+  galleries.forEach((gallery) => initGallery(gallery));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true });
+} else {
+  boot();
+}


### PR DESCRIPTION
## Summary
- replace the thumbnail strip on the project overview with a responsive gallery grid and persistent “View gallery” entry point
- add a reusable lightbox modal partial and ES module to drive keyboard-friendly, in-page photo browsing
- extend the shared stylesheet with gallery and modal treatments for hover overlays, focus states, and responsive behaviour

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dce12111d08329844d68279a7d2acf