### PR TITLE
Implement navigation drawer interactions

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -643,6 +643,156 @@ body {
     grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
 }
 
+/* ---------- Navigation drawer ---------- */
+.pm-drawer {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    display: flex;
+    align-items: stretch;
+    pointer-events: none;
+    visibility: hidden;
+}
+
+.pm-drawer.is-open {
+    pointer-events: auto;
+    visibility: visible;
+}
+
+.pm-drawer__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(11, 18, 32, .45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .25s ease;
+}
+
+.pm-drawer.is-open .pm-drawer__overlay {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.pm-drawer__panel {
+    position: relative;
+    width: min(22rem, 88vw);
+    max-width: 100%;
+    height: 100%;
+    background: var(--pm-card);
+    box-shadow: var(--pm-shadow);
+    transform: translateX(-100%);
+    transition: transform .28s cubic-bezier(.4, 0, .2, 1);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem;
+}
+
+.pm-drawer.is-open .pm-drawer__panel {
+    transform: translateX(0);
+}
+
+.pm-drawer__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.pm-drawer__title {
+    margin: 0;
+    font-weight: 600;
+    color: var(--pm-text);
+}
+
+.pm-drawer__body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    padding-right: .25rem;
+}
+
+.pm-drawer__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.pm-drawer__item > .pm-drawer__list {
+    margin-top: .25rem;
+    padding-left: 1.25rem;
+    border-left: 1px solid rgba(15, 23, 42, .08);
+    gap: .2rem;
+}
+
+.pm-drawer__link,
+.pm-drawer__label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    padding: .625rem .75rem;
+    border-radius: .75rem;
+    font-weight: 500;
+    color: var(--pm-text-secondary);
+    text-decoration: none;
+    transition: background-color .2s ease, color .2s ease, box-shadow .2s ease;
+}
+
+.pm-drawer__link:hover,
+.pm-drawer__link:focus,
+.pm-drawer__label:hover,
+.pm-drawer__label:focus {
+    color: var(--pm-text);
+    background: rgba(45, 108, 223, .12);
+    text-decoration: none;
+}
+
+.pm-drawer__link:focus-visible,
+.pm-drawer__label:focus-visible {
+    outline: 2px solid var(--pm-primary);
+    outline-offset: 2px;
+}
+
+.pm-drawer__link.is-active,
+.pm-drawer__label.is-active {
+    color: var(--pm-primary);
+    background: rgba(45, 108, 223, .16);
+    font-weight: 600;
+}
+
+.pm-drawer__meta {
+    font-size: .75rem;
+    color: var(--pm-muted);
+}
+
+@media (min-width: 992px) {
+    .pm-drawer {
+        position: static;
+        inset: auto;
+        height: auto;
+        pointer-events: auto;
+        visibility: visible;
+    }
+
+    .pm-drawer__overlay {
+        display: none;
+    }
+
+    .pm-drawer__panel {
+        transform: none;
+        width: auto;
+        height: auto;
+        box-shadow: none;
+        padding: 0;
+        transition: none;
+    }
+}
+
 .project-gallery-modal__thumb {
     border: 2px solid transparent;
     border-radius: .5rem;

--- a/wwwroot/js/navigation/drawer.js
+++ b/wwwroot/js/navigation/drawer.js
@@ -1,0 +1,221 @@
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable]',
+  '[tabindex]:not([tabindex="-1"])'
+].join(', ');
+
+function normaliseId(id) {
+  return typeof id === 'string' ? id.replace(/^#/, '') : '';
+}
+
+function findTogglesForDrawer(drawerId) {
+  if (!drawerId) {
+    return [];
+  }
+
+  const normalised = normaliseId(drawerId);
+  const candidates = document.querySelectorAll('[data-drawer-toggle]');
+  const result = [];
+
+  candidates.forEach((candidate) => {
+    if (!(candidate instanceof HTMLElement)) {
+      return;
+    }
+
+    const target =
+      candidate.getAttribute('data-drawer-target') ||
+      candidate.getAttribute('aria-controls') ||
+      candidate.getAttribute('data-target') ||
+      candidate.getAttribute('href');
+
+    if (!target) {
+      return;
+    }
+
+    if (normaliseId(target) === normalised) {
+      result.push(candidate);
+    }
+  });
+
+  return result;
+}
+
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTORS)).filter(
+    (element) =>
+      element instanceof HTMLElement &&
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true'
+  );
+}
+
+function setupDrawer(drawer) {
+  if (!(drawer instanceof HTMLElement)) {
+    return;
+  }
+
+  if (drawer.dataset.drawerInitialized === 'true') {
+    return;
+  }
+
+  drawer.dataset.drawerInitialized = 'true';
+
+  const providedId = drawer.id || drawer.getAttribute('data-drawer') || '';
+  const resolvedId = normaliseId(providedId);
+
+  if (resolvedId && !drawer.id) {
+    drawer.id = resolvedId;
+  }
+
+  const panel = drawer.querySelector('[data-drawer-panel]') || drawer;
+  const overlay = drawer.querySelector('[data-drawer-overlay]');
+  const closeButtons = Array.from(drawer.querySelectorAll('[data-drawer-close]'));
+  const toggles = findTogglesForDrawer(resolvedId);
+
+  if (!drawer.hasAttribute('aria-hidden')) {
+    drawer.setAttribute('aria-hidden', 'true');
+  }
+
+  if (panel instanceof HTMLElement && !panel.hasAttribute('tabindex')) {
+    panel.setAttribute('tabindex', '-1');
+  }
+
+  toggles.forEach((toggle) => {
+    if (!toggle.hasAttribute('aria-controls') && resolvedId) {
+      toggle.setAttribute('aria-controls', resolvedId);
+    }
+
+    toggle.setAttribute('aria-expanded', drawer.classList.contains('is-open') ? 'true' : 'false');
+  });
+
+  let restoreFocusTo = null;
+  let isOpen = drawer.classList.contains('is-open');
+
+  if (isOpen) {
+    drawer.setAttribute('aria-hidden', 'false');
+  } else {
+    drawer.classList.remove('is-open');
+  }
+
+  const handleKeydown = (event) => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault();
+      closeDrawer();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = getFocusableElements(panel instanceof HTMLElement ? panel : drawer);
+
+    if (focusable.length === 0) {
+      event.preventDefault();
+      if (panel instanceof HTMLElement) {
+        panel.focus({ preventScroll: true });
+      }
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    }
+  };
+
+  const focusFirstElement = () => {
+    const focusable = getFocusableElements(panel instanceof HTMLElement ? panel : drawer);
+
+    if (focusable.length > 0) {
+      focusable[0].focus({ preventScroll: true });
+      return;
+    }
+
+    if (panel instanceof HTMLElement) {
+      panel.focus({ preventScroll: true });
+    }
+  };
+
+  const openDrawer = () => {
+    if (isOpen) {
+      return;
+    }
+
+    restoreFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    drawer.classList.add('is-open');
+    drawer.setAttribute('aria-hidden', 'false');
+    toggles.forEach((toggle) => toggle.setAttribute('aria-expanded', 'true'));
+    isOpen = true;
+    document.addEventListener('keydown', handleKeydown);
+    window.requestAnimationFrame(focusFirstElement);
+  };
+
+  const closeDrawer = () => {
+    if (!isOpen) {
+      return;
+    }
+
+    drawer.classList.remove('is-open');
+    drawer.setAttribute('aria-hidden', 'true');
+    toggles.forEach((toggle) => toggle.setAttribute('aria-expanded', 'false'));
+    isOpen = false;
+    document.removeEventListener('keydown', handleKeydown);
+
+    if (restoreFocusTo && typeof restoreFocusTo.focus === 'function') {
+      restoreFocusTo.focus({ preventScroll: true });
+    }
+
+    restoreFocusTo = null;
+  };
+
+  const toggleDrawer = (event) => {
+    event.preventDefault();
+    if (isOpen) {
+      closeDrawer();
+    } else {
+      openDrawer();
+    }
+  };
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener('click', toggleDrawer);
+  });
+
+  closeButtons.forEach((closeButton) => {
+    closeButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeDrawer();
+    });
+  });
+
+  if (overlay) {
+    overlay.addEventListener('click', closeDrawer);
+  }
+};
+
+export function initDrawer() {
+  const drawers = document.querySelectorAll('[data-drawer]');
+  drawers.forEach((drawer) => setupDrawer(drawer));
+}
+
+export default initDrawer;

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,6 +1,8 @@
 import { initSparklines } from './charts/sparkline.js';
+import { initDrawer } from './navigation/drawer.js';
 
 function boot() {
+  initDrawer();
   initSparklines();
 }
 


### PR DESCRIPTION
## Summary
- add design-token aligned navigation drawer styles for panel layout, overlay, and nested lists
- create a drawer module that wires toggle buttons, manages aria attributes, traps focus, and responds to overlay or Escape to close
- initialize the drawer module during site boot alongside existing sparkline setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0d0dbdd888329bbd0d06d7e87f58b