### PR TITLE
Align remark actions with header layout

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1214,7 +1214,8 @@ body {
 }
 
 .remarks-actions {
-    margin-top: .25rem;
+    margin-top: 0;
+    flex-shrink: 0;
 }
 
 .remarks-actions .btn {

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1335,6 +1335,10 @@
             }
 
             header.appendChild(identity);
+
+            const actions = document.createElement('div');
+            actions.className = 'remarks-actions ms-auto d-flex flex-wrap align-items-center gap-2';
+            header.appendChild(actions);
             article.appendChild(header);
 
             const body = document.createElement('div');
@@ -1369,9 +1373,6 @@
                 tombstone.textContent = this.formatDeletionLabel(remark);
                 article.appendChild(tombstone);
             }
-
-            const actions = document.createElement('div');
-            actions.className = 'remarks-actions d-flex flex-wrap align-items-center gap-2';
 
             const withinWindow = this.isWithinEditWindow(remark.createdAtUtc);
             const hasOverride = this.actorHasOverride;
@@ -1413,7 +1414,7 @@
                         toggle.appendChild(toggleSr);
 
                         const menu = document.createElement('ul');
-                        menu.className = 'dropdown-menu';
+                        menu.className = 'dropdown-menu dropdown-menu-end';
                         menu.id = dropdownId;
 
                         const makeMenuItem = (action, text) => {
@@ -1492,8 +1493,6 @@
                     actions.appendChild(notice);
                 }
             }
-
-            article.appendChild(actions);
 
             return article;
         }

--- a/wwwroot/js/projects/remarks-panel.test.js
+++ b/wwwroot/js/projects/remarks-panel.test.js
@@ -207,6 +207,11 @@ test('non-override author sees inline action buttons within edit window', () => 
     const actions = article.querySelector('.remarks-actions');
     assert.ok(actions);
 
+    const header = actions.parentElement;
+    assert.ok(header);
+    assert.ok(header.classList.contains('d-flex'));
+    assert.ok(actions.classList.contains('ms-auto'));
+
     const editButton = actions.querySelector('button[data-remark-action="edit"]');
     const deleteButton = actions.querySelector('button[data-remark-action="delete"]');
     assert.ok(editButton);
@@ -261,6 +266,7 @@ test('override actor outside edit window gets dropdown actions', () => {
 
     const menu = dropdown.querySelector('.dropdown-menu');
     assert.ok(menu);
+    assert.ok(menu.classList.contains('dropdown-menu-end'));
     assert.ok(menu.id);
     assert.strictEqual(toggle.getAttribute('aria-controls'), menu.id);
 


### PR DESCRIPTION
## Summary
- reposition the remark actions container within the header to align buttons to the right and ensure dropdown alignment
- update remark action styles to remove excess spacing and keep controls compact in the header
- adjust unit tests to reflect the new header structure for remark actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2145a7db083298543bb5c18ec201d