### PR TITLE
Align remarks avatar styling with role badges

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1170,6 +1170,24 @@ body {
     font-size: var(--pm-font-size-tight);
 }
 
+.remarks-avatar.remarks-role-comdt {
+    background-color: var(--remarks-role-comdt-bg);
+    border-color: var(--remarks-role-comdt-border);
+    color: var(--remarks-role-comdt-text);
+}
+
+.remarks-avatar.remarks-role-hod {
+    background-color: var(--remarks-role-hod-bg);
+    border-color: var(--remarks-role-hod-border);
+    color: var(--remarks-role-hod-text);
+}
+
+.remarks-avatar.remarks-role-mco {
+    background-color: var(--remarks-role-mco-bg);
+    border-color: var(--remarks-role-mco-border);
+    color: var(--remarks-role-mco-text);
+}
+
 .remarks-meta {
     font-size: var(--pm-font-size-xs);
     color: var(--pm-muted);

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1273,6 +1273,7 @@
             const roleAccentClass = this.getRoleAccentClass(remark.authorRole);
             if (roleAccentClass) {
                 roleBadge.classList.add(roleAccentClass);
+                avatar.classList.add(roleAccentClass);
                 article.classList.add(roleAccentClass);
             } else {
                 roleBadge.classList.add('bg-light', 'text-dark');


### PR DESCRIPTION
## Summary
- add the role accent class to remark avatars so they share badge styling cues
- style role-specific remark avatars with the existing CSS variables for both themes

## Testing
- ⚠️ `DOTNET_URLS=http://0.0.0.0:5000 dotnet run` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e218dc39c08329a2a86beda09f4eb7