### PR TITLE
Add stage checklist templates and APIs

### DIFF
--- a/Contracts/Stages/StageChecklistContracts.cs
+++ b/Contracts/Stages/StageChecklistContracts.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.Contracts.Stages;
+
+public record StageChecklistTemplateDto(
+    int Id,
+    string Version,
+    string StageCode,
+    string? UpdatedByUserId,
+    DateTimeOffset? UpdatedOn,
+    byte[] RowVersion,
+    IReadOnlyList<StageChecklistItemDto> Items);
+
+public record StageChecklistItemDto(
+    int Id,
+    string Text,
+    int Sequence,
+    byte[] RowVersion,
+    string? UpdatedByUserId,
+    DateTimeOffset? UpdatedOn);
+
+public record StageChecklistItemCreateRequest(
+    string Text,
+    byte[] TemplateRowVersion,
+    int? Sequence = null);
+
+public record StageChecklistItemUpdateRequest(
+    string Text,
+    byte[] TemplateRowVersion,
+    byte[] ItemRowVersion);
+
+public record StageChecklistItemDeleteRequest(
+    byte[] TemplateRowVersion,
+    byte[] ItemRowVersion);
+
+public record StageChecklistReorderRequest(
+    byte[] TemplateRowVersion,
+    IReadOnlyList<StageChecklistReorderItem> Items);
+
+public record StageChecklistReorderItem(
+    int ItemId,
+    int Sequence,
+    byte[] RowVersion);

--- a/Migrations/20251003143218_AddStageChecklistTemplates.Designer.cs
+++ b/Migrations/20251003143218_AddStageChecklistTemplates.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251003143218_AddStageChecklistTemplates")]
+    partial class AddStageChecklistTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251003143218_AddStageChecklistTemplates.cs
+++ b/Migrations/20251003143218_AddStageChecklistTemplates.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStageChecklistTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "AttemptCount",
+                table: "NotificationDispatches",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.CreateTable(
+                name: "StageChecklistTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Version = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    StageCode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    UpdatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    UpdatedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StageChecklistTemplates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StageChecklistTemplates_AspNetUsers_UpdatedByUserId",
+                        column: x => x.UpdatedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StageChecklistItemTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TemplateId = table.Column<int>(type: "integer", nullable: false),
+                    Text = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Sequence = table.Column<int>(type: "integer", nullable: false),
+                    UpdatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    UpdatedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StageChecklistItemTemplates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StageChecklistItemTemplates_AspNetUsers_UpdatedByUserId",
+                        column: x => x.UpdatedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_StageChecklistItemTemplates_StageChecklistTemplates_Templat~",
+                        column: x => x.TemplateId,
+                        principalTable: "StageChecklistTemplates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StageChecklistAudits",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TemplateId = table.Column<int>(type: "integer", nullable: false),
+                    ItemId = table.Column<int>(type: "integer", nullable: true),
+                    Action = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    PayloadJson = table.Column<string>(type: "jsonb", nullable: true),
+                    PerformedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    PerformedOn = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StageChecklistAudits", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StageChecklistAudits_StageChecklistItemTemplates_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "StageChecklistItemTemplates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_StageChecklistAudits_StageChecklistTemplates_TemplateId",
+                        column: x => x.TemplateId,
+                        principalTable: "StageChecklistTemplates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistAudits_ItemId",
+                table: "StageChecklistAudits",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistAudits_TemplateId",
+                table: "StageChecklistAudits",
+                column: "TemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistItemTemplates_TemplateId_Sequence",
+                table: "StageChecklistItemTemplates",
+                columns: new[] { "TemplateId", "Sequence" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistItemTemplates_UpdatedByUserId",
+                table: "StageChecklistItemTemplates",
+                column: "UpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistTemplates_UpdatedByUserId",
+                table: "StageChecklistTemplates",
+                column: "UpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StageChecklistTemplates_Version_StageCode",
+                table: "StageChecklistTemplates",
+                columns: new[] { "Version", "StageCode" },
+                unique: true);
+
+            migrationBuilder.Sql(@"
+                INSERT INTO ""StageChecklistTemplates"" (""Version"", ""StageCode"", ""UpdatedOn"", ""RowVersion"")
+                SELECT DISTINCT st.""Version"", st.""Code"", now() at time zone 'utc',
+                       decode(md5(random()::text || clock_timestamp()::text), 'hex')
+                FROM ""StageTemplates"" st
+                ON CONFLICT (""Version"", ""StageCode"") DO NOTHING;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StageChecklistAudits");
+
+            migrationBuilder.DropTable(
+                name: "StageChecklistItemTemplates");
+
+            migrationBuilder.DropTable(
+                name: "StageChecklistTemplates");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AttemptCount",
+                table: "NotificationDispatches",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 0);
+        }
+    }
+}

--- a/Models/Stages/StageChecklistTemplate.cs
+++ b/Models/Stages/StageChecklistTemplate.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Models.Stages;
+
+public class StageChecklistTemplate
+{
+    public int Id { get; set; }
+
+    [MaxLength(32)]
+    public string Version { get; set; } = "SDD-1.0";
+
+    [MaxLength(16)]
+    public string StageCode { get; set; } = string.Empty;
+
+    [MaxLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    public ApplicationUser? UpdatedByUser { get; set; }
+
+    public DateTimeOffset? UpdatedOn { get; set; }
+
+    public List<StageChecklistItemTemplate> Items { get; set; } = new();
+
+    public List<StageChecklistAudit> AuditEntries { get; set; } = new();
+
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+}
+
+public class StageChecklistItemTemplate
+{
+    public int Id { get; set; }
+
+    public int TemplateId { get; set; }
+
+    public StageChecklistTemplate? Template { get; set; }
+
+    [MaxLength(512)]
+    public string Text { get; set; } = string.Empty;
+
+    public int Sequence { get; set; }
+
+    [MaxLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    public ApplicationUser? UpdatedByUser { get; set; }
+
+    public DateTimeOffset? UpdatedOn { get; set; }
+
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+}
+
+public class StageChecklistAudit
+{
+    public int Id { get; set; }
+
+    public int TemplateId { get; set; }
+
+    public StageChecklistTemplate? Template { get; set; }
+
+    public int? ItemId { get; set; }
+
+    public StageChecklistItemTemplate? Item { get; set; }
+
+    [MaxLength(32)]
+    public string Action { get; set; } = string.Empty;
+
+    public string? PayloadJson { get; set; }
+
+    [MaxLength(450)]
+    public string? PerformedByUserId { get; set; }
+
+    public DateTimeOffset PerformedOn { get; set; }
+}


### PR DESCRIPTION
## Summary
- add EF Core models/DbSets for stage checklist templates, items, and audits
- expose checklist DTOs and minimal APIs secured with new checklist policies and concurrency checks
- create a migration to add the checklist tables, seed existing stage/version pairs, and register supporting services

## Testing
- dotnet build ProjectManagement.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfda894d5883299d1b79f034c1b120