### PR TITLE
Fix nullable DateTimeOffset formatting in document notifications

### DIFF
--- a/Services/Documents/DocumentNotificationService.cs
+++ b/Services/Documents/DocumentNotificationService.cs
@@ -171,7 +171,7 @@ public sealed class DocumentNotificationService : IDocumentNotificationService
                 document.Status.ToString(),
                 document.FileStamp,
                 document.UploadedByUserId,
-                document.UploadedAtUtc.ToString("o", CultureInfo.InvariantCulture));
+                FormatTimestamp(document.UploadedAtUtc));
 
             await _publisher.PublishAsync(
                 kind,
@@ -242,6 +242,11 @@ public sealed class DocumentNotificationService : IDocumentNotificationService
 
     private static string BuildRoute(int projectId)
         => string.Format(CultureInfo.InvariantCulture, "/projects/{0}/documents", projectId);
+
+    private static string? FormatTimestamp(DateTimeOffset? value)
+        => value.HasValue
+            ? value.Value.ToString("o", CultureInfo.InvariantCulture)
+            : null;
 
     private sealed record DocumentNotificationPayload(
         int DocumentId,


### PR DESCRIPTION
## Summary
- format the document upload timestamp via a helper method when building notifications
- avoid using the null-conditional operator on a non-nullable DateTimeOffset value

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2578d04b88329a265f3cb3fc92129