### PR TITLE
Add documents card to project overview

### DIFF
--- a/Areas/Admin/Pages/Documents/Recycle.cshtml
+++ b/Areas/Admin/Pages/Documents/Recycle.cshtml
@@ -1,0 +1,20 @@
+@page
+@model ProjectManagement.Areas.Admin.Pages.Documents.RecycleModel
+@{
+    ViewData["Title"] = "Document recycle bin";
+}
+
+<div class="container-xxl py-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Document recycle bin</li>
+        </ol>
+    </nav>
+
+    <h1 class="h3 mb-3">Document recycle bin</h1>
+    <div class="alert alert-info">
+        Document recycle bin management will be available in a future update.
+    </div>
+    <a class="btn btn-outline-secondary" asp-area="Admin" asp-page="/Index">Back to admin home</a>
+</div>

--- a/Areas/Admin/Pages/Documents/Recycle.cshtml.cs
+++ b/Areas/Admin/Pages/Documents/Recycle.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Areas.Admin.Pages.Documents;
+
+[Authorize(Roles = "Admin")]
+public class RecycleModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/Pages/Projects/Documents/DeleteRequest.cshtml.cs
+++ b/Pages/Projects/Documents/DeleteRequest.cshtml.cs
@@ -16,7 +16,7 @@ using ProjectManagement.Services.Documents;
 
 namespace ProjectManagement.Pages.Projects.Documents;
 
-[Authorize(Roles = "Admin,Project Officer")]
+[Authorize(Roles = "Admin,HoD,Project Officer")]
 [AutoValidateAntiforgeryToken]
 public class DeleteRequestModel : PageModel
 {
@@ -192,8 +192,14 @@ public class DeleteRequestModel : PageModel
             return true;
         }
 
-        return principal.IsInRole("Project Officer") &&
-            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+        if (principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("HoD") &&
+            string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase);
     }
 
     public sealed class DeleteInputModel

--- a/Pages/Projects/Documents/ReplaceRequest.cshtml.cs
+++ b/Pages/Projects/Documents/ReplaceRequest.cshtml.cs
@@ -20,7 +20,7 @@ using ProjectManagement.Services.Documents;
 
 namespace ProjectManagement.Pages.Projects.Documents;
 
-[Authorize(Roles = "Admin,Project Officer")]
+[Authorize(Roles = "Admin,HoD,Project Officer")]
 [AutoValidateAntiforgeryToken]
 public class ReplaceRequestModel : PageModel
 {
@@ -238,8 +238,14 @@ public class ReplaceRequestModel : PageModel
             return true;
         }
 
-        return principal.IsInRole("Project Officer") &&
-            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+        if (principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("HoD") &&
+            string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase);
     }
 
     public sealed class ReplaceInputModel

--- a/Pages/Projects/Documents/UploadRequest.cshtml.cs
+++ b/Pages/Projects/Documents/UploadRequest.cshtml.cs
@@ -22,7 +22,7 @@ using ProjectManagement.Services.Documents;
 
 namespace ProjectManagement.Pages.Projects.Documents;
 
-[Authorize(Roles = "Admin,Project Officer")]
+[Authorize(Roles = "Admin,HoD,Project Officer")]
 [AutoValidateAntiforgeryToken]
 public class UploadRequestModel : PageModel
 {
@@ -197,8 +197,14 @@ public class UploadRequestModel : PageModel
             return true;
         }
 
-        return principal.IsInRole("Project Officer") &&
-            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase);
+        if (principal.IsInRole("Project Officer") &&
+            string.Equals(project.LeadPoUserId, userId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return principal.IsInRole("HoD") &&
+            string.Equals(project.HodUserId, userId, StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<IEnumerable<SelectListItem>> BuildStageOptionsAsync(int projectId, CancellationToken cancellationToken)

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1,6 +1,7 @@
 @page "{id:int}"
 @using System
 @using System.Linq
+@using Microsoft.AspNetCore.Routing
 @using ProjectManagement.Models
 @using ProjectManagement.Models.Execution
 @using ProjectManagement.Models.Plans
@@ -78,6 +79,53 @@
     };
 
     private static string StageStatusLabel(StageStatus status) => StageStatusLabel(status.ToString());
+
+    private string BuildDocumentFilterUrl(string? stageValue, string statusValue, int page = 1)
+    {
+        var values = new RouteValueDictionary(ViewContext.RouteData.Values);
+        values["id"] = Model.Project?.Id ?? 0;
+
+        foreach (var key in Context.Request.Query.Keys)
+        {
+            if (string.Equals(key, "docStage", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(key, "docStatus", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(key, "docPage", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            values[key] = Context.Request.Query[key].ToString();
+        }
+
+        if (string.IsNullOrEmpty(stageValue))
+        {
+            values.Remove("docStage");
+        }
+        else
+        {
+            values["docStage"] = stageValue;
+        }
+
+        if (string.Equals(statusValue, ProjectDocumentListViewModel.PublishedStatusValue, StringComparison.OrdinalIgnoreCase))
+        {
+            values.Remove("docStatus");
+        }
+        else
+        {
+            values["docStatus"] = statusValue;
+        }
+
+        if (page <= 1)
+        {
+            values.Remove("docPage");
+        }
+        else
+        {
+            values["docPage"] = page;
+        }
+
+        return Url.Page(null, values)!;
+    }
 }
 
 <div class="container-xxl">
@@ -315,6 +363,218 @@
             <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
 
             <div class="card pm-card">
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-file-earmark-text"></i>
+                        </span>
+                        <div>
+                            <h3 class="pm-card-title h5 mb-0">Documents</h3>
+                            <p class="pm-card-subtitle mb-0">Project files organised by stage.</p>
+                        </div>
+                    </div>
+                    <div class="pm-card-actions">
+                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                            @if (Model.IsDocumentApprover && Model.DocumentPendingRequestCount > 0)
+                            {
+                                <span class="badge text-bg-warning">@Model.DocumentPendingRequestCount pending</span>
+                            }
+                            @if (isAdmin || isThisProjectsPo || isThisProjectsHod)
+                            {
+                                <a class="btn btn-sm btn-outline-primary"
+                                   asp-page="/Projects/Documents/UploadRequest"
+                                   asp-route-id="@Model.Project!.Id">Upload</a>
+                            }
+                            @if (isAdmin)
+                            {
+                                <a class="btn btn-link card-action-link"
+                                   asp-area="Admin"
+                                   asp-page="/Documents/Recycle">
+                                    <i class="bi bi-trash" aria-hidden="true"></i>
+                                    <span>Recycle Bin</span>
+                                </a>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body pm-card-body">
+                    @{
+                        var documentList = Model.DocumentList;
+                        var displayedCount = documentList.Groups.Sum(g => g.Items.Count);
+                    }
+                    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                        <div class="dropdown">
+                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                                    type="button"
+                                    data-bs-toggle="dropdown"
+                                    aria-expanded="false">
+                                Stage: @Model.DocumentList.SelectedStageLabel
+                            </button>
+                            <ul class="dropdown-menu">
+                                @foreach (var option in Model.DocumentList.StageFilters)
+                                {
+                                    var stageUrl = BuildDocumentFilterUrl(option.Value, Model.DocumentList.SelectedStatusValue, 1);
+                                    <li>
+                                        <a class="dropdown-item@(option.Selected ? " active" : string.Empty)" href="@stageUrl">@option.Label</a>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                        @if (Model.DocumentList.ShowStatusFilter)
+                        {
+                            <div class="d-flex flex-wrap gap-2">
+                                @foreach (var status in Model.DocumentList.StatusFilters)
+                                {
+                                    var statusUrl = BuildDocumentFilterUrl(Model.DocumentList.SelectedStageValue, status.Value, 1);
+                                    var statusClass = status.Selected ? "btn btn-sm btn-primary" : "btn btn-sm btn-outline-secondary";
+                                    <a class="@statusClass" href="@statusUrl">@status.Label</a>
+                                }
+                            </div>
+                        }
+                    </div>
+                    <div class="mb-3 text-muted small">
+                        @if (Model.DocumentList.TotalItems > 0)
+                        {
+                            <span>Showing @displayedCount of @Model.DocumentList.TotalItems @Model.DocumentList.StatusHeading.</span>
+                        }
+                        else
+                        {
+                            <span>No @Model.DocumentList.StatusHeading found for the selected filters.</span>
+                        }
+                    </div>
+                    @if (!Model.DocumentList.HasItems)
+                    {
+                        <div class="border rounded p-4 text-center text-muted bg-light-subtle">
+                            <p class="mb-2">No @Model.DocumentList.StatusHeading found for this project.</p>
+                            @if (isAdmin || isThisProjectsPo || isThisProjectsHod)
+                            {
+                                <a class="btn btn-sm btn-primary"
+                                   asp-page="/Projects/Documents/UploadRequest"
+                                   asp-route-id="@Model.Project!.Id">Upload document</a>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="d-flex flex-column gap-3">
+                            @foreach (var group in Model.DocumentList.Groups)
+                            {
+                                <section>
+                                    <h4 class="h6 text-uppercase text-muted mb-2">@group.StageDisplayName</h4>
+                                    <div class="d-flex flex-column gap-2">
+                                        @foreach (var item in group.Items)
+                                        {
+                                            var canReplaceDocument = item.DocumentId.HasValue && (isAdmin || isThisProjectsPo || isThisProjectsHod) && !item.IsRemoved && !item.IsPending;
+                                            var canRequestDelete = item.DocumentId.HasValue && isThisProjectsPo && !item.IsRemoved && !item.IsPending;
+                                            var canDirectDelete = item.DocumentId.HasValue && (isAdmin || isThisProjectsHod) && !item.IsRemoved && !item.IsPending;
+                                            var canReviewRequest = Model.IsDocumentApprover && item.RequestId.HasValue;
+                                            var hasActions = canReplaceDocument || canRequestDelete || canDirectDelete || canReviewRequest;
+                                            <div class="border rounded p-3 d-flex flex-column flex-md-row gap-3 justify-content-between">
+                                                <div class="flex-grow-1">
+                                                    <div class="fw-semibold">
+                                                        @if (!string.IsNullOrEmpty(item.PreviewUrl))
+                                                        {
+                                                            <a href="@item.PreviewUrl">@item.Title</a>
+                                                        }
+                                                        else
+                                                        {
+                                                            @item.Title
+                                                        }
+                                                    </div>
+                                                    <div class="text-muted small mt-1">
+                                                        <span>@item.FileSizeDisplay</span>
+                                                        @if (!string.IsNullOrWhiteSpace(item.MetadataSummary))
+                                                        {
+                                                            <span class="ms-2">@item.MetadataSummary</span>
+                                                        }
+                                                    </div>
+                                                    @if (!string.IsNullOrWhiteSpace(item.SecondarySummary))
+                                                    {
+                                                        <div class="text-muted small mt-1">@item.SecondarySummary</div>
+                                                    }
+                                                    @if (!string.IsNullOrWhiteSpace(item.FileName) && !string.Equals(item.FileName, item.Title, StringComparison.OrdinalIgnoreCase))
+                                                    {
+                                                        <div class="text-muted small mt-1">File: @item.FileName</div>
+                                                    }
+                                                </div>
+                                                <div class="d-flex flex-column align-items-md-end gap-2">
+                                                    <span class="badge text-bg-@item.StatusVariant">@item.StatusLabel</span>
+                                                    @if (hasActions)
+                                                    {
+                                                        <div class="dropdown">
+                                                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                                                                    type="button"
+                                                                    data-bs-toggle="dropdown"
+                                                                    aria-expanded="false"
+                                                                    aria-label="Document actions">
+                                                                Actions
+                                                            </button>
+                                                            <ul class="dropdown-menu dropdown-menu-end">
+                                                                @if (canReplaceDocument)
+                                                                {
+                                                                    <li>
+                                                                        <a class="dropdown-item"
+                                                                           asp-page="/Projects/Documents/ReplaceRequest"
+                                                                           asp-route-id="@Model.Project!.Id"
+                                                                           asp-route-documentId="@item.DocumentId">Replace</a>
+                                                                    </li>
+                                                                }
+                                                                @if (canRequestDelete)
+                                                                {
+                                                                    <li>
+                                                                        <a class="dropdown-item"
+                                                                           asp-page="/Projects/Documents/DeleteRequest"
+                                                                           asp-route-id="@Model.Project!.Id"
+                                                                           asp-route-documentId="@item.DocumentId">Request delete</a>
+                                                                    </li>
+                                                                }
+                                                                @if (canDirectDelete)
+                                                                {
+                                                                    <li>
+                                                                        <a class="dropdown-item"
+                                                                           asp-page="/Projects/Documents/DeleteRequest"
+                                                                           asp-route-id="@Model.Project!.Id"
+                                                                           asp-route-documentId="@item.DocumentId">Delete document</a>
+                                                                    </li>
+                                                                }
+                                                                @if (canReviewRequest)
+                                                                {
+                                                                    <li>
+                                                                        <a class="dropdown-item"
+                                                                           asp-page="/Projects/Documents/Approvals/Review"
+                                                                           asp-route-id="@Model.Project!.Id"
+                                                                           asp-route-requestId="@item.RequestId">Review request</a>
+                                                                    </li>
+                                                                }
+                                                            </ul>
+                                                        </div>
+                                                    }
+                                                </div>
+                                            </div>
+                                        }
+                                    </div>
+                                </section>
+                            }
+                        </div>
+                    }
+                    @if (Model.DocumentList.ShowPagination)
+                    {
+                        <nav class="mt-3">
+                            <ul class="pagination pagination-sm mb-0">
+                                @for (var p = 1; p <= Model.DocumentList.TotalPages; p++)
+                                {
+                                    var pageUrl = BuildDocumentFilterUrl(Model.DocumentList.SelectedStageValue, Model.DocumentList.SelectedStatusValue, p);
+                                    <li class="page-item @(p == Model.DocumentList.Page ? "active" : string.Empty)">
+                                        <a class="page-link" href="@pageUrl">@p</a>
+                                    </li>
+                                }
+                            </ul>
+                        </nav>
+                    }
+                </div>
+            </div>
+
+            <div class="card pm-card">
                 @{
                     var stageTotal = Model.Stages.Count;
                     var stageCompleted = Model.Stages.Count(s => s.Status == StageStatus.Completed);
@@ -484,6 +744,69 @@
             }
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">
+            @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
+            {
+                <div class="card pm-card">
+                    <div class="card-header pm-card-header">
+                        <div class="pm-card-heading">
+                            <span class="pm-card-icon" aria-hidden="true">
+                                <i class="bi bi-inbox"></i>
+                            </span>
+                            <div>
+                                <h3 class="pm-card-title h6 mb-0">Document requests</h3>
+                                <p class="pm-card-subtitle mb-0">Newest submissions awaiting your decision.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-body pm-card-body d-flex flex-column gap-3">
+                        @foreach (var request in Model.DocumentPendingRequests)
+                        {
+                            <div class="border rounded p-3">
+                                <div class="d-flex justify-content-between align-items-start gap-2">
+                                    <div>
+                                        <div class="fw-semibold">@request.Title</div>
+                                        <div class="text-muted small">@request.StageDisplayName · @request.RequestTypeLabel</div>
+                                        <div class="text-muted small">@request.RequestedSummary</div>
+                                        <div class="text-muted small">@request.FileName (@request.FileSizeDisplay)</div>
+                                    </div>
+                                    <span class="badge text-bg-warning">Pending</span>
+                                </div>
+                                <div class="d-flex flex-wrap gap-2 mt-3">
+                                    <form method="post"
+                                          class="d-inline"
+                                          asp-page="/Projects/Documents/Approvals/Review"
+                                          asp-page-handler="Approve"
+                                          asp-route-id="@Model.Project!.Id"
+                                          asp-route-requestId="@request.RequestId">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="Input.RequestId" value="@request.RequestId" />
+                                        <input type="hidden" name="Input.RowVersion" value="@request.RowVersion" />
+                                        <button type="submit" class="btn btn-sm btn-success">Approve</button>
+                                    </form>
+                                    <form method="post"
+                                          class="d-inline"
+                                          asp-page="/Projects/Documents/Approvals/Review"
+                                          asp-page-handler="Reject"
+                                          asp-route-id="@Model.Project!.Id"
+                                          asp-route-requestId="@request.RequestId">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="Input.RequestId" value="@request.RequestId" />
+                                        <input type="hidden" name="Input.RowVersion" value="@request.RowVersion" />
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Reject</button>
+                                    </form>
+                                    <a class="btn btn-sm btn-outline-secondary"
+                                       asp-page="/Projects/Documents/Approvals/Review"
+                                       asp-route-id="@Model.Project!.Id"
+                                       asp-route-requestId="@request.RequestId">Review</a>
+                                </div>
+                            </div>
+                        }
+                        <a class="btn btn-sm btn-outline-secondary align-self-start"
+                           asp-page="/Projects/Documents/Approvals/Index"
+                           asp-route-id="@Model.Project!.Id">View all requests</a>
+                    </div>
+                </div>
+            }
             @if (Model.MetaChangeRequest is { } metaRequest)
             {
                 if (isHoD || isAdmin)

--- a/ViewModels/ProjectDocumentListViewModel.cs
+++ b/ViewModels/ProjectDocumentListViewModel.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed record ProjectDocumentListViewModel(
+    IReadOnlyList<ProjectDocumentStageGroupViewModel> Groups,
+    IReadOnlyList<ProjectDocumentFilterOptionViewModel> StageFilters,
+    IReadOnlyList<ProjectDocumentFilterOptionViewModel> StatusFilters,
+    string? SelectedStageValue,
+    string SelectedStatusValue,
+    int Page,
+    int PageSize,
+    int TotalItems)
+{
+    public static ProjectDocumentListViewModel Empty { get; } = new(
+        Array.Empty<ProjectDocumentStageGroupViewModel>(),
+        Array.Empty<ProjectDocumentFilterOptionViewModel>(),
+        Array.Empty<ProjectDocumentFilterOptionViewModel>(),
+        null,
+        PublishedStatusValue,
+        1,
+        DefaultPageSize,
+        0);
+
+    public const string PublishedStatusValue = "published";
+    public const string PendingStatusValue = "pending";
+    public const string UnassignedStageValue = "__none__";
+    public const int DefaultPageSize = 10;
+
+    public int TotalPages => TotalItems == 0
+        ? 1
+        : (int)Math.Ceiling(TotalItems / (double)Math.Max(PageSize, 1));
+
+    public bool HasItems => Groups.Count > 0;
+
+    public string SelectedStageLabel => StageFilters.FirstOrDefault(f => f.Selected)?.Label ?? "All stages";
+
+    public bool ShowStageFilter => StageFilters.Count > 0;
+
+    public bool ShowStatusFilter => StatusFilters.Count > 1;
+
+    public bool ShowPagination => TotalPages > 1;
+
+    public string StatusHeading => string.Equals(SelectedStatusValue, PendingStatusValue, StringComparison.OrdinalIgnoreCase)
+        ? "requests"
+        : "documents";
+}
+
+public sealed record ProjectDocumentStageGroupViewModel(
+    string? StageCode,
+    string StageDisplayName,
+    IReadOnlyList<ProjectDocumentRowViewModel> Items);
+
+public sealed record ProjectDocumentRowViewModel(
+    string? StageCode,
+    string StageDisplayName,
+    int? DocumentId,
+    int? RequestId,
+    string Title,
+    string? FileName,
+    string FileSizeDisplay,
+    string MetadataSummary,
+    string StatusLabel,
+    string StatusVariant,
+    bool IsPending,
+    bool IsRemoved,
+    string? PreviewUrl,
+    string? SecondarySummary,
+    ProjectDocumentRequestType? PendingRequestType);
+
+public sealed record ProjectDocumentFilterOptionViewModel(string? Value, string Label, bool Selected);
+
+public sealed record ProjectDocumentPendingRequestViewModel(
+    int RequestId,
+    string Title,
+    string StageDisplayName,
+    string RequestTypeLabel,
+    string RequestedSummary,
+    string FileName,
+    string FileSizeDisplay,
+    string RowVersion,
+    string ReviewUrl,
+    DateTimeOffset RequestedAtUtc,
+    string RequestedBy);


### PR DESCRIPTION
## Summary
- add a documents card to the project overview with stage filtering, status chips, pagination, and contextual actions
- surface pending document moderation requests to approvers and introduce supporting document list view models
- allow HoDs to submit document upload/replace/delete requests and add a placeholder admin recycle bin page

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6acfdbc88329a8306a49a843120d