### PR TITLE
Handle missing actor roles in remark API

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -91,7 +91,7 @@ internal static class RemarkApi
         [FromQuery(Name = "includeDeleted")] bool includeDeleted,
         [FromQuery] int page,
         [FromQuery] int pageSize,
-        [FromQuery(Name = "actorRole")] string? actorRole,
+        [FromQuery(Name = "actorRole")] string? actorRole = null,
         ApplicationDbContext db,
         IRemarkService remarkService,
         UserManager<ApplicationUser> userManager,
@@ -300,7 +300,7 @@ internal static class RemarkApi
     private static async Task<IResult> GetRemarkAuditAsync(
         int projectId,
         int remarkId,
-        [FromQuery(Name = "actorRole")] string? actorRole,
+        [FromQuery(Name = "actorRole")] string? actorRole = null,
         ApplicationDbContext db,
         IRemarkService remarkService,
         UserManager<ApplicationUser> userManager,

--- a/ProjectManagement.Tests/RemarkApiTests.cs
+++ b/ProjectManagement.Tests/RemarkApiTests.cs
@@ -171,6 +171,28 @@ public class RemarkApiTests
     }
 
     [Fact]
+    public async Task ListRemarksAsync_ViewerWithoutRemarkRole_ReturnsForbidden()
+    {
+        using var factory = new RemarkApiFactory();
+        var projectId = 9610;
+        await SeedProjectAsync(factory, projectId, leadPoUserId: "lead-owner");
+
+        var viewerClient = await CreateClientForUserAsync(
+            factory,
+            "viewer-no-role",
+            "Viewer No Role",
+            false,
+            "Project Officer");
+
+        var response = await viewerClient.GetAsync($"/api/projects/{projectId}/remarks");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetailsDto>(SerializerOptions);
+        Assert.NotNull(problem);
+        Assert.Equal(RemarkService.PermissionDeniedMessage, problem!.Title);
+    }
+
+    [Fact]
     public async Task EditRemarkAsync_DeniesWhenWindowExpired()
     {
         using var factory = new RemarkApiFactory();

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -694,6 +694,26 @@
                 return false;
             }
 
+            if (!this.actorRole) {
+                if (!append) {
+                    this.state.items = [];
+                    this.state.page = 1;
+                    this.state.total = 0;
+                    this.state.hasMore = false;
+                    if (this.listContainer) {
+                        this.listContainer.innerHTML = '';
+                    }
+
+                    if (this.emptyState) {
+                        this.emptyState.classList.remove('d-none');
+                        this.emptyState.textContent = 'Remarks are unavailable for your account.';
+                    }
+                }
+
+                this.state.initialised = true;
+                return false;
+            }
+
             if (!append) {
                 this.setLoading(true);
             }


### PR DESCRIPTION
## Summary
- allow the remark endpoints to accept a missing actorRole query parameter by defaulting it to null
- add a regression test that ensures viewers without a remark role receive a forbidden response instead of an error
- guard the project overview remarks panel so it skips loading when no actor role is available

## Testing
- dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df2926883c832996f9c4047f9e9efa