### PR TITLE
Align typography with GitHub font stack

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -9,9 +9,17 @@
     --pm-surface: #f5f7fb;
     --pm-card: #ffffff;
     --pm-shadow: 0 8px 20px rgba(0,0,0,.06);
+    --pm-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    --bs-font-sans-serif: var(--pm-font-stack);
+    --bs-body-font-family: var(--pm-font-stack);
+    --bs-body-font-size: 0.875rem;
+    --bs-body-line-height: 1.5;
 }
 
 body {
+    font-family: var(--bs-body-font-family);
+    font-size: var(--bs-body-font-size);
+    line-height: var(--bs-body-line-height);
     color: var(--pm-text);
     background-color: var(--pm-surface);
 }


### PR DESCRIPTION
## Summary
- add a GitHub-style system font stack token and wire it into Bootstrap font variables
- ensure the body rule uses the shared font family, size, and line height to standardize typography

## Testing
- ⚠️ `dotnet run` *(fails: `dotnet` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4fed2484832997c276f613c08151