### PR TITLE
Fix remarks panel warnings

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1120,7 +1120,7 @@
                                             @if (Model.RemarksPanel.ShowDeletedToggle)
                                             {
                                                 <div class="form-check form-switch ms-sm-2 ms-lg-3 flex-shrink-0">
-                                                    <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
+                                                    <input class="form-check-input" type="checkbox" id="remarks-include-deleted" data-remarks-include-deleted>
                                                     <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
                                                 </div>
                                             }

--- a/Pages/Projects/Remarks/Index.cshtml.cs
+++ b/Pages/Projects/Remarks/Index.cshtml.cs
@@ -35,8 +35,8 @@ namespace ProjectManagement.Pages.Projects.Remarks
 
         public int InitialPage { get; private set; } = 1;
 
-        [BindProperty(SupportsGet = true)]
-        public int Page { get; set; } = 1;
+        [BindProperty(Name = "page", SupportsGet = true)]
+        public int PageNumber { get; set; } = 1;
 
         public async Task<IActionResult> OnGetAsync(int projectId, CancellationToken ct)
         {
@@ -64,7 +64,7 @@ namespace ProjectManagement.Pages.Projects.Remarks
 
             RemarksPanel = await _remarksPanelService.BuildAsync(project, Stages, User, ct);
 
-            InitialPage = Page > 0 ? Page : 1;
+            InitialPage = PageNumber > 0 ? PageNumber : 1;
 
             return Page();
         }


### PR DESCRIPTION
## Summary
- remove the invalid ARIA role attribute from the remarks include deleted switch markup
- rename the bound page number property to avoid hiding base members while preserving query string binding

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc5495e788329a7ed17f62dc60b52