### PR TITLE
Add live region to notification bell badge

### DIFF
--- a/Pages/Shared/Components/NotificationBell/Default.cshtml
+++ b/Pages/Shared/Components/NotificationBell/Default.cshtml
@@ -24,9 +24,9 @@
             aria-expanded="false" aria-label="Open notifications">
         <i class="bi bi-bell fs-5" aria-hidden="true"></i>
         <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger @unreadClass"
-              data-notification-unread>
+              data-notification-unread aria-live="polite">
             <span class="visually-hidden">Unread notifications</span>
-            @Model.UnreadCount
+            <span data-notification-unread-count>@Model.UnreadCount</span>
         </span>
     </button>
     <div class="dropdown-menu dropdown-menu-end shadow-sm p-0" aria-labelledby="notificationDropdown">

--- a/wwwroot/js/notifications.js
+++ b/wwwroot/js/notifications.js
@@ -427,6 +427,7 @@
       this.notificationCenterUrl = element.getAttribute('data-notification-center-url') || '/Notifications';
       this.isAuthenticated = element.getAttribute('data-is-authenticated') === 'true';
       this.badge = element.querySelector('[data-notification-unread]');
+      this.badgeCount = this.badge ? this.badge.querySelector('[data-notification-unread-count]') : null;
       this.listElement = element.querySelector('[data-notification-list]');
       this.template = element.querySelector('[data-notification-item-template]');
       this.emptyElement = element.querySelector('[data-notification-empty]');
@@ -520,11 +521,14 @@
       if (this.badge) {
         if (unreadCount > 0) {
           this.badge.classList.remove('d-none');
-          this.badge.textContent = String(unreadCount);
         } else {
           this.badge.classList.add('d-none');
-          this.badge.textContent = '0';
         }
+      }
+
+      const badgeTarget = this.badgeCount ?? this.badge;
+      if (badgeTarget) {
+        badgeTarget.textContent = String(unreadCount > 0 ? unreadCount : 0);
       }
 
       if (!this.listElement || !this.template) {


### PR DESCRIPTION
## Summary
- add an aria-live region around the notification bell badge count so assistive tech is alerted to changes
- update the notification bell view script to target the nested count element when updating unread totals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2750bdd808329bdb9661f82b70385