### PR TITLE
Handle canonical role classes in remarks panel

### DIFF
--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1561,15 +1561,19 @@
 
             const canonical = this.resolveCanonicalRole(role);
             const normalized = this.normalizeRoleKey(canonical || role);
-            if (normalized === 'comdt') {
+            if (normalized === 'comdt' || normalized === 'commandant') {
                 return 'remarks-role-comdt';
             }
 
-            if (normalized === 'hod') {
+            if (normalized === 'hod' || normalized === 'headofdepartment') {
                 return 'remarks-role-hod';
             }
 
-            if (normalized === 'mco') {
+            if (
+                normalized === 'mco'
+                || normalized === 'medicalcentreofficer'
+                || normalized === 'medicalcenterofficer'
+            ) {
                 return 'remarks-role-mco';
             }
 

--- a/wwwroot/js/projects/remarks-panel.test.js
+++ b/wwwroot/js/projects/remarks-panel.test.js
@@ -152,3 +152,43 @@ test('saveEdit serializes mentions using the stored mapping', async () => {
     assert.ok(requestBody);
     assert.equal(requestBody.body, '@[John Doe](user:user-1)');
 });
+
+test('buildRemarkElement applies role accent classes for canonical roles', () => {
+    const { panel } = createPanelDom();
+
+    const baseRemark = {
+        id: 1,
+        rowVersion: 'rv',
+        isDeleted: false,
+        authorInitials: 'AB',
+        authorDisplayName: 'Alice Bob',
+        authorUserId: 'user-123',
+        type: 'Internal',
+        body: '<p>Test remark</p>',
+        eventDate: null,
+        stageRef: null,
+        stageName: null,
+        createdAtUtc: new Date().toISOString(),
+        lastEditedAtUtc: null
+    };
+
+    const commandantArticle = panel.buildRemarkElement({
+        ...baseRemark,
+        id: 101,
+        authorRole: 'Commandant'
+    });
+    const commandantBadge = commandantArticle.querySelector('.remarks-role-badge');
+    assert.ok(commandantBadge);
+    assert.ok(commandantBadge.classList.contains('remarks-role-comdt'));
+    assert.ok(commandantArticle.classList.contains('remarks-role-comdt'));
+
+    const hodArticle = panel.buildRemarkElement({
+        ...baseRemark,
+        id: 102,
+        authorRole: 'HeadOfDepartment'
+    });
+    const hodBadge = hodArticle.querySelector('.remarks-role-badge');
+    assert.ok(hodBadge);
+    assert.ok(hodBadge.classList.contains('remarks-role-hod'));
+    assert.ok(hodArticle.classList.contains('remarks-role-hod'));
+});


### PR DESCRIPTION
## Summary
- update the remarks panel role accent resolver to treat canonical role names the same as their abbreviations
- add unit coverage ensuring buildRemarkElement applies the expected CSS classes when remarks use canonical roles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e20d419d648329a7abfc5dc4faaf7b