### PR TITLE
Refine project document actions trigger

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -537,12 +537,12 @@
                                                     @if (hasActions)
                                                     {
                                                         <div class="dropdown">
-                                                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                                                            <button class="btn btn-link btn-icon dropdown-toggle"
                                                                     type="button"
                                                                     data-bs-toggle="dropdown"
                                                                     aria-expanded="false"
                                                                     aria-label="Document actions">
-                                                                Actions
+                                                                <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
                                                             </button>
                                                             <ul class="dropdown-menu dropdown-menu-end">
                                                                 @if (canReplaceDocument)

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -813,6 +813,34 @@ body {
   --pm-btn-icon: 28px;
 }
 
+.btn-icon {
+  width: var(--pm-btn-icon);
+  height: var(--pm-btn-icon);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--bs-border-radius-sm);
+}
+
+.btn-icon.btn-link {
+  color: var(--bs-body-color);
+}
+
+.btn-icon.btn-link:hover,
+.btn-icon.btn-link:focus-visible {
+  background-color: rgba(0, 0, 0, .05);
+  text-decoration: none;
+}
+
+.btn-icon.btn-link:focus-visible {
+  box-shadow: 0 0 0 .2rem rgba(13, 110, 253, .25);
+}
+
+.btn-icon.dropdown-toggle::after {
+  display: none;
+}
+
 /* Headings: calmer */
 h1, .h1 { font-size: 1.25rem; }
 .card-header { padding: .45rem .6rem; }


### PR DESCRIPTION
## Summary
- replace the document action text button with a compact icon trigger in the project overview
- add a reusable .btn-icon helper style to support the icon-only control and hide the bootstrap caret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1dda39e883299fb49d536ea824c0