### PR TITLE
Fix navigation drawer toggle alignment and visibility

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -17,10 +17,10 @@
 <body>
     <header class="pm-header border-bottom">
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
-            <div class="container">
+            <div class="container d-flex align-items-center gap-3">
+                @await Component.InvokeAsync("NavigationDrawer")
                 <a class="navbar-brand fw-semibold" asp-area="" asp-page="/Index">ProjectManagement</a>
-                <div class="d-flex align-items-center ms-auto gap-3">
-                    @await Component.InvokeAsync("NavigationDrawer")
+                <div class="ms-auto d-flex align-items-center gap-3">
                     <partial name="_LoginPartial" />
                 </div>
             </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -24,6 +24,12 @@ body {
     background-color: var(--pm-surface);
 }
 
+/* Keep the navigation drawer toggle visible when the navbar is expanded */
+.navbar-expand-lg .navbar-toggler {
+    display: inline-flex;
+    align-items: center;
+}
+
 /* ---------- Cards ---------- */
 .pm-card {
     border: 1px solid rgba(15, 23, 42, .08);


### PR DESCRIPTION
## Summary
- move the navigation drawer toggle before the brand so it stays left-aligned and keep auth controls on the right
- add a Bootstrap override to keep the drawer toggle visible at lg+ breakpoints

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f960ba048329be42de87f6ecaf29