### PR TITLE
Prevent timeline header from shifting when switching to remarks

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1180,7 +1180,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="pm-card-meta w-100" data-panel-section="timeline" id="project-panel-meta-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
+                        <div class="pm-card-meta w-100" data-panel-meta="timeline" id="project-panel-meta-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
                             <progress class="pm-progress pm-progress-slim pm-progress-fixed-180"
                                       value="@completedStages"
                                       max="@progressMax"

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -1739,6 +1739,13 @@
                 body.setAttribute('aria-hidden', isActive ? 'false' : 'true');
             });
 
+            const meta = card.querySelector('#project-panel-meta-timeline');
+            if (meta) {
+                const isTimeline = target === 'timeline';
+                meta.classList.toggle('invisible', !isTimeline);
+                meta.setAttribute('aria-hidden', isTimeline ? 'false' : 'true');
+            }
+
             try {
                 sessionStorage.setItem(storageKey, target);
             } catch (error) {


### PR DESCRIPTION
## Summary
- keep the timeline meta element out of the generic section toggler so it stays in the header layout
- hide the meta block with Bootstrap's invisible utility when Remarks is active to prevent layout jumping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa65adeb083299e514579b65adae6