### PR TITLE
Adjust remarks filter toolbar layout

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1105,8 +1105,8 @@
                                                 <p class="pm-card-subtitle mb-0">Monitor and update project progress.</p>
                                             </div>
                                         </div>
-                                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 ms-lg-auto">
-                                            <div class="btn-toolbar gap-2 flex-wrap flex-sm-nowrap" role="toolbar" aria-label="Filter remarks">
+                                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
+                                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -1119,7 +1119,7 @@
                                             </div>
                                             @if (Model.RemarksPanel.ShowDeletedToggle)
                                             {
-                                                <div class="form-check form-switch ms-sm-2 ms-lg-3">
+                                                <div class="form-check form-switch ms-sm-2 ms-lg-3 flex-shrink-0">
                                                     <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
                                                     <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
                                                 </div>


### PR DESCRIPTION
## Summary
- expand the remarks filter toolbar container to span the row and space its controls
- keep the optional "Show deleted" toggle aligned by preventing it from shrinking

## Testing
- dotnet run *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df76b1dee08329a2233e8b2931569c