### PR TITLE
Implement project document request flows

### DIFF
--- a/Pages/Projects/Documents/DeleteRequest.cshtml
+++ b/Pages/Projects/Documents/DeleteRequest.cshtml
@@ -1,0 +1,59 @@
+@page
+@model ProjectManagement.Pages.Projects.Documents.DeleteRequestModel
+@{
+    ViewData["Title"] = $"Delete document – {Model.Project?.Name}";
+}
+
+<div class="row justify-content-between gy-4">
+    <div class="col-lg-8 col-xl-6">
+        <a class="btn btn-link px-0" asp-page="../Overview" asp-route-id="@Model.Input.ProjectId">&larr; Back to documents</a>
+        <h1 class="h2 mt-2">Request document deletion</h1>
+        <p class="text-muted">Deleted documents are removed only after moderation approves this request.</p>
+
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body">
+                <h2 class="h6 text-uppercase text-muted mb-3">Document details</h2>
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Title</dt>
+                    <dd class="col-sm-8">@Model.DocumentTitle</dd>
+                    <dt class="col-sm-4">Stage</dt>
+                    <dd class="col-sm-8">@Model.DocumentStage</dd>
+                    <dt class="col-sm-4">Filename</dt>
+                    <dd class="col-sm-8">@Model.DocumentFileName</dd>
+                </dl>
+            </div>
+        </div>
+
+        <form method="post" novalidate>
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <input type="hidden" asp-for="Input.ProjectId" />
+            <input type="hidden" asp-for="Input.DocumentId" />
+
+            <div class="mb-3">
+                <label asp-for="Input.Reason" class="form-label">Reason (optional)</label>
+                <textarea asp-for="Input.Reason" class="form-control" rows="4" maxlength="2000"></textarea>
+                <span asp-validation-for="Input.Reason" class="text-danger"></span>
+                <div class="form-text">Share any context for moderators. This appears in the decision note when approved.</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-danger">Submit delete request</button>
+                <a asp-page="../Overview" asp-route-id="@Model.Input.ProjectId" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+    <div class="col-lg-4">
+        <div class="card bg-light border-0 shadow-sm">
+            <div class="card-body">
+                <h2 class="h6 text-uppercase text-muted">Project</h2>
+                <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
+                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Documents/DeleteRequest.cshtml.cs
+++ b/Pages/Projects/Documents/DeleteRequest.cshtml.cs
@@ -1,0 +1,210 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Documents;
+
+namespace ProjectManagement.Pages.Projects.Documents;
+
+[Authorize(Roles = "Admin,Project Officer")]
+[AutoValidateAntiforgeryToken]
+public class DeleteRequestModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IDocumentRequestService _requestService;
+    private readonly ILogger<DeleteRequestModel> _logger;
+
+    public DeleteRequestModel(
+        ApplicationDbContext db,
+        IUserContext userContext,
+        IDocumentRequestService requestService,
+        ILogger<DeleteRequestModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _requestService = requestService ?? throw new ArgumentNullException(nameof(requestService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public DeleteInputModel Input { get; set; } = new();
+
+    public Project? Project { get; private set; }
+
+    public string DocumentTitle { get; private set; } = string.Empty;
+
+    public string DocumentStage { get; private set; } = string.Empty;
+
+    public string DocumentFileName { get; private set; } = string.Empty;
+
+    public async Task<IActionResult> OnGetAsync(int id, int documentId, CancellationToken cancellationToken)
+    {
+        var accessResult = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (accessResult is not null)
+        {
+            return accessResult;
+        }
+
+        var documentResult = await LoadDocumentAsync(id, documentId, cancellationToken);
+        if (documentResult is not null)
+        {
+            return documentResult;
+        }
+
+        Input.ProjectId = id;
+        Input.DocumentId = documentId;
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, int documentId, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId || documentId != Input.DocumentId)
+        {
+            return BadRequest();
+        }
+
+        var accessResult = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (accessResult is not null)
+        {
+            return accessResult;
+        }
+
+        var documentResult = await LoadDocumentAsync(id, documentId, cancellationToken);
+        if (documentResult is not null)
+        {
+            return documentResult;
+        }
+
+        Input.Reason = string.IsNullOrWhiteSpace(Input.Reason)
+            ? null
+            : Input.Reason.Trim();
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        try
+        {
+            await _requestService.CreateDeleteRequestAsync(
+                Input.DocumentId,
+                Input.Reason,
+                userId,
+                cancellationToken);
+
+            TempData["Flash"] = "Document delete request submitted for moderation.";
+            return RedirectToPage("../Overview", new { id = Input.ProjectId });
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (ex.Message.Contains("was not found", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(ex, "Document {DocumentId} disappeared while creating delete request", Input.DocumentId);
+                return NotFound();
+            }
+
+            var message = ex.Message.Contains("pending request", StringComparison.OrdinalIgnoreCase)
+                ? "A pending request already exists for this document. Please wait for moderation to finish."
+                : ex.Message;
+            _logger.LogWarning(ex, "Could not create delete request for document {DocumentId}", Input.DocumentId);
+            ModelState.AddModelError(string.Empty, message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while creating delete request for document {DocumentId}", Input.DocumentId);
+            ModelState.AddModelError(string.Empty, "We couldn't submit the request. Please try again.");
+        }
+
+        return Page();
+    }
+
+    private async Task<IActionResult?> EnsureProjectAccessAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanSubmitRequests(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        return null;
+    }
+
+    private async Task<IActionResult?> LoadDocumentAsync(int projectId, int documentId, CancellationToken cancellationToken)
+    {
+        var document = await _db.ProjectDocuments
+            .Include(d => d.Stage)
+            .FirstOrDefaultAsync(d => d.ProjectId == projectId && d.Id == documentId, cancellationToken);
+
+        if (document is null)
+        {
+            return NotFound();
+        }
+
+        if (document.Status != ProjectDocumentStatus.Published || document.IsArchived)
+        {
+            return NotFound();
+        }
+
+        DocumentTitle = document.Title;
+        DocumentStage = document.Stage is null
+            ? "General"
+            : string.Format(CultureInfo.InvariantCulture, "{0} ({1})", StageCodes.DisplayNameOf(document.Stage.StageCode), document.Stage.StageCode);
+        DocumentFileName = document.OriginalFileName;
+
+        return null;
+    }
+
+    private bool UserCanSubmitRequests(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        if (principal.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public sealed class DeleteInputModel
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [Required]
+        public int DocumentId { get; set; }
+
+        [MaxLength(2000)]
+        public string? Reason { get; set; }
+    }
+}

--- a/Pages/Projects/Documents/ReplaceRequest.cshtml
+++ b/Pages/Projects/Documents/ReplaceRequest.cshtml
@@ -1,0 +1,70 @@
+@page
+@model ProjectManagement.Pages.Projects.Documents.ReplaceRequestModel
+@{
+    ViewData["Title"] = $"Replace document – {Model.Project?.Name}";
+}
+
+<div class="row justify-content-between gy-4">
+    <div class="col-lg-8 col-xl-6">
+        <a class="btn btn-link px-0" asp-page="../Overview" asp-route-id="@Model.Input.ProjectId">&larr; Back to documents</a>
+        <h1 class="h2 mt-2">Request document replacement</h1>
+        <p class="text-muted">The existing document stays live until the replacement is approved.</p>
+
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body">
+                <h2 class="h6 text-uppercase text-muted mb-3">Current document</h2>
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Title</dt>
+                    <dd class="col-sm-8">@Model.DocumentTitle</dd>
+                    <dt class="col-sm-4">Stage</dt>
+                    <dd class="col-sm-8">@Model.DocumentStage</dd>
+                    <dt class="col-sm-4">Filename</dt>
+                    <dd class="col-sm-8">@Model.DocumentFileName</dd>
+                </dl>
+            </div>
+        </div>
+
+        <form method="post" enctype="multipart/form-data" novalidate data-doc-request>
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <input type="hidden" asp-for="Input.ProjectId" />
+            <input type="hidden" asp-for="Input.DocumentId" />
+
+            <div class="mb-3">
+                <label asp-for="Input.Nomenclature" class="form-label">New nomenclature (optional)</label>
+                <input asp-for="Input.Nomenclature" class="form-control" autocomplete="off" />
+                <span asp-validation-for="Input.Nomenclature" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3" data-doc-dropzone>
+                <label class="form-label" for="replaceFile">Upload replacement PDF</label>
+                <div class="doc-request-drop border border-2 border-secondary-subtle rounded-3 p-4 text-center" data-doc-drop-target tabindex="0" role="button" aria-describedby="replace-upload-help">
+                    <div class="fw-semibold" data-doc-drop-label>Drag &amp; drop a PDF or browse</div>
+                    <div class="text-muted small" data-doc-drop-filename></div>
+                </div>
+                <input asp-for="Input.File" class="form-control visually-hidden" id="replaceFile" data-doc-file data-max-size="@Model.MaxFileSizeBytes" data-allowed="@string.Join(',', Model.AllowedContentTypes)" />
+                <span asp-validation-for="Input.File" class="text-danger"></span>
+                <div id="replace-upload-help" class="form-text">PDF only • ≤ 25 MB</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Submit request</button>
+                <a asp-page="../Overview" asp-route-id="@Model.Input.ProjectId" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+    <div class="col-lg-4">
+        <div class="card bg-light border-0 shadow-sm">
+            <div class="card-body">
+                <h2 class="h6 text-uppercase text-muted">Project</h2>
+                <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
+                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/projects/document-requests.js" asp-append-version="true"></script>
+}

--- a/Pages/Projects/Documents/ReplaceRequest.cshtml.cs
+++ b/Pages/Projects/Documents/ReplaceRequest.cshtml.cs
@@ -1,0 +1,259 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Documents;
+
+namespace ProjectManagement.Pages.Projects.Documents;
+
+[Authorize(Roles = "Admin,Project Officer")]
+[AutoValidateAntiforgeryToken]
+public class ReplaceRequestModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IDocumentService _documentService;
+    private readonly IDocumentRequestService _requestService;
+    private readonly ProjectDocumentOptions _options;
+    private readonly ILogger<ReplaceRequestModel> _logger;
+
+    public ReplaceRequestModel(
+        ApplicationDbContext db,
+        IUserContext userContext,
+        IDocumentService documentService,
+        IDocumentRequestService requestService,
+        IOptions<ProjectDocumentOptions> options,
+        ILogger<ReplaceRequestModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
+        _requestService = requestService ?? throw new ArgumentNullException(nameof(requestService));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public ReplaceInputModel Input { get; set; } = new();
+
+    public Project? Project { get; private set; }
+
+    public string DocumentTitle { get; private set; } = string.Empty;
+
+    public string DocumentStage { get; private set; } = string.Empty;
+
+    public string DocumentFileName { get; private set; } = string.Empty;
+
+    public long MaxFileSizeBytes => (long)_options.MaxSizeMb * 1024L * 1024L;
+
+    public IReadOnlyCollection<string> AllowedContentTypes => _options.AllowedMimeTypes.ToList();
+
+    public async Task<IActionResult> OnGetAsync(int id, int documentId, CancellationToken cancellationToken)
+    {
+        var accessResult = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (accessResult is not null)
+        {
+            return accessResult;
+        }
+
+        var documentResult = await LoadDocumentAsync(id, documentId, cancellationToken);
+        if (documentResult is not null)
+        {
+            return documentResult;
+        }
+
+        Input.ProjectId = id;
+        Input.DocumentId = documentId;
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, int documentId, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId || documentId != Input.DocumentId)
+        {
+            return BadRequest();
+        }
+
+        var accessResult = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (accessResult is not null)
+        {
+            return accessResult;
+        }
+
+        var documentResult = await LoadDocumentAsync(id, documentId, cancellationToken);
+        if (documentResult is not null)
+        {
+            return documentResult;
+        }
+
+        Input.Nomenclature = string.IsNullOrWhiteSpace(Input.Nomenclature)
+            ? null
+            : Input.Nomenclature.Trim();
+
+        if (Input.File is null)
+        {
+            ModelState.AddModelError("Input.File", "Select a PDF file to upload.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        DocumentFileDescriptor? tempFile = null;
+        var token = _documentService.CreateTempRequestToken();
+
+        try
+        {
+            await using var stream = Input.File!.OpenReadStream();
+            tempFile = await _documentService.SaveTempAsync(
+                token,
+                stream,
+                Input.File.FileName,
+                Input.File.ContentType,
+                cancellationToken);
+
+            await _requestService.CreateReplaceRequestAsync(
+                Input.DocumentId,
+                Input.Nomenclature,
+                tempFile,
+                userId,
+                cancellationToken);
+
+            TempData["Flash"] = "Document replacement request submitted for moderation.";
+            return RedirectToPage("../Overview", new { id = Input.ProjectId });
+        }
+        catch (InvalidOperationException ex)
+        {
+            if (tempFile is null)
+            {
+                _logger.LogWarning(ex, "Validation failed while staging replacement for document {DocumentId}", Input.DocumentId);
+                ModelState.AddModelError("Input.File", ex.Message);
+            }
+            else
+            {
+                if (ex.Message.Contains("was not found", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(ex, "Document {DocumentId} disappeared while creating replacement request", Input.DocumentId);
+                    return NotFound();
+                }
+
+                var message = ex.Message.Contains("pending request", StringComparison.OrdinalIgnoreCase)
+                    ? "A pending request already exists for this document. Please wait for moderation to finish."
+                    : ex.Message;
+                _logger.LogWarning(ex, "Could not create replacement request for document {DocumentId}", Input.DocumentId);
+                ModelState.AddModelError(string.Empty, message);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while staging replacement for document {DocumentId}", Input.DocumentId);
+            ModelState.AddModelError(string.Empty, "We couldn't process the file. Please try again.");
+        }
+        finally
+        {
+            if (!ModelState.IsValid && tempFile is not null)
+            {
+                await _documentService.DeleteTempAsync(tempFile.StorageKey, cancellationToken);
+            }
+        }
+
+        return Page();
+    }
+
+    private async Task<IActionResult?> EnsureProjectAccessAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanSubmitRequests(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        return null;
+    }
+
+    private async Task<IActionResult?> LoadDocumentAsync(int projectId, int documentId, CancellationToken cancellationToken)
+    {
+        var document = await _db.ProjectDocuments
+            .Include(d => d.Stage)
+            .FirstOrDefaultAsync(d => d.ProjectId == projectId && d.Id == documentId, cancellationToken);
+
+        if (document is null)
+        {
+            return NotFound();
+        }
+
+        if (document.Status != ProjectDocumentStatus.Published || document.IsArchived)
+        {
+            return NotFound();
+        }
+
+        DocumentTitle = document.Title;
+        DocumentStage = document.Stage is null
+            ? "General"
+            : string.Format(CultureInfo.InvariantCulture, "{0} ({1})", StageCodes.DisplayNameOf(document.Stage.StageCode), document.Stage.StageCode);
+        DocumentFileName = document.OriginalFileName;
+
+        return null;
+    }
+
+    private bool UserCanSubmitRequests(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        if (principal.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public sealed class ReplaceInputModel
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [Required]
+        public int DocumentId { get; set; }
+
+        [MaxLength(200)]
+        public string? Nomenclature { get; set; }
+
+        [Required]
+        public IFormFile? File { get; set; }
+    }
+}

--- a/Pages/Projects/Documents/UploadRequest.cshtml
+++ b/Pages/Projects/Documents/UploadRequest.cshtml
@@ -1,0 +1,64 @@
+@page
+@model ProjectManagement.Pages.Projects.Documents.UploadRequestModel
+@{
+    ViewData["Title"] = $"Upload document – {Model.Project?.Name}";
+}
+
+<div class="row justify-content-between gy-4">
+    <div class="col-lg-8 col-xl-6">
+        <a class="btn btn-link px-0" asp-page="../Overview" asp-route-id="@Model.Input.ProjectId">&larr; Back to documents</a>
+        <h1 class="h2 mt-2">Request document upload</h1>
+        <p class="text-muted">Submitted files go to moderation. Documents publish after review.</p>
+
+        <form method="post" enctype="multipart/form-data" novalidate data-doc-request>
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <input type="hidden" asp-for="Input.ProjectId" />
+
+            <div class="mb-3">
+                <label asp-for="Input.StageId" class="form-label">Stage</label>
+                <select asp-for="Input.StageId" asp-items="Model.StageOptions" class="form-select" data-doc-stage-select>
+                    <option value="">Select a stage</option>
+                </select>
+                <span asp-validation-for="Input.StageId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Nomenclature" class="form-label">Nomenclature</label>
+                <input asp-for="Input.Nomenclature" class="form-control" autocomplete="off" />
+                <span asp-validation-for="Input.Nomenclature" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3" data-doc-dropzone>
+                <label class="form-label" for="fileInput">Upload PDF</label>
+                <div class="doc-request-drop border border-2 border-secondary-subtle rounded-3 p-4 text-center" data-doc-drop-target tabindex="0" role="button" aria-describedby="doc-upload-help doc-stage-help">
+                    <div class="fw-semibold" data-doc-drop-label>Drag &amp; drop a PDF or browse</div>
+                    <div class="text-muted small" data-doc-drop-filename></div>
+                </div>
+                <input asp-for="Input.File" class="form-control visually-hidden" id="fileInput" data-doc-file data-max-size="@Model.MaxFileSizeBytes" data-allowed="@string.Join(',', Model.AllowedContentTypes)" />
+                <span asp-validation-for="Input.File" class="text-danger"></span>
+                <div id="doc-upload-help" class="form-text">PDF only • ≤ 25 MB</div>
+                <div id="doc-stage-help" class="form-text">You can upload for any stage (past or present).</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Submit request</button>
+                <a asp-page="../Overview" asp-route-id="@Model.Input.ProjectId" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+    <div class="col-lg-4">
+        <div class="card bg-light border-0 shadow-sm">
+            <div class="card-body">
+                <h2 class="h6 text-uppercase text-muted">Project</h2>
+                <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
+                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/projects/document-requests.js" asp-append-version="true"></script>
+}

--- a/Pages/Projects/Documents/UploadRequest.cshtml.cs
+++ b/Pages/Projects/Documents/UploadRequest.cshtml.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Documents;
+
+namespace ProjectManagement.Pages.Projects.Documents;
+
+[Authorize(Roles = "Admin,Project Officer")]
+[AutoValidateAntiforgeryToken]
+public class UploadRequestModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IDocumentService _documentService;
+    private readonly IDocumentRequestService _requestService;
+    private readonly ProjectDocumentOptions _options;
+    private readonly ILogger<UploadRequestModel> _logger;
+
+    public UploadRequestModel(
+        ApplicationDbContext db,
+        IUserContext userContext,
+        IDocumentService documentService,
+        IDocumentRequestService requestService,
+        IOptions<ProjectDocumentOptions> options,
+        ILogger<UploadRequestModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
+        _requestService = requestService ?? throw new ArgumentNullException(nameof(requestService));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public UploadInputModel Input { get; set; } = new();
+
+    public Project? Project { get; private set; }
+
+    public IEnumerable<SelectListItem> StageOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+    public long MaxFileSizeBytes => (long)_options.MaxSizeMb * 1024L * 1024L;
+
+    public IReadOnlyCollection<string> AllowedContentTypes => _options.AllowedMimeTypes.ToList();
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var result = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (result is not null)
+        {
+            return result;
+        }
+
+        StageOptions = await BuildStageOptionsAsync(id, cancellationToken);
+        Input.ProjectId = id;
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        if (id != Input.ProjectId)
+        {
+            return BadRequest();
+        }
+
+        var result = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (result is not null)
+        {
+            return result;
+        }
+
+        StageOptions = await BuildStageOptionsAsync(id, cancellationToken);
+
+        if (Input.StageId is null)
+        {
+            ModelState.AddModelError("Input.StageId", "Select a stage.");
+        }
+        else
+        {
+            var stageExists = await _db.ProjectStages
+                .AnyAsync(s => s.ProjectId == id && s.Id == Input.StageId, cancellationToken);
+            if (!stageExists)
+            {
+                ModelState.AddModelError("Input.StageId", "Select a valid stage.");
+            }
+        }
+
+        if (Input.File is null)
+        {
+            ModelState.AddModelError("Input.File", "Select a PDF file to upload.");
+        }
+
+        Input.Nomenclature = Input.Nomenclature?.Trim() ?? string.Empty;
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        DocumentFileDescriptor? tempFile = null;
+        var token = _documentService.CreateTempRequestToken();
+
+        try
+        {
+            await using var stream = Input.File!.OpenReadStream();
+            tempFile = await _documentService.SaveTempAsync(
+                token,
+                stream,
+                Input.File.FileName,
+                Input.File.ContentType,
+                cancellationToken);
+
+            await _requestService.CreateUploadRequestAsync(
+                Input.ProjectId,
+                Input.StageId,
+                Input.Nomenclature,
+                tempFile,
+                userId,
+                cancellationToken);
+
+            TempData["Flash"] = "Document upload request submitted for moderation.";
+            return RedirectToPage("../Overview", new { id = Input.ProjectId });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Validation failed while staging upload request for project {ProjectId}", Input.ProjectId);
+            ModelState.AddModelError("Input.File", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while staging upload request for project {ProjectId}", Input.ProjectId);
+            ModelState.AddModelError(string.Empty, "We couldn't process the file. Please try again.");
+        }
+        finally
+        {
+            if (!ModelState.IsValid && tempFile is not null)
+            {
+                await _documentService.DeleteTempAsync(tempFile.StorageKey, cancellationToken);
+            }
+        }
+
+        return Page();
+    }
+
+    private async Task<IActionResult?> EnsureProjectAccessAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanSubmitRequests(project, userId))
+        {
+            return Forbid();
+        }
+
+        Project = project;
+        return null;
+    }
+
+    private bool UserCanSubmitRequests(Project project, string userId)
+    {
+        var principal = _userContext.User;
+        if (principal.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<IEnumerable<SelectListItem>> BuildStageOptionsAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var stages = await _db.ProjectStages
+            .Where(s => s.ProjectId == projectId)
+            .OrderBy(s => s.SortOrder)
+            .Select(s => new { s.Id, s.StageCode })
+            .ToListAsync(cancellationToken);
+
+        return stages
+            .Select(stage => new SelectListItem(
+                string.Format(CultureInfo.InvariantCulture, "{0} ({1})", StageCodes.DisplayNameOf(stage.StageCode), stage.StageCode),
+                stage.Id.ToString(CultureInfo.InvariantCulture)))
+            .ToList();
+    }
+
+    public sealed class UploadInputModel
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [Required(ErrorMessage = "Select a stage.")]
+        public int? StageId { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Nomenclature { get; set; } = string.Empty;
+
+        [Required]
+        public IFormFile? File { get; set; }
+    }
+}

--- a/ProjectManagement.Tests/DocumentServicesTests.cs
+++ b/ProjectManagement.Tests/DocumentServicesTests.cs
@@ -124,7 +124,7 @@ public sealed class DocumentServicesTests
             var document = await db.ProjectDocuments.SingleAsync();
             using var replacement = CreatePdfStream(1536, payload: "New content");
             var tempReplace = await documentService.SaveTempAsync(2, replacement, "manual.pdf", "application/pdf", CancellationToken.None);
-            await requestService.CreateReplaceRequestAsync(document.Id, tempReplace, "requestor", CancellationToken.None);
+            await requestService.CreateReplaceRequestAsync(document.Id, null, tempReplace, "requestor", CancellationToken.None);
 
             var replaceRequest = await db.ProjectDocumentRequests
                 .OrderByDescending(r => r.Id)
@@ -230,13 +230,13 @@ public sealed class DocumentServicesTests
 
             using var replacement = CreatePdfStream(1024, payload: "replace");
             var tempReplace = await documentService.SaveTempAsync(2, replacement, "replace.pdf", "application/pdf", CancellationToken.None);
-            await requestService.CreateReplaceRequestAsync(document.Id, tempReplace, "requestor", CancellationToken.None);
+            await requestService.CreateReplaceRequestAsync(document.Id, null, tempReplace, "requestor", CancellationToken.None);
 
             using var another = CreatePdfStream(1024, payload: "again");
             var tempSecond = await documentService.SaveTempAsync(3, another, "replace.pdf", "application/pdf", CancellationToken.None);
 
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                requestService.CreateReplaceRequestAsync(document.Id, tempSecond, "requestor", CancellationToken.None));
+                requestService.CreateReplaceRequestAsync(document.Id, null, tempSecond, "requestor", CancellationToken.None));
 
             await documentService.DeleteTempAsync(tempSecond.StorageKey, CancellationToken.None);
         }

--- a/Services/Documents/DocumentDecisionService.cs
+++ b/Services/Documents/DocumentDecisionService.cs
@@ -167,6 +167,11 @@ public sealed class DocumentDecisionService : IDocumentDecisionService
             decidedByUserId,
             cancellationToken);
 
+        if (!string.IsNullOrWhiteSpace(request.Title))
+        {
+            document.Title = request.Title;
+        }
+
         document.RequestId = request.Id;
         request.TempStorageKey = null;
     }

--- a/Services/Documents/DocumentRequestService.cs
+++ b/Services/Documents/DocumentRequestService.cs
@@ -67,6 +67,7 @@ public sealed class DocumentRequestService : IDocumentRequestService
 
     public async Task<ProjectDocumentRequest> CreateReplaceRequestAsync(
         int documentId,
+        string? newTitle,
         DocumentFileDescriptor file,
         string requestedByUserId,
         CancellationToken cancellationToken)
@@ -89,12 +90,16 @@ public sealed class DocumentRequestService : IDocumentRequestService
 
         await EnsureNoPendingForDocumentAsync(documentId, cancellationToken);
 
+        var title = string.IsNullOrWhiteSpace(newTitle)
+            ? document.Title
+            : newTitle.Trim();
+
         var request = new ProjectDocumentRequest
         {
             ProjectId = document.ProjectId,
             StageId = document.StageId,
             DocumentId = document.Id,
-            Title = document.Title,
+            Title = title,
             RequestType = ProjectDocumentRequestType.Replace,
             Status = ProjectDocumentRequestStatus.Submitted,
             TempStorageKey = file.StorageKey,
@@ -116,6 +121,7 @@ public sealed class DocumentRequestService : IDocumentRequestService
 
     public async Task<ProjectDocumentRequest> CreateDeleteRequestAsync(
         int documentId,
+        string? reason,
         string requestedByUserId,
         CancellationToken cancellationToken)
     {
@@ -146,6 +152,7 @@ public sealed class DocumentRequestService : IDocumentRequestService
             FileSize = document.FileSize,
             RequestedByUserId = requestedByUserId,
             RequestedAtUtc = _clock.UtcNow,
+            Description = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim(),
         };
 
         _db.ProjectDocumentRequests.Add(request);

--- a/Services/Documents/DocumentService.cs
+++ b/Services/Documents/DocumentService.cs
@@ -26,6 +26,7 @@ public sealed class DocumentService : IDocumentService
     private readonly ILogger<DocumentService>? _logger;
 
     private static readonly string[] PdfMagic = { "%PDF-" };
+    private static int _tempRequestTokenSeed = (int)(DateTime.UtcNow.Ticks & 0x7FFFFFFF);
 
     public DocumentService(
         ApplicationDbContext db,
@@ -43,6 +44,18 @@ public sealed class DocumentService : IDocumentService
         _audit = audit ?? throw new ArgumentNullException(nameof(audit));
         _virusScanner = virusScanner;
         _logger = logger;
+    }
+
+    public int CreateTempRequestToken()
+    {
+        var next = Interlocked.Increment(ref _tempRequestTokenSeed);
+        if (next <= 0)
+        {
+            Interlocked.Exchange(ref _tempRequestTokenSeed, 1);
+            next = Interlocked.Increment(ref _tempRequestTokenSeed);
+        }
+
+        return next;
     }
 
     public async Task<DocumentFileDescriptor> SaveTempAsync(

--- a/Services/Documents/IDocumentRequestService.cs
+++ b/Services/Documents/IDocumentRequestService.cs
@@ -16,12 +16,14 @@ public interface IDocumentRequestService
 
     Task<ProjectDocumentRequest> CreateReplaceRequestAsync(
         int documentId,
+        string? newTitle,
         DocumentFileDescriptor file,
         string requestedByUserId,
         CancellationToken cancellationToken);
 
     Task<ProjectDocumentRequest> CreateDeleteRequestAsync(
         int documentId,
+        string? reason,
         string requestedByUserId,
         CancellationToken cancellationToken);
 }

--- a/Services/Documents/IDocumentService.cs
+++ b/Services/Documents/IDocumentService.cs
@@ -7,6 +7,8 @@ namespace ProjectManagement.Services.Documents;
 
 public interface IDocumentService
 {
+    int CreateTempRequestToken();
+
     Task<DocumentFileDescriptor> SaveTempAsync(
         int requestId,
         Stream content,

--- a/wwwroot/js/projects/document-requests.js
+++ b/wwwroot/js/projects/document-requests.js
@@ -1,0 +1,129 @@
+(function () {
+    function setupDropZone(zone) {
+        const input = zone.querySelector('[data-doc-file]');
+        const target = zone.querySelector('[data-doc-drop-target]');
+        const label = zone.querySelector('[data-doc-drop-label]');
+        const status = zone.querySelector('[data-doc-drop-filename]');
+
+        if (!input || !target || !label || !status) {
+            return;
+        }
+
+        status.setAttribute('aria-live', 'polite');
+
+        const maxSize = parseInt(input.dataset.maxSize || '0', 10) || Number.POSITIVE_INFINITY;
+        const allowed = (input.dataset.allowed || '')
+            .split(',')
+            .map(s => s.trim().toLowerCase())
+            .filter(Boolean);
+
+        function resetVisualState() {
+            target.classList.remove('border-primary', 'bg-light');
+        }
+
+        function setFileFeedback(message, isError) {
+            status.textContent = message || '';
+            if (isError) {
+                target.classList.add('border-danger');
+                target.classList.remove('border-primary');
+            } else {
+                target.classList.remove('border-danger');
+            }
+        }
+
+        function validateFile(file) {
+            if (!file) {
+                input.setCustomValidity('');
+                setFileFeedback('', false);
+                return true;
+            }
+
+            const fileType = (file.type || '').toLowerCase();
+            const extension = file.name.toLowerCase().endsWith('.pdf');
+            const mimeAllowed = allowed.length === 0 || allowed.includes(fileType) || fileType === 'application/pdf';
+
+            if (!mimeAllowed || !extension) {
+                const error = 'Only PDF files are allowed.';
+                input.setCustomValidity(error);
+                setFileFeedback(error, true);
+                return false;
+            }
+
+            if (file.size && file.size > maxSize) {
+                const sizeMb = (maxSize / (1024 * 1024)).toFixed(0);
+                const error = `File must be ${sizeMb} MB or smaller.`;
+                input.setCustomValidity(error);
+                setFileFeedback(error, true);
+                return false;
+            }
+
+            input.setCustomValidity('');
+            const sizeSummary = file.size ? ` (${(file.size / (1024 * 1024)).toFixed(2)} MB)` : '';
+            setFileFeedback(`${file.name}${sizeSummary}`, false);
+            return true;
+        }
+
+        function updateFileSelection(fileList) {
+            if (!fileList || fileList.length === 0) {
+                input.value = '';
+                input.setCustomValidity('');
+                setFileFeedback('', false);
+                return;
+            }
+
+            const [file] = fileList;
+            if (!validateFile(file)) {
+                input.value = '';
+                return;
+            }
+
+            if (typeof DataTransfer !== 'undefined') {
+                const transfer = new DataTransfer();
+                transfer.items.add(file);
+                input.files = transfer.files;
+            }
+
+            const event = new Event('change', { bubbles: true });
+            input.dispatchEvent(event);
+        }
+
+        target.addEventListener('click', () => input.click());
+        target.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                input.click();
+            }
+        });
+
+        input.addEventListener('change', () => {
+            if (input.files && input.files.length > 0) {
+                validateFile(input.files[0]);
+                const event = new Event('input', { bubbles: true });
+                input.dispatchEvent(event);
+            } else {
+                setFileFeedback('', false);
+            }
+        });
+
+        target.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            target.classList.add('border-primary', 'bg-light');
+        });
+
+        target.addEventListener('dragleave', (event) => {
+            if (event.target === target) {
+                resetVisualState();
+            }
+        });
+
+        target.addEventListener('drop', (event) => {
+            event.preventDefault();
+            resetVisualState();
+            if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length > 0) {
+                updateFileSelection(event.dataTransfer.files);
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-doc-dropzone]').forEach(setupDropZone);
+})();


### PR DESCRIPTION
## Summary
- add Razor pages and handlers so project officers can submit upload, replace, and delete document requests with server-side validation and cleanup
- extend document services to generate temp storage tokens, accept rename/delete reason metadata, and update decision approval logic
- add a reusable drag-and-drop PDF picker script and update document service tests for the new APIs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6443fb68832991587346ecdae236