### PR TITLE
Fix remarks panel actor role canonicalisation

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -238,7 +238,8 @@ namespace ProjectManagement.Pages.Projects
                 .Select(role =>
                 {
                     var label = BuildRoleDisplayName(role);
-                    return new ProjectRemarksPanelViewModel.RemarkRoleOption(label, label, role.ToString());
+                    var canonical = role.ToString();
+                    return new ProjectRemarksPanelViewModel.RemarkRoleOption(canonical, label, canonical);
                 })
                 .ToList();
 
@@ -264,7 +265,8 @@ namespace ProjectManagement.Pages.Projects
                 .ToList();
 
             var actorRole = SelectDefaultRemarkRole(remarkRoles);
-            var actorRoleName = actorRole == RemarkActorRole.Unknown ? null : BuildRoleDisplayName(actorRole);
+            var actorRoleCanonical = actorRole == RemarkActorRole.Unknown ? null : actorRole.ToString();
+            var actorRoleLabel = actorRole == RemarkActorRole.Unknown ? null : BuildRoleDisplayName(actorRole);
 
             var canOverride = remarkRoles.Any(role => role is RemarkActorRole.HeadOfDepartment or RemarkActorRole.Commandant or RemarkActorRole.Administrator);
             var canPostAsHoDOrAbove = remarkRoles.Any(role => role is RemarkActorRole.HeadOfDepartment or RemarkActorRole.Commandant or RemarkActorRole.Administrator);
@@ -279,8 +281,9 @@ namespace ProjectManagement.Pages.Projects
                 ProjectId = project.Id,
                 CurrentUserId = user.Id,
                 ActorDisplayName = DisplayName(user),
-                ActorRole = actorRoleName,
-                ActorRoles = remarkRoles.Select(BuildRoleDisplayName).ToArray(),
+                ActorRole = actorRoleCanonical,
+                ActorRoleLabel = actorRoleLabel,
+                ActorRoles = remarkRoles.Select(role => role.ToString()).ToArray(),
                 ShowComposer = showComposer,
                 AllowInternal = showComposer,
                 AllowExternal = allowExternal,

--- a/ViewModels/ProjectRemarksPanelViewModel.cs
+++ b/ViewModels/ProjectRemarksPanelViewModel.cs
@@ -15,6 +15,8 @@ public sealed class ProjectRemarksPanelViewModel
 
     public string? ActorRole { get; init; }
 
+    public string? ActorRoleLabel { get; init; }
+
     public IReadOnlyList<string> ActorRoles { get; init; } = Array.Empty<string>();
 
     public bool ShowComposer { get; init; }


### PR DESCRIPTION
## Summary
- ensure the remarks panel passes canonical actor roles to the API by serialising canonical identifiers from the page model
- add actor role label metadata and client-side canonical lookups so friendly labels still resolve correctly

## Testing
- dotnet build *(fails: .NET SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de97ba3dec8329a8dff40f6d81ce06