### PR TITLE
Fix navigation drawer partial lookup

### DIFF
--- a/Pages/Shared/Components/NavigationDrawer/Default.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/Default.cshtml
@@ -27,11 +27,15 @@
             <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close navigation menu"></button>
         </div>
         <div class="offcanvas-body">
-            @await Html.PartialAsync("_NavigationDrawerItems", new NavigationDrawerItemsViewModel(Model.Items, true, 0))
+            @await Html.PartialAsync(
+                "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
+                new NavigationDrawerItemsViewModel(Model.Items, true, 0))
         </div>
     </div>
 
     <nav class="d-none d-lg-block" aria-label="Primary navigation">
-        @await Html.PartialAsync("_NavigationDrawerItems", new NavigationDrawerItemsViewModel(Model.Items, false, 0))
+        @await Html.PartialAsync(
+            "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
+            new NavigationDrawerItemsViewModel(Model.Items, false, 0))
     </nav>
 </div>

--- a/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml
@@ -34,7 +34,9 @@
 
         @if (node.Children.Count > 0)
         {
-            @await Html.PartialAsync("_NavigationDrawerItems", Model with
+            @await Html.PartialAsync(
+                "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
+                Model with
             {
                 Nodes = node.Children,
                 Depth = Model.Depth + 1


### PR DESCRIPTION
## Summary
- ensure the navigation drawer view component loads its item partial from an explicit path
- update recursive partial to reference the same explicit path when rendering child levels

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d70c59708329a27d41969519ed97