### PR TITLE
Adjust CSP frame ancestors for document view

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -259,10 +259,14 @@ app.Use(async (ctx, next) =>
     h["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), browsing-topics=()";
     h["Cross-Origin-Opener-Policy"] = "same-origin";
     h["Cross-Origin-Resource-Policy"] = "same-origin";
+    var frameAncestors = ctx.Request.Path.StartsWithSegments("/Projects/Documents/View", StringComparison.OrdinalIgnoreCase)
+        ? "'self'"
+        : "'none'";
+
     h["Content-Security-Policy"] =
         "default-src 'self'; " +
         "base-uri 'self'; " +
-        "frame-ancestors 'none'; " +
+        $"frame-ancestors {frameAncestors}; " +
         "frame-src 'self'; " +
         "img-src 'self' data: blob:; " +
         "script-src 'self'; " +


### PR DESCRIPTION
## Summary
- ensure the CSP middleware allows `/Projects/Documents/View` to be embedded by setting `frame-ancestors 'self'`
- keep the stricter `frame-ancestors 'none'` directive for the rest of the application

## Testing
- `dotnet run` *(fails: unable to connect to PostgreSQL at 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc8988190832987fc886cfaf3a6ef