### PR TITLE
Ensure remark API returns UTC offsets

### DIFF
--- a/ProjectManagement.Tests/RemarkApiTests.cs
+++ b/ProjectManagement.Tests/RemarkApiTests.cs
@@ -524,10 +524,10 @@ public class RemarkApiTests
         public DateOnly EventDate { get; init; }
         public string? StageRef { get; init; }
         public string? StageName { get; init; }
-        public DateTime CreatedAtUtc { get; init; }
-        public DateTime? LastEditedAtUtc { get; init; }
+        public DateTimeOffset CreatedAtUtc { get; init; }
+        public DateTimeOffset? LastEditedAtUtc { get; init; }
         public bool IsDeleted { get; init; }
-        public DateTime? DeletedAtUtc { get; init; }
+        public DateTimeOffset? DeletedAtUtc { get; init; }
         public string? DeletedByUserId { get; init; }
         public RemarkActorRole? DeletedByRole { get; init; }
         public string? DeletedByDisplayName { get; init; }


### PR DESCRIPTION
## Summary
- convert remark API responses to emit timestamp fields as UTC DateTimeOffset values
- update remark audit snapshots to carry UTC offsets for stored timestamps
- adjust API integration test DTOs to consume DateTimeOffset timestamps

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df67f574a08329b09d5b7c8f98de1e