### PR TITLE
Add notification entity and migration

### DIFF
--- a/Migrations/20251005093133_AddNotifications.Designer.cs
+++ b/Migrations/20251005093133_AddNotifications.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251005093133_AddNotifications")]
+    partial class AddNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251005093133_AddNotifications.cs
+++ b/Migrations/20251005093133_AddNotifications.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.CreateTable(
+                    name: "Notifications",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "integer", nullable: false)
+                            .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                        RecipientUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                        Module = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                        EventType = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                        ScopeType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                        ScopeId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                        ProjectId = table.Column<int>(type: "integer", nullable: true),
+                        ActorUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                        Fingerprint = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                        Route = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                        Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                        Summary = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                        CreatedUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                        SeenUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                        ReadUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                        SourceDispatchId = table.Column<int>(type: "integer", nullable: true)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_Notifications", x => x.Id);
+                        table.ForeignKey(
+                            name: "FK_Notifications_NotificationDispatches_SourceDispatchId",
+                            column: x => x.SourceDispatchId,
+                            principalTable: "NotificationDispatches",
+                            principalColumn: "Id",
+                            onDelete: ReferentialAction.SetNull);
+                    });
+
+                migrationBuilder.CreateIndex(
+                    name: "IX_Notifications_Fingerprint",
+                    table: "Notifications",
+                    column: "Fingerprint",
+                    filter: "\"Fingerprint\" IS NOT NULL");
+            }
+            else
+            {
+                migrationBuilder.CreateTable(
+                    name: "Notifications",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(type: "int", nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        RecipientUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                        Module = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: true),
+                        EventType = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                        ScopeType = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: true),
+                        ScopeId = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                        ProjectId = table.Column<int>(type: "int", nullable: true),
+                        ActorUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                        Fingerprint = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                        Route = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                        Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                        Summary = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                        CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                        SeenUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                        ReadUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                        SourceDispatchId = table.Column<int>(type: "int", nullable: true)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_Notifications", x => x.Id);
+                        table.ForeignKey(
+                            name: "FK_Notifications_NotificationDispatches_SourceDispatchId",
+                            column: x => x.SourceDispatchId,
+                            principalTable: "NotificationDispatches",
+                            principalColumn: "Id",
+                            onDelete: ReferentialAction.SetNull);
+                    });
+
+                migrationBuilder.CreateIndex(
+                    name: "IX_Notifications_Fingerprint",
+                    table: "Notifications",
+                    column: "Fingerprint",
+                    filter: "[Fingerprint] IS NOT NULL");
+            }
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_RecipientUserId_CreatedUtc",
+                table: "Notifications",
+                columns: new[] { "RecipientUserId", "CreatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_RecipientUserId_ReadUtc_CreatedUtc",
+                table: "Notifications",
+                columns: new[] { "RecipientUserId", "ReadUtc", "CreatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_RecipientUserId_SeenUtc_CreatedUtc",
+                table: "Notifications",
+                columns: new[] { "RecipientUserId", "SeenUtc", "CreatedUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_SourceDispatchId",
+                table: "Notifications",
+                column: "SourceDispatchId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notifications");
+        }
+    }
+}

--- a/Models/Notifications/Notification.cs
+++ b/Models/Notifications/Notification.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace ProjectManagement.Models.Notifications;
+
+public sealed class Notification
+{
+    public int Id { get; set; }
+
+    public string RecipientUserId { get; set; } = string.Empty;
+
+    public string? Module { get; set; }
+
+    public string? EventType { get; set; }
+
+    public string? ScopeType { get; set; }
+
+    public string? ScopeId { get; set; }
+
+    public int? ProjectId { get; set; }
+
+    public string? ActorUserId { get; set; }
+
+    public string? Fingerprint { get; set; }
+
+    public string? Route { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? Summary { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+
+    public DateTime? SeenUtc { get; set; }
+
+    public DateTime? ReadUtc { get; set; }
+
+    public int? SourceDispatchId { get; set; }
+
+    public NotificationDispatch? SourceDispatch { get; set; }
+}


### PR DESCRIPTION
## Summary
- add a Notification entity model to capture per-user delivery metadata, routes, and state timestamps
- register notifications in the application DbContext with provider-specific defaults and query indexes for unread/seen ordering
- add a cross-provider AddNotifications EF Core migration and update the model snapshot

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e23a40d17c8329ab490ac8ebe5a1d4