### PR TITLE
Remove large breakpoint overrides from drawer styling

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -770,28 +770,6 @@ body {
     color: var(--pm-muted);
 }
 
-@media (min-width: 992px) {
-    .pm-drawer {
-        position: static;
-        inset: auto;
-        height: auto;
-        pointer-events: auto;
-        visibility: visible;
-    }
-
-    .pm-drawer__overlay {
-        display: none;
-    }
-
-    .pm-drawer__panel {
-        transform: none;
-        width: auto;
-        height: auto;
-        box-shadow: none;
-        padding: 0;
-        transition: none;
-    }
-}
 
 .project-gallery-modal__thumb {
     border: 2px solid transparent;


### PR DESCRIPTION
## Summary
- remove the desktop-specific overrides for the drawer so the overlay and slide-in animation remain consistent across breakpoints

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f529086883298484495376146ff6