### PR TITLE
Remove CORP header for document viewer route

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -265,7 +265,8 @@ app.Use(async (ctx, next) =>
         // Chrome's PDF viewer ignores content when the response is isolated with
         // COOP. Allow the inline preview to render by opting out for this route.
         h["Cross-Origin-Opener-Policy"] = "unsafe-none";
-        h["Cross-Origin-Resource-Policy"] = "same-origin";
+        // Remove CORP entirely so the browser's extension-based PDF viewers can access the stream.
+        h.Remove("Cross-Origin-Resource-Policy");
         h["Content-Security-Policy"] = "frame-ancestors 'self'";
     }
     else


### PR DESCRIPTION
## Summary
- remove the Cross-Origin-Resource-Policy header entirely on /Projects/Documents/View responses so Chrome's PDF viewer can access the PDF stream
- keep the existing strict security headers for the rest of the application

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfe0118b08329b1236430ef507b24