### PR TITLE
Adjust document preview frame flex direction

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1296,6 +1296,7 @@ body.has-project-photo-preview-dialog {
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
+  flex-direction: column;
 }
 
 .doc-preview-frame iframe {


### PR DESCRIPTION
## Summary
- set the document preview frame to use a column flex layout so its content can expand vertically
- keep the embedded iframe flex and height settings to fill the available space

## Testing
- dotnet run *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfdff037c8329909a5863f30983af