### PR TITLE
Fix top-level statements ordering in Program.cs

### DIFF
--- a/Contracts/Notifications/NotificationListRequest.cs
+++ b/Contracts/Notifications/NotificationListRequest.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ProjectManagement.Contracts.Notifications;
+
+public sealed record NotificationListRequest(
+    [property: FromQuery(Name = "limit")] int? Limit,
+    [property: FromQuery(Name = "unreadOnly")] bool? UnreadOnly,
+    [property: FromQuery(Name = "projectId")] int? ProjectId);

--- a/Program.cs
+++ b/Program.cs
@@ -1611,11 +1611,6 @@ static async Task<IResult> SendUnreadCountAsync(
     return Results.NoContent();
 }
 
-public sealed record NotificationListRequest(
-    [property: FromQuery(Name = "limit")] int? Limit,
-    [property: FromQuery(Name = "unreadOnly")] bool? UnreadOnly,
-    [property: FromQuery(Name = "projectId")] int? ProjectId);
-
 app.Run();
 
 public partial class Program { }


### PR DESCRIPTION
## Summary
- move `NotificationListRequest` record into the notifications contracts folder
- keep `Program.cs` focused on top-level statements followed by the partial Program type

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e23f8c5670832990109ad62275dbac