### PR TITLE
Configure project document storage options

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -172,10 +172,10 @@ builder.Services.AddScoped<IForecastWriter, ForecastWriter>();
 builder.Services.AddScoped<ForecastBackfillService>();
 builder.Services.AddScoped<ProjectMetaChangeRequestService>();
 builder.Services.AddScoped<ProjectMetaChangeDecisionService>();
-builder.Services.Configure<ProjectPhotoOptions>(
-    builder.Configuration.GetSection("ProjectPhotos"));
-builder.Services.Configure<ProjectDocumentOptions>(
-    builder.Configuration.GetSection("ProjectDocuments"));
+builder.Services.AddOptions<ProjectPhotoOptions>()
+    .Bind(builder.Configuration.GetSection("ProjectPhotos"));
+builder.Services.AddOptions<ProjectDocumentOptions>()
+    .Bind(builder.Configuration.GetSection("ProjectDocuments"));
 builder.Services.AddSingleton<IConfigureOptions<ProjectPhotoOptions>, ProjectPhotoOptionsSetup>();
 builder.Services.AddSingleton<IUploadRootProvider, UploadRootProvider>();
 builder.Services.AddScoped<IProjectPhotoService, ProjectPhotoService>();

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -29,5 +29,11 @@
     },
     "MaxProcessingConcurrency": 2,
     "MaxEncodingConcurrency": 2
+  },
+  "ProjectDocuments": {
+    "ProjectsSubpath": "projects",
+    "PhotosSubpath": "",
+    "DocumentsSubpath": "documents",
+    "CommentsSubpath": "comments"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -47,5 +47,11 @@
     },
     "MaxProcessingConcurrency": 2,
     "MaxEncodingConcurrency": 2
+  },
+  "ProjectDocuments": {
+    "ProjectsSubpath": "projects",
+    "PhotosSubpath": "",
+    "DocumentsSubpath": "documents",
+    "CommentsSubpath": "comments"
   }
 }


### PR DESCRIPTION
## Summary
- bind the ProjectDocuments configuration alongside existing photo options in Program.cs
- document the default ProjectDocuments paths in both appsettings.json variants

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4a57eb708329a0ee20e0a3c21104