### PR TITLE
Adjust remarks filter spacing

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1106,7 +1106,7 @@
                                             </div>
                                         </div>
                                         <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
-                                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
+                                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100 pm-remarks-toolbar" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -865,6 +865,17 @@ body {
     padding: .25rem .5rem;
 }
 
+.pm-remarks-toolbar .pm-remarks-filter + .pm-remarks-filter {
+    margin-left: 1rem;
+}
+
+@media (max-width: 576px) {
+    .pm-remarks-toolbar .pm-remarks-filter + .pm-remarks-filter {
+        margin-left: 0;
+        margin-top: .75rem;
+    }
+}
+
 /* ---------- Remarks panel ---------- */
 .remarks-panel {
     display: flex;


### PR DESCRIPTION
## Summary
- add a toolbar class to the remarks filter container so CSS can target consecutive filter groups
- extend the site stylesheet to provide horizontal spacing between the remarks filter button groups and convert it to vertical spacing on narrow viewports

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68df98f959748329ab22863cec4487c6