### PR TITLE
Refactor navigation drawer markup

### DIFF
--- a/Pages/Shared/Components/NavigationDrawer/Default.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/Default.cshtml
@@ -2,40 +2,39 @@
 @using System.Collections.Generic
 @using ProjectManagement.ViewComponents
 @{
-    const string offcanvasId = "pmNavigationDrawer";
-    const string offcanvasLabelId = "pmNavigationDrawerLabel";
+    const string drawerId = "pmNavigationDrawer";
+    const string drawerLabelId = "pmNavigationDrawerLabel";
 }
 
 <div class="d-flex align-items-center gap-2">
     <button class="navbar-toggler d-lg-none" type="button"
-            data-bs-toggle="offcanvas"
-            data-bs-target="#@offcanvasId"
-            aria-controls="@offcanvasId"
+            data-drawer-toggle
+            data-drawer-target="@drawerId"
+            aria-controls="@drawerId"
             aria-label="Toggle navigation menu">
         <span class="navbar-toggler-icon"></span>
     </button>
 
-    <div class="offcanvas offcanvas-start" tabindex="-1" id="@offcanvasId" aria-labelledby="@offcanvasLabelId">
-        <div class="offcanvas-header">
-            <div>
-                <h5 class="offcanvas-title mb-0" id="@offcanvasLabelId">@Model.Brand</h5>
-                @if (!string.IsNullOrEmpty(Model.UserName))
-                {
-                    <span class="text-muted small">Signed in as @Model.UserName</span>
-                }
+    <div class="pm-drawer" data-drawer="@drawerId" id="@drawerId" aria-labelledby="@drawerLabelId">
+        <div class="pm-drawer__overlay" data-drawer-overlay></div>
+        <div class="pm-drawer__panel" data-drawer-panel>
+            <div class="pm-drawer__header">
+                <div>
+                    <h2 class="pm-drawer__title" id="@drawerLabelId">@Model.Brand</h2>
+                    @if (!string.IsNullOrEmpty(Model.UserName))
+                    {
+                        <span class="text-muted small">Signed in as @Model.UserName</span>
+                    }
+                </div>
+                <button type="button" class="btn-close d-lg-none" data-drawer-close aria-label="Close navigation menu"></button>
             </div>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close navigation menu"></button>
-        </div>
-        <div class="offcanvas-body">
-            @await Html.PartialAsync(
-                "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
-                new NavigationDrawerItemsViewModel(Model.Items, true, 0))
+            <div class="pm-drawer__body">
+                <nav aria-label="Primary navigation">
+                    @await Html.PartialAsync(
+                        "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
+                        new NavigationDrawerItemsViewModel(Model.Items, true, 0))
+                </nav>
+            </div>
         </div>
     </div>
-
-    <nav class="d-none d-lg-block" aria-label="Primary navigation">
-        @await Html.PartialAsync(
-            "~/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml",
-            new NavigationDrawerItemsViewModel(Model.Items, false, 0))
-    </nav>
 </div>

--- a/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/_NavigationDrawerItems.cshtml
@@ -2,34 +2,30 @@
 @using ProjectManagement.ViewComponents
 
 @{
-    var listClasses = Model.IsOffcanvas
-        ? $"nav flex-column gap-1{(Model.Depth > 0 ? " ms-3" : string.Empty)}"
-        : Model.Depth == 0
-            ? "navbar-nav flex-row align-items-center gap-2"
-            : "nav flex-column ms-lg-3 gap-1";
+    var listClasses = "pm-drawer__list";
 }
 
 <ul class="@listClasses">
 @foreach (var node in Model.Nodes)
 {
-    var linkClasses = "nav-link";
-    if (node.IsActive)
+    var itemClasses = "pm-drawer__item";
+    var displayClasses = string.IsNullOrEmpty(node.Url)
+        ? "pm-drawer__label"
+        : "pm-drawer__link";
+
+    if (node.IsActive || node.HasActiveDescendant)
     {
-        linkClasses += " active fw-semibold";
-    }
-    else if (node.HasActiveDescendant)
-    {
-        linkClasses += " fw-semibold";
+        displayClasses += " is-active";
     }
 
-    <li class="nav-item">
+    <li class="@itemClasses">
         @if (!string.IsNullOrEmpty(node.Url))
         {
-            <a class="@linkClasses" href="@node.Url" @(node.IsActive ? "aria-current=\"page\"" : null)>@node.Text</a>
+            <a class="@displayClasses" href="@node.Url" @(node.IsActive ? "aria-current=\"page\"" : null)>@node.Text</a>
         }
         else
         {
-            <span class="@($"{linkClasses} disabled")">@node.Text</span>
+            <span class="@displayClasses" @(node.IsActive ? "aria-current=\"page\"" : null)>@node.Text</span>
         }
 
         @if (node.Children.Count > 0)


### PR DESCRIPTION
## Summary
- replace the Bootstrap offcanvas markup with the pm-drawer container, overlay, and panel that work with initDrawer
- render the drawer header/body using the pm-drawer utility classes and switch the toggle to data-drawer attributes
- update the navigation drawer items partial to output pm-drawer list/link classes with the new active styling

## Testing
- `DOTNET_ENVIRONMENT=Development dotnet run --urls http://0.0.0.0:5000` *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ed41ef308329bf877ec115727a9d