### PR TITLE
Fix optional parameter ordering in remark API

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -91,7 +91,7 @@ internal static class RemarkApi
         [FromQuery(Name = "includeDeleted")] bool includeDeleted,
         [FromQuery] int page,
         [FromQuery] int pageSize,
-        [FromQuery(Name = "actorRole")] string? actorRole = null,
+        [FromQuery(Name = "actorRole")] string? actorRole,
         ApplicationDbContext db,
         IRemarkService remarkService,
         UserManager<ApplicationUser> userManager,
@@ -300,7 +300,7 @@ internal static class RemarkApi
     private static async Task<IResult> GetRemarkAuditAsync(
         int projectId,
         int remarkId,
-        [FromQuery(Name = "actorRole")] string? actorRole = null,
+        [FromQuery(Name = "actorRole")] string? actorRole,
         ApplicationDbContext db,
         IRemarkService remarkService,
         UserManager<ApplicationUser> userManager,


### PR DESCRIPTION
## Summary
- remove default values from actorRole query parameters so they are no longer treated as optional before required dependencies

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df2b60460c8329baab53f3365d52f7