### PR TITLE
Adjust process flow label typography

### DIFF
--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -125,8 +125,8 @@
 }
 
 .proc-diagram__canvas .flow-node__label {
-  font-size: 1rem;
-  line-height: 1.35;
+  font-size: 1.125rem;
+  line-height: 1.3;
   font-weight: 600;
   fill: var(--bs-body-color);
   letter-spacing: 0.01em;

--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -454,7 +454,7 @@ if (root) {
     defs.appendChild(marker);
   }
 
-  function wrapLabelLines(text, maxChars = 20) {
+  function wrapLabelLines(text, maxChars = 18) {
     if (!text) {
       return [''];
     }
@@ -481,8 +481,8 @@ if (root) {
   }
 
   function createLabelElement(text, layout, options = {}) {
-    const lines = wrapLabelLines(text, options.maxChars || 20);
-    const lineHeight = options.lineHeight || 20;
+    const lines = wrapLabelLines(text, options.maxChars ?? 18);
+    const lineHeight = options.lineHeight ?? 22;
     const textEl = createSvgElement('text', {
       class: 'flow-node__label',
       x: layout.width / 2,


### PR DESCRIPTION
## Summary
- raise the process flow node label font size while tightening the CSS line height for better readability without changing node geometry
- bump the SVG label layout defaults to match the new text metrics and wrap slightly sooner so longer labels stay within their nodes

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0bc54e4ec8329a6df52b65921b2ea