### PR TITLE
Fix pm-card dropdown clipping

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -22,7 +22,7 @@ body {
     border-radius: 1rem;
     background-color: var(--pm-card);
     box-shadow: 0 18px 30px -24px rgba(15, 23, 42, .2);
-    overflow: hidden;
+    overflow: visible;
 }
 
 .pm-card-header {


### PR DESCRIPTION
## Summary
- allow pm-card containers to display dropdown menus outside their bounds by setting overflow to visible
- rely on existing rounded utilities on inner media so only targeted elements clip content when needed

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de2e539b5c832993bc575183c10741