### PR TITLE
Relax security headers for document preview page

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -259,8 +259,11 @@ app.Use(async (ctx, next) =>
     h["Permissions-Policy"] = "camera=(), microphone=(), geolocation=(), browsing-topics=()";
 
     var isDocumentViewer = ctx.Request.Path.StartsWithSegments("/Projects/Documents/View", StringComparison.OrdinalIgnoreCase);
+    var isDocumentPreview = ctx.Request.Path.StartsWithSegments("/Projects/Documents/Preview", StringComparison.OrdinalIgnoreCase);
 
-    if (isDocumentViewer)
+    var isDocumentPreviewContext = isDocumentViewer || isDocumentPreview;
+
+    if (isDocumentPreviewContext)
     {
         // Chrome's PDF viewer ignores content when the response is isolated with
         // COOP. Allow the inline preview to render by opting out for this route.


### PR DESCRIPTION
## Summary
- detect both the document stream and preview page when relaxing security headers
- send the unsafe-none COOP/CORP response for the preview HTML so Chrome can load its PDF viewer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de010c67348329a12456be198c9156