### PR TITLE
Reduce process hero spacing and simplify checklist layout

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -4,9 +4,9 @@
     ViewData["Title"] = "SDD Procurement Flow";
 }
 
-<section class="process-hero mb-5">
-    <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-4">
-        <div class="hero-badge text-center text-lg-start p-4 rounded-4 shadow-sm order-0">
+<section class="process-hero mb-4">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
+        <div class="hero-badge text-center text-lg-start p-3 rounded-4 shadow-sm order-0">
             <span class="badge bg-primary-subtle text-primary-emphasis text-uppercase mb-2">Updated on</span>
             <p class="h2 mb-0 fw-semibold">
                 @(Model.ProcessUpdatedOn.HasValue

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -1,21 +1,21 @@
 .process-hero {
-  padding-block: 1.25rem;
+  padding-block: 0.75rem;
 }
 
 .process-hero .hero-badge {
   background: linear-gradient(135deg, rgba(13, 110, 253, 0.08), rgba(32, 201, 151, 0.08));
   border: 1px solid rgba(13, 110, 253, 0.15);
-  min-width: 220px;
-  padding: 0.875rem 1rem;
+  min-width: 200px;
+  padding: 0.75rem 0.875rem;
 }
 
 .process-hero .display-6 {
-  font-size: clamp(1.75rem, 2.5vw, 2.25rem);
-  margin-bottom: 0.75rem !important;
+  font-size: clamp(1.7rem, 2.2vw, 2.1rem);
+  margin-bottom: 0.5rem !important;
 }
 
 .process-hero .lead {
-  margin-bottom: 0.5rem !important;
+  margin-bottom: 0 !important;
 }
 
 .process-layout {
@@ -140,10 +140,13 @@
 }
 
 .stage-checklist {
-  list-style: decimal inside;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.75rem;
+  list-style: decimal;
+  list-style-position: outside;
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0;
 }
 
 .stage-checklist[aria-busy="true"]::after {
@@ -151,18 +154,27 @@
   display: none;
 }
 
+
 .stage-checklist .checklist-item {
-  background: rgba(248, 249, 250, 0.7);
-  border-radius: 0.75rem;
-  padding: 0.75rem 0.75rem 0.75rem 1rem;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.75rem;
+  display: flex;
   align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.stage-checklist .checklist-item .item-body {
+  flex: 1;
+  min-width: 0;
 }
 
 .stage-checklist .checklist-item.read-only {
-  grid-template-columns: 1fr;
+  display: block;
+}
+
+.stage-checklist .checklist-item.read-only .item-body p {
+  margin-bottom: 0;
 }
 
 .stage-checklist .checklist-item .checklist-handle {

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -713,7 +713,7 @@ if (root) {
         const body = document.createElement('div');
         body.className = 'item-body';
         const paragraph = document.createElement('p');
-        paragraph.className = 'mb-1';
+        paragraph.className = 'mb-0';
         paragraph.textContent = item.text;
         body.appendChild(paragraph);
 


### PR DESCRIPTION
## Summary
- reduce the hero section spacing on the procurement process page to tighten the header presentation
- convert the stage checklist styling into a compact numbered list without card chrome
- trim checklist item markup spacing so items read more compactly

## Testing
- Not run (environment missing .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e093957ab883299d24813d371af1d6