### PR TITLE
Adjust project overview card placement and description styling

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -202,144 +202,144 @@
         </div>
     }
 
-    <div class="card pm-card mb-4">
-        <div class="card-header pm-card-header">
-            <div class="pm-card-heading">
-                <span class="pm-card-icon" aria-hidden="true">
-                    <i class="bi bi-layout-text-window"></i>
-                </span>
-                <div>
-                    <h2 class="pm-card-title h5 mb-0">Project overview</h2>
-                    <p class="pm-card-subtitle mb-0">Description and key project facts</p>
-                </div>
-            </div>
-            @if (canManagePhotos || isThisProjectsPo || isAdmin || isHoD)
-            {
-                <div class="pm-card-actions">
-                    <div class="d-flex flex-wrap gap-2">
-                        @if (canManagePhotos)
-                        {
-                            <a class="btn btn-link card-action-link"
-                               asp-page="/Projects/Photos/Index"
-                               asp-route-id="@Model.Project!.Id">
-                                <i class="bi bi-sliders" aria-hidden="true"></i>
-                                <span>Manage photos</span>
-                            </a>
-                        }
-                        @if (isThisProjectsPo)
-                        {
-                            <a class="btn btn-sm btn-outline-primary"
-                               asp-page="/Projects/Meta/Request"
-                               asp-route-id="@Model.Project!.Id">Request change</a>
-                        }
-                        @if (isAdmin || isHoD)
-                        {
-                            <a class="btn btn-sm btn-outline-secondary"
-                               asp-page="/Projects/Meta/Edit"
-                               asp-route-id="@Model.Project!.Id">Edit details</a>
-                        }
-                    </div>
-                </div>
-            }
-        </div>
-        <div class="card-body pm-card-body">
-            <div class="row g-4 align-items-start">
-                <div class="col-12 col-lg-5 col-xl-4">
-                    <div class="project-photo-cover">
-                        <div class="ratio ratio-4x3 w-100">
-                            @if (coverPhoto != null)
-                            {
-                                <picture>
-                                    <source type="image/webp"
-                                            srcset="@coverSrcSet"
-                                            sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw" />
-                                    <img class="w-100 h-100 object-fit-cover rounded border"
-                                         width="360"
-                                         height="270"
-                                         src="@coverXs"
-                                         srcset="@coverSrcSet"
-                                         sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw"
-                                         alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
-                                </picture>
-                            }
-                            else
-                            {
-                                <div class="d-flex align-items-center justify-content-center w-100 h-100 rounded border bg-light text-muted">
-                                    <span>No cover photo</span>
-                                </div>
-                            }
-                        </div>
-                        @if (!string.IsNullOrWhiteSpace(coverPhoto?.Caption))
-                        {
-                            <div class="mt-2 text-muted small">@coverPhoto.Caption</div>
-                        }
-                    </div>
-                </div>
-                <div class="col-12 col-lg-7 col-xl-8">
-                    <dl class="row mb-0">
-                            <dt class="col-sm-4">Description</dt>
-                            <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(project?.Description) ? project.Description : "—")</dd>
-
-                            <dt class="col-sm-4">Category</dt>
-                            <dd class="col-sm-8">
-                                @if (Model.CategoryPath.Any())
-                                {
-                                    <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
-                                }
-                                else
-                                {
-                                    <span>—</span>
-                                }
-                            </dd>
-
-                            <dt class="col-sm-4">Sponsoring Unit</dt>
-                            <dd class="col-sm-8">@(Model.Project?.SponsoringUnit?.Name ?? "—")</dd>
-
-                            <dt class="col-sm-4">Sponsoring Line Dte</dt>
-                            <dd class="col-sm-8">@(Model.Project?.SponsoringLineDirectorate?.Name ?? "—")</dd>
-
-                            <dt class="col-sm-4">Head of Department</dt>
-                            <dd class="col-sm-8">@DisplayUser(project?.HodUser)</dd>
-
-                            <dt class="col-sm-4">Project Officer</dt>
-                            <dd class="col-sm-8">@DisplayUser(project?.LeadPoUser)</dd>
-                        </dl>
-                </div>
-            </div>
-
-            @if (!additionalPhotos.Any() && coverPhoto is null)
-            {
-                var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
-                var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
-                <div class="project-photo-empty border rounded bg-light-subtle text-center"
-                     role="region"
-                     aria-labelledby="@emptyStateHeadingId"
-                     aria-describedby="@emptyStateDescriptionId">
-                    <div class="project-photo-empty-body">
-                        <span class="project-photo-empty-icon" aria-hidden="true">
-                            <i class="bi bi-images"></i>
-                        </span>
-                        <h3 id="@emptyStateHeadingId" class="h6 fw-semibold mb-2">No photos yet</h3>
-                        <p id="@emptyStateDescriptionId" class="mb-3 text-muted">
-                            Add a cover or gallery photo to help everyone recognise this project at a glance.
-                        </p>
-                        @if (canManagePhotos)
-                        {
-                            <a class="btn btn-primary"
-                               asp-page="/Projects/Photos/Index"
-                               asp-route-id="@Model.Project!.Id"
-                               aria-label="Upload the first project photo">
-                                Upload photo
-                            </a>
-                        }
-                    </div>
-                </div>
-            }
-        </div>
-    </div>
-
     <div class="row g-3 mb-4">
         <div class="col-lg-8 d-flex flex-column gap-3">
+            <div class="card pm-card">
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-layout-text-window"></i>
+                        </span>
+                        <div>
+                            <h2 class="pm-card-title h5 mb-0">Project overview</h2>
+                            <p class="pm-card-subtitle mb-0">Description and key project facts</p>
+                        </div>
+                    </div>
+                    @if (canManagePhotos || isThisProjectsPo || isAdmin || isHoD)
+                    {
+                        <div class="pm-card-actions">
+                            <div class="d-flex flex-wrap gap-2">
+                                @if (canManagePhotos)
+                                {
+                                    <a class="btn btn-link card-action-link"
+                                       asp-page="/Projects/Photos/Index"
+                                       asp-route-id="@Model.Project!.Id">
+                                        <i class="bi bi-sliders" aria-hidden="true"></i>
+                                        <span>Manage photos</span>
+                                    </a>
+                                }
+                                @if (isThisProjectsPo)
+                                {
+                                    <a class="btn btn-sm btn-outline-primary"
+                                       asp-page="/Projects/Meta/Request"
+                                       asp-route-id="@Model.Project!.Id">Request change</a>
+                                }
+                                @if (isAdmin || isHoD)
+                                {
+                                    <a class="btn btn-sm btn-outline-secondary"
+                                       asp-page="/Projects/Meta/Edit"
+                                       asp-route-id="@Model.Project!.Id">Edit details</a>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+                <div class="card-body pm-card-body">
+                    <div class="row g-4 align-items-start">
+                        <div class="col-12 col-lg-5 col-xl-4">
+                            <div class="project-photo-cover">
+                                <div class="ratio ratio-4x3 w-100">
+                                    @if (coverPhoto != null)
+                                    {
+                                        <picture>
+                                            <source type="image/webp"
+                                                    srcset="@coverSrcSet"
+                                                    sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw" />
+                                            <img class="w-100 h-100 object-fit-cover rounded border"
+                                                 width="360"
+                                                 height="270"
+                                                 src="@coverXs"
+                                                 srcset="@coverSrcSet"
+                                                 sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw"
+                                                 alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
+                                        </picture>
+                                    }
+                                    else
+                                    {
+                                        <div class="d-flex align-items-center justify-content-center w-100 h-100 rounded border bg-light text-muted">
+                                            <span>No cover photo</span>
+                                        </div>
+                                    }
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(coverPhoto?.Caption))
+                                {
+                                    <div class="mt-2 text-muted small">@coverPhoto.Caption</div>
+                                }
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-7 col-xl-8">
+                            <dl class="row mb-0">
+                                <dt class="col-sm-4">Category</dt>
+                                <dd class="col-sm-8">
+                                    @if (Model.CategoryPath.Any())
+                                    {
+                                        <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
+                                    }
+                                    else
+                                    {
+                                        <span>—</span>
+                                    }
+                                </dd>
+
+                                <dt class="col-sm-4">Sponsoring Unit</dt>
+                                <dd class="col-sm-8">@(Model.Project?.SponsoringUnit?.Name ?? "—")</dd>
+
+                                <dt class="col-sm-4">Sponsoring Line Dte</dt>
+                                <dd class="col-sm-8">@(Model.Project?.SponsoringLineDirectorate?.Name ?? "—")</dd>
+
+                                <dt class="col-sm-4">Head of Department</dt>
+                                <dd class="col-sm-8">@DisplayUser(project?.HodUser)</dd>
+
+                                <dt class="col-sm-4">Project Officer</dt>
+                                <dd class="col-sm-8">@DisplayUser(project?.LeadPoUser)</dd>
+                            </dl>
+                        </div>
+                        <div class="col-12">
+                            <h3 class="h6 mb-2">Project description</h3>
+                            <div class="project-overview__description">@(!string.IsNullOrWhiteSpace(project?.Description) ? project.Description : "—")</div>
+                        </div>
+                    </div>
+
+                    @if (!additionalPhotos.Any() && coverPhoto is null)
+                    {
+                        var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
+                        var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
+                        <div class="project-photo-empty border rounded bg-light-subtle text-center"
+                             role="region"
+                             aria-labelledby="@emptyStateHeadingId"
+                             aria-describedby="@emptyStateDescriptionId">
+                            <div class="project-photo-empty-body">
+                                <span class="project-photo-empty-icon" aria-hidden="true">
+                                    <i class="bi bi-images"></i>
+                                </span>
+                                <h3 id="@emptyStateHeadingId" class="h6 fw-semibold mb-2">No photos yet</h3>
+                                <p id="@emptyStateDescriptionId" class="mb-3 text-muted">
+                                    Add a cover or gallery photo to help everyone recognise this project at a glance.
+                                </p>
+                                @if (canManagePhotos)
+                                {
+                                    <a class="btn btn-primary"
+                                       asp-page="/Projects/Photos/Index"
+                                       asp-route-id="@Model.Project!.Id"
+                                       aria-label="Upload the first project photo">
+                                        Upload photo
+                                    </a>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
             <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
 
             <div class="card pm-card">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -285,6 +285,11 @@ body {
     }
 }
 
+.project-overview__description {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .project-photo-empty {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- move the Project overview card into the main content column so the timeline sidebar aligns with the top
- restructure the overview card to show project facts and a dedicated description section with placeholder handling
- add styling that preserves whitespace and wrapping in the description container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd05974de08329866642d28ee64871