### PR TITLE
Tighten process hero header layout

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -5,21 +5,23 @@
 }
 
 <section class="process-hero mb-4">
-    <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
-        <div class="hero-badge text-center text-lg-start p-3 rounded-4 shadow-sm order-0">
-            <span class="badge bg-primary-subtle text-primary-emphasis text-uppercase mb-2">Updated on</span>
-            <p class="h2 mb-0 fw-semibold">
-                @(Model.ProcessUpdatedOn.HasValue
-                    ? Model.ProcessUpdatedOn.Value.ToLocalTime().ToString("dd MMM yyyy")
-                    : "Not available")
-            </p>
+    <div class="d-flex flex-column gap-2">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
+            <div class="d-flex flex-wrap align-items-center gap-2">
+                <h1 class="h2 fw-semibold text-primary mb-0">Procurement Process &amp; Checklist</h1>
+                <div class="hero-badge d-inline-flex align-items-center gap-2 rounded-4 shadow-sm">
+                    <span class="badge bg-primary-subtle text-primary-emphasis text-uppercase">Updated on</span>
+                    <span class="fw-semibold text-primary-emphasis">
+                        @(Model.ProcessUpdatedOn.HasValue
+                            ? Model.ProcessUpdatedOn.Value.ToLocalTime().ToString("dd MMM yyyy")
+                            : "Not available")
+                    </span>
+                </div>
+            </div>
         </div>
-        <div class="flex-grow-1 order-1">
-            <h1 class="display-6 fw-semibold text-primary mb-3">Procurement Process &amp; Checklist</h1>
-            <p class="lead text-muted mb-3">
-                Review each stage checklist before processing the file.
-            </p>
-        </div>
+        <p class="text-muted mb-0">
+            Review each stage checklist before processing the file.
+        </p>
     </div>
 </section>
 

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -1,21 +1,12 @@
 .process-hero {
-  padding-block: 0.75rem;
+  padding-block: 0.25rem;
 }
 
 .process-hero .hero-badge {
   background: linear-gradient(135deg, rgba(13, 110, 253, 0.08), rgba(32, 201, 151, 0.08));
   border: 1px solid rgba(13, 110, 253, 0.15);
-  min-width: 200px;
-  padding: 0.75rem 0.875rem;
-}
-
-.process-hero .display-6 {
-  font-size: clamp(1.7rem, 2.2vw, 2.1rem);
-  margin-bottom: 0.5rem !important;
-}
-
-.process-hero .lead {
-  margin-bottom: 0 !important;
+  min-width: 150px;
+  padding: 0.5rem 0.75rem;
 }
 
 .process-layout {


### PR DESCRIPTION
## Summary
- streamline the process hero markup so the title uses a smaller heading and the updated badge sits inline
- reduce hero badge padding and min-width to shrink the header footprint

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0b8404e308329972804966885ace8