### PR TITLE
Expand project search with query and filter options

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -8,7 +8,7 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <div>
             <h1 class="h3 mb-0">Projects</h1>
-            <p class="text-muted mb-0">Showing the 100 most recent projects.</p>
+            <p class="text-muted mb-0">Search across case files, descriptions, categories, and assigned staff. Showing up to 100 results.</p>
         </div>
         @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
         {
@@ -16,19 +16,31 @@
         }
     </div>
 
-    <form method="get" class="row g-2 align-items-end mb-4">
-        <div class="col-sm-4 col-md-3">
-            <label for="CaseFileQuery" class="form-label">Case File Number</label>
-            <input id="CaseFileQuery" name="CaseFileQuery" value="@Model.CaseFileQuery" class="form-control" placeholder="Search Case File #" />
+    <form method="get" class="row g-3 align-items-end mb-4">
+        <div class="col-md-5 col-lg-4">
+            <label asp-for="Query" class="form-label">Search projects</label>
+            <input asp-for="Query" class="form-control" placeholder="Search by name, description, case file, category, or people" />
+        </div>
+        <div class="col-sm-6 col-md-4 col-lg-3">
+            <label asp-for="CategoryId" class="form-label">Category</label>
+            <select asp-for="CategoryId" class="form-select" asp-items="Model.CategoryOptions"></select>
+        </div>
+        <div class="col-sm-6 col-md-4 col-lg-3">
+            <label asp-for="HodUserId" class="form-label">Head of Department</label>
+            <select asp-for="HodUserId" class="form-select" asp-items="Model.HodOptions"></select>
+        </div>
+        <div class="col-sm-6 col-md-4 col-lg-3">
+            <label asp-for="LeadPoUserId" class="form-label">Project Officer</label>
+            <select asp-for="LeadPoUserId" class="form-select" asp-items="Model.LeadPoOptions"></select>
         </div>
         <div class="col-auto">
-            <button type="submit" class="btn btn-outline-primary">Search</button>
+            <button type="submit" class="btn btn-outline-primary">Apply filters</button>
         </div>
     </form>
 
     @if (!Model.Projects.Any())
     {
-        <div class="alert alert-info">No projects found.</div>
+        <div class="alert alert-info">No projects match your search. Adjust the keywords or filters and try again.</div>
     }
     else
     {

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -1,9 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Services.Projects;
 
 namespace ProjectManagement.Pages.Projects
 {
@@ -20,10 +25,27 @@ namespace ProjectManagement.Pages.Projects
         public IList<Project> Projects { get; private set; } = new List<Project>();
 
         [BindProperty(SupportsGet = true)]
-        public string? CaseFileQuery { get; set; }
+        public string? Query { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public int? CategoryId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string? LeadPoUserId { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string? HodUserId { get; set; }
+
+        public IEnumerable<SelectListItem> CategoryOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+        public IEnumerable<SelectListItem> LeadPoOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+        public IEnumerable<SelectListItem> HodOptions { get; private set; } = Array.Empty<SelectListItem>();
 
         public async Task OnGetAsync()
         {
+            await LoadFilterOptionsAsync();
+
             var query = _db.Projects
                 .AsNoTracking()
                 .Include(p => p.Category)
@@ -32,13 +54,101 @@ namespace ProjectManagement.Pages.Projects
                 .OrderByDescending(p => p.CreatedAt)
                 .AsQueryable();
 
-            if (!string.IsNullOrWhiteSpace(CaseFileQuery))
-            {
-                var term = CaseFileQuery.Trim();
-                query = query.Where(p => p.CaseFileNumber != null && EF.Functions.ILike(p.CaseFileNumber!, $"%{term}%"));
-            }
+            var filters = new ProjectSearchFilters(Query, CategoryId, LeadPoUserId, HodUserId);
+            query = query.ApplyProjectSearch(filters);
 
             Projects = await query.Take(100).ToListAsync();
         }
+
+        private async Task LoadFilterOptionsAsync()
+        {
+            var categories = await _db.ProjectCategories
+                .AsNoTracking()
+                .OrderBy(c => c.Name)
+                .Select(c => new CategoryOption(c.Id, c.Name))
+                .ToListAsync();
+
+            CategoryOptions = BuildCategoryOptions(categories, CategoryId);
+
+            var hodUsers = await _db.Projects
+                .AsNoTracking()
+                .Where(p => p.HodUserId != null)
+                .Select(p => new UserOption(
+                    p.HodUserId!,
+                    p.HodUser != null ? p.HodUser.FullName : null,
+                    p.HodUser != null ? p.HodUser.UserName : null))
+                .ToListAsync();
+
+            HodOptions = BuildUserOptions(hodUsers, HodUserId, "Any HoD");
+
+            var leadPoUsers = await _db.Projects
+                .AsNoTracking()
+                .Where(p => p.LeadPoUserId != null)
+                .Select(p => new UserOption(
+                    p.LeadPoUserId!,
+                    p.LeadPoUser != null ? p.LeadPoUser.FullName : null,
+                    p.LeadPoUser != null ? p.LeadPoUser.UserName : null))
+                .ToListAsync();
+
+            LeadPoOptions = BuildUserOptions(leadPoUsers, LeadPoUserId, "Any Project Officer");
+        }
+
+        private static IEnumerable<SelectListItem> BuildCategoryOptions(IEnumerable<CategoryOption> categories, int? selectedId)
+        {
+            var options = new List<SelectListItem>
+            {
+                new("All categories", string.Empty, !selectedId.HasValue)
+            };
+
+            var selectedValue = selectedId?.ToString();
+            options.AddRange(categories.Select(c => new SelectListItem(c.Name, c.Id.ToString())
+            {
+                Selected = selectedValue is not null && string.Equals(selectedValue, c.Id.ToString(), StringComparison.Ordinal)
+            }));
+
+            return options;
+        }
+
+        private static IEnumerable<SelectListItem> BuildUserOptions(IEnumerable<UserOption> users, string? selectedId, string emptyLabel)
+        {
+            var options = new List<SelectListItem>
+            {
+                new(emptyLabel, string.Empty, string.IsNullOrWhiteSpace(selectedId))
+            };
+
+            var uniqueUsers = users
+                .Where(u => !string.IsNullOrWhiteSpace(u.Id))
+                .GroupBy(u => u.Id, StringComparer.Ordinal)
+                .Select(g => g.First())
+                .OrderBy(u => DisplayName(u), StringComparer.OrdinalIgnoreCase)
+                .ThenBy(u => DisplayName(u));
+
+            foreach (var user in uniqueUsers)
+            {
+                var selected = selectedId is not null && string.Equals(user.Id, selectedId, StringComparison.Ordinal);
+                options.Add(new SelectListItem(DisplayName(user), user.Id, selected));
+            }
+
+            return options;
+        }
+
+        private static string DisplayName(UserOption option)
+        {
+            if (!string.IsNullOrWhiteSpace(option.FullName))
+            {
+                return option.FullName!;
+            }
+
+            if (!string.IsNullOrWhiteSpace(option.UserName))
+            {
+                return option.UserName!;
+            }
+
+            return option.Id;
+        }
+
+        private sealed record UserOption(string Id, string? FullName, string? UserName);
+
+        private sealed record CategoryOption(int Id, string Name);
     }
 }

--- a/ProjectManagement.Tests/ProjectSearchFiltersTests.cs
+++ b/ProjectManagement.Tests/ProjectSearchFiltersTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Projects;
+using Xunit;
+
+namespace ProjectManagement.Tests
+{
+    public class ProjectSearchFiltersTests
+    {
+        [Fact]
+        public async Task Query_By_Name_Finds_Project()
+        {
+            await using var context = CreateContext();
+            var project = new Project
+            {
+                Name = "Alpha Road Upgrade",
+                Description = "",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow
+            };
+            var other = new Project
+            {
+                Name = "Beta Housing",
+                Description = "",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            context.Projects.AddRange(project, other);
+            await context.SaveChangesAsync();
+
+            var query = context.Projects.AsQueryable();
+            var filters = new ProjectSearchFilters("alpha", null, null, null);
+
+            var results = await query.ApplyProjectSearch(filters).ToListAsync();
+
+            Assert.Contains(results, p => p.Name == project.Name);
+            Assert.DoesNotContain(results, p => p.Name == other.Name);
+        }
+
+        [Fact]
+        public async Task Query_By_Description_Finds_Project()
+        {
+            await using var context = CreateContext();
+            var project = new Project
+            {
+                Name = "Harbour Works",
+                Description = "Coastal bridge reinforcement",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow
+            };
+            var other = new Project
+            {
+                Name = "Airport Terminal",
+                Description = "Expansion of terminal facilities",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            context.Projects.AddRange(project, other);
+            await context.SaveChangesAsync();
+
+            var query = context.Projects.AsQueryable();
+            var filters = new ProjectSearchFilters("bridge", null, null, null);
+
+            var results = await query.ApplyProjectSearch(filters).ToListAsync();
+
+            Assert.Contains(results, p => p.Name == project.Name);
+            Assert.DoesNotContain(results, p => p.Name == other.Name);
+        }
+
+        [Fact]
+        public async Task Query_By_Assigned_User_Finds_Project()
+        {
+            await using var context = CreateContext();
+            var hod = new ApplicationUser
+            {
+                Id = "hod-1",
+                UserName = "hod.smith",
+                FullName = "Harriet Smith"
+            };
+            var po = new ApplicationUser
+            {
+                Id = "po-1",
+                UserName = "po.jones",
+                FullName = "Pat Officer"
+            };
+
+            context.Users.AddRange(hod, po);
+
+            var project = new Project
+            {
+                Name = "Schools Programme",
+                Description = "",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow,
+                HodUserId = hod.Id,
+                LeadPoUserId = po.Id
+            };
+            var other = new Project
+            {
+                Name = "Parks Revamp",
+                Description = "",
+                CreatedByUserId = "creator",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            context.Projects.AddRange(project, other);
+            await context.SaveChangesAsync();
+
+            var query = context.Projects
+                .Include(p => p.HodUser)
+                .Include(p => p.LeadPoUser)
+                .AsQueryable();
+
+            var filters = new ProjectSearchFilters("pat officer", null, null, null);
+
+            var results = await query.ApplyProjectSearch(filters).ToListAsync();
+
+            Assert.Contains(results, p => p.Name == project.Name);
+            Assert.DoesNotContain(results, p => p.Name == other.Name);
+        }
+
+        private static ApplicationDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            return new ApplicationDbContext(options);
+        }
+    }
+}

--- a/Services/Projects/ProjectSearchFilters.cs
+++ b/Services/Projects/ProjectSearchFilters.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.Projects
+{
+    public record ProjectSearchFilters(
+        string? Query,
+        int? CategoryId,
+        string? LeadPoUserId,
+        string? HodUserId);
+
+    public static class ProjectSearchQueryExtensions
+    {
+        public static IQueryable<Project> ApplyProjectSearch(this IQueryable<Project> source, ProjectSearchFilters filters)
+        {
+            if (filters is null)
+            {
+                throw new ArgumentNullException(nameof(filters));
+            }
+
+            if (!string.IsNullOrWhiteSpace(filters.Query))
+            {
+                var term = filters.Query.Trim();
+                var like = $"%{term}%";
+                var normalized = term.ToLowerInvariant();
+
+                source = source.Where(p =>
+                    EF.Functions.ILike(p.Name, like) ||
+                    p.Name.ToLower().Contains(normalized) ||
+                    (p.Description != null &&
+                        (EF.Functions.ILike(p.Description!, like) || p.Description!.ToLower().Contains(normalized))) ||
+                    (p.CaseFileNumber != null &&
+                        (EF.Functions.ILike(p.CaseFileNumber!, like) || p.CaseFileNumber!.ToLower().Contains(normalized))) ||
+                    (p.Category != null &&
+                        (EF.Functions.ILike(p.Category.Name, like) || p.Category.Name.ToLower().Contains(normalized))) ||
+                    (p.HodUser != null &&
+                        ((p.HodUser.FullName != null &&
+                            (EF.Functions.ILike(p.HodUser.FullName!, like) || p.HodUser.FullName!.ToLower().Contains(normalized))) ||
+                         (p.HodUser.UserName != null &&
+                            (EF.Functions.ILike(p.HodUser.UserName!, like) || p.HodUser.UserName!.ToLower().Contains(normalized))))) ||
+                    (p.LeadPoUser != null &&
+                        ((p.LeadPoUser.FullName != null &&
+                            (EF.Functions.ILike(p.LeadPoUser.FullName!, like) || p.LeadPoUser.FullName!.ToLower().Contains(normalized))) ||
+                         (p.LeadPoUser.UserName != null &&
+                            (EF.Functions.ILike(p.LeadPoUser.UserName!, like) || p.LeadPoUser.UserName!.ToLower().Contains(normalized))))));
+            }
+
+            if (filters.CategoryId.HasValue)
+            {
+                source = source.Where(p => p.CategoryId == filters.CategoryId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filters.LeadPoUserId))
+            {
+                var leadId = filters.LeadPoUserId.Trim();
+                source = source.Where(p => p.LeadPoUserId != null && p.LeadPoUserId == leadId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(filters.HodUserId))
+            {
+                var hodId = filters.HodUserId.Trim();
+                source = source.Where(p => p.HodUserId != null && p.HodUserId == hodId);
+            }
+
+            return source;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the case-file-only search with a broader query input and optional category/assignment filters on the projects index
- bind new query-string parameters in the index page model and delegate predicate building to a reusable project search helper
- cover the new helper with tests that confirm searches by name, description, and assigned users return the right projects

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22048281c8329957443ff47bf0315