### PR TITLE
Tighten spacing around process diagram controls

### DIFF
--- a/Pages/Process/Index.cshtml
+++ b/Pages/Process/Index.cshtml
@@ -27,7 +27,7 @@
 
 <div class="process-layout" data-process-flow-root data-process-version="@Model.ProcessVersion" data-can-edit="@(Model.CanEditChecklist ? "true" : "false")">
     <div class="proc-diagram">
-        <div class="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-3">
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-3 proc-diagram__controls">
             <button type="button"
                     class="btn btn-primary d-lg-none"
                     data-bs-toggle="offcanvas"

--- a/wwwroot/css/process-flow.css
+++ b/wwwroot/css/process-flow.css
@@ -18,7 +18,11 @@
 .proc-diagram {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
+}
+
+.proc-diagram__controls {
+  margin-bottom: 0.5rem;
 }
 
 .proc-diagram .btn-group-sm .btn {


### PR DESCRIPTION
## Summary
- reduce the margin around the process diagram control bar and tighten the column gap to minimize excess whitespace
- introduce a dedicated `.proc-diagram__controls` class for consistent spacing control across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0cc59d3288329b0a50e97f960ac24