### PR TITLE
Remove project list intro text from header

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -5,28 +5,9 @@
 }
 
 <div class="container-xxl">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
             <h1 class="h3 mb-0">Projects</h1>
-            <p class="text-muted mb-1">Search across case files, descriptions, categories, and assigned staff.</p>
-            <p class="text-muted mb-0">
-                @if (Model.TotalCount > 0)
-                {
-                    <text>Showing @Model.ResultsStart-@Model.ResultsEnd of @Model.TotalCount project@(Model.TotalCount == 1 ? string.Empty : "s").</text>
-                    if (!Model.HasActiveFilters)
-                    {
-                        <text> Sorted by the most recent additions.</text>
-                    }
-                }
-                else if (!Model.HasActiveFilters)
-                {
-                    <text>Browse the most recent projects or apply filters to narrow your search.</text>
-                }
-                else
-                {
-                    <text>No projects matched the current filters.</text>
-                }
-            </p>
         </div>
         @if (User.IsInRole("Admin") || User.IsInRole("HoD"))
         {


### PR DESCRIPTION
## Summary
- remove the introductory project summary paragraphs from the projects index header
- adjust header spacing to retain consistent layout after removing descriptive text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2272a66408329aa1d075b5ccdd6dc