### PR TITLE
Tighten analytics chart header spacing

### DIFF
--- a/Areas/Admin/Pages/Analytics/Index.cshtml
+++ b/Areas/Admin/Pages/Analytics/Index.cshtml
@@ -34,11 +34,11 @@
   <div class="col-md-3"><div class="pm-card pm-shadow p-3"><div class="text-muted">Disabled</div><div class="fs-3">@Model.DisabledUsers</div></div></div>
 </div>
 
-  <div class="pm-card pm-shadow p-3 mb-4">
-    <div class="d-flex align-items-center justify-content-between mb-2">
-      <h5 class="mb-0">Logins per day (last 30 days)</h5>
-      <small class="text-muted">IST</small>
-    </div>
+<div class="pm-card pm-shadow chart-card mb-4">
+  <div class="chart-card__header">
+    <h5 class="mb-0">Logins per day (last 30 days)</h5>
+    <small class="text-muted">IST</small>
+  </div>
 
   <div class="chart-container-240">
     <canvas id="loginsPerDayChart"

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -737,6 +737,37 @@ body {
   width: 100%;
 }
 
+.chart-card {
+  padding: 0.75rem 1rem 1rem;
+}
+
+.chart-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.chart-card__header > * {
+  margin-bottom: 0;
+}
+
+.chart-card__header small {
+  color: var(--pm-muted);
+}
+
+@media (max-width: 575.98px) {
+  .chart-card {
+    padding: 0.75rem;
+  }
+
+  .chart-card__header {
+    align-items: center;
+    flex-wrap: wrap;
+  }
+}
+
 .pm-progress {
   appearance: none;
   display: block;


### PR DESCRIPTION
## Summary
- switch the analytics chart card to a compact layout class
- add shared chart card styles to trim padding and tighten the header spacing

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bf0a30848329b7365c7a867eff2b