### PR TITLE
Add overload to format document timestamps

### DIFF
--- a/Services/Documents/DocumentNotificationService.cs
+++ b/Services/Documents/DocumentNotificationService.cs
@@ -243,9 +243,12 @@ public sealed class DocumentNotificationService : IDocumentNotificationService
     private static string BuildRoute(int projectId)
         => string.Format(CultureInfo.InvariantCulture, "/projects/{0}/documents", projectId);
 
+    private static string FormatTimestamp(DateTimeOffset value)
+        => value.ToString("o", CultureInfo.InvariantCulture);
+
     private static string? FormatTimestamp(DateTimeOffset? value)
         => value.HasValue
-            ? value.Value.ToString("o", CultureInfo.InvariantCulture)
+            ? FormatTimestamp(value.Value)
             : null;
 
     private sealed record DocumentNotificationPayload(


### PR DESCRIPTION
## Summary
- add a dedicated FormatTimestamp overload for non-null DateTimeOffset values
- reuse the overload when formatting nullable timestamps to avoid using null-conditional operators on value types

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e258c56338832980ae4314ed255bb6