### PR TITLE
Fix calendar page navigation toggle icon

### DIFF
--- a/Pages/Shared/Components/NavigationDrawer/Default.cshtml
+++ b/Pages/Shared/Components/NavigationDrawer/Default.cshtml
@@ -15,7 +15,9 @@
                 data-drawer-target="@drawerId"
                 aria-controls="@drawerId"
                 aria-label="Toggle navigation menu">
-            <span class="navbar-toggler-icon"></span>
+            <span class="navbar-toggler-icon" aria-hidden="true">
+                <i class="bi bi-list"></i>
+            </span>
         </button>
 
         <div class="pm-drawer" data-drawer="@drawerId" id="@drawerId" aria-labelledby="@drawerLabelId">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -214,6 +214,21 @@ body {
     letter-spacing: .2px;
 }
 
+.pm-header .navbar-toggler-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    background-image: none;
+    padding: 0;
+}
+
+.pm-header .navbar-toggler-icon .bi-list {
+    font-size: 1.5rem;
+    color: var(--pm-text);
+}
+
 .pm-footer {
     background: var(--pm-surface);
 }


### PR DESCRIPTION
## Summary
- replace the navigation drawer toggle markup with a Bootstrap icon so the hamburger remains visible on the calendar page
- add header-specific styling to size and color the new icon consistently across viewports

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e16b60e4e08329b468dadfb764a173