### PR TITLE
Fix document filter helpers in project overview page

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -80,12 +80,12 @@
 
     private static string StageStatusLabel(StageStatus status) => StageStatusLabel(status.ToString());
 
-    private string BuildDocumentFilterUrl(string? stageValue, string statusValue, int page = 1)
+    private string BuildDocumentFilterUrl(string? stageValue, string? statusValue, int page = 1)
     {
         var values = new RouteValueDictionary(ViewContext.RouteData.Values);
         values["id"] = Model.Project?.Id ?? 0;
 
-        foreach (var key in Context.Request.Query.Keys)
+        foreach (var key in Request.Query.Keys)
         {
             if (string.Equals(key, "docStage", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(key, "docStatus", StringComparison.OrdinalIgnoreCase) ||
@@ -94,7 +94,7 @@
                 continue;
             }
 
-            values[key] = Context.Request.Query[key].ToString();
+            values[key] = Request.Query[key].ToString();
         }
 
         if (string.IsNullOrEmpty(stageValue))
@@ -106,7 +106,8 @@
             values["docStage"] = stageValue;
         }
 
-        if (string.Equals(statusValue, ProjectDocumentListViewModel.PublishedStatusValue, StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(statusValue) ||
+            string.Equals(statusValue, ProjectDocumentListViewModel.PublishedStatusValue, StringComparison.OrdinalIgnoreCase))
         {
             values.Remove("docStatus");
         }
@@ -561,11 +562,11 @@
                     {
                         <nav class="mt-3">
                             <ul class="pagination pagination-sm mb-0">
-                                @for (var p = 1; p <= Model.DocumentList.TotalPages; p++)
+                                @for (var pageNumber = 1; pageNumber <= Model.DocumentList.TotalPages; pageNumber++)
                                 {
-                                    var pageUrl = BuildDocumentFilterUrl(Model.DocumentList.SelectedStageValue, Model.DocumentList.SelectedStatusValue, p);
-                                    <li class="page-item @(p == Model.DocumentList.Page ? "active" : string.Empty)">
-                                        <a class="page-link" href="@pageUrl">@p</a>
+                                    var pageUrl = BuildDocumentFilterUrl(Model.DocumentList.SelectedStageValue, Model.DocumentList.SelectedStatusValue, pageNumber);
+                                    <li class="page-item @(pageNumber == Model.DocumentList.Page ? "active" : string.Empty)">
+                                        <a class="page-link" href="@pageUrl">@pageNumber</a>
                                     </li>
                                 }
                             </ul>


### PR DESCRIPTION
## Summary
- use the current HTTP request when building document filter URLs and allow for missing status values
- rename the pagination loop variable to avoid conflicts with existing pattern variables

## Testing
- Not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd70099fc48329b04ece0ae11881b1