### PR TITLE
Fix remark notification email body string

### DIFF
--- a/Services/Remarks/RemarkNotificationService.cs
+++ b/Services/Remarks/RemarkNotificationService.cs
@@ -174,15 +174,13 @@ public sealed class RemarkNotificationService : IRemarkNotificationService
 
         var plainBody = ToPlainText(remark.Body);
 
-        return $"""A new {remark.Type} remark was created on project '{projectName}'.
-
-Author: {actor.ActorRole} ({actor.UserId})
-Event date: {remark.EventDate:yyyy-MM-dd}
-Stage: {stage}
-Created at (UTC): {remark.CreatedAtUtc:u}
-
-{plainBody}
-""";
+        return
+            $"A new {remark.Type} remark was created on project '{projectName}'.\n\n" +
+            $"Author: {actor.ActorRole} ({actor.UserId})\n" +
+            $"Event date: {remark.EventDate:yyyy-MM-dd}\n" +
+            $"Stage: {stage}\n" +
+            $"Created at (UTC): {remark.CreatedAtUtc:u}\n\n" +
+            plainBody;
     }
 
     private static string ToPlainText(string html)


### PR DESCRIPTION
## Summary
- replace the raw string literal used to build the remark notification email body with concatenated interpolated strings to restore compatibility with older C# language versions

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68de52387ef883299b72b725a46e6491