### PR TITLE
Add stage assignment notification kind and expose projection helper

### DIFF
--- a/Models/Notifications/NotificationKind.cs
+++ b/Models/Notifications/NotificationKind.cs
@@ -8,6 +8,7 @@ public enum NotificationKind
     PlanApproved = 11,
     PlanRejected = 12,
     StageStatusChanged = 20,
+    StageAssigned = 21,
     DocumentPublished = 30,
     DocumentReplaced = 31,
     DocumentArchived = 32,

--- a/Services/Notifications/NotificationPreferenceService.cs
+++ b/Services/Notifications/NotificationPreferenceService.cs
@@ -83,6 +83,7 @@ public sealed class NotificationPreferenceService : INotificationPreferenceServi
             NotificationKind.PlanApproved => NotificationClaimTypes.PlanEventsOptOut,
             NotificationKind.PlanRejected => NotificationClaimTypes.PlanEventsOptOut,
             NotificationKind.StageStatusChanged => NotificationClaimTypes.StageEventsOptOut,
+            NotificationKind.StageAssigned => NotificationClaimTypes.StageEventsOptOut,
             NotificationKind.DocumentPublished => NotificationClaimTypes.DocumentEventsOptOut,
             NotificationKind.DocumentReplaced => NotificationClaimTypes.DocumentEventsOptOut,
             NotificationKind.DocumentArchived => NotificationClaimTypes.DocumentEventsOptOut,

--- a/Services/Notifications/UserNotificationService.cs
+++ b/Services/Notifications/UserNotificationService.cs
@@ -67,7 +67,7 @@ public sealed class UserNotificationService
         return await ProjectAsync(principal, userId, notifications, cancellationToken);
     }
 
-    internal async Task<IReadOnlyList<NotificationListItem>> ProjectAsync(
+    public async Task<IReadOnlyList<NotificationListItem>> ProjectAsync(
         ClaimsPrincipal principal,
         string userId,
         IReadOnlyCollection<Notification> notifications,


### PR DESCRIPTION
## Summary
- add a StageAssigned notification kind so publisher tests compile
- map the new kind to stage opt-out preferences
- expose the notification projection helper used by the tests

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2a56a8fec832994cecdd6a85a0174