### PR TITLE
Fix null handling in remark API and expose service constants

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -43,9 +43,9 @@ internal static class RemarkApi
         request ??= new CreateRemarkRequestDto();
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
-        if (error is not null)
+        if (error is IResult errorResult)
         {
-            return error;
+            return errorResult;
         }
 
         try
@@ -89,9 +89,9 @@ internal static class RemarkApi
         CancellationToken cancellationToken)
     {
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, actorRole);
-        if (error is not null)
+        if (error is IResult errorResult)
         {
-            return error;
+            return errorResult;
         }
 
         if (!TryParseRemarkType(type, out var remarkType, out var typeError))
@@ -158,9 +158,9 @@ internal static class RemarkApi
         }
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
-        if (error is not null)
+        if (error is IResult errorResult)
         {
-            return error;
+            return errorResult;
         }
 
         try
@@ -213,9 +213,9 @@ internal static class RemarkApi
         }
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
-        if (error is not null)
+        if (error is IResult errorResult)
         {
-            return error;
+            return errorResult;
         }
 
         try
@@ -264,9 +264,9 @@ internal static class RemarkApi
         }
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, actorRole);
-        if (error is not null)
+        if (error is IResult errorResult)
         {
-            return error;
+            return errorResult;
         }
 
         if (!actor!.Roles.Contains(RemarkActorRole.Administrator))

--- a/Services/Remarks/RemarkService.cs
+++ b/Services/Remarks/RemarkService.cs
@@ -19,8 +19,8 @@ public sealed class RemarkService : IRemarkService
     private readonly ILogger<RemarkService> _logger;
     private readonly IRemarkNotificationService _notification;
 
-    internal const string ConcurrencyConflictMessage = "Remark was modified by another user.";
-    internal const string RowVersionRequiredMessage = "Row version is required for this operation.";
+    public const string ConcurrencyConflictMessage = "Remark was modified by another user.";
+    public const string RowVersionRequiredMessage = "Row version is required for this operation.";
 
     public RemarkService(
         ApplicationDbContext db,


### PR DESCRIPTION
## Summary
- ensure remark API returns non-null results by pattern matching result values before returning
- expose remark service concurrency and row version message constants for use in other assemblies

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68de52e183e08329ba67ab9f29ac84b7