### PR TITLE
Remove redundant bootstrap include on calendar page

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -5,7 +5,6 @@
 }
 
 @section Styles {
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/calendar.css" asp-append-version="true" />
 }
 


### PR DESCRIPTION
## Summary
- remove the redundant bootstrap stylesheet reference from the calendar page so the layout styling remains effective

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16f0a9ea88329940e059e726d9fff