### PR TITLE
Tighten document preview header spacing

### DIFF
--- a/Pages/Projects/Documents/Preview.cshtml
+++ b/Pages/Projects/Documents/Preview.cshtml
@@ -14,19 +14,19 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
 <body class="bg-light">
-    <div class="container-fluid py-3 px-4 px-lg-5 d-flex flex-column min-vh-100 doc-preview-layout">
-        <div class="d-flex align-items-center mb-2">
-            <a asp-page="/Projects/Overview" asp-route-id="@Model.Document.ProjectId" class="btn btn-link px-0 me-3">
+    <div class="container-fluid py-2 px-3 px-lg-4 d-flex flex-column min-vh-100 doc-preview-layout">
+        <div class="d-flex align-items-center gap-3 flex-wrap mb-1">
+            <a asp-page="/Projects/Overview" asp-route-id="@Model.Document.ProjectId" class="btn btn-link px-0 d-inline-flex align-items-center gap-1">
                 <i class="bi bi-arrow-left"></i>
-                <span class="ms-1">Back to project</span>
+                <span>Back to project</span>
             </a>
-            <div>
+            <div class="d-flex align-items-baseline flex-wrap gap-2">
                 <h6 class="h4 mb-0">@Model.Document.Title</h6>
                 <span class="text-muted small">@Model.Document.OriginalFileName</span>
             </div>
         </div>
 
-        <div class="doc-preview-frame flex-grow-1 mt-2">
+        <div class="doc-preview-frame flex-grow-1 mt-1">
             <iframe src="@Model.ViewUrl" title="@Model.Document.Title" class="w-100 h-100 shadow-sm bg-white border-0 rounded-3"></iframe>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- reduce padding and margins in the document preview layout so the iframe has more vertical space
- place the navigation link, title, and filename on a single compact flex row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de31d87d5c83299e720fc0897a5301