### PR TITLE
Allow remarks filters to wrap on medium screens

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1106,7 +1106,7 @@
                                             </div>
                                         </div>
                                         <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
-                                            <div class="d-flex gap-2 flex-wrap flex-md-nowrap justify-content-between flex-grow-1" role="toolbar" aria-label="Filter remarks">
+                                            <div class="d-flex gap-2 flex-wrap flex-lg-nowrap justify-content-between flex-grow-1" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>


### PR DESCRIPTION
## Summary
- relax the remarks filter toolbar to allow wrapping at medium breakpoints so buttons no longer overflow narrow cards

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfb9bad640832981d412f0b6d1dd34