### PR TITLE
Allow external remarks API in CSP

### DIFF
--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -41,5 +41,10 @@
       "application/pdf"
     ],
     "EnableVirusScan": false
+  },
+  "SecurityHeaders": {
+    "ContentSecurityPolicy": {
+      "ConnectSources": []
+    }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -59,5 +59,10 @@
       "application/pdf"
     ],
     "EnableVirusScan": false
+  },
+  "SecurityHeaders": {
+    "ContentSecurityPolicy": {
+      "ConnectSources": []
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow configuring additional Content-Security-Policy connect-src hosts so the remarks API can be called from the UI
- document the configuration via SecurityHeaders sections in the default appsettings files

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de8ea307d08329a2a89ae3868e14ec