### PR TITLE
Adjust procurement metrics spacing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -170,8 +170,8 @@ body {
 .procurement-metrics > div {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
-    gap: .5rem;
+    justify-content: flex-start;
+    gap: .75rem;
     padding-block: .125rem;
 }
 
@@ -180,7 +180,6 @@ body {
 }
 
 .procurement-metrics .procurement-value {
-    margin-left: auto;
     text-align: right;
     font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Summary
- align procurement metric rows so labels and values stay grouped together
- rely on consistent flex gap spacing by removing the auto margin from metric values while keeping numeric alignment

## Testing
- `dotnet build` *(fails: `command not found: dotnet` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de36c238848329b556414260ea622f