### PR TITLE
Adjust checklist item modal focus timing

### DIFF
--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -1194,10 +1194,16 @@ if (root) {
       spinner.hidden = true;
     }
 
+    if (itemModalEl) {
+      itemModalEl.addEventListener('shown.bs.modal', () => {
+        const focusTarget = itemForm.querySelector('textarea[name="text"]');
+        if (focusTarget) {
+          focusTarget.focus();
+        }
+      }, { once: true });
+    }
+
     itemModal.show();
-    setTimeout(() => {
-      textArea.focus();
-    }, 150);
   }
 
   function openDeleteModal(item) {


### PR DESCRIPTION
## Summary
- remove the manual timeout-based focus logic in the checklist item modal
- focus the textarea when the modal finishes opening via the `shown.bs.modal` event

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e08a27f56883298577daed081d9f8a