### PR TITLE
Align heading typography with GitHub scale

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -860,8 +860,65 @@ body {
   display: none;
 }
 
-/* Headings: calmer */
-h1, .h1 { font-size: 1.25rem; }
+/* Headings: GitHub-inspired scale */
+h1, .h1 {
+  font-size: 2rem;
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+h2, .h2 {
+  font-size: 1.5rem;
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+h3, .h3 {
+  font-size: 1.25rem;
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+h4, .h4 {
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+h5, .h5 {
+  font-size: .875rem;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+h6, .h6 {
+  font-size: .75rem;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+h1,
+h2,
+h3 {
+  margin-top: 1.5rem;
+  margin-bottom: .75rem;
+}
+
+h4,
+h5,
+h6 {
+  margin-top: 1rem;
+  margin-bottom: .5rem;
+}
+
+h1:first-child,
+h2:first-child,
+h3:first-child,
+h4:first-child,
+h5:first-child,
+h6:first-child {
+  margin-top: 0;
+}
 .card-header { padding: .45rem .6rem; }
 .card-body   { padding: var(--pm-card-pad-y) var(--pm-card-pad-x); }
 


### PR DESCRIPTION
## Summary
- update heading elements and utility classes to use GitHub-inspired font sizes, line heights, and weights
- tighten heading margins to better match the reduced scale while keeping first-child headings flush with surrounding content

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5079f91c83298da611a46beea71f