### PR TITLE
Soften card header styling

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -31,7 +31,8 @@ body {
     align-items: flex-start;
     gap: 1rem;
     padding: 1rem 1.5rem;
-    background: linear-gradient(180deg, rgba(45, 108, 223, .08) 0%, rgba(45, 108, 223, .03) 100%);
+    background-color: var(--pm-card);
+    box-shadow: inset 0 -1px 0 rgba(45, 108, 223, .12);
     border-bottom: 1px solid rgba(15, 23, 42, .06);
 }
 
@@ -49,7 +50,7 @@ body {
     width: 2.5rem;
     height: 2.5rem;
     border-radius: .85rem;
-    background-color: rgba(45, 108, 223, .12);
+    background-color: rgba(45, 108, 223, .16);
     color: var(--pm-primary);
     font-size: 1.25rem;
     flex-shrink: 0;


### PR DESCRIPTION
## Summary
- replace the card header gradient with the standard card surface and add an inset primary-accent shadow
- deepen the icon chip tint so it stays legible against the lighter header background

## Testing
- Not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dd5901bdb88329b4ff2614e58dbd2e