### PR TITLE
Add calendar celebration preference toggle

### DIFF
--- a/Contracts/ShowCelebrationsPreferenceRequest.cs
+++ b/Contracts/ShowCelebrationsPreferenceRequest.cs
@@ -1,0 +1,3 @@
+namespace ProjectManagement.Contracts;
+
+public record ShowCelebrationsPreferenceRequest(bool ShowCelebrations);

--- a/Migrations/20251006045527_ShowCelebrationsPreference.Designer.cs
+++ b/Migrations/20251006045527_ShowCelebrationsPreference.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251006045527_ShowCelebrationsPreference")]
+    partial class ShowCelebrationsPreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251006045527_ShowCelebrationsPreference.cs
+++ b/Migrations/20251006045527_ShowCelebrationsPreference.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class ShowCelebrationsPreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowCelebrationsInCalendar",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.Sql("UPDATE \"AspNetUsers\" SET \"ShowCelebrationsInCalendar\" = TRUE WHERE \"ShowCelebrationsInCalendar\" = FALSE;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShowCelebrationsInCalendar",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -21,6 +21,8 @@ namespace ProjectManagement.Models
         public bool PendingDeletion { get; set; }
         public DateTime? DeletionRequestedUtc { get; set; }
         public string? DeletionRequestedByUserId { get; set; }
+
+        public bool ShowCelebrationsInCalendar { get; set; } = true;
     }
 }
 

--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -38,20 +38,37 @@
     </div>
   </div>
 
-  @if (Model.CanEdit)
-  {
-    <button class="btn btn-success btn-sm"
-            id="btnNewEvent"
-            type="button"
-            data-bs-toggle="offcanvas"
-            data-bs-target="#eventFormCanvas"
-            aria-controls="eventFormCanvas">New Event</button>
-  }
+  <div class="d-flex align-items-center gap-3">
+    <form id="calendarPreferences"
+          method="post"
+          class="d-flex align-items-center gap-2"
+          data-preference-endpoint="@Url.Content("~/calendar/events/preferences/show-celebrations")">
+      @Html.AntiForgeryToken()
+      <div class="form-check form-switch m-0">
+        <input class="form-check-input"
+               type="checkbox"
+               id="showCelebrationsToggle"
+               @(Model.ShowCelebrations ? "checked" : null)>
+        <label class="form-check-label" for="showCelebrationsToggle">Show celebrations</label>
+      </div>
+    </form>
+
+    @if (Model.CanEdit)
+    {
+      <button class="btn btn-success btn-sm"
+              id="btnNewEvent"
+              type="button"
+              data-bs-toggle="offcanvas"
+              data-bs-target="#eventFormCanvas"
+              aria-controls="eventFormCanvas">New Event</button>
+    }
+  </div>
 </div>
 
 <div id="calendar"
      class="shadow-sm border rounded-3 bg-white"
-     data-can-edit="@Model.CanEdit.ToString().ToLowerInvariant()"></div>
+     data-can-edit="@Model.CanEdit.ToString().ToLowerInvariant()"
+     data-show-celebrations="@Model.ShowCelebrations.ToString().ToLowerInvariant()"></div>
 
 <div id="categoryLegend" class="small text-muted mt-2"></div>
 

--- a/Pages/Calendar/Index.cshtml.cs
+++ b/Pages/Calendar/Index.cshtml.cs
@@ -1,21 +1,35 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Models;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace ProjectManagement.Pages.Calendar
 {
     [Authorize]
     public class IndexModel : PageModel
     {
-        public bool CanEdit { get; private set; }
+        private readonly UserManager<ApplicationUser> _userManager;
 
-        public void OnGet()
+        public IndexModel(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public bool CanEdit { get; private set; }
+        public bool ShowCelebrations { get; private set; }
+
+        public async Task OnGetAsync()
         {
             CanEdit = User.Claims.Where(c => c.Type == ClaimTypes.Role)
                 .Any(r => string.Equals(r.Value, "Admin", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(r.Value, "TA", StringComparison.OrdinalIgnoreCase)
                     || string.Equals(r.Value, "HoD", StringComparison.OrdinalIgnoreCase));
+
+            var user = await _userManager.GetUserAsync(User);
+            ShowCelebrations = user?.ShowCelebrationsInCalendar ?? true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a persisted `ShowCelebrationsInCalendar` flag to `ApplicationUser` with a migration that seeds existing rows
- surface the preference on the calendar page and render a switch with antiforgery context for future submissions
- expose a minimal-API endpoint plus frontend wiring and tests to update and verify the preference

## Testing
- `dotnet test ProjectManagement.sln` *(fails: several existing integration tests require infrastructure not available in the in-memory test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e34ab540e88329a2cb22779ad3cd42