### PR TITLE
Add domain models for project documents and approval requests

### DIFF
--- a/Models/ProjectDocument.cs
+++ b/Models/ProjectDocument.cs
@@ -1,0 +1,68 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models.Execution;
+
+namespace ProjectManagement.Models
+{
+    public class ProjectDocument
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int ProjectId { get; set; }
+
+        public Project Project { get; set; } = null!;
+
+        public int? StageId { get; set; }
+
+        public ProjectStage? Stage { get; set; }
+
+        public int? RequestId { get; set; }
+
+        public ProjectDocumentRequest? Request { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = string.Empty;
+
+        [MaxLength(2000)]
+        public string? Description { get; set; }
+
+        [Required]
+        [MaxLength(260)]
+        public string StorageKey { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(260)]
+        public string OriginalFileName { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(128)]
+        public string ContentType { get; set; } = string.Empty;
+
+        [Range(0, long.MaxValue)]
+        public long FileSize { get; set; }
+
+        [Required]
+        [MaxLength(450)]
+        public string UploadedByUserId { get; set; } = string.Empty;
+
+        public ApplicationUser? UploadedByUser { get; set; }
+
+        [Required]
+        public DateTimeOffset UploadedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+        public bool IsArchived { get; set; }
+
+        public DateTimeOffset? ArchivedAtUtc { get; set; }
+
+        [MaxLength(450)]
+        public string? ArchivedByUserId { get; set; }
+
+        public ApplicationUser? ArchivedByUser { get; set; }
+
+        [Timestamp]
+        public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+    }
+}
+

--- a/Models/ProjectDocumentRequest.cs
+++ b/Models/ProjectDocumentRequest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models.Execution;
+
+namespace ProjectManagement.Models
+{
+    public enum ProjectDocumentRequestStatus
+    {
+        Draft = 0,
+        Submitted = 1,
+        Approved = 2,
+        Rejected = 3,
+        Cancelled = 4
+    }
+
+    public class ProjectDocumentRequest
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int ProjectId { get; set; }
+
+        public Project Project { get; set; } = null!;
+
+        public int? StageId { get; set; }
+
+        public ProjectStage? Stage { get; set; }
+
+        public int? DocumentId { get; set; }
+
+        public ProjectDocument? Document { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = string.Empty;
+
+        [MaxLength(2000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public ProjectDocumentRequestStatus Status { get; set; } = ProjectDocumentRequestStatus.Draft;
+
+        [Required]
+        [MaxLength(450)]
+        public string RequestedByUserId { get; set; } = string.Empty;
+
+        public ApplicationUser? RequestedByUser { get; set; }
+
+        [Required]
+        public DateTimeOffset RequestedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+        [MaxLength(450)]
+        public string? ReviewedByUserId { get; set; }
+
+        public ApplicationUser? ReviewedByUser { get; set; }
+
+        public DateTimeOffset? ReviewedAtUtc { get; set; }
+
+        [MaxLength(2000)]
+        public string? ReviewerNote { get; set; }
+
+        [Timestamp]
+        public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `ProjectDocument` entity capturing storage metadata, ownership, and concurrency tokens for uploads
- introduce a `ProjectDocumentRequest` model with request lifecycle state and review metadata
- wire navigation properties between projects, stages, and related request/document records to support upcoming document workflows

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd3fe2ebe083299f80515e55eaca8b