### PR TITLE
Ensure avatar retains sizing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1038,6 +1038,8 @@ body {
   font-weight: 700;
   font-size: var(--pm-font-size-compact);
   border: 1px solid rgba(0,0,0,.06);
+  flex: 0 0 auto;
+  aspect-ratio: 1 / 1;
 }
 
 /* ===== Density & scale (small, professional) ===== */


### PR DESCRIPTION
## Summary
- prevent flex layouts from shrinking avatars by giving the base `.avatar` class an explicit flex constraint
- guarantee avatars stay square by adding a 1:1 aspect ratio so the remarks variant keeps its 40px circle

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e21751e63483299831a16c521cec15