### PR TITLE
Add role-specific accents to remarks panel badges

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -29,6 +29,27 @@
     --bs-body-font-family: var(--pm-font-stack);
     --bs-body-font-size: var(--pm-font-size-base);
     --bs-body-line-height: var(--pm-line-height-base);
+    --remarks-role-comdt-bg: var(--bs-danger-bg-subtle, #f8d7da);
+    --remarks-role-comdt-border: var(--bs-danger-border-subtle, #f1aeb5);
+    --remarks-role-comdt-text: var(--bs-danger-text-emphasis, #58151c);
+    --remarks-role-hod-bg: var(--bs-success-bg-subtle, #d1e7dd);
+    --remarks-role-hod-border: var(--bs-success-border-subtle, #a3cfbb);
+    --remarks-role-hod-text: var(--bs-success-text-emphasis, #0a3622);
+    --remarks-role-mco-bg: var(--bs-primary-bg-subtle, #cfe2ff);
+    --remarks-role-mco-border: var(--bs-primary-border-subtle, #9ec5fe);
+    --remarks-role-mco-text: var(--bs-primary-text-emphasis, #052c65);
+}
+
+[data-bs-theme="dark"] {
+    --remarks-role-comdt-bg: rgba(220, 53, 69, .25);
+    --remarks-role-comdt-border: rgba(220, 53, 69, .55);
+    --remarks-role-comdt-text: #fff;
+    --remarks-role-hod-bg: rgba(25, 135, 84, .25);
+    --remarks-role-hod-border: rgba(25, 135, 84, .5);
+    --remarks-role-hod-text: #fff;
+    --remarks-role-mco-bg: rgba(13, 110, 253, .25);
+    --remarks-role-mco-border: rgba(13, 110, 253, .55);
+    --remarks-role-mco-text: #fff;
 }
 
 body {
@@ -1100,6 +1121,30 @@ body {
     background-color: var(--pm-card);
     padding: 1rem;
     box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .02);
+    position: relative;
+}
+
+.remarks-item.remarks-role-comdt::before,
+.remarks-item.remarks-role-hod::before,
+.remarks-item.remarks-role-mco::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border-inline-start: 4px solid transparent;
+    pointer-events: none;
+}
+
+.remarks-item.remarks-role-comdt::before {
+    border-inline-start-color: var(--remarks-role-comdt-border);
+}
+
+.remarks-item.remarks-role-hod::before {
+    border-inline-start-color: var(--remarks-role-hod-border);
+}
+
+.remarks-item.remarks-role-mco::before {
+    border-inline-start-color: var(--remarks-role-mco-border);
 }
 
 [data-bs-theme="dark"] .remarks-item {
@@ -1126,6 +1171,31 @@ body {
 .remarks-meta {
     font-size: var(--pm-font-size-xs);
     color: var(--pm-muted);
+}
+
+.badge.remarks-role-badge {
+    font-size: var(--pm-font-size-xs);
+    font-weight: 600;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+}
+
+.badge.remarks-role-comdt {
+    background-color: var(--remarks-role-comdt-bg);
+    border-color: var(--remarks-role-comdt-border);
+    color: var(--remarks-role-comdt-text) !important;
+}
+
+.badge.remarks-role-hod {
+    background-color: var(--remarks-role-hod-bg);
+    border-color: var(--remarks-role-hod-border);
+    color: var(--remarks-role-hod-text) !important;
+}
+
+.badge.remarks-role-mco {
+    background-color: var(--remarks-role-mco-bg);
+    border-color: var(--remarks-role-mco-border);
+    color: var(--remarks-role-mco-text) !important;
 }
 
 .remarks-body {

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1127,7 +1127,14 @@
             nameRow.appendChild(name);
 
             const roleBadge = document.createElement('span');
-            roleBadge.className = 'badge bg-light text-dark border';
+            roleBadge.className = 'badge border remarks-role-badge';
+            const roleAccentClass = this.getRoleAccentClass(remark.authorRole);
+            if (roleAccentClass) {
+                roleBadge.classList.add(roleAccentClass);
+                article.classList.add(roleAccentClass);
+            } else {
+                roleBadge.classList.add('bg-light', 'text-dark');
+            }
             roleBadge.textContent = this.getRoleLabel(remark.authorRole);
             nameRow.appendChild(roleBadge);
 
@@ -1400,6 +1407,28 @@
 
             const [first, ...rest] = parts;
             return first.toLowerCase() + rest.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()).join('');
+        }
+
+        getRoleAccentClass(role) {
+            if (!role) {
+                return '';
+            }
+
+            const canonical = this.resolveCanonicalRole(role);
+            const normalized = this.normalizeRoleKey(canonical || role);
+            if (normalized === 'comdt') {
+                return 'remarks-role-comdt';
+            }
+
+            if (normalized === 'hod') {
+                return 'remarks-role-hod';
+            }
+
+            if (normalized === 'mco') {
+                return 'remarks-role-mco';
+            }
+
+            return '';
         }
 
         getRoleLabel(role) {


### PR DESCRIPTION
## Summary
- add deterministic role accent classes to remarks items and badges for COMDT, HoD, and MCO authors
- introduce theme-aware styling tokens for the accented roles and apply subtle borders/backgrounds
- keep badge typography consistent while providing higher-contrast role-specific colour accents

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fc187494832990fbddd3271ed64d