### PR TITLE
Fix top-level statement ordering error

### DIFF
--- a/Contracts/ProcessChecklistRequest.cs
+++ b/Contracts/ProcessChecklistRequest.cs
@@ -1,0 +1,3 @@
+namespace ProjectManagement.Contracts;
+
+public record ProcessChecklistRequest(string Text, int? SortOrder);

--- a/Program.cs
+++ b/Program.cs
@@ -905,8 +905,6 @@ using (var scope = app.Services.CreateScope())
     await ProjectManagement.Data.IdentitySeeder.SeedAsync(services);
 }
 
-public record ProcessChecklistRequest(string Text, int? SortOrder);
-
 static string BuildConnectSrcDirective(IConfiguration configuration)
 {
     var sources = configuration


### PR DESCRIPTION
## Summary
- move the `ProcessChecklistRequest` record into a dedicated contract file so top-level statements remain valid

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01ebc11648329a975e6ad34fb582e