### PR TITLE
Add notification retention background worker

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -203,6 +203,9 @@ builder.Services.AddSingleton<IRemarkMetrics, RemarkMetrics>();
 builder.Services.AddScoped<INotificationPublisher, NotificationPublisher>();
 builder.Services.AddScoped<INotificationDeliveryService, NotificationDeliveryService>();
 builder.Services.AddHostedService<NotificationDispatcher>();
+builder.Services.AddOptions<NotificationRetentionOptions>()
+    .Bind(builder.Configuration.GetSection("Notifications:Retention"));
+builder.Services.AddHostedService<NotificationRetentionService>();
 builder.Services.AddScoped<UserNotificationService>();
 builder.Services.AddScoped<IDocumentService, DocumentService>();
 builder.Services.AddSingleton<IDocumentPreviewTokenService, DocumentPreviewTokenService>();

--- a/ProjectManagement.Tests/NotificationRetentionServiceTests.cs
+++ b/ProjectManagement.Tests/NotificationRetentionServiceTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Notifications;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Notifications;
+using ProjectManagement.Tests.Fakes;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class NotificationRetentionServiceTests
+{
+    [Fact]
+    public async Task RunOnceAsync_RemovesNotificationsBeyondAgeAndCountLimits()
+    {
+        var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"notification-retention-{Guid.NewGuid()}")
+            .Options;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped(_ => new ApplicationDbContext(dbOptions));
+
+        await using var provider = services.BuildServiceProvider();
+
+        using (var scope = provider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            db.Notifications.AddRange(
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Old 1",
+                    CreatedUtc = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Old 2",
+                    CreatedUtc = new DateTime(2024, 1, 2, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Keep 1",
+                    CreatedUtc = new DateTime(2024, 1, 5, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Keep 2",
+                    CreatedUtc = new DateTime(2024, 1, 6, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Keep 3",
+                    CreatedUtc = new DateTime(2024, 1, 7, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Keep 4",
+                    CreatedUtc = new DateTime(2024, 1, 8, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-1",
+                    Title = "Keep 5",
+                    CreatedUtc = new DateTime(2024, 1, 9, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-2",
+                    Title = "Other 1",
+                    CreatedUtc = new DateTime(2024, 1, 8, 12, 0, 0, DateTimeKind.Utc)
+                },
+                new Notification
+                {
+                    RecipientUserId = "user-2",
+                    Title = "Other 2",
+                    CreatedUtc = new DateTime(2024, 1, 9, 12, 0, 0, DateTimeKind.Utc)
+                });
+
+            await db.SaveChangesAsync();
+        }
+
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+        var clock = FakeClock.AtUtc(new DateTimeOffset(2024, 1, 10, 12, 0, 0, TimeSpan.Zero));
+        var options = Options.Create(new NotificationRetentionOptions
+        {
+            SweepInterval = TimeSpan.FromMinutes(5),
+            MaxAge = TimeSpan.FromDays(7),
+            MaxPerUser = 3
+        });
+
+        var service = new NotificationRetentionService(
+            scopeFactory,
+            options,
+            clock,
+            NullLogger<NotificationRetentionService>.Instance);
+
+        var removed = await service.RunOnceAsync(CancellationToken.None);
+        Assert.Equal(4, removed);
+
+        using var verificationScope = provider.CreateScope();
+        var verificationDb = verificationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var user1Notifications = await verificationDb.Notifications
+            .Where(n => n.RecipientUserId == "user-1")
+            .OrderBy(n => n.CreatedUtc)
+            .ToListAsync();
+
+        Assert.Equal(3, user1Notifications.Count);
+        Assert.Equal(new[]
+        {
+            new DateTime(2024, 1, 7, 12, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 8, 12, 0, 0, DateTimeKind.Utc),
+            new DateTime(2024, 1, 9, 12, 0, 0, DateTimeKind.Utc)
+        }, user1Notifications.Select(n => n.CreatedUtc).ToArray());
+
+        var user2Notifications = await verificationDb.Notifications
+            .Where(n => n.RecipientUserId == "user-2")
+            .OrderBy(n => n.CreatedUtc)
+            .ToListAsync();
+
+        Assert.Equal(2, user2Notifications.Count);
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ProjectManagement.Tests")]

--- a/Services/Notifications/NotificationRetentionOptions.cs
+++ b/Services/Notifications/NotificationRetentionOptions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace ProjectManagement.Services.Notifications;
+
+public sealed class NotificationRetentionOptions
+{
+    private static readonly TimeSpan DefaultSweepInterval = TimeSpan.FromHours(1);
+
+    public TimeSpan SweepInterval { get; set; } = DefaultSweepInterval;
+
+    public TimeSpan? MaxAge { get; set; }
+
+    public int? MaxPerUser { get; set; }
+
+    internal TimeSpan GetSweepIntervalOrDefault()
+    {
+        return SweepInterval > TimeSpan.Zero ? SweepInterval : DefaultSweepInterval;
+    }
+
+    internal bool IsRetentionEnabled()
+    {
+        return (MaxAge.HasValue && MaxAge.Value > TimeSpan.Zero)
+            || (MaxPerUser.HasValue && MaxPerUser.Value > 0);
+    }
+}

--- a/Services/Notifications/NotificationRetentionService.cs
+++ b/Services/Notifications/NotificationRetentionService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Notifications;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Services.Notifications;
+
+public sealed class NotificationRetentionService : BackgroundService
+{
+    private static readonly TimeSpan DefaultIdleDelay = TimeSpan.FromMinutes(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<NotificationRetentionOptions> _options;
+    private readonly IClock _clock;
+    private readonly ILogger<NotificationRetentionService> _logger;
+
+    public NotificationRetentionService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<NotificationRetentionOptions> options,
+        IClock clock,
+        ILogger<NotificationRetentionService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var options = _options.Value;
+            var delay = options.GetSweepIntervalOrDefault();
+
+            try
+            {
+                if (options.IsRetentionEnabled())
+                {
+                    var removed = await RunOnceAsync(stoppingToken);
+                    if (removed > 0)
+                    {
+                        _logger.LogInformation("Notification retention removed {RemovedCount} notifications.", removed);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (TaskCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Notification retention service failed to enforce retention policies.");
+                delay = DefaultIdleDelay;
+            }
+
+            try
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    internal async Task<int> RunOnceAsync(CancellationToken cancellationToken)
+    {
+        var options = _options.Value;
+        if (!options.IsRetentionEnabled())
+        {
+            return 0;
+        }
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var nowUtc = _clock.UtcNow.UtcDateTime;
+        var removals = new List<Notification>();
+        var removalIds = new HashSet<int>();
+
+        if (options.MaxAge is TimeSpan maxAge && maxAge > TimeSpan.Zero)
+        {
+            var cutoff = nowUtc - maxAge;
+            var stale = await db.Notifications
+                .Where(n => n.CreatedUtc < cutoff)
+                .ToListAsync(cancellationToken);
+
+            foreach (var notification in stale)
+            {
+                if (removalIds.Add(notification.Id))
+                {
+                    removals.Add(notification);
+                }
+            }
+        }
+
+        if (options.MaxPerUser is int maxPerUser && maxPerUser > 0)
+        {
+            var overflowingUsers = await db.Notifications
+                .Where(n => !string.IsNullOrEmpty(n.RecipientUserId))
+                .GroupBy(n => n.RecipientUserId)
+                .Select(g => new { UserId = g.Key!, Count = g.Count() })
+                .Where(x => x.Count > maxPerUser)
+                .Select(x => x.UserId)
+                .ToListAsync(cancellationToken);
+
+            foreach (var userId in overflowingUsers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var extras = await db.Notifications
+                    .Where(n => n.RecipientUserId == userId)
+                    .OrderByDescending(n => n.CreatedUtc)
+                    .ThenByDescending(n => n.Id)
+                    .Skip(maxPerUser)
+                    .ToListAsync(cancellationToken);
+
+                foreach (var notification in extras)
+                {
+                    if (removalIds.Add(notification.Id))
+                    {
+                        removals.Add(notification);
+                    }
+                }
+            }
+        }
+
+        if (removals.Count == 0)
+        {
+            return 0;
+        }
+
+        db.Notifications.RemoveRange(removals);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return removals.Count;
+    }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -12,6 +12,13 @@
   "Todo": {
     "RetentionDays": 7
   },
+  "Notifications": {
+    "Retention": {
+      "SweepInterval": "00:05:00",
+      "MaxAge": "14.00:00:00",
+      "MaxPerUser": 100
+    }
+  },
   "ProjectPhotos": {
     "MaxFileSizeBytes": 5242880,
     "MinWidth": 720,

--- a/appsettings.json
+++ b/appsettings.json
@@ -30,6 +30,13 @@
   "Todo": {
     "RetentionDays": 7
   },
+  "Notifications": {
+    "Retention": {
+      "SweepInterval": "00:15:00",
+      "MaxAge": "30.00:00:00",
+      "MaxPerUser": 200
+    }
+  },
   "ProjectPhotos": {
     "MaxFileSizeBytes": 5242880,
     "MinWidth": 720,


### PR DESCRIPTION
## Summary
- add configurable notification retention options and a background cleanup service for notifications
- register the retention service and surface configuration defaults
- cover the retention workflow with a unit test

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2c06bc25c832980804ef7792d2125