### PR TITLE
Adjust CSP to allow inline document previews

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -259,20 +259,26 @@ app.Use(async (ctx, next) =>
     h["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), browsing-topics=()";
     h["Cross-Origin-Opener-Policy"] = "same-origin";
     h["Cross-Origin-Resource-Policy"] = "same-origin";
-    var frameAncestors = ctx.Request.Path.StartsWithSegments("/Projects/Documents/View", StringComparison.OrdinalIgnoreCase)
-        ? "'self'"
-        : "'none'";
 
-    h["Content-Security-Policy"] =
-        "default-src 'self'; " +
-        "base-uri 'self'; " +
-        $"frame-ancestors {frameAncestors}; " +
-        "frame-src 'self'; " +
-        "img-src 'self' data: blob:; " +
-        "script-src 'self'; " +
-        "style-src 'self'; " +
-        "font-src 'self' data:; " +
-        "connect-src 'self';";
+    var isDocumentViewer = ctx.Request.Path.StartsWithSegments("/Projects/Documents/View", StringComparison.OrdinalIgnoreCase);
+
+    if (isDocumentViewer)
+    {
+        h["Content-Security-Policy"] = "frame-ancestors 'self'";
+    }
+    else
+    {
+        h["Content-Security-Policy"] =
+            "default-src 'self'; " +
+            "base-uri 'self'; " +
+            "frame-ancestors 'none'; " +
+            "frame-src 'self'; " +
+            "img-src 'self' data: blob:; " +
+            "script-src 'self'; " +
+            "style-src 'self'; " +
+            "font-src 'self' data:; " +
+            "connect-src 'self';";
+    }
     await next();
 });
 


### PR DESCRIPTION
## Summary
- relax the Content-Security-Policy header for the document viewer route so browser PDF resources can load
- keep the restrictive CSP for the rest of the app to preserve clickjacking protections

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcff0acf8832985ad259f46a24617