### PR TITLE
Refactor remarks composer into modal

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1205,52 +1205,79 @@
                         <div class="remarks-panel" data-remarks-panel data-config='@remarksConfigJson'>
                             @if (Model.RemarksPanel.ShowComposer)
                             {
-                                <form class="remarks-composer" data-remarks-composer>
-                                    @Html.AntiForgeryToken()
-                                    <div class="d-flex flex-column gap-3">
-                                        <div>
-                                            <label for="remark-body" class="form-label fw-semibold mb-1">Add a remark</label>
-                                            <textarea id="remark-body" class="form-control" rows="3" maxlength="4000" data-remarks-body required></textarea>
-                                            <div class="form-text">Maximum 4000 characters.</div>
-                                            @if (!string.IsNullOrWhiteSpace(Model.RemarksPanel.ActorDisplayName))
-                                            {
-                                                <div class="small text-muted mt-1">Posting as @Model.RemarksPanel.ActorDisplayName</div>
-                                            }
-                                        </div>
-                                        <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
-                                            <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
-                                                <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
-                                                @if (Model.RemarksPanel.AllowExternal)
-                                                {
-                                                    <button type="button" class="btn btn-outline-secondary" data-remarks-composer-option="External" aria-pressed="false">External</button>
-                                                }
+                                var composerModalId = $"remarks-composer-modal-{Model.Project?.Id ?? 0}";
+                                <div class="remarks-launcher d-flex justify-content-end">
+                                    <button type="button"
+                                            class="btn btn-primary remarks-composer-trigger"
+                                            data-remarks-open-modal
+                                            aria-haspopup="dialog"
+                                            aria-controls="@composerModalId"
+                                            aria-label="Add a remark"
+                                            title="Add a remark">
+                                        <span aria-hidden="true">+</span>
+                                    </button>
+                                </div>
+                                <div class="modal fade"
+                                     id="@composerModalId"
+                                     tabindex="-1"
+                                     aria-hidden="true"
+                                     aria-labelledby="@($"{composerModalId}-label")"
+                                     data-remarks-modal>
+                                    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <h2 class="modal-title h5" id="@($"{composerModalId}-label")">Add a remark</h2>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                             </div>
-                                            <div class="remarks-composer-external d-flex flex-wrap align-items-end gap-2 d-none" data-remarks-external-fields>
-                                                <div>
-                                                    <label for="remark-event-date" class="form-label mb-1 small">Event date</label>
-                                                    <input type="date" id="remark-event-date" class="form-control form-control-sm" data-remarks-event-date value="@Model.RemarksPanel.Today" max="@Model.RemarksPanel.Today" />
-                                                </div>
-                                                <div>
-                                                    <label for="remark-stage" class="form-label mb-1 small">Stage <span class="text-muted">(optional)</span></label>
-                                                    <select id="remark-stage" class="form-select form-select-sm" data-remarks-stage>
-                                                        <option value="">Not linked</option>
-                                                        @foreach (var stage in Model.RemarksPanel.StageOptions)
+                                            <form class="remarks-composer" data-remarks-composer>
+                                                @Html.AntiForgeryToken()
+                                                <div class="modal-body d-flex flex-column gap-3">
+                                                    <div>
+                                                        <label for="remark-body" class="form-label fw-semibold mb-1">Remark</label>
+                                                        <textarea id="remark-body" class="form-control" rows="4" maxlength="4000" data-remarks-body required></textarea>
+                                                        <div class="form-text">Maximum 4000 characters.</div>
+                                                        @if (!string.IsNullOrWhiteSpace(Model.RemarksPanel.ActorDisplayName))
                                                         {
-                                                            <option value="@stage.Value">@stage.Label</option>
+                                                            <div class="small text-muted mt-1">Posting as @Model.RemarksPanel.ActorDisplayName</div>
                                                         }
-                                                    </select>
+                                                    </div>
+                                                    <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                                        <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
+                                                            <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
+                                                            @if (Model.RemarksPanel.AllowExternal)
+                                                            {
+                                                                <button type="button" class="btn btn-outline-secondary" data-remarks-composer-option="External" aria-pressed="false">External</button>
+                                                            }
+                                                        </div>
+                                                        <div class="remarks-composer-external d-flex flex-wrap align-items-end gap-2 d-none" data-remarks-external-fields>
+                                                            <div>
+                                                                <label for="remark-event-date" class="form-label mb-1 small">Event date</label>
+                                                                <input type="date" id="remark-event-date" class="form-control form-control-sm" data-remarks-event-date value="@Model.RemarksPanel.Today" max="@Model.RemarksPanel.Today" />
+                                                            </div>
+                                                            <div>
+                                                                <label for="remark-stage" class="form-label mb-1 small">Stage <span class="text-muted">(optional)</span></label>
+                                                                <select id="remark-stage" class="form-select form-select-sm" data-remarks-stage>
+                                                                    <option value="">Not linked</option>
+                                                                    @foreach (var stage in Model.RemarksPanel.StageOptions)
+                                                                    {
+                                                                        <option value="@stage.Value">@stage.Label</option>
+                                                                    }
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                        </div>
-                                        <div class="d-flex flex-column flex-sm-row gap-2 align-items-sm-center justify-content-between">
-                                            <div class="small" data-remarks-feedback></div>
-                                            <div class="d-flex gap-2 ms-sm-auto">
-                                                <button type="reset" class="btn btn-sm btn-outline-secondary" data-remarks-reset>Clear</button>
-                                                <button type="submit" class="btn btn-primary btn-sm" data-remarks-submit>Post remark</button>
-                                            </div>
+                                                <div class="modal-footer flex-column flex-sm-row gap-2 align-items-stretch align-items-sm-center">
+                                                    <div class="small text-start" data-remarks-feedback></div>
+                                                    <div class="d-flex gap-2 ms-sm-auto">
+                                                        <button type="reset" class="btn btn-sm btn-outline-secondary" data-remarks-reset>Clear</button>
+                                                        <button type="submit" class="btn btn-primary btn-sm" data-remarks-submit>Post remark</button>
+                                                    </div>
+                                                </div>
+                                            </form>
                                         </div>
                                     </div>
-                                </form>
+                                </div>
                             }
                             else
                             {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -873,16 +873,33 @@ body {
 }
 
 .remarks-composer {
-    border: 1px solid rgba(15, 23, 42, .08);
-    border-radius: .75rem;
-    background-color: var(--pm-card);
-    padding: 1rem;
-    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .02);
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    box-shadow: none;
 }
 
-[data-bs-theme="dark"] .remarks-composer {
-    border-color: rgba(255, 255, 255, .1);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .04);
+.remarks-launcher {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.remarks-composer-trigger {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    padding: 0;
+    box-shadow: 0 0.35rem 1rem rgba(15, 23, 42, .15);
+}
+
+[data-bs-theme="dark"] .remarks-composer-trigger {
+    box-shadow: 0 0.35rem 1rem rgba(0, 0, 0, .6);
 }
 
 .remarks-composer-options {

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -453,6 +453,9 @@
             this.listContainer = this.root.querySelector('[data-remarks-items]');
             this.emptyState = this.root.querySelector('[data-remarks-empty]');
             this.loadMoreButton = this.root.querySelector('[data-remarks-load-more]');
+            this.modalElement = this.root.querySelector('[data-remarks-modal]');
+            this.modalTriggers = Array.from(this.root.querySelectorAll('[data-remarks-open-modal]'));
+            this.modalInstance = this.modalElement ? bootstrap.Modal.getOrCreateInstance(this.modalElement) : null;
             this.composerForm = this.root.querySelector('[data-remarks-composer]');
             this.feedback = this.root.querySelector('[data-remarks-feedback]');
             this.externalFields = this.root.querySelector('[data-remarks-external-fields]');
@@ -466,6 +469,28 @@
         }
 
         bindEvents() {
+            if (this.modalTriggers && this.modalTriggers.length > 0 && this.modalInstance) {
+                this.modalTriggers.forEach((button) => {
+                    button.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        this.resetComposer();
+                        this.modalInstance?.show();
+                    });
+                });
+            }
+
+            if (this.modalElement) {
+                this.modalElement.addEventListener('shown.bs.modal', () => {
+                    if (this.bodyField instanceof HTMLElement) {
+                        this.bodyField.focus();
+                    }
+                });
+
+                this.modalElement.addEventListener('hidden.bs.modal', () => {
+                    this.resetComposer();
+                });
+            }
+
             if (this.typeButtons.length > 0) {
                 this.typeButtons.forEach((button) => {
                     button.addEventListener('click', () => {
@@ -1644,6 +1669,9 @@
 
                 this.setFeedback('Remark added.', 'success');
                 this.resetComposer();
+                if (this.modalInstance) {
+                    this.modalInstance.hide();
+                }
                 this.state.page = 1;
                 await this.fetchPage(1, false);
             } catch (error) {


### PR DESCRIPTION
## Summary
- replace the inline remarks composer with a compact trigger and modal-based form on the project overview page
- adjust site styling to support the modal composer and provide a floating trigger button
- update the overview JavaScript to manage the modal lifecycle while reusing the existing remark submission logic

## Testing
- dotnet build *(fails: `dotnet` not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df955e4cd88329a105b09006b4f0a8