### PR TITLE
Adjust remarks toolbar spacing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -860,20 +860,18 @@ body {
     display: none;
 }
 
+.pm-remarks-toolbar {
+    gap: 1rem;
+}
+
+.pm-remarks-toolbar .pm-remarks-filter {
+    flex: 1 1 auto;
+}
+
 .pm-remarks-filter .btn {
     font-size: .75rem;
     padding: .25rem .5rem;
-}
-
-.pm-remarks-toolbar .pm-remarks-filter + .pm-remarks-filter {
-    margin-left: 1rem;
-}
-
-@media (max-width: 576px) {
-    .pm-remarks-toolbar .pm-remarks-filter + .pm-remarks-filter {
-        margin-left: 0;
-        margin-top: .75rem;
-    }
+    white-space: nowrap;
 }
 
 /* ---------- Remarks panel ---------- */


### PR DESCRIPTION
## Summary
- switch the remarks toolbar spacing to use flex gap so filter groups space evenly
- allow each remarks filter group to flex independently and keep buttons on a single line

## Testing
- not run (CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68df9df158908329b3e050d8c39b65cc