### PR TITLE
Fix Razor CSS media queries for process page

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -265,13 +265,13 @@
             color: var(--bs-secondary-color);
         }
 
-        @media (max-width: 991.98px) {
+        @@media (max-width: 991.98px) {
             .process-flow-canvas {
                 min-height: 380px;
             }
         }
 
-        @media (max-width: 575.98px) {
+        @@media (max-width: 575.98px) {
             .process-flow-canvas {
                 min-height: 320px;
             }


### PR DESCRIPTION
## Summary
- escape Razor literal `@` characters in the process page CSS media queries so they render correctly

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe76ce12483298b2067322645c0d3