### PR TITLE
Improve document preview layout and metadata toggle

### DIFF
--- a/Pages/Projects/Documents/Preview.cshtml
+++ b/Pages/Projects/Documents/Preview.cshtml
@@ -14,34 +14,45 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
 <body class="bg-light">
-    <div class="container py-4">
-        <div class="d-flex align-items-center mb-3">
-            <a asp-page="/Projects/Overview" asp-route-id="@Model.Document.ProjectId" class="btn btn-link px-0 me-3">
-                <i class="bi bi-arrow-left"></i>
-                <span class="ms-1">Back to project</span>
-            </a>
-            <div>
-                <h1 class="h4 mb-0">@Model.Document.Title</h1>
-                <div class="text-muted small">@Model.Document.OriginalFileName</div>
+    <div class="doc-preview-layout d-flex flex-column min-vh-100">
+        <div class="container py-4 d-flex flex-column flex-grow-1">
+            <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
+                <div class="d-flex align-items-center">
+                    <a asp-page="/Projects/Overview" asp-route-id="@Model.Document.ProjectId" class="btn btn-link px-0 me-3">
+                        <i class="bi bi-arrow-left"></i>
+                        <span class="ms-1">Back to project</span>
+                    </a>
+                    <div>
+                        <h1 class="h4 mb-0">@Model.Document.Title</h1>
+                        <div class="text-muted small">@Model.Document.OriginalFileName</div>
+                    </div>
+                </div>
+                <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#docMetadata" aria-expanded="true" aria-controls="docMetadata">
+                    <i class="bi bi-info-circle me-1"></i>
+                    Document details
+                </button>
             </div>
-        </div>
 
-        <div class="card shadow-sm mb-3">
-            <div class="card-body">
-                <dl class="row mb-0">
-                    <dt class="col-sm-3">Nomenclature</dt>
-                    <dd class="col-sm-9">@Model.Document.Title</dd>
-                    <dt class="col-sm-3">Stage</dt>
-                    <dd class="col-sm-9">@Model.Document.StageDisplayName</dd>
-                    <dt class="col-sm-3">Uploaded on/by</dt>
-                    <dd class="col-sm-9">@Model.Document.UploadedSummary</dd>
-                </dl>
+            <div class="collapse show" id="docMetadata">
+                <div class="card shadow-sm mb-3 mb-lg-4">
+                    <div class="card-body">
+                        <dl class="row mb-0">
+                            <dt class="col-sm-3">Nomenclature</dt>
+                            <dd class="col-sm-9">@Model.Document.Title</dd>
+                            <dt class="col-sm-3">Stage</dt>
+                            <dd class="col-sm-9">@Model.Document.StageDisplayName</dd>
+                            <dt class="col-sm-3">Uploaded on/by</dt>
+                            <dd class="col-sm-9">@Model.Document.UploadedSummary</dd>
+                        </dl>
+                    </div>
+                </div>
             </div>
-        </div>
 
-        <div class="ratio ratio-4x3 doc-preview-frame">
-            <iframe src="@Model.ViewUrl" title="@Model.Document.Title" class="w-100 h-100 border rounded bg-white"></iframe>
+            <div class="doc-preview-frame flex-grow-1 d-flex">
+                <iframe src="@Model.ViewUrl" title="@Model.Document.Title" class="flex-grow-1 w-100 border rounded bg-white"></iframe>
+            </div>
         </div>
     </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1288,5 +1288,10 @@ body.has-project-photo-preview-dialog {
 }
 
 .doc-preview-frame {
-  min-height: 70vh;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.doc-preview-frame iframe {
+  height: 100%;
 }


### PR DESCRIPTION
## Summary
- wrap the document preview page content in a flex column layout so the viewer can fill the viewport
- add a collapsible metadata card toggle and bootstrap bundle script for interactive behavior
- update the document preview frame styles to rely on flex sizing instead of a fixed viewport height

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ddf391eb5883299bbc34134a599f24