### PR TITLE
Make process checklist card sticky with scrollable content

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -48,49 +48,51 @@
             </div>
         </div>
         <div class="col-12 col-lg-5 col-xl-4 d-none d-lg-block">
-            <div class="card h-100 shadow-sm" data-checklist-panel>
+            <div class="card pm-card h-100 shadow-sm sticky-lg-top process-stage-info" data-checklist-panel>
                 <div class="card-body">
-                    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-start gap-3 mb-4">
-                        <div>
-                            <h2 class="h4 mb-1" data-stage-title aria-live="polite">Select a stage</h2>
-                            <p class="text-muted mb-0" data-stage-subtitle>Choose a stage on the diagram to see its checklist.</p>
+                    <div class="process-stage-info__body">
+                        <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-start gap-3 mb-4">
+                            <div>
+                                <h2 class="h4 mb-1" data-stage-title aria-live="polite">Select a stage</h2>
+                                <p class="text-muted mb-0" data-stage-subtitle>Choose a stage on the diagram to see its checklist.</p>
+                            </div>
+                            <span class="badge rounded-pill bg-info-subtle text-info-emphasis d-inline-flex align-items-center gap-2" data-stage-optional hidden>
+                                <i class="bi bi-stars"></i>
+                                Optional stage
+                            </span>
                         </div>
-                        <span class="badge rounded-pill bg-info-subtle text-info-emphasis d-inline-flex align-items-center gap-2" data-stage-optional hidden>
-                            <i class="bi bi-stars"></i>
-                            Optional stage
-                        </span>
+
+                        <dl class="row g-3 process-stage-meta mb-0">
+                            <div class="col-12 col-sm-4">
+                                <dt class="text-uppercase text-muted small">Code</dt>
+                                <dd class="h6 mb-0" data-stage-code>—</dd>
+                            </div>
+                            <div class="col-12 col-sm-4">
+                                <dt class="text-uppercase text-muted small">Parallel group</dt>
+                                <dd class="h6 mb-0" data-stage-parallel>—</dd>
+                            </div>
+                            <div class="col-12 col-sm-4">
+                                <dt class="text-uppercase text-muted small">Depends on</dt>
+                                <dd class="mb-0" data-stage-dependencies>
+                                    <span class="text-muted">—</span>
+                                </dd>
+                            </div>
+                        </dl>
+
+                        <hr class="my-4" />
+
+                        <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+                            <h3 class="h5 mb-0">Stage checklist</h3>
+                            <div class="btn-group" data-checklist-actions hidden>
+                                <button type="button" class="btn btn-outline-primary btn-sm" data-action="add-item">
+                                    <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>
+                                    Add item
+                                </button>
+                            </div>
+                        </div>
+
+                        <ol class="stage-checklist" data-checklist-list data-checklist-primary aria-live="polite" aria-busy="false"></ol>
                     </div>
-
-                    <dl class="row g-3 process-stage-meta mb-0">
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Code</dt>
-                            <dd class="h6 mb-0" data-stage-code>—</dd>
-                        </div>
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Parallel group</dt>
-                            <dd class="h6 mb-0" data-stage-parallel>—</dd>
-                        </div>
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Depends on</dt>
-                            <dd class="mb-0" data-stage-dependencies>
-                                <span class="text-muted">—</span>
-                            </dd>
-                        </div>
-                    </dl>
-
-                    <hr class="my-4" />
-
-                    <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
-                        <h3 class="h5 mb-0">Stage checklist</h3>
-                        <div class="btn-group" data-checklist-actions hidden>
-                            <button type="button" class="btn btn-outline-primary btn-sm" data-action="add-item">
-                                <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>
-                                Add item
-                            </button>
-                        </div>
-                    </div>
-
-                    <ol class="stage-checklist" data-checklist-list data-checklist-primary aria-live="polite" aria-busy="false"></ol>
                 </div>
             </div>
         </div>
@@ -207,13 +209,24 @@
         }
 
         .process-flow-canvas {
-            min-height: 460px;
+            height: 520px;
             position: relative;
         }
 
         .process-flow-canvas canvas,
         .process-flow-canvas svg {
             border-radius: 1rem;
+        }
+
+        .process-stage-info {
+            --process-stage-sticky-offset: 1.5rem;
+            --process-stage-info-chrome: 6rem; /* accounts for header spacing and card padding */
+            top: var(--process-stage-sticky-offset);
+        }
+
+        .process-stage-info__body {
+            max-height: calc(100vh - (var(--process-stage-sticky-offset) + var(--process-stage-info-chrome)));
+            overflow: auto;
         }
 
         .process-stage-meta dt {
@@ -267,13 +280,18 @@
 
         @@media (max-width: 991.98px) {
             .process-flow-canvas {
-                min-height: 380px;
+                height: 420px;
+            }
+
+            .process-stage-info__body {
+                max-height: none;
+                overflow: visible;
             }
         }
 
         @@media (max-width: 575.98px) {
             .process-flow-canvas {
-                min-height: 320px;
+                height: 320px;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- make the desktop checklist card sticky and add a wrapper for scrollable checklist content
- set a fixed height for the flow canvas and apply a viewport-based max height to the checklist body
- remove the height cap on smaller screens so the panel flows normally on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff00ae7008329af90ee417f6c12a0