### PR TITLE
Align remarks filter toolbars on desktop

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1106,7 +1106,7 @@
                                             </div>
                                         </div>
                                         <div class="d-flex flex-column gap-2 w-100 align-items-lg-end">
-                                            <div class="d-flex flex-wrap gap-2 justify-content-between justify-content-lg-end w-100" role="toolbar" aria-label="Filter remarks">
+                                            <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-between justify-content-lg-end w-100" role="toolbar" aria-label="Filter remarks">
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>

--- a/Pages/Projects/Remarks/Index.cshtml
+++ b/Pages/Projects/Remarks/Index.cshtml
@@ -43,7 +43,7 @@
                             </div>
                         </div>
                         <div class="d-flex flex-column gap-2 align-items-lg-end w-100 w-lg-auto">
-                            <div class="d-flex flex-wrap gap-2 justify-content-between justify-content-lg-end" role="toolbar" aria-label="Filter remarks">
+                            <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-between justify-content-lg-end" role="toolbar" aria-label="Filter remarks">
                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>


### PR DESCRIPTION
## Summary
- add a desktop nowrap utility to the remarks filter toolbar on the overview page
- mirror the responsive flex wrapping on the standalone remarks page so both layouts stay consistent

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2bd9675c08329a8b3a6b7cdde0ffe