### PR TITLE
Fix nullability warnings in remark API

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -96,12 +96,12 @@ internal static class RemarkApi
 
         if (!TryParseRemarkType(type, out var remarkType, out var typeError))
         {
-            return typeError;
+            return typeError!;
         }
 
         if (!TryParseRemarkRole(role, out var authorRole, out var roleError))
         {
-            return roleError;
+            return roleError!;
         }
 
         try
@@ -154,7 +154,7 @@ internal static class RemarkApi
 
         if (!TryParseRowVersion(request.RowVersion, out var rowVersion, out var rowError))
         {
-            return rowError;
+            return rowError!;
         }
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);
@@ -209,7 +209,7 @@ internal static class RemarkApi
 
         if (!TryParseRowVersion(request.RowVersion, out var rowVersion, out var rowError))
         {
-            return rowError;
+            return rowError!;
         }
 
         var (actor, error) = await BuildActorContextAsync(userManager, httpContext, request.ActorRole);


### PR DESCRIPTION
## Summary
- ensure API endpoints return non-null results after validation
- satisfy nullable analysis by marking validated error responses as non-null

## Testing
- dotnet build ProjectManagement.sln *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de542926288329b28f6e4101c96db2