### PR TITLE
Adjust process diagram layout

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -24,26 +24,24 @@
 </section>
 
 <div class="process-layout" data-process-flow-root data-process-version="@Model.ProcessVersion" data-can-edit="@(Model.CanEditChecklist ? "true" : "false")">
-    <div class="proc-diagram card shadow-sm">
-        <div class="card-body">
-            <div class="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-3">
-                <div>
-                    <h2 class="h5 mb-1 text-uppercase text-muted">Stage flow</h2>
-                    <p class="mb-0 text-muted small">Select a stage in the diagram to review its checklist.</p>
-                </div>
-                <button type="button"
-                        class="btn btn-primary d-lg-none"
-                        data-bs-toggle="offcanvas"
-                        data-bs-target="#checklistOffcanvas"
-                        aria-controls="checklistOffcanvas">
-                    View checklist
-                </button>
+    <div class="proc-diagram">
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-3">
+            <div>
+                <h2 class="h5 mb-1 text-uppercase text-muted">Stage flow</h2>
+                <p class="mb-0 text-muted small">Select a stage in the diagram to review its checklist.</p>
             </div>
-            <div class="proc-diagram__canvas" data-flow-canvas role="region" aria-live="polite" aria-busy="true" aria-label="Procurement stage flow">
-                <div class="text-center text-muted py-5" data-flow-placeholder>
-                    <div class="spinner-border text-primary mb-3" role="status" aria-hidden="true"></div>
-                    <p class="mb-0">Loading flow…</p>
-                </div>
+            <button type="button"
+                    class="btn btn-primary d-lg-none"
+                    data-bs-toggle="offcanvas"
+                    data-bs-target="#checklistOffcanvas"
+                    aria-controls="checklistOffcanvas">
+                View checklist
+            </button>
+        </div>
+        <div class="proc-diagram__canvas" data-flow-canvas role="region" aria-live="polite" aria-busy="true" aria-label="Procurement stage flow">
+            <div class="text-center text-muted py-5" data-flow-placeholder>
+                <div class="spinner-border text-primary mb-3" role="status" aria-hidden="true"></div>
+                <p class="mb-0">Loading flow…</p>
             </div>
         </div>
     </div>

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -10,7 +10,7 @@
   gap: 1.5rem;
 }
 
-.proc-diagram .card-body {
+.proc-diagram {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -18,20 +18,20 @@
 
 .proc-diagram__canvas {
   position: relative;
-  min-height: 520px;
-  height: clamp(520px, 70vh, 820px);
+  min-height: 600px;
+  height: clamp(600px, 72vh, 920px);
   border: 1px solid var(--bs-border-color);
   border-radius: 0.75rem;
   background: var(--bs-body-bg);
   overflow: auto;
-  padding: 1.5rem;
+  padding: 1rem;
 }
 
 .proc-diagram__canvas svg {
   width: 100%;
   height: 100%;
-  min-width: 520px;
-  min-height: 420px;
+  min-width: 600px;
+  min-height: 480px;
 }
 
 .proc-diagram__canvas [data-flow-placeholder] {
@@ -194,12 +194,12 @@
 
 @media (max-width: 575.98px) {
   .proc-diagram__canvas {
-    padding: 1rem;
-    min-height: 360px;
-    height: 360px;
+    padding: 0.75rem;
+    min-height: 400px;
+    height: 400px;
   }
 
   .proc-diagram__canvas svg {
-    min-width: 420px;
+    min-width: 460px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the procurement process diagram card markup with a simpler container so the SVG can use the full layout width
- update the process flow stylesheet to drop the card-specific styles, expand the canvas dimensions, and tweak responsive spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e091a913148329aafa5696634409b9