### PR TITLE
Fix project document request pages to use case file number

### DIFF
--- a/Pages/Projects/Documents/DeleteRequest.cshtml
+++ b/Pages/Projects/Documents/DeleteRequest.cshtml
@@ -48,7 +48,9 @@
             <div class="card-body">
                 <h2 class="h6 text-uppercase text-muted">Project</h2>
                 <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
-                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+                <p class="mb-0 text-muted">
+                    Case file number: @(string.IsNullOrWhiteSpace(Model.Project?.CaseFileNumber) ? "—" : Model.Project!.CaseFileNumber)
+                </p>
             </div>
         </div>
     </div>

--- a/Pages/Projects/Documents/ReplaceRequest.cshtml
+++ b/Pages/Projects/Documents/ReplaceRequest.cshtml
@@ -58,7 +58,9 @@
             <div class="card-body">
                 <h2 class="h6 text-uppercase text-muted">Project</h2>
                 <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
-                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+                <p class="mb-0 text-muted">
+                    Case file number: @(string.IsNullOrWhiteSpace(Model.Project?.CaseFileNumber) ? "—" : Model.Project!.CaseFileNumber)
+                </p>
             </div>
         </div>
     </div>

--- a/Pages/Projects/Documents/UploadRequest.cshtml
+++ b/Pages/Projects/Documents/UploadRequest.cshtml
@@ -52,7 +52,9 @@
             <div class="card-body">
                 <h2 class="h6 text-uppercase text-muted">Project</h2>
                 <p class="mb-1 fw-semibold">@Model.Project?.Name</p>
-                <p class="mb-0 text-muted">Project code: @Model.Project?.ProjectCode</p>
+                <p class="mb-0 text-muted">
+                    Case file number: @(string.IsNullOrWhiteSpace(Model.Project?.CaseFileNumber) ? "—" : Model.Project!.CaseFileNumber)
+                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- replace document request sidebar project code display with the available case file number
- show a placeholder when the case file number is not set to avoid null references

## Testing
- Not run (environment missing `dotnet` CLI)


------
https://chatgpt.com/codex/tasks/task_e_68dd6844718083298cfb82f7ccb7139a