### PR TITLE
Expand NotificationDispatch metadata

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -220,11 +220,26 @@ namespace ProjectManagement.Data
                     .HasConversion<string>()
                     .HasMaxLength(64)
                     .IsRequired();
+                e.Property(x => x.Module).HasMaxLength(64);
+                e.Property(x => x.EventType).HasMaxLength(128);
+                e.Property(x => x.ScopeType).HasMaxLength(64);
+                e.Property(x => x.ScopeId).HasMaxLength(128);
+                e.Property(x => x.ProjectId).IsRequired(false);
+                e.Property(x => x.ActorUserId).HasMaxLength(450);
+                e.Property(x => x.Fingerprint).HasMaxLength(128);
+                e.Property(x => x.Route).HasMaxLength(2048);
+                e.Property(x => x.Title).HasMaxLength(200);
+                e.Property(x => x.Summary).HasMaxLength(2000);
                 e.Property(x => x.PayloadJson).HasMaxLength(4000).IsRequired();
                 e.Property(x => x.Error).HasMaxLength(2000);
                 e.Property(x => x.AttemptCount).HasDefaultValue(0);
                 e.HasIndex(x => x.DispatchedUtc);
                 e.HasIndex(x => new { x.RecipientUserId, x.Kind, x.DispatchedUtc });
+                e.HasIndex(x => new { x.Module, x.EventType, x.DispatchedUtc });
+                e.HasIndex(x => new { x.ScopeType, x.ScopeId, x.DispatchedUtc });
+                e.HasIndex(x => new { x.ProjectId, x.DispatchedUtc });
+                e.HasIndex(x => new { x.ActorUserId, x.DispatchedUtc });
+                e.HasIndex(x => x.Fingerprint);
             });
 
             builder.Entity<ProjectDocumentRequest>(e =>

--- a/Migrations/20251006090000_ExpandNotificationDispatchMetadata.Designer.cs
+++ b/Migrations/20251006090000_ExpandNotificationDispatchMetadata.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251006090000_ExpandNotificationDispatchMetadata")]
+    partial class ExpandNotificationDispatchMetadata : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251006090000_ExpandNotificationDispatchMetadata.cs
+++ b/Migrations/20251006090000_ExpandNotificationDispatchMetadata.cs
@@ -1,0 +1,169 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    public partial class ExpandNotificationDispatchMetadata : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ActorUserId",
+                table: "NotificationDispatches",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EventType",
+                table: "NotificationDispatches",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Fingerprint",
+                table: "NotificationDispatches",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Module",
+                table: "NotificationDispatches",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectId",
+                table: "NotificationDispatches",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Route",
+                table: "NotificationDispatches",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScopeId",
+                table: "NotificationDispatches",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScopeType",
+                table: "NotificationDispatches",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Summary",
+                table: "NotificationDispatches",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "NotificationDispatches",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationDispatches_ActorUserId_DispatchedUtc",
+                table: "NotificationDispatches",
+                columns: new[] { "ActorUserId", "DispatchedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationDispatches_Fingerprint",
+                table: "NotificationDispatches",
+                column: "Fingerprint");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationDispatches_Module_EventType_DispatchedUtc",
+                table: "NotificationDispatches",
+                columns: new[] { "Module", "EventType", "DispatchedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationDispatches_ProjectId_DispatchedUtc",
+                table: "NotificationDispatches",
+                columns: new[] { "ProjectId", "DispatchedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationDispatches_ScopeType_ScopeId_DispatchedUtc",
+                table: "NotificationDispatches",
+                columns: new[] { "ScopeType", "ScopeId", "DispatchedUtc" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDispatches_ActorUserId_DispatchedUtc",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDispatches_Fingerprint",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDispatches_Module_EventType_DispatchedUtc",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDispatches_ProjectId_DispatchedUtc",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationDispatches_ScopeType_ScopeId_DispatchedUtc",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "ActorUserId",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "EventType",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "Fingerprint",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "Module",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "Route",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "ScopeId",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "ScopeType",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "Summary",
+                table: "NotificationDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "NotificationDispatches");
+        }
+    }
+}

--- a/Models/Notifications/NotificationDispatch.cs
+++ b/Models/Notifications/NotificationDispatch.cs
@@ -10,6 +10,26 @@ public sealed class NotificationDispatch
 
     public NotificationKind Kind { get; set; }
 
+    public string? Module { get; set; }
+
+    public string? EventType { get; set; }
+
+    public string? ScopeType { get; set; }
+
+    public string? ScopeId { get; set; }
+
+    public int? ProjectId { get; set; }
+
+    public string? ActorUserId { get; set; }
+
+    public string? Fingerprint { get; set; }
+
+    public string? Route { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? Summary { get; set; }
+
     public string PayloadJson { get; set; } = string.Empty;
 
     public DateTime CreatedUtc { get; set; }


### PR DESCRIPTION
## Summary
- extend `NotificationDispatch` with optional metadata fields to capture module, event scope, routing, and descriptive data
- update the EF model configuration with max lengths, nullability, and additional indexes to support the new metadata
- add a schema migration (plus snapshot) to introduce the columns and indexes without data loss

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e22d708a308329b3ffd9eb7c7cba33