### PR TITLE
Refine process checklist layout

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -50,56 +50,6 @@
             </div>
         </div>
     </div>
-
-    <aside class="proc-panel">
-        <div class="card pm-card shadow-sm sticky-lg-top process-stage-info" data-checklist-panel>
-            <div class="card-body">
-                <div class="process-stage-info__body">
-                    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-start gap-3 mb-4">
-                        <div>
-                            <h2 class="h4 mb-1" data-stage-title aria-live="polite">Select a stage</h2>
-                            <p class="text-muted mb-0" data-stage-subtitle>Choose a stage on the diagram to see its checklist.</p>
-                        </div>
-                        <span class="badge rounded-pill bg-info-subtle text-info-emphasis d-inline-flex align-items-center gap-2" data-stage-optional hidden>
-                            <i class="bi bi-stars"></i>
-                            Optional stage
-                        </span>
-                    </div>
-
-                    <dl class="row g-3 process-stage-meta mb-0">
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Code</dt>
-                            <dd class="h6 mb-0" data-stage-code>—</dd>
-                        </div>
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Parallel group</dt>
-                            <dd class="h6 mb-0" data-stage-parallel>—</dd>
-                        </div>
-                        <div class="col-12 col-sm-4">
-                            <dt class="text-uppercase text-muted small">Depends on</dt>
-                            <dd class="mb-0" data-stage-dependencies>
-                                <span class="text-muted">—</span>
-                            </dd>
-                        </div>
-                    </dl>
-
-                    <hr class="my-4" />
-
-                    <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
-                        <h3 class="h5 mb-0">Stage checklist</h3>
-                        <div class="btn-group" data-checklist-actions hidden>
-                            <button type="button" class="btn btn-outline-primary btn-sm" data-action="add-item">
-                                <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>
-                                Add item
-                            </button>
-                        </div>
-                    </div>
-
-                    <ol class="stage-checklist" data-checklist-list data-checklist-primary aria-live="polite" aria-busy="false"></ol>
-                </div>
-            </div>
-        </div>
-    </aside>
 </div>
 
 <div class="offcanvas offcanvas-end" tabindex="-1" id="checklistOffcanvas" aria-labelledby="checklistOffcanvasLabel">
@@ -142,7 +92,7 @@
                     </button>
                 </div>
             </div>
-            <ol class="stage-checklist flex-grow-1" data-checklist-list aria-live="polite" aria-busy="false"></ol>
+            <ol class="stage-checklist flex-grow-1" data-checklist-list data-checklist-primary aria-live="polite" aria-busy="false"></ol>
         </div>
     </div>
 </div>

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -5,16 +5,9 @@
 }
 
 .process-layout {
-  display: grid;
-  grid-template-columns: minmax(520px, 1fr) 360px;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
-  align-items: start;
-}
-
-.proc-diagram {
-  --process-bg: var(--bs-body-bg);
-  --process-border: var(--bs-border-color);
-  border-radius: 1rem;
 }
 
 .proc-diagram .card-body {
@@ -27,9 +20,9 @@
   position: relative;
   min-height: 520px;
   height: clamp(520px, 70vh, 820px);
-  border: 1px solid var(--process-border);
+  border: 1px solid var(--bs-border-color);
   border-radius: 0.75rem;
-  background: var(--process-bg);
+  background: var(--bs-body-bg);
   overflow: auto;
   padding: 1.5rem;
 }
@@ -129,26 +122,6 @@
   fill: var(--bs-body-color);
   letter-spacing: 0.01em;
   pointer-events: none;
-}
-
-.proc-panel .process-stage-info {
-  --process-stage-sticky-offset: 1.5rem;
-  top: var(--process-stage-sticky-offset);
-  max-height: calc(100vh - var(--process-stage-sticky-offset));
-  display: flex;
-  flex-direction: column;
-}
-
-.process-stage-info .card-body {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.process-stage-info__body {
-  overflow-y: auto;
-  max-height: calc(100vh - 6rem);
-  padding-right: 0.25rem;
 }
 
 .process-stage-meta dt {

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -15,7 +15,7 @@ if (root) {
   const stageDependenciesEls = Array.from(document.querySelectorAll('[data-stage-dependencies]'));
   const optionalBadgeEls = Array.from(document.querySelectorAll('[data-stage-optional]'));
   const checklistLists = Array.from(document.querySelectorAll('[data-checklist-list]'));
-  const primaryChecklist = root.querySelector('[data-checklist-primary]');
+  const primaryChecklist = document.querySelector('[data-checklist-primary]');
   const actionGroups = Array.from(document.querySelectorAll('[data-checklist-actions]'));
   const itemModalEl = document.getElementById('checklistItemModal');
   const deleteModalEl = document.getElementById('checklistDeleteModal');
@@ -23,6 +23,8 @@ if (root) {
   const deleteForm = deleteModalEl ? deleteModalEl.querySelector('[data-checklist-delete-form]') : null;
   const itemModal = itemModalEl ? new bootstrap.Modal(itemModalEl) : null;
   const deleteModal = deleteModalEl ? new bootstrap.Modal(deleteModalEl) : null;
+  const checklistOffcanvasEl = document.getElementById('checklistOffcanvas');
+  const checklistOffcanvas = checklistOffcanvasEl ? bootstrap.Offcanvas.getOrCreateInstance(checklistOffcanvasEl) : null;
   const flowPlaceholderTemplate = (() => {
     if (!flowCanvas) {
       return null;
@@ -1105,6 +1107,9 @@ if (root) {
     }
 
     highlightStageOnGraph(stage.code);
+    if (checklistOffcanvas && checklistOffcanvasEl && !checklistOffcanvasEl.classList.contains('show')) {
+      checklistOffcanvas.show();
+    }
     loadChecklist(stage.code);
   }
 


### PR DESCRIPTION
## Summary
- remove the desktop checklist card so the flow diagram layout stands alone
- simplify the process layout styling to a single column with a full-width diagram canvas
- automatically open the checklist offcanvas when selecting a stage

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e07fe496b08329a7a27e12752774e9