### PR TITLE
Fix notification dropdown stale unread state handling

### DIFF
--- a/wwwroot/js/notifications.js
+++ b/wwwroot/js/notifications.js
@@ -76,7 +76,15 @@
       }
 
       const existing = map.get(normalised.id);
-      if (!existing || existing.createdAt < normalised.createdAt) {
+      if (!existing) {
+        map.set(normalised.id, normalised);
+        return;
+      }
+
+      const existingCreated = existing.createdAt?.getTime?.() ?? 0;
+      const normalisedCreated = normalised.createdAt?.getTime?.() ?? 0;
+
+      if (normalisedCreated >= existingCreated) {
         map.set(normalised.id, normalised);
       }
     });
@@ -204,8 +212,14 @@
         }
 
         const payload = await response.json();
-        if (typeof payload?.count === 'number') {
-          this.unreadCount = payload.count;
+        const count = typeof payload?.count === 'number'
+          ? payload.count
+          : typeof payload?.unreadCount === 'number'
+            ? payload.unreadCount
+            : null;
+
+        if (count != null) {
+          this.unreadCount = count;
           this.notifyListeners();
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- ensure deduplication favours newer notification payloads so read state refreshes correctly
- read either `count` or `unreadCount` when refreshing the unread badge total

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b5126e548329897cf560aae73780