### PR TITLE
Add styling hook for remarks filter buttons

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1107,12 +1107,12 @@
                                         </div>
                                         <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
                                             <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
-                                                <div class="btn-group btn-group-sm" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
+                                                <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
                                                 </div>
-                                                <div class="btn-group btn-group-sm" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
+                                                <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
                                                 </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -860,6 +860,11 @@ body {
     display: none;
 }
 
+.pm-remarks-filter .btn {
+    font-size: .75rem;
+    padding: .25rem .5rem;
+}
+
 /* ---------- Remarks panel ---------- */
 .remarks-panel {
     display: flex;


### PR DESCRIPTION
## Summary
- add a dedicated pm-remarks-filter class to the remarks filter button groups
- tweak the remarks filter button styling to reduce their size while keeping readability

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df7954852483299d44c0788265f610