### PR TITLE
Add REST API endpoints for project remarks

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -1,0 +1,585 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Remarks;
+using ProjectManagement.Services.Remarks;
+
+namespace ProjectManagement.Features.Remarks;
+
+internal static class RemarkApi
+{
+    private const string AllowedRoles = "Admin,HoD,Project Officer,Comdt,MCO,Project Office,Main Office,TA";
+
+    public static void MapRemarkApi(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/projects/{projectId:int}/remarks")
+            .RequireAuthorization(new AuthorizeAttribute { Roles = AllowedRoles });
+
+        group.MapPost("", CreateRemarkAsync);
+        group.MapGet("", ListRemarksAsync);
+        group.MapPut("/{remarkId:int}", UpdateRemarkAsync);
+        group.MapDelete("/{remarkId:int}", DeleteRemarkAsync);
+        group.MapGet("/{remarkId:int}/audit", GetRemarkAuditAsync);
+    }
+
+    private static async Task<IResult> CreateRemarkAsync(
+        int projectId,
+        [FromBody] CreateRemarkRequestDto request,
+        IRemarkService remarkService,
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        request ??= new CreateRemarkRequestDto();
+
+        var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        try
+        {
+            var remark = await remarkService.CreateRemarkAsync(
+                new CreateRemarkRequest(
+                    ProjectId: projectId,
+                    Actor: actor!,
+                    Type: request.Type,
+                    Body: request.Body ?? string.Empty,
+                    EventDate: request.EventDate,
+                    StageRef: request.StageRef,
+                    StageNameSnapshot: request.StageName,
+                    Meta: request.Meta),
+                cancellationToken);
+
+            var response = ToDto(remark);
+            return Results.Created($"/api/projects/{projectId}/remarks/{remark.Id}", response);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return MapServiceException(ex);
+        }
+    }
+
+    private static async Task<IResult> ListRemarksAsync(
+        int projectId,
+        [FromQuery] string? type,
+        [FromQuery] string? role,
+        [FromQuery] string? stageRef,
+        [FromQuery(Name = "mine")] bool mine,
+        [FromQuery(Name = "dateFrom")] DateOnly? from,
+        [FromQuery(Name = "dateTo")] DateOnly? to,
+        [FromQuery(Name = "includeDeleted")] bool includeDeleted,
+        [FromQuery] int page,
+        [FromQuery] int pageSize,
+        [FromQuery(Name = "actorRole")] string? actorRole,
+        IRemarkService remarkService,
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var (actor, error) = await BuildActorContextAsync(userManager, httpContext, actorRole);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        if (!TryParseRemarkType(type, out var remarkType, out var typeError))
+        {
+            return typeError;
+        }
+
+        if (!TryParseRemarkRole(role, out var authorRole, out var roleError))
+        {
+            return roleError;
+        }
+
+        try
+        {
+            var result = await remarkService.ListRemarksAsync(
+                new ListRemarksRequest(
+                    ProjectId: projectId,
+                    Actor: actor!,
+                    Type: remarkType,
+                    AuthorRole: authorRole,
+                    StageRef: stageRef,
+                    FromDate: from,
+                    ToDate: to,
+                    Mine: mine,
+                    IncludeDeleted: includeDeleted,
+                    Page: page,
+                    PageSize: pageSize),
+                cancellationToken);
+
+            var response = new RemarkListResponse(
+                result.TotalCount,
+                result.Page,
+                result.PageSize,
+                result.Items.Select(ToDto).ToArray());
+
+            return Results.Ok(response);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return MapServiceException(ex);
+        }
+    }
+
+    private static async Task<IResult> UpdateRemarkAsync(
+        int projectId,
+        int remarkId,
+        [FromBody] UpdateRemarkRequestDto request,
+        ApplicationDbContext db,
+        IRemarkService remarkService,
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        request ??= new UpdateRemarkRequestDto();
+
+        if (!await db.Remarks.AsNoTracking().AnyAsync(r => r.Id == remarkId && r.ProjectId == projectId, cancellationToken))
+        {
+            return Results.NotFound();
+        }
+
+        if (!TryParseRowVersion(request.RowVersion, out var rowVersion, out var rowError))
+        {
+            return rowError;
+        }
+
+        var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        try
+        {
+            var remark = await remarkService.EditRemarkAsync(
+                remarkId,
+                new EditRemarkRequest(
+                    Actor: actor!,
+                    Body: request.Body ?? string.Empty,
+                    EventDate: request.EventDate,
+                    StageRef: request.StageRef,
+                    StageNameSnapshot: request.StageName,
+                    Meta: request.Meta,
+                    RowVersion: rowVersion),
+                cancellationToken);
+
+            if (remark is null || remark.ProjectId != projectId)
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(ToDto(remark));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return MapServiceException(ex);
+        }
+    }
+
+    private static async Task<IResult> DeleteRemarkAsync(
+        int projectId,
+        int remarkId,
+        [FromBody] DeleteRemarkRequestDto request,
+        ApplicationDbContext db,
+        IRemarkService remarkService,
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        request ??= new DeleteRemarkRequestDto();
+
+        if (!await db.Remarks.AsNoTracking().AnyAsync(r => r.Id == remarkId && r.ProjectId == projectId, cancellationToken))
+        {
+            return Results.NotFound();
+        }
+
+        if (!TryParseRowVersion(request.RowVersion, out var rowVersion, out var rowError))
+        {
+            return rowError;
+        }
+
+        var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        try
+        {
+            var deleted = await remarkService.SoftDeleteRemarkAsync(
+                remarkId,
+                new SoftDeleteRemarkRequest(
+                    Actor: actor!,
+                    Meta: request.Meta,
+                    RowVersion: rowVersion),
+                cancellationToken);
+
+            if (!deleted)
+            {
+                return Results.NotFound();
+            }
+
+            var remark = await db.Remarks.AsNoTracking()
+                .FirstOrDefaultAsync(r => r.Id == remarkId, cancellationToken);
+
+            var response = new DeleteRemarkResponse(
+                Success: true,
+                RowVersion: remark?.RowVersion is { Length: > 0 } rv ? Convert.ToBase64String(rv) : null);
+
+            return Results.Ok(response);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return MapServiceException(ex);
+        }
+    }
+
+    private static async Task<IResult> GetRemarkAuditAsync(
+        int projectId,
+        int remarkId,
+        [FromQuery(Name = "actorRole")] string? actorRole,
+        ApplicationDbContext db,
+        IRemarkService remarkService,
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (!await db.Remarks.AsNoTracking().AnyAsync(r => r.Id == remarkId && r.ProjectId == projectId, cancellationToken))
+        {
+            return Results.NotFound();
+        }
+
+        var (actor, error) = await BuildActorContextAsync(userManager, httpContext, actorRole);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        if (!actor!.Roles.Contains(RemarkActorRole.Administrator))
+        {
+            return Results.Forbid();
+        }
+
+        try
+        {
+            var audits = await remarkService.GetRemarkAuditAsync(remarkId, actor, cancellationToken);
+            var response = audits
+                .Select(a => new RemarkAuditDto(
+                    a.Id,
+                    a.Action,
+                    a.ActorRole,
+                    a.ActorUserId ?? string.Empty,
+                    a.ActionAtUtc,
+                    a.Meta,
+                    new RemarkSnapshotDto(
+                        a.SnapshotType,
+                        a.SnapshotAuthorRole,
+                        a.SnapshotAuthorUserId,
+                        a.SnapshotBody,
+                        a.SnapshotEventDate,
+                        a.SnapshotStageRef,
+                        a.SnapshotStageName,
+                        a.SnapshotCreatedAtUtc,
+                        a.SnapshotLastEditedAtUtc,
+                        a.SnapshotIsDeleted,
+                        a.SnapshotDeletedAtUtc,
+                        a.SnapshotDeletedByUserId,
+                        a.SnapshotDeletedByRole)))
+                .ToArray();
+
+            return Results.Ok(response);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return MapServiceException(ex);
+        }
+    }
+
+    private static RemarkResponseDto ToDto(Remark remark)
+        => new(
+            remark.Id,
+            remark.ProjectId,
+            remark.Type,
+            remark.AuthorRole,
+            remark.AuthorUserId,
+            remark.Body,
+            remark.EventDate,
+            remark.StageRef,
+            remark.StageNameSnapshot,
+            remark.CreatedAtUtc,
+            remark.LastEditedAtUtc,
+            remark.IsDeleted,
+            remark.DeletedAtUtc,
+            remark.DeletedByUserId,
+            remark.DeletedByRole,
+            remark.RowVersion is { Length: > 0 } rowVersion ? Convert.ToBase64String(rowVersion) : string.Empty);
+
+    private static async Task<(RemarkActorContext? Actor, IResult? Error)> BuildActorContextAsync(
+        UserManager<ApplicationUser> userManager,
+        HttpContext httpContext,
+        string? requestedRole)
+    {
+        var user = await userManager.GetUserAsync(httpContext.User);
+        if (user is null)
+        {
+            return (null, Results.Unauthorized());
+        }
+
+        var assignedRoles = await userManager.GetRolesAsync(user);
+        var remarkRoles = assignedRoles
+            .Select(r => RemarkActorRoleExtensions.TryParse(r, out var parsed) ? parsed : RemarkActorRole.Unknown)
+            .Where(r => r != RemarkActorRole.Unknown)
+            .Distinct()
+            .ToArray();
+
+        if (remarkRoles.Length == 0)
+        {
+            return (null, Results.Forbid());
+        }
+
+        RemarkActorRole? desiredRole = null;
+        if (!string.IsNullOrWhiteSpace(requestedRole))
+        {
+            if (!RemarkActorRoleExtensions.TryParse(requestedRole, out var parsed) || parsed == RemarkActorRole.Unknown)
+            {
+                return (null, Results.BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid actor role.",
+                    Detail = "Actor role is not recognised."
+                }));
+            }
+
+            if (!remarkRoles.Contains(parsed))
+            {
+                return (null, Results.Forbid());
+            }
+
+            desiredRole = parsed;
+        }
+
+        var selected = desiredRole ?? SelectDefaultRole(remarkRoles);
+        if (selected == RemarkActorRole.Unknown)
+        {
+            return (null, Results.Forbid());
+        }
+
+        return (new RemarkActorContext(user.Id, selected, remarkRoles), null);
+    }
+
+    private static RemarkActorRole SelectDefaultRole(IReadOnlyCollection<RemarkActorRole> roles)
+    {
+        foreach (var candidate in new[]
+                 {
+                     RemarkActorRole.ProjectOfficer,
+                     RemarkActorRole.HeadOfDepartment,
+                     RemarkActorRole.Commandant,
+                     RemarkActorRole.Administrator,
+                     RemarkActorRole.ProjectOffice,
+                     RemarkActorRole.MainOffice,
+                     RemarkActorRole.Mco,
+                     RemarkActorRole.Ta
+                 })
+        {
+            if (roles.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return RemarkActorRole.Unknown;
+    }
+
+    private static bool TryParseRemarkType(string? value, out RemarkType? type, out IResult? error)
+    {
+        type = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (Enum.TryParse<RemarkType>(value, true, out var parsed))
+        {
+            type = parsed;
+            return true;
+        }
+
+        error = Results.BadRequest(new ProblemDetails
+        {
+            Title = "Invalid type.",
+            Detail = "Type must be 'Internal' or 'External'."
+        });
+        return false;
+    }
+
+    private static bool TryParseRemarkRole(string? value, out RemarkActorRole? role, out IResult? error)
+    {
+        role = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (RemarkActorRoleExtensions.TryParse(value, out var parsed) && parsed != RemarkActorRole.Unknown)
+        {
+            role = parsed;
+            return true;
+        }
+
+        error = Results.BadRequest(new ProblemDetails
+        {
+            Title = "Invalid role filter.",
+            Detail = "Role is not recognised."
+        });
+        return false;
+    }
+
+    private static bool TryParseRowVersion(string? value, out byte[] rowVersion, out IResult? error)
+    {
+        rowVersion = Array.Empty<byte>();
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = Results.BadRequest(new ProblemDetails
+            {
+                Title = "Row version required.",
+                Detail = "Row version must be supplied as a base64 string."
+            });
+            return false;
+        }
+
+        try
+        {
+            rowVersion = Convert.FromBase64String(value);
+            if (rowVersion.Length == 0)
+            {
+                error = Results.BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid row version.",
+                    Detail = "Row version must not be empty."
+                });
+                return false;
+            }
+
+            return true;
+        }
+        catch (FormatException)
+        {
+            error = Results.BadRequest(new ProblemDetails
+            {
+                Title = "Invalid row version.",
+                Detail = "Row version must be base64 encoded."
+            });
+            return false;
+        }
+    }
+
+    private static IResult MapServiceException(InvalidOperationException ex)
+        => ex.Message switch
+        {
+            "Project not found." => Results.NotFound(new ProblemDetails { Title = "Project not found.", Detail = ex.Message }),
+            RemarkService.ConcurrencyConflictMessage => Results.Conflict(new ProblemDetails { Title = "Concurrency conflict.", Detail = ex.Message }),
+            RemarkService.RowVersionRequiredMessage => Results.BadRequest(new ProblemDetails { Title = "Row version required.", Detail = ex.Message }),
+            "Not authorised to edit this remark." => Results.Forbid(),
+            "Not authorised to delete this remark." => Results.Forbid(),
+            "Only administrators may view remark audits." => Results.Forbid(),
+            "Actor role is not recognised or not assigned." => Results.Forbid(),
+            "External remarks require HoD, Comdt or Admin role." => Results.Forbid(),
+            _ => Results.BadRequest(new ProblemDetails { Title = "Remark request failed.", Detail = ex.Message })
+        };
+
+    private sealed record CreateRemarkRequestDto
+    {
+        public RemarkType Type { get; init; }
+        public string? Body { get; init; }
+        public DateOnly EventDate { get; init; }
+        public string? StageRef { get; init; }
+        public string? StageName { get; init; }
+        public string? Meta { get; init; }
+        public string? ActorRole { get; init; }
+    }
+
+    private sealed record UpdateRemarkRequestDto
+    {
+        public string? Body { get; init; }
+        public DateOnly EventDate { get; init; }
+        public string? StageRef { get; init; }
+        public string? StageName { get; init; }
+        public string? Meta { get; init; }
+        public string? RowVersion { get; init; }
+        public string? ActorRole { get; init; }
+    }
+
+    private sealed record DeleteRemarkRequestDto
+    {
+        public string? RowVersion { get; init; }
+        public string? Meta { get; init; }
+        public string? ActorRole { get; init; }
+    }
+
+    private sealed record RemarkResponseDto(
+        int Id,
+        int ProjectId,
+        RemarkType Type,
+        RemarkActorRole AuthorRole,
+        string AuthorUserId,
+        string Body,
+        DateOnly EventDate,
+        string? StageRef,
+        string? StageName,
+        DateTime CreatedAtUtc,
+        DateTime? LastEditedAtUtc,
+        bool IsDeleted,
+        DateTime? DeletedAtUtc,
+        string? DeletedByUserId,
+        RemarkActorRole? DeletedByRole,
+        string RowVersion);
+
+    private sealed record RemarkListResponse(
+        int Total,
+        int Page,
+        int PageSize,
+        IReadOnlyList<RemarkResponseDto> Items);
+
+    private sealed record DeleteRemarkResponse(bool Success, string? RowVersion);
+
+    private sealed record RemarkAuditDto(
+        int Id,
+        RemarkAuditAction Action,
+        RemarkActorRole ActorRole,
+        string ActorUserId,
+        DateTime ActionAtUtc,
+        string? Meta,
+        RemarkSnapshotDto Snapshot);
+
+    private sealed record RemarkSnapshotDto(
+        RemarkType Type,
+        RemarkActorRole AuthorRole,
+        string AuthorUserId,
+        string Body,
+        DateOnly EventDate,
+        string? StageRef,
+        string? StageName,
+        DateTime CreatedAtUtc,
+        DateTime? LastEditedAtUtc,
+        bool IsDeleted,
+        DateTime? DeletedAtUtc,
+        string? DeletedByUserId,
+        RemarkActorRole? DeletedByRole);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,7 @@ using ProjectManagement.Utilities;
 using ProjectManagement.Services.Stages;
 using Microsoft.Net.Http.Headers;
 using System.Threading;
+using ProjectManagement.Features.Remarks;
 
 var runForecastBackfill = args.Any(a => string.Equals(a, "--backfill-forecast", StringComparison.OrdinalIgnoreCase));
 
@@ -170,6 +171,7 @@ builder.Services.AddScoped<ProjectProcurementReadService>();
 builder.Services.AddScoped<ProjectTimelineReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<IRemarkService, RemarkService>();
+builder.Services.AddScoped<IRemarkNotificationService, RemarkNotificationService>();
 builder.Services.AddScoped<IDocumentService, DocumentService>();
 builder.Services.AddSingleton<IDocumentPreviewTokenService, DocumentPreviewTokenService>();
 builder.Services.AddScoped<IDocumentRequestService, DocumentRequestService>();
@@ -636,6 +638,7 @@ app.MapGet("/Projects/Documents/View", async (
     return Results.File(streamResult.Stream, contentType: "application/pdf", enableRangeProcessing: true);
 }).AllowAnonymous();
 
+app.MapRemarkApi();
 app.MapRazorPages();
 
 // Celebrations endpoints

--- a/Services/Remarks/IRemarkNotificationService.cs
+++ b/Services/Remarks/IRemarkNotificationService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ProjectManagement.Models.Remarks;
+
+namespace ProjectManagement.Services.Remarks;
+
+public interface IRemarkNotificationService
+{
+    Task NotifyRemarkCreatedAsync(
+        Remark remark,
+        RemarkActorContext actor,
+        RemarkProjectInfo project,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record RemarkProjectInfo(int ProjectId, string ProjectName, string? LeadPoUserId, string? HodUserId);

--- a/Services/Remarks/IRemarkService.cs
+++ b/Services/Remarks/IRemarkService.cs
@@ -39,6 +39,7 @@ public sealed record ListRemarksRequest(
     string? StageRef = null,
     DateOnly? FromDate = null,
     DateOnly? ToDate = null,
+    bool Mine = false,
     bool IncludeDeleted = false,
     int Page = 1,
     int PageSize = 50);
@@ -51,8 +52,10 @@ public sealed record EditRemarkRequest(
     DateOnly EventDate,
     string? StageRef,
     string? StageNameSnapshot,
-    string? Meta);
+    string? Meta,
+    byte[] RowVersion);
 
 public sealed record SoftDeleteRemarkRequest(
     RemarkActorContext Actor,
-    string? Meta);
+    string? Meta,
+    byte[] RowVersion);

--- a/Services/Remarks/RemarkNotificationService.cs
+++ b/Services/Remarks/RemarkNotificationService.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Remarks;
+
+namespace ProjectManagement.Services.Remarks;
+
+public sealed class RemarkNotificationService : IRemarkNotificationService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<RemarkNotificationService> _logger;
+
+    public RemarkNotificationService(
+        ApplicationDbContext db,
+        UserManager<ApplicationUser> userManager,
+        IEmailSender emailSender,
+        ILogger<RemarkNotificationService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _emailSender = emailSender ?? throw new ArgumentNullException(nameof(emailSender));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task NotifyRemarkCreatedAsync(
+        Remark remark,
+        RemarkActorContext actor,
+        RemarkProjectInfo project,
+        CancellationToken cancellationToken = default)
+    {
+        if (remark is null)
+        {
+            throw new ArgumentNullException(nameof(remark));
+        }
+
+        if (project is null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+
+        try
+        {
+            var projectDetails = await LoadProjectDetailsAsync(project.ProjectId, cancellationToken);
+            var recipients = await ResolveRecipientsAsync(projectDetails, remark.Type, cancellationToken);
+
+            if (recipients.Count == 0)
+            {
+                _logger.LogInformation(
+                    "No remark notification recipients found for project {ProjectId}.",
+                    project.ProjectId);
+                return;
+            }
+
+            var subject = $"[{projectDetails.Name}] New {remark.Type} remark";
+            var body = BuildBody(remark, actor, projectDetails.Name);
+
+            foreach (var recipient in recipients)
+            {
+                try
+                {
+                    await _emailSender.SendEmailAsync(recipient.Email, subject, body);
+                    _logger.LogInformation(
+                        "Sent remark notification for remark {RemarkId} to {Recipient}.",
+                        remark.Id,
+                        recipient.Email);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed sending remark notification for remark {RemarkId} to {Recipient}.",
+                        remark.Id,
+                        recipient.Email);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed preparing remark notification for remark {RemarkId}.", remark.Id);
+        }
+    }
+
+    private async Task<ProjectNotificationDetails> LoadProjectDetailsAsync(int projectId, CancellationToken cancellationToken)
+    {
+        var details = await _db.Projects
+            .AsNoTracking()
+            .Where(p => p.Id == projectId)
+            .Select(p => new ProjectNotificationDetails(
+                p.Id,
+                p.Name,
+                p.LeadPoUser != null ? p.LeadPoUser.Email : null,
+                p.HodUser != null ? p.HodUser.Email : null,
+                p.LeadPoUser != null ? p.LeadPoUser.FullName : null,
+                p.HodUser != null ? p.HodUser.FullName : null))
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (details is null)
+        {
+            throw new InvalidOperationException($"Project {projectId} not found when sending remark notification.");
+        }
+
+        return details;
+    }
+
+    private async Task<IReadOnlyCollection<NotificationRecipient>> ResolveRecipientsAsync(
+        ProjectNotificationDetails project,
+        RemarkType remarkType,
+        CancellationToken cancellationToken)
+    {
+        var recipients = new Dictionary<string, NotificationRecipient>(StringComparer.OrdinalIgnoreCase);
+
+        AddRecipient(recipients, project.LeadPoEmail, project.LeadPoName);
+        AddRecipient(recipients, project.HodEmail, project.HodName);
+
+        await AddRoleRecipientsAsync(recipients, "Comdt", cancellationToken);
+
+        if (remarkType == RemarkType.External)
+        {
+            await AddRoleRecipientsAsync(recipients, "MCO", cancellationToken);
+        }
+
+        return recipients.Values.ToArray();
+    }
+
+    private async Task AddRoleRecipientsAsync(
+        IDictionary<string, NotificationRecipient> recipients,
+        string role,
+        CancellationToken cancellationToken)
+    {
+        var users = await _userManager.GetUsersInRoleAsync(role);
+        foreach (var user in users)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AddRecipient(recipients, user.Email, user.FullName);
+        }
+    }
+
+    private static void AddRecipient(
+        IDictionary<string, NotificationRecipient> recipients,
+        string? email,
+        string? name)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return;
+        }
+
+        if (!recipients.ContainsKey(email))
+        {
+            recipients[email] = new NotificationRecipient(email, name);
+        }
+    }
+
+    private static string BuildBody(Remark remark, RemarkActorContext actor, string projectName)
+    {
+        var stage = string.IsNullOrWhiteSpace(remark.StageNameSnapshot)
+            ? remark.StageRef ?? "N/A"
+            : remark.StageNameSnapshot;
+
+        var plainBody = ToPlainText(remark.Body);
+
+        return $"""A new {remark.Type} remark was created on project '{projectName}'.
+
+Author: {actor.ActorRole} ({actor.UserId})
+Event date: {remark.EventDate:yyyy-MM-dd}
+Stage: {stage}
+Created at (UTC): {remark.CreatedAtUtc:u}
+
+{plainBody}
+""";
+    }
+
+    private static string ToPlainText(string html)
+        => Regex.Replace(html ?? string.Empty, "<.*?>", string.Empty).Trim();
+
+    private sealed record ProjectNotificationDetails(
+        int Id,
+        string Name,
+        string? LeadPoEmail,
+        string? HodEmail,
+        string? LeadPoName,
+        string? HodName);
+
+    private sealed record NotificationRecipient(string Email, string? Name);
+}

--- a/docs/openapi/remarks.yaml
+++ b/docs/openapi/remarks.yaml
@@ -1,0 +1,426 @@
+openapi: 3.0.3
+info:
+  title: Project Management Remarks API
+  version: "1.0.0"
+  description: |
+    REST endpoints for creating, listing, updating, deleting and auditing project remarks.
+servers:
+  - url: https://example.local
+paths:
+  /api/projects/{projectId}/remarks:
+    post:
+      summary: Create a remark
+      operationId: createRemark
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRemarkRequest'
+      responses:
+        '201':
+          description: Remark created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remark'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+      security:
+        - cookieAuth: []
+    get:
+      summary: List remarks for a project
+      operationId: listRemarks
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - name: type
+          in: query
+          schema:
+            $ref: '#/components/schemas/RemarkType'
+          description: Filter by remark type.
+        - name: role
+          in: query
+          schema:
+            $ref: '#/components/schemas/RemarkActorRole'
+          description: Filter by author role.
+        - name: stageRef
+          in: query
+          schema:
+            type: string
+          description: Filter by stage reference code.
+        - name: mine
+          in: query
+          schema:
+            type: boolean
+          description: When true, only remarks authored by the caller are returned.
+        - name: dateFrom
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Include remarks on or after this event date.
+        - name: dateTo
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Include remarks on or before this event date.
+        - name: includeDeleted
+          in: query
+          schema:
+            type: boolean
+          description: Include soft-deleted remarks (Admin only).
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+          description: Page number (defaults to 1).
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+          description: Number of items per page (defaults to 50).
+        - name: actorRole
+          in: query
+          schema:
+            $ref: '#/components/schemas/RemarkActorRole'
+          description: Explicit acting role for the caller.
+      responses:
+        '200':
+          description: Paged remarks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemarkList'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+      security:
+        - cookieAuth: []
+  /api/projects/{projectId}/remarks/{remarkId}:
+    put:
+      summary: Update a remark
+      operationId: updateRemark
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/RemarkId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRemarkRequest'
+      responses:
+        '200':
+          description: Updated remark
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Remark'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+      security:
+        - cookieAuth: []
+    delete:
+      summary: Soft delete a remark
+      operationId: deleteRemark
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/RemarkId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteRemarkRequest'
+      responses:
+        '200':
+          description: Deletion acknowledged
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteRemarkResponse'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+      security:
+        - cookieAuth: []
+  /api/projects/{projectId}/remarks/{remarkId}/audit:
+    get:
+      summary: Retrieve remark audit history
+      operationId: getRemarkAudit
+      parameters:
+        - $ref: '#/components/parameters/ProjectId'
+        - $ref: '#/components/parameters/RemarkId'
+        - name: actorRole
+          in: query
+          schema:
+            $ref: '#/components/schemas/RemarkActorRole'
+          description: Acting role for the caller (must include Admin).
+      responses:
+        '200':
+          description: Audit trail
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RemarkAudit'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+      security:
+        - cookieAuth: []
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: __Host-PMAuth
+  parameters:
+    ProjectId:
+      name: projectId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Numeric project identifier.
+    RemarkId:
+      name: remarkId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Numeric remark identifier.
+  responses:
+    BadRequest:
+      description: Invalid request
+    Unauthorized:
+      description: Authentication required
+    Forbidden:
+      description: Caller is not authorised
+    NotFound:
+      description: Resource not found
+    Conflict:
+      description: Request could not be completed due to a conflict (e.g. stale row version)
+  schemas:
+    RemarkType:
+      type: string
+      enum: [Internal, External]
+    RemarkActorRole:
+      type: string
+      enum:
+        - ProjectOfficer
+        - HeadOfDepartment
+        - Commandant
+        - Administrator
+        - Ta
+        - Mco
+        - ProjectOffice
+        - MainOffice
+    Remark:
+      type: object
+      required: [id, projectId, type, authorRole, authorUserId, body, eventDate, createdAtUtc, isDeleted, rowVersion]
+      properties:
+        id:
+          type: integer
+        projectId:
+          type: integer
+        type:
+          $ref: '#/components/schemas/RemarkType'
+        authorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+        authorUserId:
+          type: string
+        body:
+          type: string
+        eventDate:
+          type: string
+          format: date
+        stageRef:
+          type: string
+          nullable: true
+        stageName:
+          type: string
+          nullable: true
+        createdAtUtc:
+          type: string
+          format: date-time
+        lastEditedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
+        isDeleted:
+          type: boolean
+        deletedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
+        deletedByUserId:
+          type: string
+          nullable: true
+        deletedByRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+          nullable: true
+        rowVersion:
+          type: string
+          description: Base64 encoded concurrency token.
+    RemarkList:
+      type: object
+      required: [total, page, pageSize, items]
+      properties:
+        total:
+          type: integer
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Remark'
+    RemarkAudit:
+      type: object
+      required: [id, action, actorRole, actorUserId, actionAtUtc, snapshot]
+      properties:
+        id:
+          type: integer
+        action:
+          type: string
+          enum: [Created, Edited, Deleted]
+        actorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+        actorUserId:
+          type: string
+        actionAtUtc:
+          type: string
+          format: date-time
+        meta:
+          type: string
+          nullable: true
+        snapshot:
+          $ref: '#/components/schemas/RemarkAuditSnapshot'
+    RemarkAuditSnapshot:
+      type: object
+      required: [type, authorRole, authorUserId, body, eventDate, createdAtUtc, isDeleted]
+      properties:
+        type:
+          $ref: '#/components/schemas/RemarkType'
+        authorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+        authorUserId:
+          type: string
+        body:
+          type: string
+        eventDate:
+          type: string
+          format: date
+        stageRef:
+          type: string
+          nullable: true
+        stageName:
+          type: string
+          nullable: true
+        createdAtUtc:
+          type: string
+          format: date-time
+        lastEditedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
+        isDeleted:
+          type: boolean
+        deletedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
+        deletedByUserId:
+          type: string
+          nullable: true
+        deletedByRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+          nullable: true
+    CreateRemarkRequest:
+      type: object
+      required: [type, body, eventDate]
+      properties:
+        type:
+          $ref: '#/components/schemas/RemarkType'
+        body:
+          type: string
+        eventDate:
+          type: string
+          format: date
+        stageRef:
+          type: string
+          nullable: true
+        stageName:
+          type: string
+          nullable: true
+        meta:
+          type: string
+          nullable: true
+        actorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+          nullable: true
+    UpdateRemarkRequest:
+      type: object
+      required: [body, eventDate, rowVersion]
+      properties:
+        body:
+          type: string
+        eventDate:
+          type: string
+          format: date
+        stageRef:
+          type: string
+          nullable: true
+        stageName:
+          type: string
+          nullable: true
+        meta:
+          type: string
+          nullable: true
+        rowVersion:
+          type: string
+          description: Base64 encoded concurrency token.
+        actorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+          nullable: true
+    DeleteRemarkRequest:
+      type: object
+      required: [rowVersion]
+      properties:
+        rowVersion:
+          type: string
+          description: Base64 encoded concurrency token.
+        meta:
+          type: string
+          nullable: true
+        actorRole:
+          $ref: '#/components/schemas/RemarkActorRole'
+          nullable: true
+    DeleteRemarkResponse:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        rowVersion:
+          type: string
+          nullable: true
+          description: Latest row version for the tombstone.

--- a/docs/postman/remarks.postman_collection.json
+++ b/docs/postman/remarks.postman_collection.json
@@ -1,0 +1,102 @@
+{
+  "info": {
+    "name": "Project Remarks API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Sample requests for the project remarks REST endpoints."
+  },
+  "item": [
+    {
+      "name": "Create remark",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/projects/{{projectId}}/remarks",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "projects", "{{projectId}}", "remarks"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"type\": \"Internal\",\n  \"body\": \"Reviewed vendor proposal\",\n  \"eventDate\": \"2024-10-01\",\n  \"stageRef\": \"FS\",\n  \"actorRole\": \"ProjectOfficer\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List remarks",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/api/projects/{{projectId}}/remarks?type=Internal&mine=true&page=1&pageSize=20",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "projects", "{{projectId}}", "remarks"],
+          "query": [
+            { "key": "type", "value": "Internal" },
+            { "key": "mine", "value": "true" },
+            { "key": "page", "value": "1" },
+            { "key": "pageSize", "value": "20" }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Update remark",
+      "request": {
+        "method": "PUT",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/projects/{{projectId}}/remarks/{{remarkId}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "projects", "{{projectId}}", "remarks", "{{remarkId}}"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"body\": \"Updated vendor assessment\",\n  \"eventDate\": \"2024-10-02\",\n  \"stageRef\": \"FS\",\n  \"rowVersion\": \"{{rowVersion}}\",\n  \"actorRole\": \"ProjectOfficer\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Delete remark",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/projects/{{projectId}}/remarks/{{remarkId}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "projects", "{{projectId}}", "remarks", "{{remarkId}}"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"rowVersion\": \"{{rowVersion}}\",\n  \"actorRole\": \"ProjectOfficer\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Audit trail",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/api/projects/{{projectId}}/remarks/{{remarkId}}/audit",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "projects", "{{projectId}}", "remarks", "{{remarkId}}", "audit"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "https://example.local" },
+    { "key": "projectId", "value": "1" },
+    { "key": "remarkId", "value": "1" },
+    { "key": "rowVersion", "value": "BASE64_ROW_VERSION" }
+  ]
+}


### PR DESCRIPTION
## Summary
- expose REST endpoints for creating, listing, updating, deleting and auditing project remarks with role-aware validation
- extend remark service with row-version concurrency handling, actor notifications and mine filtering
- document the new endpoints in OpenAPI and provide Postman examples while expanding unit tests for concurrency and filtering

## Testing
- `dotnet test` *(fails: dotnet CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4df379b88329aa36f68075989c96