### PR TITLE
Rename Projects Index page property to avoid hiding base member

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -109,21 +109,21 @@
         {
             <nav class="mt-3" aria-label="Project pagination">
                 <ul class="pagination">
-                    <li class="page-item @(Model.Page <= 1 ? "disabled" : null)">
+                    <li class="page-item @(Model.CurrentPage <= 1 ? "disabled" : null)">
                         <a class="page-link"
                            asp-page="./Index"
-                           asp-route-page="@(Model.Page - 1)"
+                           asp-route-page="@(Model.CurrentPage - 1)"
                            asp-route-PageSize="@Model.PageSize"
                            asp-route-Query="@Model.Query"
                            asp-route-CategoryId="@Model.CategoryId"
                            asp-route-LeadPoUserId="@Model.LeadPoUserId"
                            asp-route-HodUserId="@Model.HodUserId"
                            aria-label="Previous"
-                           aria-disabled="@(Model.Page <= 1)">Previous</a>
+                           aria-disabled="@(Model.CurrentPage <= 1)">Previous</a>
                     </li>
                     @for (var i = 1; i <= Model.TotalPages; i++)
                     {
-                        <li class="page-item @(i == Model.Page ? "active" : null)">
+                        <li class="page-item @(i == Model.CurrentPage ? "active" : null)">
                             <a class="page-link"
                                asp-page="./Index"
                                asp-route-page="@i"
@@ -134,17 +134,17 @@
                                asp-route-HodUserId="@Model.HodUserId">@i</a>
                         </li>
                     }
-                    <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : null)">
+                    <li class="page-item @(Model.CurrentPage >= Model.TotalPages ? "disabled" : null)">
                         <a class="page-link"
                            asp-page="./Index"
-                           asp-route-page="@(Model.Page + 1)"
+                           asp-route-page="@(Model.CurrentPage + 1)"
                            asp-route-PageSize="@Model.PageSize"
                            asp-route-Query="@Model.Query"
                            asp-route-CategoryId="@Model.CategoryId"
                            asp-route-LeadPoUserId="@Model.LeadPoUserId"
                            asp-route-HodUserId="@Model.HodUserId"
                            aria-label="Next"
-                           aria-disabled="@(Model.Page >= Model.TotalPages)">Next</a>
+                           aria-disabled="@(Model.CurrentPage >= Model.TotalPages)">Next</a>
                     </li>
                 </ul>
             </nav>

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -36,8 +36,8 @@ namespace ProjectManagement.Pages.Projects
         [BindProperty(SupportsGet = true)]
         public string? HodUserId { get; set; }
 
-        [BindProperty(SupportsGet = true)]
-        public int Page { get; set; } = 1;
+        [BindProperty(SupportsGet = true, Name = "page")]
+        public int CurrentPage { get; set; } = 1;
 
         [BindProperty(SupportsGet = true)]
         public int PageSize { get; set; } = 25;
@@ -87,25 +87,25 @@ namespace ProjectManagement.Pages.Projects
             TotalCount = await query.CountAsync();
             TotalPages = TotalCount == 0 ? 0 : (int)Math.Ceiling(TotalCount / (double)PageSize);
 
-            if (Page < 1)
+            if (CurrentPage < 1)
             {
-                Page = 1;
+                CurrentPage = 1;
             }
 
-            if (TotalPages > 0 && Page > TotalPages)
+            if (TotalPages > 0 && CurrentPage > TotalPages)
             {
-                Page = TotalPages;
+                CurrentPage = TotalPages;
             }
             else if (TotalPages == 0)
             {
-                Page = 1;
+                CurrentPage = 1;
             }
 
-            var skip = (Page - 1) * PageSize;
+            var skip = (CurrentPage - 1) * PageSize;
             if (TotalCount > 0 && skip >= TotalCount)
             {
-                Page = TotalPages;
-                skip = Math.Max(0, (Page - 1) * PageSize);
+                CurrentPage = TotalPages;
+                skip = Math.Max(0, (CurrentPage - 1) * PageSize);
             }
 
             Projects = await query.Skip(skip).Take(PageSize).ToListAsync();


### PR DESCRIPTION
## Summary
- rename the Projects index page bindable pagination property to `CurrentPage` to avoid hiding `PageModel.Page()`
- keep query string compatibility by binding the `page` parameter to the renamed property and update the Razor view references

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e233bae8048329b40bdd33753257c1