### PR TITLE
Limit remark edit notice to active window

### DIFF
--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1487,11 +1487,13 @@
                         });
                         actions.appendChild(deleteButton);
                     }
-                } else if (remark.authorUserId === this.currentUserId) {
-                    const notice = document.createElement('div');
-                    notice.className = 'text-muted small';
-                    notice.textContent = 'You can edit your remark within 3 hours of posting.';
-                    actions.appendChild(notice);
+
+                    if (!hasOverride && remark.authorUserId === this.currentUserId && withinWindow) {
+                        const notice = document.createElement('div');
+                        notice.className = 'text-muted small text-wrap w-100';
+                        notice.textContent = 'You can edit your remark within 3 hours of posting.';
+                        actions.appendChild(notice);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- only render the 3-hour edit reminder for remark authors while they are still within the edit window
- add wrapping utility classes to the reminder so the text no longer overflows in the action bar

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e277c0c91c83298690b1ec89bfd219