### PR TITLE
Add description character counter to project forms

### DIFF
--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -34,7 +34,8 @@
                     </div>
                     <div class="col-md-6">
                         <label asp-for="Input.Description" class="form-label"></label>
-                        <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+                        <textarea asp-for="Input.Description" class="form-control" rows="3" maxlength="1000"></textarea>
+                        <div class="form-text" data-char-count-for="Input_Description">0/1000</div>
                         <span asp-validation-for="Input.Description" class="text-danger"></span>
                     </div>
                 </div>
@@ -122,5 +123,6 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
     <script src="~/js/widgets/async-select.js" asp-append-version="true" defer></script>
+    <script src="~/js/widgets/char-count.js" asp-append-version="true" defer></script>
     <script src="~/js/projects/create.js" asp-append-version="true"></script>
 }

--- a/Pages/Projects/Meta/Edit.cshtml
+++ b/Pages/Projects/Meta/Edit.cshtml
@@ -17,7 +17,8 @@
     </div>
     <div class="mb-3">
         <label asp-for="Input.Description" class="form-label"></label>
-        <textarea asp-for="Input.Description" class="form-control" rows="4"></textarea>
+        <textarea asp-for="Input.Description" class="form-control" rows="4" maxlength="1000"></textarea>
+        <div class="form-text" data-char-count-for="Input_Description">0/1000</div>
         <span asp-validation-for="Input.Description" class="text-danger"></span>
     </div>
     <div class="mb-3">
@@ -46,4 +47,5 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
     <script src="~/js/widgets/async-select.js" asp-append-version="true" defer></script>
+    <script src="~/js/widgets/char-count.js" asp-append-version="true" defer></script>
 }

--- a/wwwroot/js/widgets/char-count.js
+++ b/wwwroot/js/widgets/char-count.js
@@ -1,0 +1,52 @@
+(function () {
+    function parseMaxLength(target) {
+        if (typeof target.maxLength === 'number' && target.maxLength > 0) {
+            return target.maxLength;
+        }
+
+        var attributeValue = target.getAttribute('maxlength') || target.getAttribute('data-val-length-max');
+        if (!attributeValue) {
+            return null;
+        }
+
+        var parsed = parseInt(attributeValue, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    }
+
+    function initCounter(counter) {
+        var targetId = counter.getAttribute('data-char-count-for');
+        if (!targetId) {
+            return;
+        }
+
+        var target = document.getElementById(targetId);
+        if (!target) {
+            return;
+        }
+
+        var maxLength = parseMaxLength(target);
+        if (!maxLength) {
+            return;
+        }
+
+        var update = function () {
+            var length = target.value ? target.value.length : 0;
+            counter.textContent = length + '/' + maxLength;
+        };
+
+        update();
+        target.addEventListener('input', update);
+        target.addEventListener('change', update);
+    }
+
+    function init() {
+        var counters = document.querySelectorAll('[data-char-count-for]');
+        counters.forEach(initCounter);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary
- add maxlength and character usage helper text for project description fields
- introduce a reusable character count widget script and load it on the project forms

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcf8c9bab88329ab2f752fe7f603f3