### PR TITLE
Adjust zoom button padding

### DIFF
--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -21,6 +21,10 @@
   gap: 1rem;
 }
 
+.proc-diagram .btn-group-sm .btn {
+  padding-block: 0.125rem;
+}
+
 .proc-diagram__canvas {
   position: relative;
   min-height: 600px;


### PR DESCRIPTION
## Summary
- reduce the vertical padding on the process diagram zoom buttons to make them more compact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c12b790c8329a873ff4c7fe65b56