### PR TITLE
Fix DateTimeOffset formatting in document notifications

### DIFF
--- a/Services/Documents/DocumentNotificationService.cs
+++ b/Services/Documents/DocumentNotificationService.cs
@@ -171,7 +171,7 @@ public sealed class DocumentNotificationService : IDocumentNotificationService
                 document.Status.ToString(),
                 document.FileStamp,
                 document.UploadedByUserId,
-                document.UploadedAtUtc?.ToString("o", CultureInfo.InvariantCulture));
+                document.UploadedAtUtc.ToString("o", CultureInfo.InvariantCulture));
 
             await _publisher.PublishAsync(
                 kind,


### PR DESCRIPTION
## Summary
- remove the null-conditional when formatting the document upload timestamp so DateTimeOffset is formatted correctly

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e25694e1ac8329b66f9ad309ca95a5