### PR TITLE
Add navigation drawer view component for responsive navigation

### DIFF
--- a/Pages/Shared/Components/NavigationDrawer/Default.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/Default.cshtml
@@ -1,0 +1,77 @@
+@model ProjectManagement.ViewComponents.NavigationDrawerViewModel
+@using System.Collections.Generic
+@using ProjectManagement.ViewComponents
+@{
+    const string offcanvasId = "pmNavigationDrawer";
+    const string offcanvasLabelId = "pmNavigationDrawerLabel";
+}
+
+<div class="d-flex align-items-center gap-2">
+    <button class="navbar-toggler d-lg-none" type="button"
+            data-bs-toggle="offcanvas"
+            data-bs-target="#@offcanvasId"
+            aria-controls="@offcanvasId"
+            aria-label="Toggle navigation menu">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="offcanvas offcanvas-start" tabindex="-1" id="@offcanvasId" aria-labelledby="@offcanvasLabelId">
+        <div class="offcanvas-header">
+            <div>
+                <h5 class="offcanvas-title mb-0" id="@offcanvasLabelId">@Model.Brand</h5>
+                @if (!string.IsNullOrEmpty(Model.UserName))
+                {
+                    <span class="text-muted small">Signed in as @Model.UserName</span>
+                }
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close navigation menu"></button>
+        </div>
+        <div class="offcanvas-body">
+            @RenderNavigationItems(Model.Items, isOffcanvas: true, depth: 0)
+        </div>
+    </div>
+
+    <nav class="d-none d-lg-block" aria-label="Primary navigation">
+        @RenderNavigationItems(Model.Items, isOffcanvas: false, depth: 0)
+    </nav>
+</div>
+
+@helper RenderNavigationItems(IReadOnlyList<NavigationDrawerNode> nodes, bool isOffcanvas, int depth)
+{
+    var listClasses = isOffcanvas
+        ? $"nav flex-column gap-1{(depth > 0 ? " ms-3" : string.Empty)}"
+        : depth == 0
+            ? "navbar-nav flex-row align-items-center gap-2"
+            : "nav flex-column ms-lg-3 gap-1";
+
+    <ul class="@listClasses">
+        @foreach (var node in nodes)
+        {
+            var linkClasses = "nav-link";
+            if (node.IsActive)
+            {
+                linkClasses += " active fw-semibold";
+            }
+            else if (node.HasActiveDescendant)
+            {
+                linkClasses += " fw-semibold";
+            }
+
+            <li class="nav-item">
+                @if (!string.IsNullOrEmpty(node.Url))
+                {
+                    <a class="@linkClasses" href="@node.Url" @(node.IsActive ? "aria-current=\"page\"" : string.Empty)>@node.Text</a>
+                }
+                else
+                {
+                    <span class="@($"{linkClasses} disabled")">@node.Text</span>
+                }
+
+                @if (node.Children.Count > 0)
+                {
+                    @RenderNavigationItems(node.Children, isOffcanvas, depth + 1)
+                }
+            </li>
+        }
+    </ul>
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -19,39 +19,8 @@
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
             <div class="container">
                 <a class="navbar-brand fw-semibold" asp-area="" asp-page="/Index">ProjectManagement</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#pmNavbar">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div id="pmNavbar" class="collapse navbar-collapse">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                        @if (SignInManager.IsSignedIn(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-page="/Projects/Index">Projects</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" asp-page="/Process/Index">Process</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" asp-page="/Dashboard/Index">Dashboard</a>
-                            </li>
-                            if (User.IsInRole("Admin"))
-                            {
-                                <li class="nav-item">
-                                    <a class="nav-link" asp-area="Admin" asp-page="/Index">Admin Panel</a>
-                                </li>
-                                if ((ViewContext.RouteData.Values["area"]?.ToString() ?? "") == "Admin")
-                                {
-                                    <li class="nav-item">
-                                        <a class="nav-link" asp-area="Admin" asp-page="/Analytics/Logins">Login scatter</a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" asp-area="Admin" asp-page="/Help/Index">Help</a>
-                                    </li>
-                                }
-                            }
-                        }
-                    </ul>
+                <div class="d-flex align-items-center ms-auto gap-3">
+                    @await Component.InvokeAsync("NavigationDrawer")
                     <partial name="_LoginPartial" />
                 </div>
             </div>

--- a/ViewComponents/NavigationDrawerViewComponent.cs
+++ b/ViewComponents/NavigationDrawerViewComponent.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using ProjectManagement.Models.Navigation;
+using ProjectManagement.Services.Navigation;
+
+namespace ProjectManagement.ViewComponents;
+
+public class NavigationDrawerViewComponent : ViewComponent
+{
+    private readonly INavigationProvider _navigationProvider;
+    private readonly LinkGenerator _linkGenerator;
+
+    public NavigationDrawerViewComponent(
+        INavigationProvider navigationProvider,
+        LinkGenerator linkGenerator)
+    {
+        _navigationProvider = navigationProvider;
+        _linkGenerator = linkGenerator;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync()
+    {
+        var items = await _navigationProvider.GetNavigationAsync();
+        var model = BuildViewModel(items);
+        return View(model);
+    }
+
+    private NavigationDrawerViewModel BuildViewModel(IEnumerable<NavigationItem> items)
+    {
+        var area = ViewContext.RouteData.Values.TryGetValue("area", out var areaValue)
+            ? areaValue?.ToString()
+            : null;
+        var page = ViewContext.RouteData.Values.TryGetValue("page", out var pageValue)
+            ? pageValue?.ToString()
+            : null;
+        var controller = ViewContext.RouteData.Values.TryGetValue("controller", out var controllerValue)
+            ? controllerValue?.ToString()
+            : null;
+        var action = ViewContext.RouteData.Values.TryGetValue("action", out var actionValue)
+            ? actionValue?.ToString()
+            : null;
+
+        var nodes = items.Select(item => CreateNode(item, area, page, controller, action)).ToList();
+
+        return new NavigationDrawerViewModel
+        {
+            Brand = ViewContext.ViewData["AppName"] as string ?? "ProjectManagement",
+            UserName = HttpContext.User.Identity?.IsAuthenticated == true ? HttpContext.User.Identity?.Name : null,
+            Items = nodes
+        };
+    }
+
+    private NavigationDrawerNode CreateNode(
+        NavigationItem item,
+        string? currentArea,
+        string? currentPage,
+        string? currentController,
+        string? currentAction)
+    {
+        var childNodes = item.Children.Select(child => CreateNode(child, currentArea, currentPage, currentController, currentAction)).ToList();
+        var url = BuildUrl(item);
+        var isActive = IsActive(item, currentArea, currentPage, currentController, currentAction);
+        var hasActiveDescendant = childNodes.Any(child => child.IsActive || child.HasActiveDescendant);
+
+        return new NavigationDrawerNode
+        {
+            Text = item.Text,
+            Url = url,
+            IsActive = isActive,
+            HasActiveDescendant = hasActiveDescendant,
+            Children = childNodes
+        };
+    }
+
+    private string? BuildUrl(NavigationItem item)
+    {
+        if (!string.IsNullOrEmpty(item.Page))
+        {
+            var values = item.Area is null ? null : new { area = item.Area };
+            return _linkGenerator.GetPathByPage(HttpContext, page: item.Page, values: values);
+        }
+
+        if (!string.IsNullOrEmpty(item.Controller) && !string.IsNullOrEmpty(item.Action))
+        {
+            var values = item.Area is null ? null : new { area = item.Area };
+            return _linkGenerator.GetPathByAction(HttpContext, action: item.Action, controller: item.Controller, values: values);
+        }
+
+        return null;
+    }
+
+    private static bool IsActive(
+        NavigationItem item,
+        string? currentArea,
+        string? currentPage,
+        string? currentController,
+        string? currentAction)
+    {
+        if (!string.IsNullOrEmpty(item.Page))
+        {
+            if (!string.Equals(currentPage, item.Page, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.Equals(item.Area ?? string.Empty, currentArea ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!string.IsNullOrEmpty(item.Controller) && !string.IsNullOrEmpty(item.Action))
+        {
+            if (!string.Equals(currentController, item.Controller, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!string.Equals(currentAction, item.Action, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.Equals(item.Area ?? string.Empty, currentArea ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+}
+
+public sealed record class NavigationDrawerViewModel
+{
+    public required IReadOnlyList<NavigationDrawerNode> Items { get; init; }
+
+    public string Brand { get; init; } = "ProjectManagement";
+
+    public string? UserName { get; init; }
+}
+
+public sealed record class NavigationDrawerNode
+{
+    public required string Text { get; init; }
+
+    public string? Url { get; init; }
+
+    public bool IsActive { get; init; }
+
+    public bool HasActiveDescendant { get; init; }
+
+    public IReadOnlyList<NavigationDrawerNode> Children { get; init; } = Array.Empty<NavigationDrawerNode>();
+}


### PR DESCRIPTION
## Summary
- add a navigation drawer view component that builds hierarchical menu data from the registered navigation provider
- create the default component view with an offcanvas drawer, toggle button, and responsive desktop navigation markup
- update the shared layout to render the new navigation drawer and keep the login partial alongside it

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cf21a9148329820752ff23a9a9a8