### PR TITLE
Ensure optional flow styling applies only to PNC stage

### DIFF
--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -282,7 +282,7 @@ if (root) {
         name: node.name || node.label || node.code,
         sequence: Number.parseInt(node.sequence, 10) || 0,
         displayIndex: 0,
-        optional: Boolean(node.optional),
+        optional: node.optional === true || node.optional === 'true',
         parallelGroup: node.parallelGroup || null,
         dependsOn: Array.isArray(node.dependsOn) ? node.dependsOn.map((d) => String(d)) : []
       }))
@@ -897,9 +897,9 @@ if (root) {
       state.stageByCode.clear();
       flow.nodes.forEach((node) => {
         const stage = { ...node };
-        const isOptionalStage =
-          typeof stage.code === 'string' && stage.code.toUpperCase() === OPTIONAL_STAGE_CODE;
-        stage.optional = Boolean(stage.optional && isOptionalStage);
+        const normalizedCode =
+          typeof stage.code === 'string' ? stage.code.toUpperCase() : '';
+        stage.optional = normalizedCode === OPTIONAL_STAGE_CODE;
         node.optional = stage.optional;
         state.stageByCode.set(stage.code, stage);
       });


### PR DESCRIPTION
## Summary
- normalize flow nodes so the optional flag is only preserved when the API returns `true`
- force stage optional state to follow the PNC code rule during flow loading

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0856d98c88329b7bd3d3983f39aa7