### PR TITLE
Adjust remarks filter layout

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1105,8 +1105,8 @@
                                                 <p class="pm-card-subtitle mb-0">Monitor and update project progress.</p>
                                             </div>
                                         </div>
-                                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 w-100 justify-content-between">
-                                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between w-100" role="toolbar" aria-label="Filter remarks">
+                                        <div class="d-flex flex-column gap-2 w-100 align-items-lg-end">
+                                            <div class="d-flex flex-wrap gap-2 justify-content-between justify-content-lg-end w-100" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -1119,7 +1119,7 @@
                                             </div>
                                             @if (Model.RemarksPanel.ShowDeletedToggle)
                                             {
-                                                <div class="form-check form-switch ms-sm-2 ms-lg-3 flex-shrink-0">
+                                                <div class="form-check form-switch mt-1 mt-lg-0 align-self-start align-self-lg-end">
                                                     <input class="form-check-input" type="checkbox" id="remarks-include-deleted" data-remarks-include-deleted>
                                                     <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
                                                 </div>

--- a/Pages/Projects/Remarks/Index.cshtml
+++ b/Pages/Projects/Remarks/Index.cshtml
@@ -42,8 +42,8 @@
                                 <p class="pm-card-subtitle mb-0">Review the full remark history for this project.</p>
                             </div>
                         </div>
-                        <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
-                            <div class="d-flex gap-2 flex-wrap flex-sm-nowrap justify-content-between" role="toolbar" aria-label="Filter remarks">
+                        <div class="d-flex flex-column gap-2 align-items-lg-end w-100 w-lg-auto">
+                            <div class="d-flex flex-wrap gap-2 justify-content-between justify-content-lg-end" role="toolbar" aria-label="Filter remarks">
                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -56,7 +56,7 @@
                             </div>
                             @if (Model.RemarksPanel.ShowDeletedToggle)
                             {
-                                <div class="form-check form-switch ms-lg-3">
+                                <div class="form-check form-switch mt-1 mt-lg-0 align-self-start align-self-lg-end">
                                     <input class="form-check-input" type="checkbox" role="switch" id="remarks-include-deleted" data-remarks-include-deleted>
                                     <label class="form-check-label" for="remarks-include-deleted">Show deleted</label>
                                 </div>


### PR DESCRIPTION
## Summary
- reflow the remarks filter controls so the deleted toggle sits below the button groups
- apply consistent spacing for the remarks panel on the overview page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bb592f8083299df6b1855d771fd8