### PR TITLE
Apply project filter before remark projection

### DIFF
--- a/Services/Remarks/RemarkService.cs
+++ b/Services/Remarks/RemarkService.cs
@@ -48,8 +48,9 @@ public sealed class RemarkService : IRemarkService
 
         var project = await _db.Projects
             .AsNoTracking()
+            .Where(p => p.Id == request.ProjectId)
             .Select(p => new RemarkProjectInfo(p.Id, p.Name, p.LeadPoUserId, p.HodUserId))
-            .FirstOrDefaultAsync(p => p.ProjectId == request.ProjectId, cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (project is null)
         {


### PR DESCRIPTION
## Summary
- filter the project query by id before projecting to remark info in CreateRemarkAsync

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8d1c77988329821939eb469a58dd