### PR TITLE
Fix media queries in process view styles

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -240,7 +240,7 @@
             font-size: 0.85rem;
         }
 
-        @media (max-width: 1200px) {
+        @@media (max-width: 1200px) {
             .process-layout {
                 grid-template-columns: 1fr;
             }
@@ -255,7 +255,7 @@
             }
         }
 
-        @media (max-width: 576px) {
+        @@media (max-width: 576px) {
             .flow-track {
                 gap: 1rem;
             }


### PR DESCRIPTION
## Summary
- escape CSS media queries in Pages/Process/Index.cshtml so Razor renders them correctly
- ensure the Styles and Scripts sections remain properly closed

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc92810548329b5aa30cd7a6ae1a5