### PR TITLE
Expand navbar layout width

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
 <body>
     <header class="pm-header border-bottom">
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
-            <div class="container d-flex align-items-center gap-3">
+            <div class="container-fluid px-3 px-md-4 px-lg-5 d-flex align-items-center gap-3">
                 @await Component.InvokeAsync("NavigationDrawer")
                 <a class="navbar-brand fw-semibold" asp-area="" asp-page="/Index">ProjectManagement</a>
                 <div class="ms-auto d-flex align-items-center gap-3">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -246,6 +246,10 @@ body {
 }
 
 /* ---------- Header & footer ---------- */
+.pm-header .navbar {
+    padding-inline: 0;
+}
+
 .pm-header .navbar-brand {
     letter-spacing: .2px;
 }


### PR DESCRIPTION
## Summary
- allow the navigation drawer, brand, and auth controls to use the full navbar width with a fluid container
- remove the default navbar horizontal padding so the header keeps GitHub-like spacing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e21c25414c8329906456d3ac0ab9d8