### PR TITLE
Refine remarks panel header layout

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1130,6 +1130,10 @@ body {
     position: relative;
 }
 
+.remarks-item-compact {
+    gap: .75rem;
+}
+
 .remarks-item.remarks-role-comdt::before,
 .remarks-item.remarks-role-hod::before,
 .remarks-item.remarks-role-mco::before {
@@ -1172,6 +1176,34 @@ body {
     width: 40px;
     height: 40px;
     font-size: var(--pm-font-size-tight);
+}
+
+.remarks-header {
+    gap: 1rem;
+}
+
+@media (min-width: 576px) {
+    .remarks-header {
+        flex-wrap: nowrap;
+    }
+}
+
+.remarks-identity {
+    display: flex;
+    flex-direction: column;
+    gap: .375rem;
+    min-width: 0;
+}
+
+.remarks-name {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    min-width: 0;
+}
+
+.remarks-timestamp {
+    display: block;
 }
 
 .remarks-avatar.remarks-role-comdt {
@@ -1240,10 +1272,17 @@ body {
 .remarks-actions {
     margin-top: 0;
     flex-shrink: 0;
+    margin-left: auto;
+    align-self: flex-start;
 }
 
 .remarks-actions .btn {
     min-width: 0;
+}
+
+.remarks-item-compact .remark-edit-window-notice {
+    margin-top: .25rem;
+    margin-bottom: 0;
 }
 
 /* Headings: GitHub-inspired scale */

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -1242,7 +1242,7 @@
 
         buildRemarkElement(remark) {
             const article = document.createElement('article');
-            article.className = 'remarks-item d-flex flex-column gap-2';
+            article.className = 'remarks-item remarks-item-compact d-flex flex-column';
             article.setAttribute('data-remark-id', String(remark.id));
             article.setAttribute('data-row-version', remark.rowVersion || '');
 
@@ -1251,7 +1251,7 @@
             }
 
             const header = document.createElement('div');
-            header.className = 'd-flex flex-wrap gap-3 align-items-start';
+            header.className = 'remarks-header d-flex flex-wrap flex-sm-nowrap gap-3 align-items-start';
 
             const avatar = document.createElement('div');
             avatar.className = 'remarks-avatar avatar';
@@ -1259,10 +1259,10 @@
             header.appendChild(avatar);
 
             const identity = document.createElement('div');
-            identity.className = 'flex-grow-1';
+            identity.className = 'remarks-identity flex-grow-1';
 
             const nameRow = document.createElement('div');
-            nameRow.className = 'd-flex flex-wrap align-items-center gap-2';
+            nameRow.className = 'remarks-name d-flex flex-wrap align-items-center gap-2';
             const name = document.createElement('span');
             name.className = 'fw-semibold';
             name.textContent = remark.authorDisplayName || remark.authorUserId;
@@ -1281,19 +1281,19 @@
             roleBadge.textContent = this.getRoleLabel(remark.authorRole);
             nameRow.appendChild(roleBadge);
 
+            identity.appendChild(nameRow);
+
             if (remark.createdAtUtc) {
                 const timestamp = document.createElement('time');
-                timestamp.className = 'text-muted small';
+                timestamp.className = 'remarks-timestamp text-muted small';
                 const formatted = this.formatTimestamp(remark.createdAtUtc);
                 timestamp.textContent = formatted.label;
                 timestamp.dateTime = formatted.iso;
                 if (formatted.tooltip) {
                     timestamp.title = formatted.tooltip;
                 }
-                nameRow.appendChild(timestamp);
+                identity.appendChild(timestamp);
             }
-
-            identity.appendChild(nameRow);
 
             const metaRow = document.createElement('div');
             metaRow.className = 'remarks-meta d-flex flex-wrap align-items-center gap-2';
@@ -1338,7 +1338,7 @@
             header.appendChild(identity);
 
             const actions = document.createElement('div');
-            actions.className = 'remarks-actions ms-auto d-flex flex-wrap align-items-center gap-2';
+            actions.className = 'remarks-actions d-flex flex-wrap align-items-center gap-2';
             header.appendChild(actions);
             article.appendChild(header);
 

--- a/wwwroot/js/projects/remarks-panel.test.js
+++ b/wwwroot/js/projects/remarks-panel.test.js
@@ -198,6 +198,34 @@ test('buildRemarkElement applies role accent classes for canonical roles', () =>
     assert.ok(hodArticle.classList.contains('remarks-role-hod'));
 });
 
+test('buildRemarkElement uses helper layout classes for header structure', () => {
+    const { panel } = createPanelDom();
+
+    const remark = makeRemark();
+    const article = panel.buildRemarkElement(remark);
+
+    assert.ok(article.classList.contains('remarks-item'));
+    assert.ok(article.classList.contains('remarks-item-compact'));
+
+    const header = article.querySelector('.remarks-header');
+    assert.ok(header);
+    assert.ok(header.classList.contains('d-flex'));
+    assert.ok(header.classList.contains('flex-sm-nowrap'));
+
+    const identity = header.querySelector('.remarks-identity');
+    assert.ok(identity);
+
+    const nameRow = identity.querySelector('.remarks-name');
+    assert.ok(nameRow);
+    assert.ok(nameRow.classList.contains('d-flex'));
+
+    const timestamp = identity.querySelector('.remarks-timestamp');
+    assert.ok(timestamp);
+    assert.equal(timestamp.tagName, 'TIME');
+    assert.equal(timestamp.parentElement, identity);
+    assert.ok(!nameRow.contains(timestamp));
+});
+
 test('non-override author sees inline action buttons within edit window', () => {
     const { panel } = createPanelDom();
     panel.actorHasOverride = false;
@@ -209,8 +237,8 @@ test('non-override author sees inline action buttons within edit window', () => 
 
     const header = actions.parentElement;
     assert.ok(header);
-    assert.ok(header.classList.contains('d-flex'));
-    assert.ok(actions.classList.contains('ms-auto'));
+    assert.ok(header.classList.contains('remarks-header'));
+    assert.ok(actions.classList.contains('remarks-actions'));
 
     const editButton = actions.querySelector('button[data-remark-action="edit"]');
     const deleteButton = actions.querySelector('button[data-remark-action="delete"]');
@@ -218,8 +246,6 @@ test('non-override author sees inline action buttons within edit window', () => 
     assert.ok(deleteButton);
     assert.strictEqual(editButton.textContent.trim(), 'Edit');
     assert.strictEqual(deleteButton.textContent.trim(), 'Delete');
-    assert.ok(!editButton.classList.contains('btn-icon'));
-    assert.ok(!deleteButton.classList.contains('btn-icon'));
 });
 
 test('override actor within edit window gets icon action buttons', () => {


### PR DESCRIPTION
## Summary
- update the remarks panel header markup to use dedicated helper classes and relocate the timestamp beneath the identity row
- style the new helper classes to tighten spacing and keep actions aligned on small breakpoints
- extend the remarks panel tests to cover the new layout structure and helper class usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e28d6b0ef08329a6145c2ca905bd0f