### PR TITLE
Fix invalid role attribute on calendar switch

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -127,7 +127,7 @@
             </div>
             <div class="col-12 col-md-4">
               <div class="form-check form-switch mt-1">
-                <input class="form-check-input" type="checkbox" role="switch" id="toggleAllDay" name="isAllDay">
+                <input class="form-check-input" type="checkbox" id="toggleAllDay" name="isAllDay">
                 <label class="form-check-label" for="toggleAllDay">All-day event</label>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the invalid `role="switch"` attribute from the calendar all-day toggle to silence the HTML0209 warning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1622138988329972c76a6f0928ba2