### PR TITLE
Fix checklist action handling in offcanvas

### DIFF
--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -1136,6 +1136,13 @@ if (root) {
       return;
     }
 
+    const withinRoot = root.contains(button);
+    const withinOffcanvas = checklistOffcanvasEl ? checklistOffcanvasEl.contains(button) : false;
+
+    if (!withinRoot && !withinOffcanvas) {
+      return;
+    }
+
     const action = button.dataset.action;
     if (!action) {
       return;
@@ -1365,7 +1372,7 @@ if (root) {
     setStageDetails(null);
     renderChecklist(null);
     showFlowLoading();
-    root.addEventListener('click', handleActionClick);
+    document.addEventListener('click', handleActionClick);
     if (itemForm) {
       itemForm.addEventListener('submit', handleItemFormSubmit);
     }


### PR DESCRIPTION
## Summary
- delegate checklist action clicks from the document so offcanvas buttons are handled
- ignore click events that fall outside the process flow or checklist offcanvas to prevent stray handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e090f33f608329a457138cb1d0f81e