### PR TITLE
Add project document options and enhance upload root provider

### DIFF
--- a/Configuration/ProjectDocumentOptions.cs
+++ b/Configuration/ProjectDocumentOptions.cs
@@ -1,0 +1,13 @@
+namespace ProjectManagement.Configuration
+{
+    public class ProjectDocumentOptions
+    {
+        public string ProjectsSubpath { get; set; } = "projects";
+
+        public string PhotosSubpath { get; set; } = string.Empty;
+
+        public string DocumentsSubpath { get; set; } = "documents";
+
+        public string CommentsSubpath { get; set; } = "comments";
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ProjectManagement.Helpers;
+using ProjectManagement.Configuration;
 using ProjectManagement.Contracts;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
@@ -173,6 +174,8 @@ builder.Services.AddScoped<ProjectMetaChangeRequestService>();
 builder.Services.AddScoped<ProjectMetaChangeDecisionService>();
 builder.Services.Configure<ProjectPhotoOptions>(
     builder.Configuration.GetSection("ProjectPhotos"));
+builder.Services.Configure<ProjectDocumentOptions>(
+    builder.Configuration.GetSection("ProjectDocuments"));
 builder.Services.AddSingleton<IConfigureOptions<ProjectPhotoOptions>, ProjectPhotoOptionsSetup>();
 builder.Services.AddSingleton<IUploadRootProvider, UploadRootProvider>();
 builder.Services.AddScoped<IProjectPhotoService, ProjectPhotoService>();

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -21,6 +21,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
+using ProjectManagement.Configuration;
 using Microsoft.Net.Http.Headers;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
@@ -123,7 +124,8 @@ public sealed class ProjectPhotoPageTests
         try
         {
             var optionsWrapper = Options.Create(options);
-            var uploadRoot = new UploadRootProvider(optionsWrapper);
+            var documentOptions = Options.Create(new ProjectDocumentOptions());
+            var uploadRoot = new UploadRootProvider(optionsWrapper, documentOptions);
             var photoService = new ProjectPhotoService(db, clock, new RecordingAudit(), optionsWrapper, uploadRoot, NullLogger<ProjectPhotoService>.Instance);
 
             await using var stream = await CreateImageStreamAsync(1600, 1200);

--- a/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
@@ -498,7 +499,8 @@ public sealed class ProjectPhotoServiceTests
         var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 12, 0, 0, TimeSpan.Zero));
         var audit = new RecordingAudit();
         var optionsWrapper = Options.Create(options);
-        var uploadRoot = new UploadRootProvider(optionsWrapper);
+        var documentOptions = Options.Create(new ProjectDocumentOptions());
+        var uploadRoot = new UploadRootProvider(optionsWrapper, documentOptions);
         return new ProjectPhotoService(db, clock, audit, optionsWrapper, uploadRoot, NullLogger<ProjectPhotoService>.Instance);
     }
 

--- a/Services/ProjectCommentService.cs
+++ b/Services/ProjectCommentService.cs
@@ -20,7 +20,7 @@ namespace ProjectManagement.Services
         private readonly IClock _clock;
         private readonly IAuditService _audit;
         private readonly ILogger<ProjectCommentService> _logger;
-        private readonly string _basePath;
+        private readonly IUploadRootProvider _uploadRootProvider;
 
         public const long MaxAttachmentSizeBytes = 25 * 1024 * 1024; // 25 MB per file
 
@@ -43,12 +43,7 @@ namespace ProjectManagement.Services
             _clock = clock;
             _audit = audit;
             _logger = logger;
-            if (uploadRootProvider == null)
-            {
-                throw new ArgumentNullException(nameof(uploadRootProvider));
-            }
-
-            _basePath = uploadRootProvider.RootPath;
+            _uploadRootProvider = uploadRootProvider ?? throw new ArgumentNullException(nameof(uploadRootProvider));
         }
 
         public async Task<ProjectComment> CreateAsync(int projectId,
@@ -343,7 +338,8 @@ namespace ProjectManagement.Services
 
         private string BuildCommentDirectory(int projectId, int commentId)
         {
-            return Path.Combine(_basePath, "projects", projectId.ToString(), "comments", commentId.ToString());
+            var baseDirectory = _uploadRootProvider.GetProjectCommentsRoot(projectId);
+            return Path.Combine(baseDirectory, commentId.ToString());
         }
     }
 }

--- a/Services/Projects/ProjectPhotoService.cs
+++ b/Services/Projects/ProjectPhotoService.cs
@@ -30,7 +30,7 @@ namespace ProjectManagement.Services.Projects
         private readonly ProjectPhotoOptions _options;
         private readonly ILogger<ProjectPhotoService> _logger;
         private readonly IVirusScanner? _virusScanner;
-        private readonly string _basePath;
+        private readonly IUploadRootProvider _uploadRootProvider;
 
         private static readonly object SemaphoreSync = new();
         private static SemaphoreSlim? _processingSemaphore;
@@ -50,12 +50,7 @@ namespace ProjectManagement.Services.Projects
             _options = options.Value;
             _logger = logger;
             _virusScanner = virusScanner;
-            if (uploadRootProvider == null)
-            {
-                throw new ArgumentNullException(nameof(uploadRootProvider));
-            }
-
-            _basePath = uploadRootProvider.RootPath;
+            _uploadRootProvider = uploadRootProvider ?? throw new ArgumentNullException(nameof(uploadRootProvider));
 
             EnsureSemaphores();
         }
@@ -678,7 +673,7 @@ namespace ProjectManagement.Services.Projects
 
         private string BuildProjectDirectory(int projectId)
         {
-            return Path.Combine(_basePath, "projects", projectId.ToString());
+            return _uploadRootProvider.GetProjectPhotosRoot(projectId);
         }
 
         private static string GetFallbackExtension(ProjectPhoto photo)

--- a/Services/Storage/IUploadRootProvider.cs
+++ b/Services/Storage/IUploadRootProvider.cs
@@ -3,4 +3,12 @@ namespace ProjectManagement.Services.Storage;
 public interface IUploadRootProvider
 {
     string RootPath { get; }
+
+    string GetProjectRoot(int projectId);
+
+    string GetProjectPhotosRoot(int projectId);
+
+    string GetProjectDocumentsRoot(int projectId);
+
+    string GetProjectCommentsRoot(int projectId);
 }

--- a/Services/Storage/UploadRootProvider.cs
+++ b/Services/Storage/UploadRootProvider.cs
@@ -1,20 +1,31 @@
 using System;
 using System.IO;
 using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
 using ProjectManagement.Services.Projects;
 
 namespace ProjectManagement.Services.Storage;
 
 public sealed class UploadRootProvider : IUploadRootProvider
 {
-    public UploadRootProvider(IOptions<ProjectPhotoOptions> photoOptions)
+    private readonly ProjectDocumentOptions _documentOptions;
+
+    public UploadRootProvider(IOptions<ProjectPhotoOptions> photoOptions,
+                              IOptions<ProjectDocumentOptions> documentOptions)
     {
         if (photoOptions == null)
         {
             throw new ArgumentNullException(nameof(photoOptions));
         }
 
+        if (documentOptions == null)
+        {
+            throw new ArgumentNullException(nameof(documentOptions));
+        }
+
         var options = photoOptions.Value ?? throw new ArgumentException("Options value cannot be null.", nameof(photoOptions));
+        _documentOptions = documentOptions.Value ?? throw new ArgumentException("Options value cannot be null.", nameof(documentOptions));
+
         var configuredRoot = string.IsNullOrWhiteSpace(options.StorageRoot) ? "/var/pm/uploads" : options.StorageRoot;
         var resolvedRoot = Environment.GetEnvironmentVariable("PM_UPLOAD_ROOT");
 
@@ -28,10 +39,50 @@ public sealed class UploadRootProvider : IUploadRootProvider
             throw new InvalidOperationException("Upload root path cannot be empty.");
         }
 
-        var fullPath = Path.GetFullPath(resolvedRoot);
-        Directory.CreateDirectory(fullPath);
-        RootPath = fullPath;
+        RootPath = EnsureDirectory(Path.GetFullPath(resolvedRoot));
+        ProjectsRootPath = EnsureDirectory(CombineOptional(RootPath, _documentOptions.ProjectsSubpath));
     }
 
     public string RootPath { get; }
+
+    public string ProjectsRootPath { get; }
+
+    public string GetProjectRoot(int projectId)
+    {
+        if (projectId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(projectId));
+        }
+
+        return EnsureDirectory(Path.Combine(ProjectsRootPath, projectId.ToString()));
+    }
+
+    public string GetProjectPhotosRoot(int projectId)
+    {
+        var projectRoot = GetProjectRoot(projectId);
+        return EnsureDirectory(CombineOptional(projectRoot, _documentOptions.PhotosSubpath));
+    }
+
+    public string GetProjectDocumentsRoot(int projectId)
+    {
+        var projectRoot = GetProjectRoot(projectId);
+        return EnsureDirectory(CombineOptional(projectRoot, _documentOptions.DocumentsSubpath));
+    }
+
+    public string GetProjectCommentsRoot(int projectId)
+    {
+        var projectRoot = GetProjectRoot(projectId);
+        return EnsureDirectory(CombineOptional(projectRoot, _documentOptions.CommentsSubpath));
+    }
+
+    private static string CombineOptional(string root, string? subpath)
+    {
+        return string.IsNullOrWhiteSpace(subpath) ? root : Path.Combine(root, subpath);
+    }
+
+    private static string EnsureDirectory(string path)
+    {
+        Directory.CreateDirectory(path);
+        return path;
+    }
 }


### PR DESCRIPTION
## Summary
- add ProjectDocumentOptions to represent configurable project upload subpaths
- refactor UploadRootProvider and dependent services to supply photo, document, and comment directories
- bind the new options in Program.cs and update tests for the revised provider signature

## Testing
- dotnet test *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd477b3c508329bdefa005b58d621e