### PR TITLE
Add role-based navigation provider

### DIFF
--- a/Models/Navigation/NavigationItem.cs
+++ b/Models/Navigation/NavigationItem.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.Models.Navigation;
+
+public record class NavigationItem
+{
+    public required string Text { get; init; }
+
+    public string? Area { get; init; }
+
+    public string? Page { get; init; }
+
+    public string? Controller { get; init; }
+
+    public string? Action { get; init; }
+
+    public IReadOnlyList<NavigationItem> Children { get; init; } = Array.Empty<NavigationItem>();
+
+    public string? AuthorizationPolicy { get; init; }
+
+    public IReadOnlyList<string>? RequiredRoles { get; init; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -42,6 +42,7 @@ using Microsoft.Net.Http.Headers;
 using System.Threading;
 using ProjectManagement.Features.Remarks;
 using ProjectManagement.Services.Notifications;
+using ProjectManagement.Services.Navigation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 
@@ -169,6 +170,7 @@ builder.Services.AddHostedService<LoginAggregationWorker>();
 builder.Services.AddHostedService<TodoPurgeWorker>();
 builder.Services.AddScoped<PlanDraftService>();
 builder.Services.AddScoped<PlanApprovalService>();
+builder.Services.AddScoped<INavigationProvider, RoleBasedNavigationProvider>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<IStageValidationService, StageValidationService>();

--- a/Services/Navigation/INavigationProvider.cs
+++ b/Services/Navigation/INavigationProvider.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ProjectManagement.Models.Navigation;
+
+namespace ProjectManagement.Services.Navigation;
+
+public interface INavigationProvider
+{
+    Task<IReadOnlyList<NavigationItem>> GetNavigationAsync();
+}

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Navigation;
+
+namespace ProjectManagement.Services.Navigation;
+
+public class RoleBasedNavigationProvider : INavigationProvider
+{
+    private static readonly IReadOnlyList<NavigationItem> AnonymousNavigation = Array.Empty<NavigationItem>();
+
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public RoleBasedNavigationProvider(
+        UserManager<ApplicationUser> userManager,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        _userManager = userManager;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<IReadOnlyList<NavigationItem>> GetNavigationAsync()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext?.User?.Identity?.IsAuthenticated != true)
+        {
+            return AnonymousNavigation;
+        }
+
+        var user = await _userManager.GetUserAsync(httpContext.User);
+        if (user is null)
+        {
+            return AnonymousNavigation;
+        }
+
+        var roleSet = await GetRoleSetAsync(user);
+
+        var items = new List<NavigationItem>
+        {
+            new()
+            {
+                Text = "Projects",
+                Page = "/Projects/Index"
+            },
+            new()
+            {
+                Text = "Process",
+                Page = "/Process/Index"
+            },
+            new()
+            {
+                Text = "Dashboard",
+                Page = "/Dashboard/Index"
+            }
+        };
+
+        if (roleSet.Contains("Admin"))
+        {
+            items.Add(new NavigationItem
+            {
+                Text = "Admin Panel",
+                Area = "Admin",
+                Page = "/Index",
+                RequiredRoles = new[] { "Admin" },
+                Children = new[]
+                {
+                    new NavigationItem
+                    {
+                        Text = "Login scatter",
+                        Area = "Admin",
+                        Page = "/Analytics/Logins",
+                        RequiredRoles = new[] { "Admin" }
+                    },
+                    new NavigationItem
+                    {
+                        Text = "Help",
+                        Area = "Admin",
+                        Page = "/Help/Index",
+                        RequiredRoles = new[] { "Admin" }
+                    }
+                }
+            });
+        }
+
+        if (roleSet.Contains("HoD") || roleSet.Contains("Admin"))
+        {
+            items.Add(new NavigationItem
+            {
+                Text = "Approvals",
+                Page = "/Projects/Documents/Approvals/Index",
+                RequiredRoles = new[] { "HoD", "Admin" }
+            });
+        }
+
+        return items;
+    }
+
+    private async Task<HashSet<string>> GetRoleSetAsync(ApplicationUser user)
+    {
+        var roles = await _userManager.GetRolesAsync(user);
+        return roles.Count == 0
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(roles, StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add a NavigationItem record to model navigation metadata and authorization requirements
- introduce a role-aware navigation provider that builds menu items for the signed-in user
- register the navigation provider in the dependency injection container for reuse

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0ce5a2e248329826862dc188647f2