### PR TITLE
Adjust process flow diagram sizing behavior

### DIFF
--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -33,7 +33,8 @@
 .proc-diagram__canvas {
   position: relative;
   min-height: 600px;
-  height: clamp(600px, 72vh, 920px);
+  height: auto;
+  max-height: none;
   border: 1px solid var(--bs-border-color);
   border-radius: 0.75rem;
   background: var(--bs-body-bg);
@@ -42,8 +43,10 @@
 }
 
 .proc-diagram__canvas svg {
-  width: 100%;
-  height: 100%;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  display: block;
   min-width: 600px;
   min-height: 480px;
 }

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -902,11 +902,14 @@ if (root) {
     const svg = createSvgElement('svg', {
       class: 'process-flow-diagram',
       viewBox: `0 0 ${layout.width} ${layout.height}`,
-      width: '100%',
-      height: '100%',
+      width: layout.width,
+      height: layout.height,
       focusable: 'false',
       'aria-label': 'Process flow diagram'
     });
+    svg.style.maxWidth = '100%';
+    svg.style.height = 'auto';
+    svg.setAttribute('preserveAspectRatio', 'xMidYMin meet');
     ensureDefs(svg);
 
     const connectorsLayer = createSvgElement('g', { class: 'flow-connectors' });
@@ -916,6 +919,7 @@ if (root) {
 
     flowCanvas.innerHTML = '';
     flowCanvas.appendChild(svg);
+    flowCanvas.scrollTop = 0;
 
     const nodeElements = new Map();
     const edgeElements = new Map();


### PR DESCRIPTION
## Summary
- relax the process flow canvas height to allow taller diagrams while keeping a minimum size
- allow the SVG to size itself intrinsically with responsive constraints and preserve aspect ratio
- update renderFlow to size the SVG from layout dimensions, preserve aspect ratio, and reset canvas scroll position

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b7b997a48329b2a25a4bed11af76