### PR TITLE
Streamline remarks filters with time range toggle

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1095,7 +1095,7 @@
                                     }
                                 </div>
                                 <div class="d-flex flex-column gap-3 d-none" data-panel-section="remarks" id="project-panel-section-remarks" role="region" aria-labelledby="project-panel-toggle-remarks" aria-hidden="true">
-                                    <div class="d-flex flex-wrap align-items-center gap-3">
+                                    <div class="d-flex flex-wrap align-items-center gap-3 w-100">
                                         <div class="pm-card-heading">
                                             <span class="pm-card-icon" aria-hidden="true">
                                                 <i class="bi bi-chat-dots"></i>
@@ -1105,48 +1105,24 @@
                                                 <p class="pm-card-subtitle mb-0">Collaborate with stakeholders and capture project context.</p>
                                             </div>
                                         </div>
-                                        <div class="btn-group btn-group-sm mt-2 mt-lg-0" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
-                                            <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
-                                            <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
-                                            <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
-                                        </div>
-                                    </div>
-                                    <div class="d-flex flex-wrap align-items-center gap-2" data-remarks-filter-bar>
-                                        <div>
-                                            <label class="form-label visually-hidden" for="remarks-role-filter">Author role</label>
-                                            <select id="remarks-role-filter" class="form-select form-select-sm" data-remarks-role-filter>
-                                                <option value="">All roles</option>
-                                                @foreach (var option in Model.RemarksPanel.RoleOptions)
-                                                {
-                                                    <option value="@option.Value">@option.Label</option>
-                                                }
-                                            </select>
-                                        </div>
-                                        <div>
-                                            <label class="form-label visually-hidden" for="remarks-stage-filter">Stage</label>
-                                            <select id="remarks-stage-filter" class="form-select form-select-sm" data-remarks-stage-filter>
-                                                <option value="">All stages</option>
-                                                @foreach (var stage in Model.RemarksPanel.StageOptions)
-                                                {
-                                                    <option value="@stage.Value">@stage.Label</option>
-                                                }
-                                            </select>
-                                        </div>
-                                        <div>
-                                            <label class="form-label visually-hidden" for="remarks-date-from">From date</label>
-                                            <input type="date" id="remarks-date-from" class="form-control form-control-sm" data-remarks-date-from max="@Model.RemarksPanel.Today" aria-label="Show remarks from date" />
-                                        </div>
-                                        <div>
-                                            <label class="form-label visually-hidden" for="remarks-date-to">To date</label>
-                                            <input type="date" id="remarks-date-to" class="form-control form-control-sm" data-remarks-date-to max="@Model.RemarksPanel.Today" aria-label="Show remarks to date" />
-                                        </div>
-                                        @if (Model.RemarksPanel.ShowDeletedToggle)
-                                        {
-                                            <div class="form-check form-switch ms-lg-auto">
-                                                <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
-                                                <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
+                                        <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
+                                            <div class="btn-group btn-group-sm mt-2 mt-lg-0" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
+                                                <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
+                                                <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
+                                                <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
                                             </div>
-                                        }
+                                            <div class="btn-group btn-group-sm mt-2 mt-lg-0" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
+                                                <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
+                                                <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+                                            </div>
+                                            @if (Model.RemarksPanel.ShowDeletedToggle)
+                                            {
+                                                <div class="form-check form-switch ms-lg-2">
+                                                    <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
+                                                    <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
+                                                </div>
+                                            }
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- replace the remarks filter row with a compact type/time toggle alongside the deleted toggle
- update the remarks panel script to track a time range and derive the last-month query parameter on reload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df6882d20883298f6098ab74a477da