### PR TITLE
Filter notification bell to only show unread items

### DIFF
--- a/wwwroot/js/notifications.js
+++ b/wwwroot/js/notifications.js
@@ -535,11 +535,12 @@
         return;
       }
 
-      const items = notifications.slice(0, this.limit);
+      const unreadNotifications = notifications.filter(notification => !notification.isRead);
+      const items = unreadNotifications.slice(0, this.limit);
       this.listElement.innerHTML = '';
 
       if (this.emptyElement) {
-        this.emptyElement.hidden = items.length !== 0;
+        this.emptyElement.hidden = unreadNotifications.length !== 0;
       }
 
       items.forEach(item => {


### PR DESCRIPTION
## Summary
- filter the notification bell dropdown to only render unread items before applying the display limit
- toggle the bell empty state based on unread notifications so it shows once all are read

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2b179907c8329aac580b3adbcc439