### PR TITLE
Implement admin recycle bin for soft-deleted documents

### DIFF
--- a/Areas/Admin/Models/ConfirmModal.cs
+++ b/Areas/Admin/Models/ConfirmModal.cs
@@ -1,4 +1,11 @@
 namespace ProjectManagement.Areas.Admin.Models
 {
-    public record ConfirmModal(string Id, string Title, string Body, string FormId, string ConfirmText);
+    public record ConfirmModal(
+        string Id,
+        string Title,
+        string Body,
+        string FormId,
+        string ConfirmText,
+        string? FormAction = null,
+        string? FormMethod = null);
 }

--- a/Areas/Admin/Pages/Documents/Recycle.cshtml
+++ b/Areas/Admin/Pages/Documents/Recycle.cshtml
@@ -1,7 +1,8 @@
 @page
 @model ProjectManagement.Areas.Admin.Pages.Documents.RecycleModel
-@{
+@{ 
     ViewData["Title"] = "Document recycle bin";
+    var hasRows = Model.Rows.Any();
 }
 
 <div class="container-xxl py-4">
@@ -12,9 +13,175 @@
         </ol>
     </nav>
 
-    <h1 class="h3 mb-3">Document recycle bin</h1>
-    <div class="alert alert-info">
-        Document recycle bin management will be available in a future update.
+    <h1 class="h3 mb-4">Document recycle bin</h1>
+
+    @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+    {
+        <div class="alert alert-success" role="status">@Model.StatusMessage</div>
+    }
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+    }
+
+    <form method="get" class="pm-card pm-shadow mb-4 p-3">
+        <div class="row g-3 align-items-end">
+            <div class="col-12 col-lg-3">
+                <label class="form-label" asp-for="ProjectId">Project</label>
+                <select asp-for="ProjectId" asp-items="Model.ProjectOptions" class="form-select">
+                    <option value="">All projects</option>
+                </select>
+            </div>
+            <div class="col-12 col-lg-3">
+                <label class="form-label" asp-for="StageCode">Stage</label>
+                <select asp-for="StageCode" asp-items="Model.StageOptions" class="form-select">
+                    <option value="">All stages</option>
+                </select>
+            </div>
+            <div class="col-6 col-lg-2">
+                <label class="form-label" asp-for="DeletedFrom">Deleted from</label>
+                <input asp-for="DeletedFrom" type="date" class="form-control" />
+            </div>
+            <div class="col-6 col-lg-2">
+                <label class="form-label" asp-for="DeletedTo">Deleted to</label>
+                <input asp-for="DeletedTo" type="date" class="form-control" />
+            </div>
+            <div class="col-12 col-lg-2">
+                <label class="form-label" asp-for="DeletedBy">Deleted by</label>
+                <input asp-for="DeletedBy" class="form-control" placeholder="Name or username" />
+            </div>
+            <div class="col-6 col-lg-2">
+                <label class="form-label" asp-for="SizeMinMb">Min size (MB)</label>
+                <input asp-for="SizeMinMb" class="form-control" type="number" min="0" />
+            </div>
+            <div class="col-6 col-lg-2">
+                <label class="form-label" asp-for="SizeMaxMb">Max size (MB)</label>
+                <input asp-for="SizeMaxMb" class="form-control" type="number" min="0" />
+            </div>
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Apply filters</button>
+                <a asp-page="Recycle" class="btn btn-outline-secondary">Reset</a>
+            </div>
+        </div>
+    </form>
+
+    <form method="post" id="selectionForm" class="d-none">
+        @Html.AntiForgeryToken()
+        <input type="hidden" name="ProjectId" value="@(Model.ProjectId?.ToString() ?? string.Empty)" />
+        <input type="hidden" name="StageCode" value="@(Model.StageCode ?? string.Empty)" />
+        <input type="hidden" name="DeletedFrom" value="@(Model.DeletedFrom?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+        <input type="hidden" name="DeletedTo" value="@(Model.DeletedTo?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+        <input type="hidden" name="DeletedBy" value="@(Model.DeletedBy ?? string.Empty)" />
+        <input type="hidden" name="SizeMinMb" value="@(Model.SizeMinMb?.ToString() ?? string.Empty)" />
+        <input type="hidden" name="SizeMaxMb" value="@(Model.SizeMaxMb?.ToString() ?? string.Empty)" />
+    </form>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div class="text-muted">
+            <strong>@Model.TotalCount</strong> document(s), totaling <strong>@Model.TotalSizeDisplay</strong>.
+        </div>
+        <div class="btn-group">
+            <button type="submit" class="btn btn-outline-primary" form="selectionForm" asp-page-handler="RestoreSelected" @(hasRows ? null : "disabled")>Restore selected</button>
+            <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#confirmBulkDelete" @(hasRows ? null : "disabled")>Hard delete selected</button>
+        </div>
     </div>
-    <a class="btn btn-outline-secondary" asp-area="Admin" asp-page="/Index">Back to admin home</a>
+
+    @if (!hasRows)
+    {
+        <div class="alert alert-info">No soft-deleted documents match the current filters.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th scope="col" class="text-center" style="width: 3rem;">Select</th>
+                        <th scope="col">Project</th>
+                        <th scope="col">Stage</th>
+                        <th scope="col">Nomenclature</th>
+                        <th scope="col">Original file</th>
+                        <th scope="col" class="text-end">Size</th>
+                        <th scope="col">Deleted on/by</th>
+                        <th scope="col" class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var row in Model.Rows)
+                {
+                    <tr>
+                        <td class="text-center">
+                            <input type="checkbox" class="form-check-input" form="selectionForm" name="SelectedIds" value="@row.DocumentId" id="select-@row.DocumentId" />
+                        </td>
+                        <td>
+                            <div class="fw-semibold">@row.ProjectName</div>
+                            <div class="text-muted small">Project #@row.ProjectId</div>
+                        </td>
+                        <td>
+                            <div>@row.StageDisplayName</div>
+                            @if (!string.IsNullOrEmpty(row.StageCode))
+                            {
+                                <div class="text-muted small">@row.StageCode</div>
+                            }
+                        </td>
+                        <td>
+                            <div class="fw-semibold">@row.Title</div>
+                        </td>
+                        <td>
+                            <div class="text-break">@row.OriginalFileName</div>
+                        </td>
+                        <td class="text-end">@row.FileSizeDisplay</td>
+                        <td>
+                            @if (row.DeletedAtUtc.HasValue)
+                            {
+                                var deletedIst = TimeFmt.ToIst(row.DeletedAtUtc.Value.UtcDateTime);
+                                <div>@deletedIst.ToString("dd MMM yyyy HH:mm") IST</div>
+                            }
+                            else
+                            {
+                                <div class="text-muted">—</div>
+                            }
+                            <div class="text-muted small">@row.DeletedByDisplay</div>
+                        </td>
+                        <td class="text-end">
+                            <div class="btn-group btn-group-sm">
+                                <button type="submit" class="btn btn-outline-primary" form="restoreForm-@row.DocumentId">Restore</button>
+                                <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#confirmHardDelete-@row.DocumentId">Hard delete</button>
+                            </div>
+                            <form method="post" asp-page-handler="Restore" asp-route-id="@row.DocumentId" id="restoreForm-@row.DocumentId" class="d-none">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="ProjectId" value="@(Model.ProjectId?.ToString() ?? string.Empty)" />
+                                <input type="hidden" name="StageCode" value="@(Model.StageCode ?? string.Empty)" />
+                                <input type="hidden" name="DeletedFrom" value="@(Model.DeletedFrom?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                <input type="hidden" name="DeletedTo" value="@(Model.DeletedTo?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                <input type="hidden" name="DeletedBy" value="@(Model.DeletedBy ?? string.Empty)" />
+                                <input type="hidden" name="SizeMinMb" value="@(Model.SizeMinMb?.ToString() ?? string.Empty)" />
+                                <input type="hidden" name="SizeMaxMb" value="@(Model.SizeMaxMb?.ToString() ?? string.Empty)" />
+                            </form>
+                            <form method="post" asp-page-handler="HardDelete" asp-route-id="@row.DocumentId" id="hardDeleteForm-@row.DocumentId" class="d-none">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="ProjectId" value="@(Model.ProjectId?.ToString() ?? string.Empty)" />
+                                <input type="hidden" name="StageCode" value="@(Model.StageCode ?? string.Empty)" />
+                                <input type="hidden" name="DeletedFrom" value="@(Model.DeletedFrom?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                <input type="hidden" name="DeletedTo" value="@(Model.DeletedTo?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                <input type="hidden" name="DeletedBy" value="@(Model.DeletedBy ?? string.Empty)" />
+                                <input type="hidden" name="SizeMinMb" value="@(Model.SizeMinMb?.ToString() ?? string.Empty)" />
+                                <input type="hidden" name="SizeMaxMb" value="@(Model.SizeMaxMb?.ToString() ?? string.Empty)" />
+                            </form>
+                            <partial name="../Shared/_ConfirmModal" model="@(new ConfirmModal($"confirmHardDelete-{row.DocumentId}", "Permanently delete document", $"This will permanently remove '{row.Title}' and its stored file. This cannot be undone.", $"hardDeleteForm-{row.DocumentId}", "Delete"))" />
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    }
+
+    <partial name="../Shared/_ConfirmModal" model="@(new ConfirmModal(
+        "confirmBulkDelete",
+        "Permanently delete selected",
+        "All selected documents and their files will be permanently removed. This cannot be undone.",
+        "selectionForm",
+        "Delete selected",
+        Url.Page(null, new { handler = "HardDeleteSelected" })))" />
 </div>

--- a/Areas/Admin/Pages/Documents/Recycle.cshtml.cs
+++ b/Areas/Admin/Pages/Documents/Recycle.cshtml.cs
@@ -1,12 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Documents;
 
 namespace ProjectManagement.Areas.Admin.Pages.Documents;
 
 [Authorize(Roles = "Admin")]
 public class RecycleModel : PageModel
 {
-    public void OnGet()
+    private readonly ApplicationDbContext _db;
+    private readonly IDocumentService _documents;
+    private readonly IAuditService _audit;
+
+    public RecycleModel(ApplicationDbContext db, IDocumentService documents, IAuditService audit)
     {
+        _db = db;
+        _documents = documents;
+        _audit = audit;
+    }
+
+    [BindProperty(SupportsGet = true)]
+    public int? ProjectId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? StageCode { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    [DataType(DataType.Date)]
+    public DateTime? DeletedFrom { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    [DataType(DataType.Date)]
+    public DateTime? DeletedTo { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? DeletedBy { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? SizeMinMb { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? SizeMaxMb { get; set; }
+
+    [BindProperty]
+    public List<int> SelectedIds { get; set; } = new();
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    [TempData]
+    public string? ErrorMessage { get; set; }
+
+    public IReadOnlyList<SelectListItem> ProjectOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+    public IReadOnlyList<SelectListItem> StageOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+    public IReadOnlyList<DocumentRow> Rows { get; private set; } = Array.Empty<DocumentRow>();
+
+    public int TotalCount { get; private set; }
+
+    public long TotalSizeBytes { get; private set; }
+
+    public string TotalSizeDisplay => DocumentRow.FormatFileSize(TotalSizeBytes);
+
+    public async Task OnGetAsync()
+    {
+        await LoadAsync();
+    }
+
+    public async Task<IActionResult> OnPostRestoreAsync(int id)
+    {
+        var actorId = GetUserId();
+        try
+        {
+            var document = await _documents.RestoreAsync(id, actorId, HttpContext.RequestAborted);
+            StatusMessage = $"Restored '{document.Title}' (#{document.Id}).";
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+
+        return RedirectToPage(GetRouteValues());
+    }
+
+    public async Task<IActionResult> OnPostHardDeleteAsync(int id)
+    {
+        var actorId = GetUserId();
+        var success = new List<int>();
+        try
+        {
+            var existing = await _db.ProjectDocuments
+                .Where(d => d.Id == id && d.Status == ProjectDocumentStatus.SoftDeleted)
+                .Select(d => new { d.Id })
+                .FirstOrDefaultAsync(HttpContext.RequestAborted);
+
+            if (existing == null)
+            {
+                ErrorMessage = "Document not found or already removed.";
+                return RedirectToPage(GetRouteValues());
+            }
+
+            await _documents.HardDeleteAsync(id, actorId, HttpContext.RequestAborted);
+            success.Add(id);
+            StatusMessage = "Permanently deleted 1 document.";
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+
+        if (success.Count > 0)
+        {
+            await Audit.Events.ProjectDocumentsHardDeletedBulk(actorId, success)
+                .WriteAsync(_audit);
+        }
+
+        return RedirectToPage(GetRouteValues());
+    }
+
+    public async Task<IActionResult> OnPostHardDeleteSelectedAsync()
+    {
+        if (SelectedIds == null || SelectedIds.Count == 0)
+        {
+            ErrorMessage = "Select at least one document.";
+            return RedirectToPage(GetRouteValues());
+        }
+
+        var actorId = GetUserId();
+        var requested = SelectedIds.Distinct().ToList();
+
+        var existingSet = new HashSet<int>(await _db.ProjectDocuments.AsNoTracking()
+            .Where(d => requested.Contains(d.Id) && d.Status == ProjectDocumentStatus.SoftDeleted)
+            .Select(d => d.Id)
+            .ToListAsync(HttpContext.RequestAborted));
+
+        var successes = new List<int>();
+        var failures = new List<string>();
+
+        foreach (var docId in requested)
+        {
+            if (!existingSet.Contains(docId))
+            {
+                failures.Add($"#{docId} missing");
+                continue;
+            }
+
+            try
+            {
+                await _documents.HardDeleteAsync(docId, actorId, HttpContext.RequestAborted);
+                successes.Add(docId);
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"#{docId} {ex.Message}");
+            }
+        }
+
+        if (successes.Count > 0)
+        {
+            StatusMessage = successes.Count == 1
+                ? "Permanently deleted 1 document."
+                : $"Permanently deleted {successes.Count} documents.";
+
+            await Audit.Events.ProjectDocumentsHardDeletedBulk(actorId, successes)
+                .WriteAsync(_audit);
+        }
+
+        if (failures.Count > 0)
+        {
+            ErrorMessage = $"Some deletions failed: {string.Join(", ", failures)}";
+        }
+
+        return RedirectToPage(GetRouteValues());
+    }
+
+    public async Task<IActionResult> OnPostRestoreSelectedAsync()
+    {
+        if (SelectedIds == null || SelectedIds.Count == 0)
+        {
+            ErrorMessage = "Select at least one document.";
+            return RedirectToPage(GetRouteValues());
+        }
+
+        var actorId = GetUserId();
+        var requested = SelectedIds.Distinct().ToList();
+
+        var existingDocs = await _db.ProjectDocuments.AsNoTracking()
+            .Where(d => requested.Contains(d.Id) && d.Status == ProjectDocumentStatus.SoftDeleted)
+            .Select(d => new { d.Id, d.ProjectId })
+            .ToListAsync(HttpContext.RequestAborted);
+
+        if (existingDocs.Count == 0)
+        {
+            ErrorMessage = "Selected documents were not found.";
+            return RedirectToPage(GetRouteValues());
+        }
+
+        var successes = new List<int>();
+        var failures = new List<string>();
+
+        foreach (var doc in existingDocs)
+        {
+            try
+            {
+                await _documents.RestoreAsync(doc.Id, actorId, HttpContext.RequestAborted);
+                successes.Add(doc.Id);
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"#{doc.Id} {ex.Message}");
+            }
+        }
+
+        if (successes.Count > 0)
+        {
+            StatusMessage = successes.Count == 1
+                ? "Restored 1 document."
+                : $"Restored {successes.Count} documents.";
+
+            await Audit.Events.ProjectDocumentsRestoredBulk(actorId, successes)
+                .WriteAsync(_audit);
+        }
+
+        if (failures.Count > 0)
+        {
+            ErrorMessage = $"Some restores failed: {string.Join(", ", failures)}";
+        }
+
+        return RedirectToPage(GetRouteValues());
+    }
+
+    private async Task LoadAsync()
+    {
+        ProjectOptions = await _db.Projects.AsNoTracking()
+            .OrderBy(p => p.Name)
+            .Select(p => new SelectListItem(p.Name, p.Id.ToString(CultureInfo.InvariantCulture)))
+            .ToListAsync();
+
+        StageOptions = StageCodes.All
+            .Select(code => new SelectListItem(StageCodes.DisplayNameOf(code), code))
+            .ToList();
+
+        var query = _db.ProjectDocuments
+            .AsNoTracking()
+            .Where(d => d.Status == ProjectDocumentStatus.SoftDeleted)
+            .Include(d => d.Project)
+            .Include(d => d.Stage)
+            .Include(d => d.ArchivedByUser)
+            .AsQueryable();
+
+        if (ProjectId.HasValue)
+        {
+            query = query.Where(d => d.ProjectId == ProjectId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(StageCode))
+        {
+            query = query.Where(d => d.Stage != null && d.Stage.StageCode == StageCode);
+        }
+
+        if (DeletedFrom.HasValue)
+        {
+            var fromUtc = ConvertToUtc(DeletedFrom.Value);
+            query = query.Where(d => d.ArchivedAtUtc >= fromUtc);
+        }
+
+        if (DeletedTo.HasValue)
+        {
+            var toUtc = ConvertToUtc(DeletedTo.Value.AddDays(1).AddTicks(-1));
+            query = query.Where(d => d.ArchivedAtUtc <= toUtc);
+        }
+
+        if (!string.IsNullOrWhiteSpace(DeletedBy))
+        {
+            var term = DeletedBy.Trim();
+            if (SupportsILike())
+            {
+                query = query.Where(d =>
+                    (d.ArchivedByUser != null && EF.Functions.ILike(d.ArchivedByUser.FullName ?? string.Empty, $"%{term}%")) ||
+                    (d.ArchivedByUser != null && EF.Functions.ILike(d.ArchivedByUser.UserName ?? string.Empty, $"%{term}%")) ||
+                    (d.ArchivedByUserId != null && EF.Functions.ILike(d.ArchivedByUserId, $"%{term}%")));
+            }
+            else
+            {
+                var lowered = term.ToLowerInvariant();
+                query = query.Where(d =>
+                    (d.ArchivedByUser != null && d.ArchivedByUser.FullName != null && d.ArchivedByUser.FullName.ToLower().Contains(lowered)) ||
+                    (d.ArchivedByUser != null && d.ArchivedByUser.UserName != null && d.ArchivedByUser.UserName.ToLower().Contains(lowered)) ||
+                    (d.ArchivedByUserId != null && d.ArchivedByUserId.ToLower().Contains(lowered)));
+            }
+        }
+
+        if (SizeMinMb.HasValue)
+        {
+            var minBytes = (long)Math.Max(SizeMinMb.Value, 0) * 1024 * 1024;
+            query = query.Where(d => d.FileSize >= minBytes);
+        }
+
+        if (SizeMaxMb.HasValue)
+        {
+            var maxBytes = (long)Math.Max(SizeMaxMb.Value, 0) * 1024 * 1024;
+            query = query.Where(d => d.FileSize <= maxBytes);
+        }
+
+        TotalCount = await query.CountAsync(HttpContext.RequestAborted);
+        TotalSizeBytes = await query.SumAsync(d => (long?)d.FileSize, HttpContext.RequestAborted) ?? 0;
+
+        Rows = await query
+            .OrderByDescending(d => d.ArchivedAtUtc)
+            .Select(d => new DocumentRow
+            {
+                DocumentId = d.Id,
+                ProjectId = d.ProjectId,
+                ProjectName = d.Project.Name,
+                StageCode = d.Stage != null ? d.Stage.StageCode : null,
+                Title = d.Title,
+                OriginalFileName = d.OriginalFileName,
+                FileSize = d.FileSize,
+                DeletedAtUtc = d.ArchivedAtUtc,
+                DeletedByUserId = d.ArchivedByUserId,
+                DeletedByUserName = d.ArchivedByUser != null ? (d.ArchivedByUser.FullName ?? d.ArchivedByUser.UserName) : null
+            })
+            .ToListAsync(HttpContext.RequestAborted);
+    }
+
+    private static bool SupportsILike()
+        => EF.Functions.GetType().GetMethod("ILike") != null;
+
+    private static DateTimeOffset ConvertToUtc(DateTime date)
+    {
+        var unspecified = DateTime.SpecifyKind(date, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(unspecified, IstClock.TimeZone);
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
+    private object GetRouteValues() => new
+    {
+        ProjectId,
+        StageCode,
+        DeletedFrom = DeletedFrom?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        DeletedTo = DeletedTo?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        DeletedBy,
+        SizeMinMb,
+        SizeMaxMb
+    };
+
+    private string GetUserId()
+        => User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+
+    public sealed class DocumentRow
+    {
+        public int DocumentId { get; init; }
+        public int ProjectId { get; init; }
+        public string ProjectName { get; init; } = string.Empty;
+        public string? StageCode { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string OriginalFileName { get; init; } = string.Empty;
+        public long FileSize { get; init; }
+        public DateTimeOffset? DeletedAtUtc { get; init; }
+        public string? DeletedByUserId { get; init; }
+        public string? DeletedByUserName { get; init; }
+
+        public string StageDisplayName => StageCode is null ? "—" : StageCodes.DisplayNameOf(StageCode);
+
+        public string DeletedByDisplay => !string.IsNullOrWhiteSpace(DeletedByUserName)
+            ? DeletedByUserName!
+            : (DeletedByUserId ?? "—");
+
+        public string FileSizeDisplay => FormatFileSize(FileSize);
+
+        public static string FormatFileSize(long bytes)
+        {
+            if (bytes < 1024)
+            {
+                return $"{bytes} B";
+            }
+
+            double size = bytes / 1024d;
+            string[] units = { "KB", "MB", "GB", "TB", "PB" };
+            int unitIndex = 0;
+
+            while (size >= 1024 && unitIndex < units.Length - 1)
+            {
+                size /= 1024;
+                unitIndex++;
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0:0.##} {1}", size, units[unitIndex]);
+        }
     }
 }

--- a/Areas/Admin/Pages/Shared/_ConfirmModal.cshtml
+++ b/Areas/Admin/Pages/Shared/_ConfirmModal.cshtml
@@ -6,7 +6,7 @@
       <div class="modal-body small">@Model.Body</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" form="@Model.FormId" class="btn btn-danger">@Model.ConfirmText</button>
+        <button type="submit" form="@Model.FormId" formaction="@Model.FormAction" formmethod="@Model.FormMethod" class="btn btn-danger">@Model.ConfirmText</button>
       </div>
     </div>
   </div>

--- a/Services/AuditEvents.cs
+++ b/Services/AuditEvents.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using ProjectManagement.Models;
 
@@ -161,6 +162,28 @@ public static class Audit
             };
 
             return new AuditEvent("Project.DocumentHardDeleted", userId, data);
+        }
+
+        public static AuditEvent ProjectDocumentsRestoredBulk(string? userId, IReadOnlyCollection<int> documentIds)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["Count"] = documentIds.Count.ToString(CultureInfo.InvariantCulture),
+                ["DocumentIds"] = string.Join(',', documentIds)
+            };
+
+            return new AuditEvent("Project.DocumentRestoredBulk", userId, data);
+        }
+
+        public static AuditEvent ProjectDocumentsHardDeletedBulk(string? userId, IReadOnlyCollection<int> documentIds)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["Count"] = documentIds.Count.ToString(CultureInfo.InvariantCulture),
+                ["DocumentIds"] = string.Join(',', documentIds)
+            };
+
+            return new AuditEvent("Project.DocumentHardDeletedBulk", userId, data);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the admin recycle bin placeholder with a full listing of soft-deleted documents, including filters, per-row restore/hard delete actions, and bulk delete with confirmation
- extend the shared confirmation modal to allow overriding the target form action and add new audit events for bulk restore/delete tracking

## Testing
- dotnet test *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6fcbab808329a9b3e7993186c9a5