### PR TITLE
Adjust procurement card layout

### DIFF
--- a/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
+++ b/Pages/Shared/_ProjectProcurementAtAGlance.cshtml
@@ -24,7 +24,7 @@
     string DateDmy(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
 }
 
-<div class="card pm-card h-100">
+<div class="card pm-card">
   <div class="card-header pm-card-header">
     <div class="pm-card-heading">
       <span class="pm-card-icon" aria-hidden="true">


### PR DESCRIPTION
## Summary
- remove the fixed `h-100` height class from the procurement card partial so the card height matches its content

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd08ec877083299b4a133573a4a4fb