### PR TITLE
Fix migration snapshot accessibility

### DIFF
--- a/Migrations/20250318000000_AddDocumentServices.Designer.cs
+++ b/Migrations/20250318000000_AddDocumentServices.Designer.cs
@@ -16,7 +16,7 @@ namespace ProjectManagement.Migrations
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            new ApplicationDbContextModelSnapshot().BuildModel(modelBuilder);
+            new ApplicationDbContextModelSnapshot().BuildModelSnapshot(modelBuilder);
 #pragma warning restore 612, 618
         }
     }

--- a/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.Extensions.cs
@@ -1,0 +1,10 @@
+namespace ProjectManagement.Migrations
+{
+    public partial class ApplicationDbContextModelSnapshot
+    {
+        public void BuildModelSnapshot(Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder)
+        {
+            BuildModel(modelBuilder);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a public wrapper in the model snapshot to expose the generated BuildModel method
- update the AddDocumentServices migration designer to invoke the new wrapper, resolving the accessibility error

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6229b2f88329a8937f7c8b39e2d4