### PR TITLE
Remove process stage metadata panel from checklist offcanvas

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -57,31 +57,7 @@
         <h2 class="h5 mb-0" id="checklistOffcanvasLabel" data-stage-title>Stage checklist</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close checklist panel"></button>
     </div>
-    <div class="offcanvas-body d-flex flex-column gap-4" data-checklist-panel>
-        <div>
-            <p class="text-muted mb-2" data-stage-subtitle>Choose a stage on the diagram to see its checklist.</p>
-            <dl class="row g-3 process-stage-meta small mb-0">
-                <div class="col-12 col-sm-4">
-                    <dt class="text-uppercase text-muted small">Code</dt>
-                    <dd class="fw-semibold mb-0" data-stage-code>—</dd>
-                </div>
-                <div class="col-12 col-sm-4">
-                    <dt class="text-uppercase text-muted small">Parallel group</dt>
-                    <dd class="fw-semibold mb-0" data-stage-parallel>—</dd>
-                </div>
-                <div class="col-12 col-sm-4">
-                    <dt class="text-uppercase text-muted small">Depends on</dt>
-                    <dd class="mb-0" data-stage-dependencies>
-                        <span class="text-muted">—</span>
-                    </dd>
-                </div>
-            </dl>
-            <span class="badge rounded-pill bg-info-subtle text-info-emphasis mt-3 d-inline-flex align-items-center gap-2" data-stage-optional hidden>
-                <i class="bi bi-stars"></i>
-                Optional stage
-            </span>
-        </div>
-
+    <div class="offcanvas-body d-flex flex-column" data-checklist-panel>
         <div class="flex-grow-1 d-flex flex-column">
             <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
                 <h3 class="h5 mb-0">Stage checklist</h3>

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -125,10 +125,6 @@
   pointer-events: none;
 }
 
-.process-stage-meta dt {
-  letter-spacing: 0.08em;
-}
-
 .stage-checklist {
   list-style: decimal inside;
   padding-left: 1.25rem;

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -9,11 +9,6 @@ if (root) {
   const canEdit = root.dataset.canEdit === 'true';
   const flowCanvas = root.querySelector('[data-flow-canvas]');
   const stageTitleEls = Array.from(document.querySelectorAll('[data-stage-title]'));
-  const stageSubtitleEls = Array.from(document.querySelectorAll('[data-stage-subtitle]'));
-  const stageCodeEls = Array.from(document.querySelectorAll('[data-stage-code]'));
-  const stageParallelEls = Array.from(document.querySelectorAll('[data-stage-parallel]'));
-  const stageDependenciesEls = Array.from(document.querySelectorAll('[data-stage-dependencies]'));
-  const optionalBadgeEls = Array.from(document.querySelectorAll('[data-stage-optional]'));
   const checklistLists = Array.from(document.querySelectorAll('[data-checklist-list]'));
   const primaryChecklist = document.querySelector('[data-checklist-primary]');
   const actionGroups = Array.from(document.querySelectorAll('[data-checklist-actions]'));
@@ -639,52 +634,18 @@ if (root) {
   function setStageDetails(stage) {
     if (!stage) {
       updateElements(stageTitleEls, 'Select a stage');
-      updateElements(stageSubtitleEls, 'Choose a stage on the diagram to see its checklist.');
-      updateElements(stageCodeEls, '—');
-      updateElements(stageParallelEls, '—');
-      updateDependencies([]);
-      optionalBadgeEls.forEach((el) => { el.hidden = true; });
       toggleActionGroups(false);
       return;
     }
 
     const title = `${stage.displayIndex}. ${stage.name}`;
     updateElements(stageTitleEls, title);
-    updateElements(stageSubtitleEls, 'Review the required activities before progressing to the next milestone.');
-    updateElements(stageCodeEls, stage.code);
-    updateElements(stageParallelEls, stage.parallelGroup || '—');
-    updateDependencies(stage.dependsOn || []);
-    optionalBadgeEls.forEach((el) => { el.hidden = !stage.optional; });
     toggleActionGroups(canEdit);
   }
 
   function updateElements(elements, text) {
     elements.forEach((el) => {
       el.textContent = text;
-    });
-  }
-
-  function updateDependencies(dependsOnCodes) {
-    const codes = Array.isArray(dependsOnCodes) ? dependsOnCodes : [];
-    const fragmentFactory = (code) => {
-      const badge = document.createElement('span');
-      badge.className = 'badge rounded-pill bg-light border text-secondary me-2 mb-2';
-      const stage = state.stageByCode.get(code);
-      badge.textContent = stage ? `${code} · ${stage.name}` : code;
-      return badge;
-    };
-
-    stageDependenciesEls.forEach((container) => {
-      container.innerHTML = '';
-      if (codes.length === 0) {
-        const empty = document.createElement('span');
-        empty.className = 'text-muted';
-        empty.textContent = 'None';
-        container.appendChild(empty);
-        return;
-      }
-
-      codes.forEach((code) => container.appendChild(fragmentFactory(code)));
     });
   }
 


### PR DESCRIPTION
## Summary
- remove the stage metadata block and helper copy from the checklist offcanvas
- trim related CSS selectors and spacing for the removed markup
- simplify the process flow script to only update the stage title and checklist controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e086f2172c832990dc52ff58df56fa