### PR TITLE
Fix Project index pagination tests to use CurrentPage property

### DIFF
--- a/ProjectManagement.Tests/ProjectIndexPageTests.cs
+++ b/ProjectManagement.Tests/ProjectIndexPageTests.cs
@@ -31,14 +31,14 @@ namespace ProjectManagement.Tests
 
             var firstPage = new IndexModel(context)
             {
-                Page = 1,
+                CurrentPage = 1,
                 PageSize = 10
             };
             await firstPage.OnGetAsync();
 
             var secondPage = new IndexModel(context)
             {
-                Page = 2,
+                CurrentPage = 2,
                 PageSize = 10
             };
             await secondPage.OnGetAsync();
@@ -49,7 +49,7 @@ namespace ProjectManagement.Tests
 
             var thirdPage = new IndexModel(context)
             {
-                Page = 3,
+                CurrentPage = 3,
                 PageSize = 10
             };
             await thirdPage.OnGetAsync();


### PR DESCRIPTION
## Summary
- update the Project index page tests to set the CurrentPage property instead of the non-existent Page member

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e235ba8cb48329a9ca059e305a4d8c