### PR TITLE
Add Head of Department alias for remark roles

### DIFF
--- a/Models/Remarks/Remark.cs
+++ b/Models/Remarks/Remark.cs
@@ -147,6 +147,7 @@ namespace ProjectManagement.Models.Remarks
             ["ProjectOfficer"] = RemarkActorRole.ProjectOfficer,
             ["HoD"] = RemarkActorRole.HeadOfDepartment,
             ["HeadOfDepartment"] = RemarkActorRole.HeadOfDepartment,
+            ["Head of Department"] = RemarkActorRole.HeadOfDepartment,
             ["Comdt"] = RemarkActorRole.Commandant,
             ["Commandant"] = RemarkActorRole.Commandant,
             ["Admin"] = RemarkActorRole.Administrator,

--- a/ProjectManagement.Tests/RemarkApiTests.cs
+++ b/ProjectManagement.Tests/RemarkApiTests.cs
@@ -30,16 +30,16 @@ namespace ProjectManagement.Tests;
 
 public class RemarkApiTests
 {
-    private static readonly IReadOnlyDictionary<RemarkActorRole, string> FriendlyRoleNames = new Dictionary<RemarkActorRole, string>
+    private static readonly IReadOnlyDictionary<RemarkActorRole, IReadOnlyList<string>> FriendlyRoleNames = new Dictionary<RemarkActorRole, IReadOnlyList<string>>
     {
-        [RemarkActorRole.ProjectOfficer] = "Project Officer",
-        [RemarkActorRole.HeadOfDepartment] = "HoD",
-        [RemarkActorRole.Commandant] = "Comdt",
-        [RemarkActorRole.Administrator] = "Admin",
-        [RemarkActorRole.Mco] = "MCO",
-        [RemarkActorRole.ProjectOffice] = "Project Office",
-        [RemarkActorRole.MainOffice] = "Main Office",
-        [RemarkActorRole.Ta] = "TA"
+        [RemarkActorRole.ProjectOfficer] = new[] { "Project Officer" },
+        [RemarkActorRole.HeadOfDepartment] = new[] { "HoD", "Head of Department" },
+        [RemarkActorRole.Commandant] = new[] { "Comdt" },
+        [RemarkActorRole.Administrator] = new[] { "Admin" },
+        [RemarkActorRole.Mco] = new[] { "MCO" },
+        [RemarkActorRole.ProjectOffice] = new[] { "Project Office" },
+        [RemarkActorRole.MainOffice] = new[] { "Main Office" },
+        [RemarkActorRole.Ta] = new[] { "TA" }
     };
 
     public static IEnumerable<object[]> CanonicalActorRoles
@@ -64,7 +64,10 @@ public class RemarkApiTests
         {
             foreach (var pair in FriendlyRoleNames)
             {
-                yield return new object[] { pair.Key, pair.Value };
+                foreach (var alias in pair.Value)
+                {
+                    yield return new object[] { pair.Key, alias };
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- map the "Head of Department" friendly name to the HoD remark actor role
- exercise both HoD aliases in the remark API friendly-role tests to prevent regressions

## Testing
- unable to run tests (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0eac804c83299b3f58cf2413733b