### PR TITLE
Relax CORP for document viewer route

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -265,7 +265,8 @@ app.Use(async (ctx, next) =>
         // Chrome's PDF viewer ignores content when the response is isolated with
         // COOP. Allow the inline preview to render by opting out for this route.
         h["Cross-Origin-Opener-Policy"] = "unsafe-none";
-        h["Cross-Origin-Resource-Policy"] = "same-origin";
+        // Relax CORP so the browser's extension-based PDF viewers can access the stream.
+        h["Cross-Origin-Resource-Policy"] = "cross-origin";
         h["Content-Security-Policy"] = "frame-ancestors 'self'";
     }
     else


### PR DESCRIPTION
## Summary
- relax the Cross-Origin-Resource-Policy header for the /Projects/Documents/View route so Chrome extensions can inline PDFs
- keep the stricter security headers for the rest of the application

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfe0118b08329b1236430ef507b24