### PR TITLE
Add migration for project document tables

### DIFF
--- a/Migrations/20251001151753_AddProjectDocuments.Designer.cs
+++ b/Migrations/20251001151753_AddProjectDocuments.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001151753_AddProjectDocuments")]
+    partial class AddProjectDocuments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251001151753_AddProjectDocuments.cs
+++ b/Migrations/20251001151753_AddProjectDocuments.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectDocuments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProjectDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    StageId = table.Column<int>(type: "integer", nullable: true),
+                    RequestId = table.Column<int>(type: "integer", nullable: true),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    StorageKey = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    OriginalFileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    FileSize = table.Column<long>(type: "bigint", nullable: false),
+                    UploadedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    UploadedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    IsArchived = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    ArchivedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ArchivedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectDocuments", x => x.Id);
+                    table.CheckConstraint("ck_projectdocuments_filesize", "\"FileSize\" >= 0");
+                    table.ForeignKey(
+                        name: "FK_ProjectDocuments_AspNetUsers_ArchivedByUserId",
+                        column: x => x.ArchivedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocuments_AspNetUsers_UploadedByUserId",
+                        column: x => x.UploadedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocuments_ProjectStages_StageId",
+                        column: x => x.StageId,
+                        principalTable: "ProjectStages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocuments_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectDocumentRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    StageId = table.Column<int>(type: "integer", nullable: true),
+                    DocumentId = table.Column<int>(type: "integer", nullable: true),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "Draft"),
+                    RequestedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    RequestedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    ReviewedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    ReviewedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ReviewerNote = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectDocumentRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocumentRequests_AspNetUsers_RequestedByUserId",
+                        column: x => x.RequestedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocumentRequests_AspNetUsers_ReviewedByUserId",
+                        column: x => x.ReviewedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocumentRequests_ProjectDocuments_DocumentId",
+                        column: x => x.DocumentId,
+                        principalTable: "ProjectDocuments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocumentRequests_ProjectStages_StageId",
+                        column: x => x.StageId,
+                        principalTable: "ProjectStages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ProjectDocumentRequests_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_DocumentId",
+                table: "ProjectDocumentRequests",
+                column: "DocumentId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_ProjectId",
+                table: "ProjectDocumentRequests",
+                column: "ProjectId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_ProjectId_Status",
+                table: "ProjectDocumentRequests",
+                columns: new[] { "ProjectId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_RequestedByUserId",
+                table: "ProjectDocumentRequests",
+                column: "RequestedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_ReviewedByUserId",
+                table: "ProjectDocumentRequests",
+                column: "ReviewedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocumentRequests_StageId",
+                table: "ProjectDocumentRequests",
+                column: "StageId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_projectdocumentrequests_pending",
+                table: "ProjectDocumentRequests",
+                columns: new[] { "ProjectId", "StageId" },
+                unique: true,
+                filter: "\"Status\" IN ('Draft', 'Submitted')");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_ArchivedByUserId",
+                table: "ProjectDocuments",
+                column: "ArchivedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_ProjectId",
+                table: "ProjectDocuments",
+                column: "ProjectId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_ProjectId_StageId_IsArchived",
+                table: "ProjectDocuments",
+                columns: new[] { "ProjectId", "StageId", "IsArchived" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_StageId",
+                table: "ProjectDocuments",
+                column: "StageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_UploadedByUserId",
+                table: "ProjectDocuments",
+                column: "UploadedByUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectDocumentRequests");
+
+            migrationBuilder.DropTable(
+                name: "ProjectDocuments");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the AddProjectDocuments EF Core migration to create the ProjectDocuments and ProjectDocumentRequests tables with the required foreign keys and filtered unique index
- update the model snapshot to reflect the new document entities

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68dd43797d608329b817ae8781709c1f