### PR TITLE
Update stage dependencies and handle optional PNC path

### DIFF
--- a/Services/Stages/StageDependencies.cs
+++ b/Services/Stages/StageDependencies.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ProjectManagement.Models.Stages;
 
 namespace ProjectManagement.Services;
@@ -12,10 +13,13 @@ public static class StageDependencies
             [StageCodes.IPA] = new[] { StageCodes.FS },
             [StageCodes.SOW] = new[] { StageCodes.IPA },
             [StageCodes.AON] = new[] { StageCodes.SOW },
-            [StageCodes.BM] = new[] { StageCodes.AON },
-            [StageCodes.COB] = new[] { StageCodes.BM },
+            [StageCodes.BID] = new[] { StageCodes.AON },
+            [StageCodes.TEC] = new[] { StageCodes.BID },
+            [StageCodes.BM] = new[] { StageCodes.BID },
+            [StageCodes.COB] = new[] { StageCodes.TEC, StageCodes.BM },
             [StageCodes.PNC] = new[] { StageCodes.COB },
-            [StageCodes.SO] = new[] { StageCodes.PNC },
+            [StageCodes.EAS] = new[] { StageCodes.COB, StageCodes.PNC },
+            [StageCodes.SO] = new[] { StageCodes.EAS },
             [StageCodes.DEVP] = new[] { StageCodes.SO },
             [StageCodes.ATP] = new[] { StageCodes.DEVP },
             [StageCodes.PAYMENT] = new[] { StageCodes.ATP }
@@ -23,4 +27,20 @@ public static class StageDependencies
 
     public static IReadOnlyList<string> RequiredPredecessors(string stageCode)
         => Required.TryGetValue(stageCode, out var deps) ? deps : Array.Empty<string>();
+
+    public static IReadOnlyList<string> RequiredPredecessors(string stageCode, bool pncApplicable)
+    {
+        var required = RequiredPredecessors(stageCode);
+
+        if (pncApplicable || required.Count == 0)
+        {
+            return required;
+        }
+
+        var filtered = required
+            .Where(code => !string.Equals(code, StageCodes.PNC, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        return filtered.Length == required.Count ? required : filtered;
+    }
 }

--- a/Services/Stages/StageValidationService.cs
+++ b/Services/Stages/StageValidationService.cs
@@ -122,9 +122,7 @@ public sealed class StageValidationService : IStageValidationService
         if (desiredStatus is StageStatus.InProgress or StageStatus.Completed)
         {
             var pncApplicable = await ResolvePncApplicabilityAsync(projectId, ct);
-            var predecessors = StageDependencies.RequiredPredecessors(stage.StageCode)
-                .Where(code => pncApplicable || !string.Equals(code, StageCodes.PNC, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            var predecessors = StageDependencies.RequiredPredecessors(stage.StageCode, pncApplicable);
 
             if (predecessors.Count > 0)
             {


### PR DESCRIPTION
## Summary
- align the in-memory stage dependency map with the seeded template ordering, including Bid, TEC, COB, EAS, and downstream stages
- ensure validation, decision, and progress services respect optional PNC applicability when evaluating predecessors and auto actions
- expand unit coverage for the optional PNC branch to guard stage validation, decision approval, and progress cascades

## Testing
- dotnet test *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0227ac8a08329a58aa5428c1c6542