### PR TITLE
Expand notification dropdown width

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1882,3 +1882,9 @@ body.has-project-photo-preview-dialog {
   height: 100%;
   min-height: 0;
 }
+
+/* Notification dropdown */
+.notification-bell .dropdown-menu {
+  min-width: 20rem;
+  max-width: 24rem;
+}


### PR DESCRIPTION
## Summary
- expand the notification bell dropdown menu width to provide more room for its contents
- cap the dropdown width to prevent the panel from growing too wide on large displays

## Testing
- N/A (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2ae39894c83298b5b20972b384d1b