### PR TITLE
Use clock ticks in role notification fingerprints

### DIFF
--- a/Services/Notifications/RoleNotificationService.cs
+++ b/Services/Notifications/RoleNotificationService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Notifications;
+using ProjectManagement.Services;
 
 namespace ProjectManagement.Services.Notifications;
 
@@ -14,15 +15,18 @@ public sealed class RoleNotificationService : ProjectManagement.Services.IRoleNo
 {
     private readonly INotificationPublisher _publisher;
     private readonly INotificationPreferenceService _preferences;
+    private readonly IClock _clock;
     private readonly ILogger<RoleNotificationService> _logger;
 
     public RoleNotificationService(
         INotificationPublisher publisher,
         INotificationPreferenceService preferences,
+        IClock clock,
         ILogger<RoleNotificationService> logger)
     {
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -116,7 +120,7 @@ public sealed class RoleNotificationService : ProjectManagement.Services.IRoleNo
                     CultureInfo.InvariantCulture,
                     "role:{0}:{1}",
                     user.Id,
-                    DateTimeOffset.UtcNow.ToUnixTimeSeconds()),
+                    _clock.UtcNow.UtcTicks),
                 cancellationToken: cancellationToken);
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
## Summary
- inject the shared clock into `RoleNotificationService` and build fingerprints with tick-level precision
- update the role notification unit tests to pass a controllable clock and verify unique fingerprints per invocation

## Testing
- `dotnet test ProjectManagement.sln --filter RoleNotificationServiceTests` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2875982f48329b6565a160c9f4181