### PR TITLE
Adjust calendar scheduling column breakpoints

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -96,29 +96,29 @@
         <section class="event-form-section">
           <h6 class="event-form-heading mb-3 text-uppercase text-muted">Scheduling</h6>
           <div class="row gy-3 gx-3 align-items-end">
-            <div class="col-12 col-md-8">
+            <div class="col-12 col-lg-8">
               <div class="row gy-2 gx-3" id="timePickers">
-                <div class="col-12 col-md-6">
+                <div class="col-12 col-lg-6">
                   <label class="form-label">Start</label>
                   <input type="datetime-local" class="form-control" name="start" />
                 </div>
-                <div class="col-12 col-md-6">
+                <div class="col-12 col-lg-6">
                   <label class="form-label">End</label>
                   <input type="datetime-local" class="form-control" name="end" />
                 </div>
               </div>
               <div class="row gy-2 gx-3 d-none" id="datePickers">
-                <div class="col-12 col-md-6">
+                <div class="col-12 col-lg-6">
                   <label class="form-label">Start date</label>
                   <input type="date" class="form-control" name="startDate" />
                 </div>
-                <div class="col-12 col-md-6">
+                <div class="col-12 col-lg-6">
                   <label class="form-label">End date</label>
                   <input type="date" class="form-control" name="endDate" />
                 </div>
               </div>
             </div>
-            <div class="col-12 col-md-4">
+            <div class="col-12 col-lg-4">
               <div class="form-check form-switch mt-1">
                 <input class="form-check-input" type="checkbox" id="toggleAllDay" name="isAllDay">
                 <label class="form-check-label" for="toggleAllDay">All-day event</label>


### PR DESCRIPTION
## Summary
- keep the scheduling start/end inputs full width until large screens
- align the all-day date picker layout with the timed pickers

## Testing
- dotnet run *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1682930e483299976b6a09bdec125