### PR TITLE
Load procurement stage data from embedded JSON script

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -268,9 +268,21 @@
 }
 
 @section Scripts {
+    <script id="procurementStagesData" type="application/json">@Html.Raw(serializedStages)</script>
     <script>
         (() => {
-            const stages = @Html.Raw(serializedStages);
+            const stagesDataEl = document.getElementById('procurementStagesData');
+            if (!stagesDataEl) {
+                return;
+            }
+
+            let stages = [];
+            try {
+                stages = JSON.parse(stagesDataEl.textContent ?? '[]');
+            } catch (error) {
+                console.error('Failed to parse procurement stages data.', error);
+                return;
+            }
             const stageButtons = Array.from(document.querySelectorAll('.stage-node'));
             const titleEl = document.getElementById('stageTitle');
             const subtitleEl = document.getElementById('stageSubtitle');


### PR DESCRIPTION
## Summary
- embed the serialized procurement stage data in a dedicated JSON script tag
- parse and validate the stage data before using it in the interactive script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfca169980832999611bc997e4f16d