### PR TITLE
Wrap remarks filters with project panel container

### DIFF
--- a/Pages/Projects/Remarks/Index.cshtml
+++ b/Pages/Projects/Remarks/Index.cshtml
@@ -30,102 +30,104 @@
 
     <div class="card">
         <div class="card-body">
-            <div class="d-flex flex-column gap-3 mb-4">
-                <div class="d-flex flex-wrap align-items-center gap-3 justify-content-between">
-                    <div class="pm-card-heading">
-                        <span class="pm-card-icon" aria-hidden="true">
-                            <i class="bi bi-chat-dots"></i>
-                        </span>
-                        <div>
-                            <h2 class="pm-card-title h5 mb-0">Remarks</h2>
-                            <p class="pm-card-subtitle mb-0">Review the full remark history for this project.</p>
-                        </div>
-                    </div>
-                    <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
-                        <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between" role="toolbar" aria-label="Filter remarks">
-                            <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
-                                <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
-                                <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
-                                <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
-                            </div>
-                            <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
-                                <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
-                                <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+            <div data-panel-project-id="@Model.Project!.Id">
+                <div class="d-flex flex-column gap-3 mb-4">
+                    <div class="d-flex flex-wrap align-items-center gap-3 justify-content-between">
+                        <div class="pm-card-heading">
+                            <span class="pm-card-icon" aria-hidden="true">
+                                <i class="bi bi-chat-dots"></i>
+                            </span>
+                            <div>
+                                <h2 class="pm-card-title h5 mb-0">Remarks</h2>
+                                <p class="pm-card-subtitle mb-0">Review the full remark history for this project.</p>
                             </div>
                         </div>
-                        @if (Model.RemarksPanel.ShowDeletedToggle)
-                        {
-                            <div class="form-check form-switch ms-lg-3">
-                                <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
-                                <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
+                        <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
+                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between" role="toolbar" aria-label="Filter remarks">
+                                <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
+                                    <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
+                                    <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
+                                    <button type="button" class="btn btn-outline-primary" data-remarks-type="External" aria-pressed="false">External</button>
+                                </div>
+                                <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by time" data-remarks-time-group>
+                                    <button type="button" class="btn btn-outline-primary active" data-remarks-time="all" aria-pressed="true">All</button>
+                                    <button type="button" class="btn btn-outline-primary" data-remarks-time="last-month" aria-pressed="false">Last month</button>
+                                </div>
                             </div>
-                        }
+                            @if (Model.RemarksPanel.ShowDeletedToggle)
+                            {
+                                <div class="form-check form-switch ms-lg-3">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
+                                    <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
+                                </div>
+                            }
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="remarks-panel" data-remarks-panel data-config='@remarksConfigJson' data-initial-page="@Model.InitialPage">
-                @if (Model.RemarksPanel.ShowComposer)
-                {
-                    <form class="remarks-composer" data-remarks-composer>
-                        @Html.AntiForgeryToken()
-                        <div class="d-flex flex-column gap-3">
-                            <div>
-                                <label for="remark-body" class="form-label fw-semibold mb-1">Add a remark</label>
-                                <textarea id="remark-body" class="form-control" rows="3" maxlength="4000" data-remarks-body required></textarea>
-                                <div class="form-text">Maximum 4000 characters.</div>
-                                @if (!string.IsNullOrWhiteSpace(Model.RemarksPanel.ActorDisplayName))
-                                {
-                                    <div class="small text-muted mt-1">Posting as @Model.RemarksPanel.ActorDisplayName</div>
-                                }
-                            </div>
-                            <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
-                                <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
-                                    <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
-                                    @if (Model.RemarksPanel.AllowExternal)
+                <div class="remarks-panel" data-remarks-panel data-config='@remarksConfigJson' data-initial-page="@Model.InitialPage">
+                    @if (Model.RemarksPanel.ShowComposer)
+                    {
+                        <form class="remarks-composer" data-remarks-composer>
+                            @Html.AntiForgeryToken()
+                            <div class="d-flex flex-column gap-3">
+                                <div>
+                                    <label for="remark-body" class="form-label fw-semibold mb-1">Add a remark</label>
+                                    <textarea id="remark-body" class="form-control" rows="3" maxlength="4000" data-remarks-body required></textarea>
+                                    <div class="form-text">Maximum 4000 characters.</div>
+                                    @if (!string.IsNullOrWhiteSpace(Model.RemarksPanel.ActorDisplayName))
                                     {
-                                        <button type="button" class="btn btn-outline-secondary" data-remarks-composer-option="External" aria-pressed="false">External</button>
+                                        <div class="small text-muted mt-1">Posting as @Model.RemarksPanel.ActorDisplayName</div>
                                     }
                                 </div>
-                                <div class="remarks-composer-external d-flex flex-wrap align-items-end gap-2 d-none" data-remarks-external-fields>
-                                    <div>
-                                        <label for="remark-event-date" class="form-label mb-1 small">Event date</label>
-                                        <input type="date" id="remark-event-date" class="form-control form-control-sm" data-remarks-event-date value="@Model.RemarksPanel.Today" max="@Model.RemarksPanel.Today" />
+                                <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                    <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
+                                        <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
+                                        @if (Model.RemarksPanel.AllowExternal)
+                                        {
+                                            <button type="button" class="btn btn-outline-secondary" data-remarks-composer-option="External" aria-pressed="false">External</button>
+                                        }
                                     </div>
-                                    <div>
-                                        <label for="remark-stage" class="form-label mb-1 small">Stage <span class="text-muted">(optional)</span></label>
-                                        <select id="remark-stage" class="form-select form-select-sm" data-remarks-stage>
-                                            <option value="">Not linked</option>
-                                            @foreach (var stage in Model.RemarksPanel.StageOptions)
-                                            {
-                                                <option value="@stage.Value">@stage.Label</option>
-                                            }
-                                        </select>
+                                    <div class="remarks-composer-external d-flex flex-wrap align-items-end gap-2 d-none" data-remarks-external-fields>
+                                        <div>
+                                            <label for="remark-event-date" class="form-label mb-1 small">Event date</label>
+                                            <input type="date" id="remark-event-date" class="form-control form-control-sm" data-remarks-event-date value="@Model.RemarksPanel.Today" max="@Model.RemarksPanel.Today" />
+                                        </div>
+                                        <div>
+                                            <label for="remark-stage" class="form-label mb-1 small">Stage <span class="text-muted">(optional)</span></label>
+                                            <select id="remark-stage" class="form-select form-select-sm" data-remarks-stage>
+                                                <option value="">Not linked</option>
+                                                @foreach (var stage in Model.RemarksPanel.StageOptions)
+                                                {
+                                                    <option value="@stage.Value">@stage.Label</option>
+                                                }
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="d-flex flex-column flex-sm-row gap-2 align-items-sm-center justify-content-between">
+                                    <div class="small" data-remarks-feedback></div>
+                                    <div class="d-flex gap-2 ms-sm-auto">
+                                        <button type="reset" class="btn btn-sm btn-outline-secondary" data-remarks-reset>Clear</button>
+                                        <button type="submit" class="btn btn-primary btn-sm" data-remarks-submit>Post remark</button>
                                     </div>
                                 </div>
                             </div>
-                            <div class="d-flex flex-column flex-sm-row gap-2 align-items-sm-center justify-content-between">
-                                <div class="small" data-remarks-feedback></div>
-                                <div class="d-flex gap-2 ms-sm-auto">
-                                    <button type="reset" class="btn btn-sm btn-outline-secondary" data-remarks-reset>Clear</button>
-                                    <button type="submit" class="btn btn-primary btn-sm" data-remarks-submit>Post remark</button>
-                                </div>
-                            </div>
+                        </form>
+                    }
+                    else
+                    {
+                        <div class="alert alert-info border-info-subtle bg-info-subtle text-dark" role="status">
+                            Remarks can only be posted by the assigned project team and leadership.
                         </div>
-                    </form>
-                }
-                else
-                {
-                    <div class="alert alert-info border-info-subtle bg-info-subtle text-dark" role="status">
-                        Remarks can only be posted by the assigned project team and leadership.
-                    </div>
-                }
+                    }
 
-                <div class="remarks-list" data-remarks-list>
-                    <div class="text-muted" data-remarks-empty>Loading remarks…</div>
-                    <div class="vstack gap-3" data-remarks-items></div>
+                    <div class="remarks-list" data-remarks-list>
+                        <div class="text-muted" data-remarks-empty>Loading remarks…</div>
+                        <div class="vstack gap-3" data-remarks-items></div>
+                    </div>
+                    <nav class="d-flex justify-content-center mt-3" aria-label="Remarks pagination" data-remarks-pagination></nav>
                 </div>
-                <nav class="d-flex justify-content-center mt-3" aria-label="Remarks pagination" data-remarks-pagination></nav>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap the remarks filter toolbar and panel in a shared container with the project ID data attribute
- keep the filter buttons within the new container so the remarks panel script can locate them

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfc76cdf088329b5131aaa53321dfd