### PR TITLE
Fix document preview iframe sizing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1289,6 +1289,7 @@ body.has-project-photo-preview-dialog {
 
 .doc-preview-layout {
   gap: 0.5rem;
+  min-height: 100vh;
 }
 
 .doc-preview-frame {
@@ -1299,4 +1300,7 @@ body.has-project-photo-preview-dialog {
 
 .doc-preview-frame iframe {
   flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }


### PR DESCRIPTION
## Summary
- ensure the document preview layout enforces a full viewport height so the flex container can size its children
- force the embedded iframe to explicitly fill its container so Chrome renders the PDF viewer correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfa6b030c8329ab77db74f2217b6f