### PR TITLE
Refine project management card actions

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -189,15 +189,18 @@
 
     <div class="card mb-4">
         <div class="card-body">
-            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
+            <div class="card-action-bar mb-3">
                 <h2 class="h5 mb-0">Project photos</h2>
                 @if (canManagePhotos)
                 {
-                    <a class="btn btn-sm btn-outline-primary"
-                       asp-page="/Projects/Photos/Index"
-                       asp-route-id="@Model.Project!.Id">
-                        Manage photos
-                    </a>
+                    <div class="card-action-bar-actions">
+                        <a class="btn btn-link card-action-link"
+                           asp-page="/Projects/Photos/Index"
+                           asp-route-id="@Model.Project!.Id">
+                            <i class="bi bi-sliders" aria-hidden="true"></i>
+                            <span>Manage photos</span>
+                        </a>
+                    </div>
                 }
             </div>
             <div class="row g-4 align-items-start">
@@ -383,7 +386,7 @@
                         </p>
                         @if (canManagePhotos)
                         {
-                            <a class="btn btn-sm btn-primary"
+                            <a class="btn btn-primary"
                                asp-page="/Projects/Photos/Index"
                                asp-route-id="@Model.Project!.Id"
                                aria-label="Upload the first project photo">

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -25,17 +25,26 @@
 }
 
 <div class="card">
-  <div class="card-header d-flex align-items-center justify-content-between">
-    <div class="d-flex align-items-center">
-      <i class="bi bi-receipt me-2" aria-hidden="true"></i>
-      <span class="fw-semibold">Procurement At-a-Glance</span>
+  <div class="card-header">
+    <div class="card-action-bar">
+      <div class="d-flex align-items-center gap-2">
+        <i class="bi bi-receipt" aria-hidden="true"></i>
+        <span class="fw-semibold">Procurement At-a-Glance</span>
+      </div>
+      @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("Project Officer"))
+      {
+        <div class="card-action-bar-actions">
+          <button type="button"
+                  class="btn btn-link card-action-link"
+                  data-bs-toggle="offcanvas"
+                  data-bs-target="#offcanvasProcurement"
+                  aria-controls="offcanvasProcurement">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+            <span>Edit procurement</span>
+          </button>
+        </div>
+      }
     </div>
-    @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("Project Officer"))
-    {
-      <button class="btn btn-sm btn-outline-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasProcurement" aria-controls="offcanvasProcurement">
-        Edit Procurement
-      </button>
-    }
   </div>
 
   <div class="card-body">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -194,6 +194,51 @@ body {
     white-space: nowrap;
 }
 
+/* ---------- Card action helpers ---------- */
+.card-action-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .75rem;
+}
+
+.card-action-bar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem;
+    margin-left: auto;
+}
+
+.card-action-link {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: .25rem .5rem;
+    border-radius: .5rem;
+    font-weight: 600;
+    color: var(--bs-link-color);
+}
+
+.card-action-link:hover,
+.card-action-link:focus {
+    text-decoration: none;
+}
+
+.card-action-link:hover {
+    background-color: rgba(var(--bs-link-color-rgb, 13, 110, 253), .08);
+}
+
+.card-action-link:focus-visible {
+    outline: 2px solid var(--bs-focus-ring-color, rgba(13, 110, 253, .4));
+    outline-offset: 2px;
+    background-color: rgba(var(--bs-link-color-rgb, 13, 110, 253), .12);
+}
+
+.card-action-link .bi {
+    font-size: 1rem;
+}
+
 /* ---------- Project gallery ---------- */
 .project-gallery {
     border: 1px solid var(--pm-border);


### PR DESCRIPTION
## Summary
- restyle project photo and procurement management actions as compact link buttons with icons
- introduce reusable card action helper utilities for alignment and spacing
- keep the empty state upload call-to-action visually primary after layout tweaks

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dce3d63e748329bfa7395fd9828950