### PR TITLE
Align remarks filters in single row

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1106,7 +1106,7 @@
                                             </div>
                                         </div>
                                         <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
-                                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
+                                            <div class="d-flex gap-2 flex-wrap flex-md-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -1114,7 +1114,7 @@
                                                 </div>
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
-                                                    <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+                                                    <button type="button" class="btn btn-outline-primary text-nowrap" data-remarks-time="last-month" aria-pressed="false">Last month</button>
                                                 </div>
                                             </div>
                                             @if (Model.RemarksPanel.ShowDeletedToggle)


### PR DESCRIPTION
## Summary
- keep the remarks filter groups on a single row on wider layouts while allowing them to wrap on narrow viewports to avoid overflow
- ensure the "Last month" filter label stays on one line for consistent button sizing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfaf7841008329bf2ccc131bf7b636