### PR TITLE
Align remarks filters in overview toolbar

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1105,19 +1105,21 @@
                                                 <p class="pm-card-subtitle mb-0">Monitor and update project progress.</p>
                                             </div>
                                         </div>
-                                        <div class="d-flex flex-wrap align-items-center gap-2 ms-lg-auto">
-                                            <div class="btn-group btn-group-sm mt-2 mt-lg-0" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
-                                                <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
-                                                <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
-                                                <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
-                                            </div>
-                                            <div class="btn-group btn-group-sm mt-2 mt-lg-0" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
-                                                <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
-                                                <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+                                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 ms-lg-auto">
+                                            <div class="btn-toolbar gap-2 flex-wrap flex-sm-nowrap" role="toolbar" aria-label="Filter remarks">
+                                                <div class="btn-group btn-group-sm" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
+                                                    <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
+                                                    <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
+                                                    <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
+                                                </div>
+                                                <div class="btn-group btn-group-sm" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
+                                                    <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
+                                                    <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+                                                </div>
                                             </div>
                                             @if (Model.RemarksPanel.ShowDeletedToggle)
                                             {
-                                                <div class="form-check form-switch ms-lg-2">
+                                                <div class="form-check form-switch ms-sm-2 ms-lg-3">
                                                     <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
                                                     <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
                                                 </div>


### PR DESCRIPTION
## Summary
- wrap the remarks type and time filter controls in a toolbar so they align on a single row by default
- adjust spacing utilities to keep the toolbar responsive while preserving the deleted toggle offset

## Testing
- `dotnet test` *(fails: `dotnet` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df6d6420848329b7f29e905d7b0be3