### PR TITLE
Style remark action buttons for symmetry

### DIFF
--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1434,24 +1434,20 @@
                         };
 
                         const editButton = createActionButton({
-                            className: hasOverride && withinWindow
-                                ? 'btn btn-sm btn-outline-secondary btn-icon'
-                                : 'btn btn-sm btn-outline-secondary',
+                            className: 'btn btn-sm btn-outline-secondary btn-icon',
                             action: 'edit',
                             label: 'Edit',
-                            ariaLabel: hasOverride && withinWindow ? 'Edit remark' : null,
-                            iconClass: hasOverride && withinWindow ? 'bi bi-pencil' : null
+                            ariaLabel: 'Edit remark',
+                            iconClass: 'bi bi-pencil'
                         });
                         actions.appendChild(editButton);
 
                         const deleteButton = createActionButton({
-                            className: hasOverride && withinWindow
-                                ? 'btn btn-sm btn-outline-danger btn-icon'
-                                : 'btn btn-sm btn-outline-danger',
+                            className: 'btn btn-sm btn-outline-danger btn-icon',
                             action: 'delete',
                             label: 'Delete',
-                            ariaLabel: hasOverride && withinWindow ? 'Delete remark' : null,
-                            iconClass: hasOverride && withinWindow ? 'bi bi-trash' : null
+                            ariaLabel: 'Delete remark',
+                            iconClass: 'bi bi-trash'
                         });
                         actions.appendChild(deleteButton);
                     }


### PR DESCRIPTION
## Summary
- update remark panel action buttons to always use icon styling for edit and delete
- ensure buttons keep accessible labels while matching HoD positioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e284fe14bc8329a6cf2fe2090048c6