### PR TITLE
Adjust document preview layout and fix Chrome PDF display

### DIFF
--- a/Pages/Projects/Documents/Preview.cshtml
+++ b/Pages/Projects/Documents/Preview.cshtml
@@ -14,8 +14,8 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
 <body class="bg-light">
-    <div class="container py-4">
-        <div class="d-flex align-items-center mb-3">
+    <div class="container-fluid py-3 px-4 px-lg-5 d-flex flex-column min-vh-100 doc-preview-layout">
+        <div class="d-flex align-items-center mb-2">
             <a asp-page="/Projects/Overview" asp-route-id="@Model.Document.ProjectId" class="btn btn-link px-0 me-3">
                 <i class="bi bi-arrow-left"></i>
                 <span class="ms-1">Back to project</span>
@@ -26,21 +26,8 @@
             </div>
         </div>
 
-        <div class="card shadow-sm mb-3">
-            <div class="card-body">
-                <dl class="row mb-0">
-                    <dt class="col-sm-3">Nomenclature</dt>
-                    <dd class="col-sm-9">@Model.Document.Title</dd>
-                    <dt class="col-sm-3">Stage</dt>
-                    <dd class="col-sm-9">@Model.Document.StageDisplayName</dd>
-                    <dt class="col-sm-3">Uploaded on/by</dt>
-                    <dd class="col-sm-9">@Model.Document.UploadedSummary</dd>
-                </dl>
-            </div>
-        </div>
-
-        <div class="ratio ratio-4x3 doc-preview-frame">
-            <iframe src="@Model.ViewUrl" title="@Model.Document.Title" class="w-100 h-100 border rounded bg-white"></iframe>
+        <div class="doc-preview-frame flex-grow-1 mt-2">
+            <iframe src="@Model.ViewUrl" title="@Model.Document.Title" class="w-100 h-100 shadow-sm bg-white border-0 rounded-3"></iframe>
         </div>
     </div>
 </body>

--- a/Program.cs
+++ b/Program.cs
@@ -257,17 +257,21 @@ app.Use(async (ctx, next) =>
     h["X-Content-Type-Options"] = "nosniff";
     h["Referrer-Policy"] = "no-referrer";
     h["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), browsing-topics=()";
-    h["Cross-Origin-Opener-Policy"] = "same-origin";
-    h["Cross-Origin-Resource-Policy"] = "same-origin";
 
     var isDocumentViewer = ctx.Request.Path.StartsWithSegments("/Projects/Documents/View", StringComparison.OrdinalIgnoreCase);
 
     if (isDocumentViewer)
     {
+        // Chrome's PDF viewer ignores content when the response is isolated with
+        // COOP. Allow the inline preview to render by opting out for this route.
+        h["Cross-Origin-Opener-Policy"] = "unsafe-none";
+        h["Cross-Origin-Resource-Policy"] = "same-origin";
         h["Content-Security-Policy"] = "frame-ancestors 'self'";
     }
     else
     {
+        h["Cross-Origin-Opener-Policy"] = "same-origin";
+        h["Cross-Origin-Resource-Policy"] = "same-origin";
         h["Content-Security-Policy"] =
             "default-src 'self'; " +
             "base-uri 'self'; " +

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1287,6 +1287,16 @@ body.has-project-photo-preview-dialog {
   position: absolute;
 }
 
+.doc-preview-layout {
+  gap: 0.5rem;
+}
+
 .doc-preview-frame {
-  min-height: 70vh;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.doc-preview-frame iframe {
+  flex: 1 1 auto;
 }


### PR DESCRIPTION
## Summary
- simplify the document preview page so the iframe occupies the available viewport
- remove the unused metadata card and tighten spacing around the viewer
- update the response headers for the inline document route to allow Chrome to render PDFs

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddf7b97900832994a4e4a822c1adc0