### PR TITLE
Fix timeline toggle alignment on overview page

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1129,11 +1129,9 @@
                                 </div>
                             </div>
                             <div class="d-flex flex-column flex-lg-row align-items-stretch align-items-lg-center gap-2 w-100">
-                                <div class="d-flex justify-content-lg-end w-100">
-                                    <div class="btn-group btn-group-sm" role="group" aria-label="Toggle timeline or remarks" data-panel-switch>
-                                        <button type="button" class="btn btn-outline-primary active" id="project-panel-toggle-timeline" data-panel-target="timeline" aria-pressed="true" aria-expanded="true" aria-controls="project-panel-body-timeline">Timeline</button>
-                                        <button type="button" class="btn btn-outline-primary" id="project-panel-toggle-remarks" data-panel-target="remarks" aria-pressed="false" aria-expanded="false" aria-controls="project-panel-body-remarks">Remarks</button>
-                                    </div>
+                                <div class="btn-group btn-group-sm w-100 w-lg-auto me-lg-auto" role="group" aria-label="Toggle timeline or remarks" data-panel-switch>
+                                    <button type="button" class="btn btn-outline-primary active" id="project-panel-toggle-timeline" data-panel-target="timeline" aria-pressed="true" aria-expanded="true" aria-controls="project-panel-body-timeline">Timeline</button>
+                                    <button type="button" class="btn btn-outline-primary" id="project-panel-toggle-remarks" data-panel-target="remarks" aria-pressed="false" aria-expanded="false" aria-controls="project-panel-body-remarks">Remarks</button>
                                 </div>
                                 <div class="pm-card-actions d-flex flex-wrap align-items-center gap-2 justify-content-lg-end ms-lg-auto" data-panel-section="timeline" id="project-panel-section-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
                                     @{


### PR DESCRIPTION
## Summary
- remove the large breakpoint justification wrapper around the timeline/remarks toggle
- let the button group grow full width on small screens and sit before the timeline actions on large screens

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfa20ba0588329987219c9889a5dd0