### PR TITLE
Fix calendar page bootstrap duplication

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -5,7 +5,6 @@
 }
 
 @section Styles {
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/calendar.css" asp-append-version="true" />
 }
 
@@ -235,9 +234,7 @@
 </div>
 
 @section Scripts {
-  <!-- Order matters: Bootstrap JS → FullCalendar → page script -->
-  <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-
+  <!-- FullCalendar depends on Bootstrap, which is already loaded by the layout. -->
   <!-- EITHER: single bundle -->
   <script src="~/lib/fullcalendar/bundle/index.global.min.js"></script>
 


### PR DESCRIPTION
## Summary
- remove the Calendar page's redundant Bootstrap CSS and JS imports so layout styles remain in effect
- document that FullCalendar uses the Bootstrap bundle provided by the layout

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e15f5a91308329b1a5a6e08bb91a37