### PR TITLE
Fix remarks toggle layout shift

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1133,7 +1133,7 @@
                                     <button type="button" class="btn btn-outline-primary active" id="project-panel-toggle-timeline" data-panel-target="timeline" aria-pressed="true" aria-expanded="true" aria-controls="project-panel-body-timeline">Timeline</button>
                                     <button type="button" class="btn btn-outline-primary" id="project-panel-toggle-remarks" data-panel-target="remarks" aria-pressed="false" aria-expanded="false" aria-controls="project-panel-body-remarks">Remarks</button>
                                 </div>
-                                <div class="pm-card-actions d-flex flex-wrap align-items-center gap-2 justify-content-lg-end ms-lg-auto" data-panel-section="timeline" id="project-panel-section-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
+                                <div class="pm-card-actions d-flex flex-wrap align-items-center gap-2 justify-content-lg-end ms-lg-auto" data-panel-actions="timeline" id="project-panel-section-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
                                     @{
                                         var canReviewTimeline = planState.HasPendingSubmission && isHoD;
                                         var canEditTimelinePlan = canEditTimeline && !(hasMyDraft && !pendingOwnedByCurrentUser);
@@ -1180,7 +1180,11 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="pm-card-meta w-100" data-panel-meta="timeline" id="project-panel-meta-timeline" role="region" aria-labelledby="project-panel-toggle-timeline" aria-hidden="false">
+                        <div class="pm-card-meta w-100"
+                             id="project-panel-meta-timeline"
+                             role="region"
+                             aria-labelledby="project-panel-toggle-timeline"
+                             aria-hidden="false">
                             <progress class="pm-progress pm-progress-slim pm-progress-fixed-180"
                                       value="@completedStages"
                                       max="@progressMax"

--- a/wwwroot/js/projects/overview.js
+++ b/wwwroot/js/projects/overview.js
@@ -1739,6 +1739,13 @@
                 body.setAttribute('aria-hidden', isActive ? 'false' : 'true');
             });
 
+            const timelineActions = card.querySelector('#project-panel-section-timeline');
+            if (timelineActions) {
+                const isTimeline = target === 'timeline';
+                timelineActions.classList.toggle('invisible', !isTimeline);
+                timelineActions.setAttribute('aria-hidden', isTimeline ? 'false' : 'true');
+            }
+
             const meta = card.querySelector('#project-panel-meta-timeline');
             if (meta) {
                 const isTimeline = target === 'timeline';


### PR DESCRIPTION
## Summary
- stop the header action buttons from being hidden with `d-none` when showing remarks by removing them from the generic panel section handling
- hide the header actions with the `invisible` utility while on the remarks tab so the toggle stays in place
- tidy the remarks meta container markup for consistent accessibility attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfac9fdeb88329a1968ae5b179d111