### PR TITLE
Reduce process hero height

### DIFF
--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -1,7 +1,21 @@
+.process-hero {
+  padding-block: 1.25rem;
+}
+
 .process-hero .hero-badge {
   background: linear-gradient(135deg, rgba(13, 110, 253, 0.08), rgba(32, 201, 151, 0.08));
   border: 1px solid rgba(13, 110, 253, 0.15);
   min-width: 220px;
+  padding: 0.875rem 1rem;
+}
+
+.process-hero .display-6 {
+  font-size: clamp(1.75rem, 2.5vw, 2.25rem);
+  margin-bottom: 0.75rem !important;
+}
+
+.process-hero .lead {
+  margin-bottom: 0.5rem !important;
 }
 
 .process-layout {


### PR DESCRIPTION
## Summary
- compress the process header by reducing padding and typography spacing
- adjust hero badge sizing to keep a compact presentation

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e091c47e4c8329bc213ba49eec03a3