### PR TITLE
Refine procurement glance grid layout

### DIFF
--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -51,35 +51,30 @@
   </div>
 
   <div class="card-body pm-card-body">
-    <div class="row g-3">
-      <div class="col-md-6">
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">IPA Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.IpaCost)">@Money(Model.IpaCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">AON Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.AonCost)">@Money(Model.AonCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">Benchmark Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.BenchmarkCost)">@Money(Model.BenchmarkCost)</span>
-        </div>
+    <div class="procurement-metrics">
+      <div>
+        <span class="procurement-label text-muted">IPA Cost</span>
+        <span class="procurement-value fw-semibold" title="@FullInr(Model.IpaCost)">@Money(Model.IpaCost)</span>
       </div>
-
-      <div class="col-md-6">
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">L1 Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.L1Cost)">@Money(Model.L1Cost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">PNC Cost</span>
-          <span class="fw-semibold" title="@FullInr(Model.PncCost)">@Money(Model.PncCost)</span>
-        </div>
-        <div class="d-flex justify-content-between">
-          <span class="text-muted">Supply Order Date</span>
-          <span class="fw-semibold">@DateDmy(Model.SupplyOrderDate)</span>
-        </div>
+      <div>
+        <span class="procurement-label text-muted">AON Cost</span>
+        <span class="procurement-value fw-semibold" title="@FullInr(Model.AonCost)">@Money(Model.AonCost)</span>
+      </div>
+      <div>
+        <span class="procurement-label text-muted">Benchmark Cost</span>
+        <span class="procurement-value fw-semibold" title="@FullInr(Model.BenchmarkCost)">@Money(Model.BenchmarkCost)</span>
+      </div>
+      <div>
+        <span class="procurement-label text-muted">L1 Cost</span>
+        <span class="procurement-value fw-semibold" title="@FullInr(Model.L1Cost)">@Money(Model.L1Cost)</span>
+      </div>
+      <div>
+        <span class="procurement-label text-muted">PNC Cost</span>
+        <span class="procurement-value fw-semibold" title="@FullInr(Model.PncCost)">@Money(Model.PncCost)</span>
+      </div>
+      <div>
+        <span class="procurement-label text-muted">Supply Order Date</span>
+        <span class="procurement-value fw-semibold">@DateDmy(Model.SupplyOrderDate)</span>
       </div>
     </div>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -108,6 +108,30 @@ body {
     margin-bottom: 0;
 }
 
+.procurement-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: .5rem 1rem;
+}
+
+.procurement-metrics > div {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: .5rem;
+    padding-block: .125rem;
+}
+
+.procurement-metrics .procurement-label {
+    color: var(--pm-muted);
+}
+
+.procurement-metrics .procurement-value {
+    margin-left: auto;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 575.98px) {
     .pm-card-header,
     .pm-card-body {


### PR DESCRIPTION
## Summary
- replace the procurement at a glance two-column row with a grid-friendly wrapper
- style the new procurement metrics grid for better spacing and responsive collapse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf79954bc8329948a559bf3d1a99d