### PR TITLE
Keep navigation drawer controls visible on large screens

### DIFF
--- a/Pages/Shared/Components/NavigationDrawer/Default.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/Default.cshtml
@@ -10,7 +10,7 @@
 @if (Model.Items?.Any() ?? false)
 {
     <div class="d-flex align-items-center gap-2">
-        <button class="navbar-toggler d-lg-none" type="button"
+        <button class="navbar-toggler" type="button"
                 data-drawer-toggle
                 data-drawer-target="@drawerId"
                 aria-controls="@drawerId"
@@ -29,7 +29,7 @@
                             <span class="text-muted small">Signed in as @Model.UserName</span>
                         }
                     </div>
-                    <button type="button" class="btn-close d-lg-none" data-drawer-close aria-label="Close navigation menu"></button>
+                    <button type="button" class="btn-close" data-drawer-close aria-label="Close navigation menu"></button>
                 </div>
                 <div class="pm-drawer__body">
                     <nav aria-label="Primary navigation">


### PR DESCRIPTION
## Summary
- keep the navigation drawer toggle button visible at large breakpoints
- allow desktop users to close the drawer using the built-in close button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f5a63f708329ba1e4005a8888be8