### PR TITLE
Propagate project names in notification payloads

### DIFF
--- a/Contracts/Notifications/NotificationListItem.cs
+++ b/Contracts/Notifications/NotificationListItem.cs
@@ -9,6 +9,7 @@ public sealed record NotificationListItem(
     string? ScopeType,
     string? ScopeId,
     int? ProjectId,
+    string? ProjectName,
     string? ActorUserId,
     string? Route,
     string? Title,

--- a/ProjectManagement.Tests/NotificationDispatcherTests.cs
+++ b/ProjectManagement.Tests/NotificationDispatcherTests.cs
@@ -56,6 +56,14 @@ public sealed class NotificationDispatcherTests
 
             await userManager.CreateAsync(new ApplicationUser { Id = "recipient-1", UserName = "recipient@example.com" });
 
+            db.Projects.Add(new Project
+            {
+                Id = 1,
+                Name = "Project Orion",
+                CreatedByUserId = "creator-1",
+                LeadPoUserId = "recipient-1",
+            });
+
             db.NotificationDispatches.Add(new NotificationDispatch
             {
                 RecipientUserId = "recipient-1",
@@ -65,6 +73,7 @@ public sealed class NotificationDispatcherTests
                 Title = "New Remark",
                 Summary = "A remark was created.",
                 Route = "/remarks/1",
+                ProjectId = 1,
             });
 
             await db.SaveChangesAsync();
@@ -86,6 +95,8 @@ public sealed class NotificationDispatcherTests
         var notification = Assert.Single(client.Notifications);
         Assert.Equal("New Remark", notification.Title);
         Assert.Equal("/remarks/1", notification.Route);
+        Assert.Equal(1, notification.ProjectId);
+        Assert.Equal("Project Orion", notification.ProjectName);
 
         var unreadCount = Assert.Single(client.UnreadCounts);
         Assert.Equal(1, unreadCount);

--- a/ProjectManagement.Tests/UserNotificationServiceTests.cs
+++ b/ProjectManagement.Tests/UserNotificationServiceTests.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
+using ProjectManagement.Models;
 using ProjectManagement.Models.Notifications;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Notifications;
@@ -39,6 +40,46 @@ public sealed class UserNotificationServiceTests
 
         var result = Assert.Single(results);
         Assert.Equal("/projects/2/kanbans/54", result.Route);
+    }
+
+    [Fact]
+    public async Task ProjectAsync_IncludesAccessibleProjectNames()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"user-notification-tests-{Guid.NewGuid()}")
+            .Options;
+
+        await using var context = new ApplicationDbContext(options);
+        var clock = new TestClock(new DateTimeOffset(2024, 10, 6, 12, 0, 0, TimeSpan.Zero));
+        var service = new UserNotificationService(context, clock);
+
+        context.Projects.Add(new Project
+        {
+            Id = 42,
+            Name = "Project Nebula",
+            CreatedByUserId = "creator-1",
+            LeadPoUserId = "user-1",
+        });
+
+        await context.SaveChangesAsync();
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        var notifications = new[]
+        {
+            new Notification
+            {
+                Id = 1,
+                RecipientUserId = "user-1",
+                ProjectId = 42,
+                CreatedUtc = clock.UtcNow.UtcDateTime,
+            }
+        };
+
+        var results = await service.ProjectAsync(principal, "user-1", notifications, default);
+
+        var result = Assert.Single(results);
+        Assert.Equal(42, result.ProjectId);
+        Assert.Equal("Project Nebula", result.ProjectName);
     }
 
     private sealed class TestClock : IClock

--- a/ViewModels/Notifications/NotificationDisplayModel.cs
+++ b/ViewModels/Notifications/NotificationDisplayModel.cs
@@ -46,6 +46,7 @@ public sealed record NotificationDisplayModel
             ScopeType = notification.ScopeType,
             ScopeId = notification.ScopeId,
             ProjectId = notification.ProjectId,
+            ProjectName = notification.ProjectName,
             ActorUserId = notification.ActorUserId,
             Route = notification.Route,
             Title = notification.Title,


### PR DESCRIPTION
## Summary
- add an optional projectName field to notification list items and surface it in the display model
- enrich UserNotificationService projections with accessible project names and simplify the notifications page filters
- extend notification service and dispatcher tests to assert project names flow through refreshes and realtime delivery

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2a52183ac8329bf714196c4a6b7d0