### PR TITLE
Adjust procurement metrics grid breakpoints

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -151,8 +151,20 @@ body {
 
 .procurement-metrics {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: 1fr;
     gap: .5rem 1rem;
+}
+
+@media (min-width: 576px) {
+    .procurement-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 992px) {
+    .procurement-metrics {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 .procurement-metrics > div {


### PR DESCRIPTION
## Summary
- update the procurement metrics grid to use explicit 1/2/3 column breakpoints so cards stay balanced across viewport sizes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de33ec2d6c8329a681ce0556d9ff89