### PR TITLE
Add pagination and relevance sorting to projects index

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -8,7 +8,25 @@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <div>
             <h1 class="h3 mb-0">Projects</h1>
-            <p class="text-muted mb-0">Search across case files, descriptions, categories, and assigned staff. Showing up to 100 results.</p>
+            <p class="text-muted mb-1">Search across case files, descriptions, categories, and assigned staff.</p>
+            <p class="text-muted mb-0">
+                @if (Model.TotalCount > 0)
+                {
+                    <text>Showing @Model.ResultsStart-@Model.ResultsEnd of @Model.TotalCount project@(Model.TotalCount == 1 ? string.Empty : "s").</text>
+                    if (!Model.HasActiveFilters)
+                    {
+                        <text> Sorted by the most recent additions.</text>
+                    }
+                }
+                else if (!Model.HasActiveFilters)
+                {
+                    <text>Browse the most recent projects or apply filters to narrow your search.</text>
+                }
+                else
+                {
+                    <text>No projects matched the current filters.</text>
+                }
+            </p>
         </div>
         @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
         {
@@ -105,5 +123,50 @@
                 </tbody>
             </table>
         </div>
+
+        @if (Model.TotalPages > 1)
+        {
+            <nav class="mt-3" aria-label="Project pagination">
+                <ul class="pagination">
+                    <li class="page-item @(Model.Page <= 1 ? "disabled" : null)">
+                        <a class="page-link"
+                           asp-page="./Index"
+                           asp-route-page="@(Model.Page - 1)"
+                           asp-route-PageSize="@Model.PageSize"
+                           asp-route-Query="@Model.Query"
+                           asp-route-CategoryId="@Model.CategoryId"
+                           asp-route-LeadPoUserId="@Model.LeadPoUserId"
+                           asp-route-HodUserId="@Model.HodUserId"
+                           aria-label="Previous"
+                           aria-disabled="@(Model.Page <= 1)">Previous</a>
+                    </li>
+                    @for (var i = 1; i <= Model.TotalPages; i++)
+                    {
+                        <li class="page-item @(i == Model.Page ? "active" : null)">
+                            <a class="page-link"
+                               asp-page="./Index"
+                               asp-route-page="@i"
+                               asp-route-PageSize="@Model.PageSize"
+                               asp-route-Query="@Model.Query"
+                               asp-route-CategoryId="@Model.CategoryId"
+                               asp-route-LeadPoUserId="@Model.LeadPoUserId"
+                               asp-route-HodUserId="@Model.HodUserId">@i</a>
+                        </li>
+                    }
+                    <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : null)">
+                        <a class="page-link"
+                           asp-page="./Index"
+                           asp-route-page="@(Model.Page + 1)"
+                           asp-route-PageSize="@Model.PageSize"
+                           asp-route-Query="@Model.Query"
+                           asp-route-CategoryId="@Model.CategoryId"
+                           asp-route-LeadPoUserId="@Model.LeadPoUserId"
+                           asp-route-HodUserId="@Model.HodUserId"
+                           aria-label="Next"
+                           aria-disabled="@(Model.Page >= Model.TotalPages)">Next</a>
+                    </li>
+                </ul>
+            </nav>
+        }
     }
 </div>

--- a/ProjectManagement.Tests/ProjectIndexPageTests.cs
+++ b/ProjectManagement.Tests/ProjectIndexPageTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Pages.Projects;
+using Xunit;
+
+namespace ProjectManagement.Tests
+{
+    public class ProjectIndexPageTests
+    {
+        [Fact]
+        public async Task Pagination_SurfacesOlderProjectsOnLaterPages()
+        {
+            await using var context = CreateContext();
+            var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            for (var i = 0; i < 25; i++)
+            {
+                context.Projects.Add(new Project
+                {
+                    Name = $"Project {i:D2}",
+                    CreatedAt = baseDate.AddDays(i),
+                    CreatedByUserId = "creator"
+                });
+            }
+
+            await context.SaveChangesAsync();
+
+            var firstPage = new IndexModel(context)
+            {
+                Page = 1,
+                PageSize = 10
+            };
+            await firstPage.OnGetAsync();
+
+            var secondPage = new IndexModel(context)
+            {
+                Page = 2,
+                PageSize = 10
+            };
+            await secondPage.OnGetAsync();
+
+            Assert.Equal(10, firstPage.Projects.Count);
+            Assert.Equal(10, secondPage.Projects.Count);
+            Assert.True(firstPage.Projects.First().CreatedAt > secondPage.Projects.First().CreatedAt);
+
+            var thirdPage = new IndexModel(context)
+            {
+                Page = 3,
+                PageSize = 10
+            };
+            await thirdPage.OnGetAsync();
+
+            Assert.Equal(5, thirdPage.Projects.Count);
+            Assert.Contains(thirdPage.Projects, p => p.Name == "Project 00");
+        }
+
+        [Fact]
+        public async Task Search_ReordersResultsByRelevance()
+        {
+            await using var context = CreateContext();
+            var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var caseMatch = new Project
+            {
+                Name = "Legacy capital works",
+                CaseFileNumber = "ALPHA100",
+                CreatedAt = baseDate.AddDays(1),
+                CreatedByUserId = "creator"
+            };
+            var nameOlder = new Project
+            {
+                Name = "Alpha100 legacy",
+                CreatedAt = baseDate.AddDays(2),
+                CreatedByUserId = "creator"
+            };
+            var nameNewer = new Project
+            {
+                Name = "Alpha100 expansion",
+                CreatedAt = baseDate.AddDays(3),
+                CreatedByUserId = "creator"
+            };
+            var unrelated = new Project
+            {
+                Name = "Harbour renewal",
+                CreatedAt = baseDate.AddDays(4),
+                CreatedByUserId = "creator"
+            };
+
+            context.Projects.AddRange(caseMatch, nameOlder, nameNewer, unrelated);
+            await context.SaveChangesAsync();
+
+            var model = new IndexModel(context)
+            {
+                Query = "alpha100",
+                PageSize = 10
+            };
+
+            await model.OnGetAsync();
+
+            Assert.Equal(3, model.Projects.Count);
+            Assert.Equal(caseMatch.Id, model.Projects[0].Id);
+            Assert.Equal(nameNewer.Id, model.Projects[1].Id);
+            Assert.Equal(nameOlder.Id, model.Projects[2].Id);
+        }
+
+        private static ApplicationDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            return new ApplicationDbContext(options);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add page and page size parameters to the project index to provide pageable results and updated summaries
- prioritize search relevance (exact case-file matches, then textual matches, then recency) when filtering projects
- cover the new pagination and ordering rules with integration-style tests for the projects index page

## Testing
- `dotnet test ProjectManagement.sln` *(fails: dotnet not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e221b27f4c83299f0768b680228d9f