### PR TITLE
Align remark date handling with IST

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -16,6 +16,7 @@ using ProjectManagement.Features.Backfill;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
+using ProjectManagement.Infrastructure;
 using ProjectManagement.Models.Remarks;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
@@ -243,7 +244,8 @@ namespace ProjectManagement.Pages.Projects
                 })
                 .ToList();
 
-            var today = DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var today = DateOnly.FromDateTime(IstClock.ToIst(_clock.UtcNow.UtcDateTime))
+                .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
             var user = await _users.GetUserAsync(User);
             if (user is null)

--- a/Services/Remarks/RemarkService.cs
+++ b/Services/Remarks/RemarkService.cs
@@ -7,6 +7,7 @@ using Ganss.Xss;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
 using ProjectManagement.Models.Remarks;
 using ProjectManagement.Models.Stages;
 
@@ -60,8 +61,8 @@ public sealed class RemarkService : IRemarkService
         ValidateRoleForType(request.Actor, request.Type, request.ProjectId);
 
         var now = _clock.UtcNow.UtcDateTime;
-        var today = DateOnly.FromDateTime(now);
-        EnsureValidEventDate(request.EventDate, today);
+        var todayIst = DateOnly.FromDateTime(IstClock.ToIst(now));
+        EnsureValidEventDate(request.EventDate, todayIst);
 
         var sanitizedBody = SanitizeBody(request.Body);
         if (string.IsNullOrWhiteSpace(sanitizedBody))
@@ -187,8 +188,8 @@ public sealed class RemarkService : IRemarkService
         }
 
         var now = _clock.UtcNow.UtcDateTime;
-        var today = DateOnly.FromDateTime(now);
-        EnsureValidEventDate(request.EventDate, today);
+        var todayIst = DateOnly.FromDateTime(IstClock.ToIst(now));
+        EnsureValidEventDate(request.EventDate, todayIst);
 
         var editPermission = EvaluateRemarkPermission(remark, request.Actor, now, isDelete: false);
         if (!editPermission.Allowed)

--- a/ViewModels/ProjectRemarksPanelViewModel.cs
+++ b/ViewModels/ProjectRemarksPanelViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.ViewModels;
 
@@ -29,7 +30,7 @@ public sealed class ProjectRemarksPanelViewModel
 
     public bool ActorHasOverride { get; init; }
 
-    public string Today { get; init; } = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+    public string Today { get; init; } = DateOnly.FromDateTime(IstClock.ToIst(DateTime.UtcNow)).ToString("yyyy-MM-dd");
 
     public int PageSize { get; init; } = 20;
 


### PR DESCRIPTION
## Summary
- compute IST-based "today" when validating remark event dates while keeping persisted timestamps in UTC
- feed the project remarks panel with the IST-adjusted current date for composer defaults and constraints
- default the remarks panel view model to IST so any downstream usage receives the local day

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dea786d0648329be56bf86cc6f5792