### PR TITLE
Refine checklist offcanvas actions

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -77,9 +77,13 @@
             <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
                 <h3 class="h5 mb-0">Stage checklist</h3>
                 <div class="btn-group" data-checklist-actions hidden>
-                    <button type="button" class="btn btn-outline-primary btn-sm" data-action="add-item">
-                        <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>
-                        Add item
+                    <button type="button"
+                            class="btn btn-primary btn-icon"
+                            data-action="add-item"
+                            title="Add checklist item"
+                            aria-label="Add checklist item">
+                        <i class="bi bi-plus-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Add item</span>
                     </button>
                 </div>
             </div>

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -180,8 +180,18 @@
   cursor: grabbing;
 }
 
+.stage-checklist .checklist-item .item-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .stage-checklist .checklist-item .item-actions .btn {
   padding: 0.25rem 0.5rem;
+}
+
+.stage-checklist .checklist-item .item-actions .btn-icon {
+  padding: 0;
 }
 
 .stage-checklist .checklist-empty {

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -823,19 +823,23 @@ if (root) {
 
         if (state.canEdit) {
           const actions = document.createElement('div');
-          actions.className = 'item-actions btn-group btn-group-sm';
+          actions.className = 'item-actions d-inline-flex align-items-center gap-1';
 
           const editBtn = document.createElement('button');
           editBtn.type = 'button';
-          editBtn.className = 'btn btn-outline-secondary';
+          editBtn.className = 'btn btn-outline-secondary btn-icon';
           editBtn.dataset.action = 'edit-item';
-          editBtn.textContent = 'Edit';
+          editBtn.setAttribute('title', 'Edit checklist item');
+          editBtn.setAttribute('aria-label', 'Edit checklist item');
+          editBtn.innerHTML = '<i class="bi bi-pencil" aria-hidden="true"></i><span class="visually-hidden">Edit</span>';
 
           const deleteBtn = document.createElement('button');
           deleteBtn.type = 'button';
-          deleteBtn.className = 'btn btn-outline-danger';
+          deleteBtn.className = 'btn btn-outline-danger btn-icon';
           deleteBtn.dataset.action = 'delete-item';
-          deleteBtn.textContent = 'Delete';
+          deleteBtn.setAttribute('title', 'Delete checklist item');
+          deleteBtn.setAttribute('aria-label', 'Delete checklist item');
+          deleteBtn.innerHTML = '<i class="bi bi-trash" aria-hidden="true"></i><span class="visually-hidden">Delete</span>';
 
           actions.appendChild(editBtn);
           actions.appendChild(deleteBtn);


### PR DESCRIPTION
## Summary
- restyle the checklist add-item control as a compact icon button within the offcanvas
- convert checklist edit and delete actions to icon-only buttons with accessible titles
- adjust checklist action layout styles so the new icon buttons align cleanly

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0baf0644c8329b09d5001a491347b