### PR TITLE
Simplify process checklist display

### DIFF
--- a/wwwroot/css/process/flow.css
+++ b/wwwroot/css/process/flow.css
@@ -95,7 +95,21 @@
 
 .proc-checklist-list .pci-actions {
   display: flex;
-  gap: .5rem;
+  align-items: center;
+  gap: .35rem;
+}
+
+.proc-checklist-list .pci-action-btn {
+  inline-size: 2.25rem;
+  block-size: 2.25rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.proc-checklist-list .pci-action-btn .bi {
+  font-size: 1rem;
 }
 
 @media (max-width: 767px) {

--- a/wwwroot/js/process/flow.js
+++ b/wwwroot/js/process/flow.js
@@ -146,18 +146,6 @@ const ready = () => {
     }[char] ?? char));
   }
 
-  function formatWhen(value) {
-    if (!value) {
-      return '';
-    }
-
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-      return '';
-    }
-    return date.toLocaleString();
-  }
-
   async function fetchChecklist(stageId) {
     const response = await fetch(`/process/stages/${stageId}/checklist`, {
       credentials: 'same-origin',
@@ -187,25 +175,13 @@ const ready = () => {
 
       const textWrapper = document.createElement('div');
       textWrapper.innerHTML = `<div class="fw-semibold">${index + 1}. ${escapeHtml(item.text)}</div>`;
-      const meta = document.createElement('div');
-      meta.className = 'small text-muted';
-      const updated = formatWhen(item.updatedOnUtc);
-      const who = item.updatedBy ? escapeHtml(item.updatedBy) : '';
-      if (updated && who) {
-        meta.textContent = `Updated ${updated} — ${who}`;
-      } else if (updated) {
-        meta.textContent = `Updated ${updated}`;
-      } else if (who) {
-        meta.textContent = who;
-      }
-      textWrapper.appendChild(meta);
       row.appendChild(textWrapper);
 
       if (canEdit) {
         const actions = document.createElement('div');
         actions.className = 'pci-actions';
-        actions.appendChild(makeButton('Edit', 'btn btn-outline-secondary btn-sm', () => editItem(item)));
-        actions.appendChild(makeButton('Delete', 'btn btn-outline-danger btn-sm', () => deleteItem(item)));
+        actions.appendChild(makeButton('Edit checklist item', 'bi-pencil', 'btn btn-outline-secondary btn-sm', () => editItem(item)));
+        actions.appendChild(makeButton('Delete checklist item', 'bi-trash', 'btn btn-outline-danger btn-sm', () => deleteItem(item)));
         row.appendChild(actions);
       }
 
@@ -238,11 +214,13 @@ const ready = () => {
     offcanvas.show();
   }
 
-  function makeButton(label, className, action) {
+  function makeButton(label, iconClass, className, action) {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = className;
-    button.textContent = label;
+    button.className = `${className} pci-action-btn`;
+    button.setAttribute('aria-label', label);
+    button.setAttribute('title', label);
+    button.innerHTML = `<i class="bi ${iconClass}" aria-hidden="true"></i><span class="visually-hidden">${label}</span>`;
     button.addEventListener('click', action);
     return button;
   }


### PR DESCRIPTION
## Summary
- remove the metadata text from procurement process checklist items so only the item body is shown
- replace the checklist action buttons with compact icon-only buttons and supporting styling adjustments

## Testing
- not run (environment does not include the .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e0234c643c83298451b7391187088d