### PR TITLE
Update decision nodes to use rounded rectangles

### DIFF
--- a/wwwroot/js/process-flow.js
+++ b/wwwroot/js/process-flow.js
@@ -415,7 +415,7 @@ if (root) {
   const NODE_SIZES = {
     terminator: { width: 220, height: 72 },
     process: { width: 240, height: 88 },
-    decision: { width: 132, height: 132 }
+    decision: { width: 240, height: 88 }
   };
 
   function createSvgElement(name, attributes = {}) {
@@ -548,11 +548,15 @@ if (root) {
 
   function drawDecision(node, layout) {
     const group = createNodeGroup(node, layout, 'decision');
-    const polygon = createSvgElement('polygon', {
-      points: `${layout.width / 2},0 ${layout.width},${layout.height / 2} ${layout.width / 2},${layout.height} 0,${layout.height / 2}`,
+    const rect = createSvgElement('rect', {
+      x: 0,
+      y: 0,
+      width: layout.width,
+      height: layout.height,
+      rx: 18,
       class: 'flow-node__body'
     });
-    group.appendChild(polygon);
+    group.appendChild(rect);
     group.appendChild(createLabelElement(node.label, layout));
     return group;
   }


### PR DESCRIPTION
## Summary
- render decision nodes with rounded rectangles to match process nodes
- align decision node default size with rectangular proportions

## Testing
- dotnet run --urls http://0.0.0.0:5000 *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bd04a2588329bb48f683026b895a