### PR TITLE
Add HoD/Admin document approval workflow

### DIFF
--- a/Pages/Projects/Documents/Approvals/Index.cshtml
+++ b/Pages/Projects/Documents/Approvals/Index.cshtml
@@ -1,0 +1,77 @@
+@page
+@model ProjectManagement.Pages.Projects.Documents.Approvals.IndexModel
+@{
+    ViewData["Title"] ??= $"Document approvals – {Model.Project.Name}";
+
+    string FormatFileSize(long? bytes)
+    {
+        if (!bytes.HasValue || bytes.Value <= 0)
+        {
+            return "—";
+        }
+
+        double size = bytes.Value;
+        var units = new[] { "bytes", "KB", "MB", "GB", "TB" };
+        var unitIndex = 0;
+        while (size >= 1024 && unitIndex < units.Length - 1)
+        {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return unitIndex == 0
+            ? string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0} {1}", size, units[unitIndex])
+            : string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.##} {1}", size, units[unitIndex]);
+    }
+}
+
+<div class="row gy-4">
+    <div class="col-12">
+        <a class="btn btn-link px-0" asp-page="../../Overview" asp-route-id="@Model.Project.Id">&larr; Back to project overview</a>
+        <h1 class="h2 mt-2">Document approvals</h1>
+        <p class="text-muted">Review pending document requests for <strong>@Model.Project.Name</strong>.</p>
+    </div>
+
+    <div class="col-12">
+        @if (Model.Requests.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">
+                There are no pending document requests for this project.
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Stage</th>
+                            <th scope="col">Nomenclature</th>
+                            <th scope="col">Action</th>
+                            <th scope="col">Requested by</th>
+                            <th scope="col">Requested on</th>
+                            <th scope="col">File size</th>
+                            <th scope="col" class="text-end">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var request in Model.Requests)
+                        {
+                            <tr>
+                                <td>@request.Stage</td>
+                                <td class="fw-semibold">@request.Nomenclature</td>
+                                <td>@request.Action</td>
+                                <td>@request.RequestedBy</td>
+                                <td>@request.RequestedAtLocal.ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) IST</td>
+                                <td>@FormatFileSize(request.FileSize)</td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-primary" asp-page="./Review" asp-route-id="@Model.Project.Id" asp-route-requestId="@request.RequestId">Review</a>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>

--- a/Pages/Projects/Documents/Approvals/Index.cshtml.cs
+++ b/Pages/Projects/Documents/Approvals/Index.cshtml.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Utilities;
+
+namespace ProjectManagement.Pages.Projects.Documents.Approvals;
+
+[Authorize(Roles = "Admin,HoD")]
+public sealed class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+
+    public IndexModel(ApplicationDbContext db, IUserContext userContext)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+    }
+
+    public ProjectSummaryViewModel Project { get; private set; } = default!;
+
+    public IReadOnlyList<PendingRequestViewModel> Requests { get; private set; } = Array.Empty<PendingRequestViewModel>();
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects
+            .AsNoTracking()
+            .Select(p => new { p.Id, p.Name, p.HodUserId })
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!UserCanModerate(project.HodUserId, userId))
+        {
+            return Forbid();
+        }
+
+        Project = new ProjectSummaryViewModel(project.Id, project.Name);
+        ViewData["Title"] = string.Format(CultureInfo.InvariantCulture, "Document approvals – {0}", project.Name);
+
+        Requests = await LoadPendingRequestsAsync(id, cancellationToken);
+
+        return Page();
+    }
+
+    private bool UserCanModerate(string? hodUserId, string userId)
+    {
+        var principal = _userContext.User;
+        if (principal.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("HoD") &&
+            string.Equals(hodUserId, userId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<IReadOnlyList<PendingRequestViewModel>> LoadPendingRequestsAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var pending = await _db.ProjectDocumentRequests
+            .AsNoTracking()
+            .Where(r => r.ProjectId == projectId && r.Status == ProjectDocumentRequestStatus.Submitted)
+            .OrderBy(r => r.RequestedAtUtc)
+            .Select(r => new
+            {
+                r.Id,
+                r.Title,
+                r.RequestType,
+                r.FileSize,
+                r.OriginalFileName,
+                r.RequestedAtUtc,
+                StageCode = r.Stage != null ? r.Stage.StageCode : null,
+                RequestedByName = r.RequestedByUser != null
+                    ? (string.IsNullOrWhiteSpace(r.RequestedByUser.FullName)
+                        ? (r.RequestedByUser.UserName ?? r.RequestedByUser.Email ?? "Unknown")
+                        : r.RequestedByUser.FullName)
+                    : "Unknown"
+            })
+            .ToListAsync(cancellationToken);
+
+        if (pending.Count == 0)
+        {
+            return Array.Empty<PendingRequestViewModel>();
+        }
+
+        var ist = TimeZoneHelper.GetIst();
+        return pending
+            .Select(r => new PendingRequestViewModel(
+                r.Id,
+                r.Title,
+                DescribeAction(r.RequestType),
+                string.IsNullOrWhiteSpace(r.StageCode) ? "General" : StageCodes.DisplayNameOf(r.StageCode),
+                r.OriginalFileName ?? "—",
+                r.FileSize,
+                r.RequestedByName,
+                TimeZoneInfo.ConvertTime(r.RequestedAtUtc, ist)))
+            .ToList();
+    }
+
+    private static string DescribeAction(ProjectDocumentRequestType type) => type switch
+    {
+        ProjectDocumentRequestType.Upload => "Publish new",
+        ProjectDocumentRequestType.Replace => "Overwrite",
+        ProjectDocumentRequestType.Delete => "Remove",
+        _ => type.ToString()
+    };
+
+    public sealed record ProjectSummaryViewModel(int Id, string Name);
+
+    public sealed record PendingRequestViewModel(
+        int RequestId,
+        string Nomenclature,
+        string Action,
+        string Stage,
+        string OriginalFileName,
+        long? FileSize,
+        string RequestedBy,
+        DateTimeOffset RequestedAtLocal);
+}

--- a/Pages/Projects/Documents/Approvals/Review.cshtml
+++ b/Pages/Projects/Documents/Approvals/Review.cshtml
@@ -1,0 +1,140 @@
+@page
+@model ProjectManagement.Pages.Projects.Documents.Approvals.ReviewModel
+@{
+    ViewData["Title"] ??= $"Review document request – {Model.Project.Name}";
+
+    string FormatFileSize(long? bytes)
+    {
+        if (!bytes.HasValue || bytes.Value <= 0)
+        {
+            return "—";
+        }
+
+        double size = bytes.Value;
+        string[] units = { "bytes", "KB", "MB", "GB", "TB" };
+        var unitIndex = 0;
+        while (size >= 1024 && unitIndex < units.Length - 1)
+        {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return unitIndex == 0
+            ? string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0} {1}", size, units[unitIndex])
+            : string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.##} {1}", size, units[unitIndex]);
+    }
+
+    string ApproveButtonLabel => Model.Request.RequestType switch
+    {
+        ProjectManagement.Models.ProjectDocumentRequestType.Upload => "Approve & publish",
+        ProjectManagement.Models.ProjectDocumentRequestType.Replace => "Approve & overwrite",
+        ProjectManagement.Models.ProjectDocumentRequestType.Delete => "Approve removal",
+        _ => "Approve"
+    };
+}
+
+<div class="row gy-4">
+    <div class="col-12">
+        <a class="btn btn-link px-0" asp-page="./Index" asp-route-id="@Model.Project.Id">&larr; Back to approvals</a>
+        <h1 class="h2 mt-2">Review document request</h1>
+        <p class="text-muted">Moderate pending document changes for <strong>@Model.Project.Name</strong>.</p>
+    </div>
+
+    <div class="col-lg-7">
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body">
+                <div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+                    <span class="badge text-bg-primary">@Model.Request.Stage</span>
+                    @if (!string.IsNullOrWhiteSpace(Model.Request.StageCode))
+                    {
+                        <span class="badge text-bg-light text-muted">@Model.Request.StageCode</span>
+                    }
+                    <span class="badge text-bg-secondary">@Model.Request.Action</span>
+                </div>
+
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Nomenclature</dt>
+                    <dd class="col-sm-8">@Model.Request.Title</dd>
+
+                    <dt class="col-sm-4">Requested by</dt>
+                    <dd class="col-sm-8">@Model.Request.RequestedBy</dd>
+
+                    <dt class="col-sm-4">Requested on</dt>
+                    <dd class="col-sm-8">@Model.Request.RequestedAtLocal.ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) IST</dd>
+
+                    <dt class="col-sm-4">Original filename</dt>
+                    <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(Model.Request.OriginalFileName) ? Model.Request.OriginalFileName : "—")</dd>
+
+                    <dt class="col-sm-4">File size</dt>
+                    <dd class="col-sm-8">@FormatFileSize(Model.Request.FileSize)</dd>
+
+                    <dt class="col-sm-4">Content type</dt>
+                    <dd class="col-sm-8">@(!string.IsNullOrWhiteSpace(Model.Request.ContentType) ? Model.Request.ContentType : "—")</dd>
+
+                    @if (!string.IsNullOrWhiteSpace(Model.Request.Description))
+                    {
+                        <dt class="col-sm-4">Submitter note</dt>
+                        <dd class="col-sm-8">@Model.Request.Description</dd>
+                    }
+                </dl>
+            </div>
+        </div>
+
+        @if (Model.Request.Document is not null)
+        {
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body">
+                    <h2 class="h6 text-uppercase text-muted mb-3">Current document</h2>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Title</dt>
+                        <dd class="col-sm-8">@Model.Request.Document.Title</dd>
+
+                        <dt class="col-sm-4">Filename</dt>
+                        <dd class="col-sm-8">@Model.Request.Document.OriginalFileName</dd>
+
+                        <dt class="col-sm-4">File size</dt>
+                        <dd class="col-sm-8">@FormatFileSize(Model.Request.Document.FileSize)</dd>
+
+                        <dt class="col-sm-4">File stamp</dt>
+                        <dd class="col-sm-8">@Model.Request.Document.FileStamp</dd>
+
+                        <dt class="col-sm-4">Last uploaded</dt>
+                        <dd class="col-sm-8">@Model.Request.Document.UploadedAtLocal.ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) IST by @Model.Request.Document.UploadedBy</dd>
+
+                        @if (Model.Request.Document.IsArchived)
+                        {
+                            <dt class="col-sm-4">Status</dt>
+                            <dd class="col-sm-8"><span class="badge text-bg-warning">Archived</span></dd>
+                        }
+                    </dl>
+                </div>
+            </div>
+        }
+    </div>
+
+    <div class="col-lg-5">
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Decision</h2>
+                <p class="text-muted">Approvals publish the change immediately. Rejections discard staged files.</p>
+
+                <form method="post" novalidate>
+                    <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+                    <input type="hidden" asp-for="Input.RequestId" />
+                    <input type="hidden" asp-for="Input.RowVersion" />
+
+                    <div class="mb-3">
+                        <label asp-for="Input.Note" class="form-label">Decision note</label>
+                        <textarea asp-for="Input.Note" class="form-control" rows="4" placeholder="Optional feedback for the requester"></textarea>
+                        <span asp-validation-for="Input.Note" class="text-danger"></span>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="submit" class="btn btn-success" asp-page-handler="Approve">@ApproveButtonLabel</button>
+                        <button type="submit" class="btn btn-outline-danger" asp-page-handler="Reject">Reject</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Pages/Projects/Documents/Approvals/Review.cshtml.cs
+++ b/Pages/Projects/Documents/Approvals/Review.cshtml.cs
@@ -1,0 +1,363 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Documents;
+using ProjectManagement.Utilities;
+
+namespace ProjectManagement.Pages.Projects.Documents.Approvals;
+
+[Authorize(Roles = "Admin,HoD")]
+[AutoValidateAntiforgeryToken]
+public sealed class ReviewModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IUserContext _userContext;
+    private readonly IDocumentDecisionService _decisionService;
+    private readonly ILogger<ReviewModel> _logger;
+
+    public ReviewModel(
+        ApplicationDbContext db,
+        IUserContext userContext,
+        IDocumentDecisionService decisionService,
+        ILogger<ReviewModel> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _decisionService = decisionService ?? throw new ArgumentNullException(nameof(decisionService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [BindProperty]
+    public DecisionInput Input { get; set; } = new();
+
+    public ProjectSummaryViewModel Project { get; private set; } = default!;
+
+    public RequestDetailViewModel Request { get; private set; } = default!;
+
+    public async Task<IActionResult> OnGetAsync(int id, int requestId, CancellationToken cancellationToken)
+    {
+        var projectResult = await EnsureProjectAccessAsync(id, cancellationToken);
+        if (projectResult is not null)
+        {
+            return projectResult;
+        }
+
+        if (!await TryPopulateRequestAsync(id, requestId, cancellationToken))
+        {
+            TempData["Error"] = "Document request could not be found.";
+            return RedirectToPage("./Index", new { id });
+        }
+
+        ViewData["Title"] = string.Format(CultureInfo.InvariantCulture, "Review document request – {0}", Project.Name);
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostApproveAsync(int id, int requestId, CancellationToken cancellationToken)
+    {
+        return await DecideAsync(id, requestId, DecisionAction.Approve, cancellationToken);
+    }
+
+    public async Task<IActionResult> OnPostRejectAsync(int id, int requestId, CancellationToken cancellationToken)
+    {
+        return await DecideAsync(id, requestId, DecisionAction.Reject, cancellationToken);
+    }
+
+    private async Task<IActionResult> DecideAsync(int projectId, int requestId, DecisionAction action, CancellationToken cancellationToken)
+    {
+        if (requestId != Input.RequestId)
+        {
+            return BadRequest();
+        }
+
+        var projectResult = await EnsureProjectAccessAsync(projectId, cancellationToken);
+        if (projectResult is not null)
+        {
+            return projectResult;
+        }
+
+        Input.Note = string.IsNullOrWhiteSpace(Input.Note) ? null : Input.Note.Trim();
+
+        if (!ModelState.IsValid)
+        {
+            if (await TryPopulateRequestAsync(projectId, requestId, cancellationToken))
+            {
+                ViewData["Title"] = string.Format(CultureInfo.InvariantCulture, "Review document request – {0}", Project.Name);
+                return Page();
+            }
+
+            TempData["Error"] = "Document request could not be found.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+
+        if (!TryDecodeRowVersion(Input.RowVersion, out var expectedRowVersion))
+        {
+            ModelState.AddModelError(string.Empty, "We couldn't verify the request. Reload the page and try again.");
+            if (await TryPopulateRequestAsync(projectId, requestId, cancellationToken))
+            {
+                ViewData["Title"] = string.Format(CultureInfo.InvariantCulture, "Review document request – {0}", Project.Name);
+                return Page();
+            }
+
+            TempData["Error"] = "Document request could not be found.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+
+        var entity = await FetchRequestAsync(projectId, requestId, cancellationToken);
+        if (entity is null)
+        {
+            TempData["Error"] = "Document request could not be found.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+
+        if (entity.Status != ProjectDocumentRequestStatus.Submitted)
+        {
+            TempData["Flash"] = "This request has already been processed.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+
+        if (!expectedRowVersion.AsSpan().SequenceEqual(entity.RowVersion))
+        {
+            TempData["Error"] = "This request was updated by someone else. Refresh the list and try again.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+
+        PopulateViewModel(entity);
+
+        var userId = _userContext.UserId;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Challenge();
+        }
+
+        try
+        {
+            switch (action)
+            {
+                case DecisionAction.Approve:
+                    await _decisionService.ApproveAsync(entity.Id, userId, Input.Note, cancellationToken);
+                    TempData["Flash"] = GetApproveMessage(entity.RequestType);
+                    break;
+                case DecisionAction.Reject:
+                    await _decisionService.RejectAsync(entity.Id, userId, Input.Note, cancellationToken);
+                    TempData["Flash"] = "Document request rejected.";
+                    break;
+                default:
+                    TempData["Error"] = "Unsupported action.";
+                    return RedirectToPage("./Index", new { id = projectId });
+            }
+
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            TempData["Error"] = "This request has already been processed.";
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["Error"] = ex.Message;
+            return RedirectToPage("./Index", new { id = projectId });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deciding document request {RequestId} for project {ProjectId}", entity.Id, projectId);
+            ModelState.AddModelError(string.Empty, "We couldn't complete the action. Please try again.");
+            ViewData["Title"] = string.Format(CultureInfo.InvariantCulture, "Review document request – {0}", Project.Name);
+            return Page();
+        }
+    }
+
+    private async Task<IActionResult?> EnsureProjectAccessAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var userId = _userContext.UserId;
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Challenge();
+        }
+
+        var project = await _db.Projects
+            .AsNoTracking()
+            .Select(p => new { p.Id, p.Name, p.HodUserId })
+            .FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        var principal = _userContext.User;
+        var authorised = principal.IsInRole("Admin") ||
+            (principal.IsInRole("HoD") && string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase));
+
+        if (!authorised)
+        {
+            return Forbid();
+        }
+
+        Project = new ProjectSummaryViewModel(project.Id, project.Name);
+        return null;
+    }
+
+    private async Task<ProjectDocumentRequest?> FetchRequestAsync(int projectId, int requestId, CancellationToken cancellationToken)
+    {
+        return await _db.ProjectDocumentRequests
+            .AsNoTracking()
+            .Include(r => r.Stage)
+            .Include(r => r.Document)
+            .ThenInclude(d => d.UploadedByUser)
+            .Include(r => r.RequestedByUser)
+            .FirstOrDefaultAsync(r => r.ProjectId == projectId && r.Id == requestId, cancellationToken);
+    }
+
+    private async Task<bool> TryPopulateRequestAsync(int projectId, int requestId, CancellationToken cancellationToken)
+    {
+        var entity = await FetchRequestAsync(projectId, requestId, cancellationToken);
+        if (entity is null)
+        {
+            return false;
+        }
+
+        PopulateViewModel(entity);
+        return true;
+    }
+
+    private static bool TryDecodeRowVersion(string value, out byte[] rowVersion)
+    {
+        try
+        {
+            rowVersion = Convert.FromBase64String(value);
+            return true;
+        }
+        catch
+        {
+            rowVersion = Array.Empty<byte>();
+            return false;
+        }
+    }
+
+    private void PopulateViewModel(ProjectDocumentRequest request)
+    {
+        var ist = TimeZoneHelper.GetIst();
+        var requestedAtLocal = TimeZoneInfo.ConvertTime(request.RequestedAtUtc, ist);
+        var stageDisplay = request.Stage is null
+            ? "General"
+            : StageCodes.DisplayNameOf(request.Stage.StageCode);
+
+        var requestedBy = request.RequestedByUser is null
+            ? "Unknown"
+            : (string.IsNullOrWhiteSpace(request.RequestedByUser.FullName)
+                ? (request.RequestedByUser.UserName ?? request.RequestedByUser.Email ?? "Unknown")
+                : request.RequestedByUser.FullName);
+
+        DocumentSummaryViewModel? documentSummary = null;
+        if (request.Document is not null)
+        {
+            var uploadedAtLocal = TimeZoneInfo.ConvertTime(request.Document.UploadedAtUtc, ist);
+            var uploadedBy = request.Document.UploadedByUser is null
+                ? "Unknown"
+                : (string.IsNullOrWhiteSpace(request.Document.UploadedByUser.FullName)
+                    ? (request.Document.UploadedByUser.UserName ?? request.Document.UploadedByUser.Email ?? "Unknown")
+                    : request.Document.UploadedByUser.FullName);
+
+            documentSummary = new DocumentSummaryViewModel(
+                request.Document.Id,
+                request.Document.Title,
+                request.Document.OriginalFileName,
+                request.Document.FileSize,
+                request.Document.FileStamp,
+                uploadedBy,
+                uploadedAtLocal,
+                request.Document.Status == ProjectDocumentStatus.SoftDeleted);
+        }
+
+        Request = new RequestDetailViewModel(
+            request.Id,
+            stageDisplay,
+            request.Stage?.StageCode ?? string.Empty,
+            request.Title,
+            DescribeAction(request.RequestType),
+            requestedBy,
+            requestedAtLocal,
+            request.OriginalFileName,
+            request.FileSize,
+            request.ContentType,
+            request.Description,
+            documentSummary,
+            request.RequestType);
+
+        Input.RequestId = request.Id;
+        Input.RowVersion = Convert.ToBase64String(request.RowVersion);
+    }
+
+    private static string DescribeAction(ProjectDocumentRequestType type) => type switch
+    {
+        ProjectDocumentRequestType.Upload => "Publish new document",
+        ProjectDocumentRequestType.Replace => "Overwrite existing document",
+        ProjectDocumentRequestType.Delete => "Remove document",
+        _ => type.ToString()
+    };
+
+    private static string GetApproveMessage(ProjectDocumentRequestType type) => type switch
+    {
+        ProjectDocumentRequestType.Upload => "Document published.",
+        ProjectDocumentRequestType.Replace => "Document replaced with the new file.",
+        ProjectDocumentRequestType.Delete => "Document removed from the project.",
+        _ => "Document request approved."
+    };
+
+    public sealed record ProjectSummaryViewModel(int Id, string Name);
+
+    public sealed record RequestDetailViewModel(
+        int RequestId,
+        string Stage,
+        string StageCode,
+        string Title,
+        string Action,
+        string RequestedBy,
+        DateTimeOffset RequestedAtLocal,
+        string? OriginalFileName,
+        long? FileSize,
+        string? ContentType,
+        string? Description,
+        DocumentSummaryViewModel? Document,
+        ProjectDocumentRequestType RequestType);
+
+    public sealed record DocumentSummaryViewModel(
+        int DocumentId,
+        string Title,
+        string OriginalFileName,
+        long FileSize,
+        int FileStamp,
+        string UploadedBy,
+        DateTimeOffset UploadedAtLocal,
+        bool IsArchived);
+
+    public sealed class DecisionInput
+    {
+        [Required]
+        public int RequestId { get; set; }
+
+        [StringLength(2000)]
+        public string? Note { get; set; }
+
+        [Required]
+        public string RowVersion { get; set; } = string.Empty;
+    }
+
+    private enum DecisionAction
+    {
+        Approve,
+        Reject
+    }
+}


### PR DESCRIPTION
## Summary
- add a project-scoped approvals list so HoDs/Admins can see pending document moderation requests
- implement a review workflow that surfaces request details and calls the document decision service to approve or reject
- guard access to HoD/Admin roles, enforce optimistic concurrency, and present friendly success/error messages

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd681cfd7c8329b6cbfff48084c566