### PR TITLE
Add zoom controls to process flow diagram

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -35,6 +35,28 @@
                     aria-controls="checklistOffcanvas">
                 View checklist
             </button>
+            <div class="btn-group btn-group-sm d-none d-sm-inline-flex ms-auto"
+                 role="group"
+                 aria-label="Diagram zoom controls">
+                <button type="button"
+                        class="btn btn-outline-secondary"
+                        data-zoom-out
+                        title="Zoom out">
+                    Zoom out
+                </button>
+                <button type="button"
+                        class="btn btn-outline-secondary"
+                        data-zoom-reset
+                        title="Reset zoom">
+                    Reset
+                </button>
+                <button type="button"
+                        class="btn btn-outline-secondary"
+                        data-zoom-in
+                        title="Zoom in">
+                    Zoom in
+                </button>
+            </div>
         </div>
         <div class="proc-diagram__canvas" data-flow-canvas role="region" aria-live="polite" aria-busy="true" aria-label="Procurement stage flow">
             <div class="text-center text-muted py-5" data-flow-placeholder>


### PR DESCRIPTION
## Summary
- add responsive zoom control buttons to the process diagram toolbar
- track diagram zoom state and apply scaling when rendering
- wire buttons and keyboard shortcuts to adjust zoom while respecting limits

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0b94d04688329b9f57c36a4cb82cb