### PR TITLE
Refresh project overview cards

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -187,22 +187,30 @@
         </div>
     }
 
-    <div class="card mb-4">
-        <div class="card-body">
-            <div class="card-action-bar mb-3">
-                <h2 class="h5 mb-0">Project photos</h2>
-                @if (canManagePhotos)
-                {
-                    <div class="card-action-bar-actions">
-                        <a class="btn btn-link card-action-link"
-                           asp-page="/Projects/Photos/Index"
-                           asp-route-id="@Model.Project!.Id">
-                            <i class="bi bi-sliders" aria-hidden="true"></i>
-                            <span>Manage photos</span>
-                        </a>
-                    </div>
-                }
+    <div class="card pm-card mb-4">
+        <div class="card-header pm-card-header">
+            <div class="pm-card-heading">
+                <span class="pm-card-icon" aria-hidden="true">
+                    <i class="bi bi-camera"></i>
+                </span>
+                <div>
+                    <h2 class="pm-card-title h5 mb-0">Project photos</h2>
+                    <p class="pm-card-subtitle mb-0">Latest cover and gallery highlights.</p>
+                </div>
             </div>
+            @if (canManagePhotos)
+            {
+                <div class="pm-card-actions">
+                    <a class="btn btn-link card-action-link"
+                       asp-page="/Projects/Photos/Index"
+                       asp-route-id="@Model.Project!.Id">
+                        <i class="bi bi-sliders" aria-hidden="true"></i>
+                        <span>Manage photos</span>
+                    </a>
+                </div>
+            }
+        </div>
+        <div class="card-body pm-card-body">
             <div class="row g-4 align-items-start">
                 <div class="col-12 col-lg-5 col-xl-4">
                     <div class="project-photo-cover">
@@ -402,9 +410,40 @@
         <div class="col-lg-8 d-flex flex-column gap-3">
             <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
 
-            <div class="card">
-                <div class="card-header">Stage progress</div>
-                <div class="card-body">
+            <div class="card pm-card">
+                @{
+                    var stageTotal = Model.Stages.Count;
+                    var stageCompleted = Model.Stages.Count(s => s.Status == StageStatus.Completed);
+                    var stageBlocked = Model.Stages.Count(s => s.Status == StageStatus.Blocked);
+                    var stageProgressPercent = stageTotal == 0
+                        ? 0
+                        : (int)Math.Round((decimal)stageCompleted / stageTotal * 100, MidpointRounding.AwayFromZero);
+                }
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-list-check"></i>
+                        </span>
+                        <div>
+                            <h3 class="pm-card-title h5 mb-0">Stage progress</h3>
+                            <p class="pm-card-subtitle mb-0">Milestone updates recorded across procurement stages.</p>
+                        </div>
+                    </div>
+                    @if (stageTotal > 0)
+                    {
+                        <div class="pm-card-meta">
+                            <div class="pm-card-progress" aria-hidden="true">
+                                <span class="pm-card-progress-bar" style="width: @stageProgressPercent%;"></span>
+                            </div>
+                            <span class="text-muted small">@stageCompleted of @stageTotal completed</span>
+                            @if (stageBlocked > 0)
+                            {
+                                <span class="badge bg-warning-subtle text-warning-emphasis small">@stageBlocked blocked</span>
+                            }
+                        </div>
+                    }
+                </div>
+                <div class="card-body pm-card-body">
                     @if (!Model.Stages.Any())
                     {
                         <p class="mb-0 text-muted">No stage updates recorded yet.</p>
@@ -441,14 +480,19 @@
             {
                 if (isHoD || isAdmin)
                 {
-                    <div class="card">
-                        <div class="card-header">
-                            <div class="d-flex flex-column">
-                                <span>Meta change pending</span>
-                                <span class="text-muted small">Requested @metaRequest.RequestedOnUtc.ToLocalTime().ToString("dd MMM yyyy, HH:mm")</span>
+                    <div class="card pm-card">
+                        <div class="card-header pm-card-header">
+                            <div class="pm-card-heading">
+                                <span class="pm-card-icon" aria-hidden="true">
+                                    <i class="bi bi-clipboard2-data"></i>
+                                </span>
+                                <div>
+                                    <h3 class="pm-card-title h6 mb-0">Meta change pending</h3>
+                                    <p class="pm-card-subtitle mb-0">Requested @metaRequest.RequestedOnUtc.ToLocalTime().ToString("dd MMM yyyy, HH:mm")</p>
+                                </div>
                             </div>
                         </div>
-                        <div class="card-body d-flex flex-column gap-3">
+                        <div class="card-body pm-card-body d-flex flex-column gap-3">
                             @if (metaRequest.HasDrift)
                             {
                                 <div class="alert alert-warning border-warning-subtle bg-warning-subtle text-dark" role="alert">
@@ -587,9 +631,19 @@
                 if (Model.Timeline.PendingRequests.Any())
                 {
                     var decisionTokens = Antiforgery.GetAndStoreTokens(HttpContext);
-                    <div class="card" data-stage-requests-card>
-                        <div class="card-header">Stage change requests</div>
-                        <div class="card-body d-flex flex-column gap-3">
+                    <div class="card pm-card" data-stage-requests-card>
+                        <div class="card-header pm-card-header">
+                            <div class="pm-card-heading">
+                                <span class="pm-card-icon" aria-hidden="true">
+                                    <i class="bi bi-repeat"></i>
+                                </span>
+                                <div>
+                                    <h3 class="pm-card-title h6 mb-0">Stage change requests</h3>
+                                    <p class="pm-card-subtitle mb-0">Pending updates awaiting HoD decisions.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="card-body pm-card-body d-flex flex-column gap-3">
                             <input type="hidden" value="@decisionTokens.RequestToken" data-stage-decision-token />
                             <div class="text-muted small @(Model.Timeline.PendingRequests.Any() ? "d-none" : string.Empty)" data-stage-requests-empty>
                                 No pending stage change requests.
@@ -641,12 +695,17 @@
                     </div>
                 }
             }
-            <div class="card">
-                <div class="card-header">
+            <div class="card pm-card">
+                <div class="card-header pm-card-header flex-column gap-3">
                     <div class="d-flex flex-column gap-2">
                         <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center gap-3 justify-content-lg-between">
                             <div class="d-flex flex-wrap align-items-center gap-2">
-                                <h5 class="mb-0">Timeline</h5>
+                                <div class="pm-card-heading">
+                                    <span class="pm-card-icon" aria-hidden="true">
+                                        <i class="bi bi-clock-history"></i>
+                                    </span>
+                                    <div>
+                                        <h5 class="pm-card-title mb-0">Timeline</h5>
                                 @{ 
                                     string? viewerRole = null;
                                     if (isHoD && isThisProjectsPo)
@@ -662,6 +721,9 @@
                                         viewerRole = "Project Officer";
                                     }
                                 }
+                                        <div class="pm-card-subtitle text-muted mb-0 small">Live view of the implementation roadmap.</div>
+                                    </div>
+                                </div>
                                 <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-2 mt-2 mt-lg-0">
                                     @if (!string.IsNullOrEmpty(viewerRole))
                                     {
@@ -713,7 +775,7 @@
                                     </div>
                                 }
                             </div>
-                            <div class="d-flex flex-wrap align-items-center gap-2 justify-content-lg-end">
+                            <div class="pm-card-actions d-flex flex-wrap align-items-center gap-2 justify-content-lg-end">
                                 @if (planState.HasPendingSubmission && isHoD)
                                 {
                                     <button class="btn btn-sm btn-outline-primary"
@@ -736,19 +798,17 @@
                                 }
                             </div>
                         </div>
-                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
-                            <div class="d-flex align-items-center gap-2">
-                                <progress class="pm-progress pm-progress-slim pm-progress-fixed-180"
-                                          value="@completedStages"
-                                          max="@progressMax"
-                                          aria-label="Stages completed">
-                                </progress>
-                                <span class="text-muted small">@completedStages of @totalStages</span>
-                            </div>
+                        <div class="pm-card-meta w-100">
+                            <progress class="pm-progress pm-progress-slim pm-progress-fixed-180"
+                                      value="@completedStages"
+                                      max="@progressMax"
+                                      aria-label="Timeline stages completed">
+                            </progress>
+                            <span class="text-muted small">@completedStages of @totalStages complete</span>
                         </div>
                     </div>
                 </div>
-                <div class="card-body">
+                <div class="card-body pm-card-body">
                     @if (submissionBlocked)
                     {
                         <div class="alert alert-warning" role="status">

--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -24,30 +24,33 @@
     string DateDmy(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
 }
 
-<div class="card">
-  <div class="card-header">
-    <div class="card-action-bar">
-      <div class="d-flex align-items-center gap-2">
-        <i class="bi bi-receipt" aria-hidden="true"></i>
-        <span class="fw-semibold">Procurement At-a-Glance</span>
+<div class="card pm-card h-100">
+  <div class="card-header pm-card-header">
+    <div class="pm-card-heading">
+      <span class="pm-card-icon" aria-hidden="true">
+        <i class="bi bi-receipt"></i>
+      </span>
+      <div>
+        <h2 class="pm-card-title h5 mb-0">Procurement at a glance</h2>
+        <p class="pm-card-subtitle mb-0">Key budget markers for this project.</p>
       </div>
-      @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("Project Officer"))
-      {
-        <div class="card-action-bar-actions">
-          <button type="button"
-                  class="btn btn-link card-action-link"
-                  data-bs-toggle="offcanvas"
-                  data-bs-target="#offcanvasProcurement"
-                  aria-controls="offcanvasProcurement">
-            <i class="bi bi-pencil-square" aria-hidden="true"></i>
-            <span>Edit procurement</span>
-          </button>
-        </div>
-      }
     </div>
+    @if (User.IsInRole("Admin") || User.IsInRole("HoD") || User.IsInRole("Project Officer"))
+    {
+      <div class="pm-card-actions">
+        <button type="button"
+                class="btn btn-link card-action-link"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#offcanvasProcurement"
+                aria-controls="offcanvasProcurement">
+          <i class="bi bi-pencil-square" aria-hidden="true"></i>
+          <span>Edit procurement</span>
+        </button>
+      </div>
+    }
   </div>
 
-  <div class="card-body">
+  <div class="card-body pm-card-body">
     <div class="row g-3">
       <div class="col-md-6">
         <div class="d-flex justify-content-between">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -15,6 +15,110 @@ body {
     color: var(--pm-text);
 }
 
+/* ---------- Cards ---------- */
+.pm-card {
+    border: 1px solid rgba(15, 23, 42, .08);
+    border-radius: 1rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, .98) 0%, rgba(248, 250, 252, .98) 100%);
+    box-shadow: 0 24px 40px -32px rgba(15, 23, 42, .35);
+    overflow: hidden;
+}
+
+.pm-card-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: linear-gradient(180deg, rgba(45, 108, 223, .08) 0%, rgba(45, 108, 223, .03) 100%);
+    border-bottom: 1px solid rgba(15, 23, 42, .06);
+}
+
+.pm-card-heading {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    min-width: 0;
+}
+
+.pm-card-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: .85rem;
+    background-color: rgba(45, 108, 223, .12);
+    color: var(--pm-primary);
+    font-size: 1.25rem;
+    flex-shrink: 0;
+}
+
+.pm-card-title {
+    margin: 0;
+    font-weight: 600;
+    letter-spacing: .15px;
+    color: var(--pm-text);
+}
+
+.pm-card-subtitle {
+    margin: .125rem 0 0;
+    font-size: .85rem;
+    color: var(--pm-text-secondary);
+}
+
+.pm-card-actions {
+    margin-left: auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem;
+}
+
+.pm-card-meta {
+    margin-left: auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem;
+}
+
+.pm-card-progress {
+    position: relative;
+    width: 140px;
+    height: 6px;
+    border-radius: 999px;
+    background-color: rgba(15, 23, 42, .08);
+    overflow: hidden;
+}
+
+.pm-card-progress-bar {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, var(--pm-primary) 0%, var(--pm-primary-hover) 100%);
+    border-radius: inherit;
+    transition: width .3s ease;
+}
+
+.pm-card-body {
+    padding: 1.25rem 1.5rem;
+}
+
+.pm-card-body > :last-child {
+    margin-bottom: 0;
+}
+
+@media (max-width: 575.98px) {
+    .pm-card-header,
+    .pm-card-body {
+        padding: 1rem 1.125rem;
+    }
+
+    .pm-card-progress {
+        width: 100%;
+    }
+}
+
 /* ---------- Header & footer ---------- */
 .pm-header .navbar-brand {
     letter-spacing: .2px;


### PR DESCRIPTION
## Summary
- add a bespoke `.pm-card` style with softened surfaces, icons, and progress utilities
- restyle the project overview and procurement glance cards to adopt the new variant with descriptive headers
- surface quick status context for stage progress and timeline sections while aligning right-column cards to the new system

## Testing
- dotnet build *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf1c9abe08329be36022e5ab9002a