### PR TITLE
Fix notification projection result type handling

### DIFF
--- a/Services/Notifications/UserNotificationService.cs
+++ b/Services/Notifications/UserNotificationService.cs
@@ -63,7 +63,7 @@ public sealed class UserNotificationService
                      .ThenByDescending(n => n.CreatedUtc);
 
         var fetchedNotifications = new List<Notification>(capacity: limit);
-        var accessibleResults = new List<NotificationListItem>();
+        IReadOnlyList<NotificationListItem> accessibleResults = Array.Empty<NotificationListItem>();
         var skip = 0;
         var batchSize = limit;
 


### PR DESCRIPTION
## Summary
- ensure the notification projection results use an IReadOnlyList placeholder
- avoid type conversion issues when refreshing accessible notification results

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e34748dcb48329a7e8fa359ef85c0d