### PR TITLE
Fix remark notification routes

### DIFF
--- a/ProjectManagement.Tests/RemarkNotificationServiceTests.cs
+++ b/ProjectManagement.Tests/RemarkNotificationServiceTests.cs
@@ -151,7 +151,7 @@ public class RemarkNotificationServiceTests
         Assert.Equal("RemarkCreated", metadata.EventType);
         Assert.Equal("Remark", metadata.ScopeType);
         Assert.Equal(remark.Id.ToString(), metadata.ScopeId);
-        Assert.Equal($"/projects/{project.ProjectId}/remarks/{remark.Id}", metadata.Route);
+        Assert.Equal($"/projects/remarks/{project.ProjectId}?remarkId={remark.Id}", metadata.Route);
 
         string preview = payload.Preview;
         Assert.Equal(121, preview.Length);

--- a/Services/Remarks/RemarkNotificationService.cs
+++ b/Services/Remarks/RemarkNotificationService.cs
@@ -275,7 +275,7 @@ public sealed class RemarkNotificationService : IRemarkNotificationService
 
         var route = string.Format(
             CultureInfo.InvariantCulture,
-            "/projects/{0}/remarks/{1}",
+            "/projects/remarks/{0}?remarkId={1}",
             project.ProjectId,
             remark.Id);
 


### PR DESCRIPTION
## Summary
- point remark notification metadata to the Razor remarks page so links open correctly
- update tests to match the new notification route and continue validating payload metadata

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aab37dd88329b85a1c3fcf1731c8