### PR TITLE
Fix nullability warning in approvals review

### DIFF
--- a/Pages/Projects/Documents/Approvals/Review.cshtml.cs
+++ b/Pages/Projects/Documents/Approvals/Review.cshtml.cs
@@ -215,7 +215,7 @@ public sealed class ReviewModel : PageModel
             .AsNoTracking()
             .Include(r => r.Stage)
             .Include(r => r.Document)
-            .ThenInclude(d => d.UploadedByUser)
+            .ThenInclude(d => d!.UploadedByUser)
             .Include(r => r.RequestedByUser)
             .FirstOrDefaultAsync(r => r.ProjectId == projectId && r.Id == requestId, cancellationToken);
     }


### PR DESCRIPTION
## Summary
- avoid nullable dereference warning when including the document uploader on the approval review page

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd6c6d9bf88329866477554ec3e1ae