### PR TITLE
Adjust remarks filter toolbar responsiveness

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1106,7 +1106,7 @@
                                             </div>
                                         </div>
                                         <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
-                                            <div class="d-flex gap-2 flex-wrap flex-md-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
+                                            <div class="d-flex gap-2 flex-wrap flex-md-nowrap justify-content-between flex-grow-1" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>


### PR DESCRIPTION
## Summary
- allow the remarks filter toolbar to flex by replacing the fixed width utility with a flex-grow class
- keeps the Show deleted toggle aligned within the header on larger breakpoints

## Testing
- dotnet run *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb7ecdee883299f6c0f6cffbb6bce