### PR TITLE
Fix CalendarEventVm record placement for top-level statements

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -50,20 +50,6 @@ using ProjectManagement.Services.Navigation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 
-record CalendarEventVm(
-    string Id,
-    Guid SeriesId,
-    string Title,
-    DateTimeOffset Start,
-    DateTimeOffset End,
-    bool AllDay,
-    string Category,
-    string? Location,
-    bool IsRecurring,
-    bool IsCelebration,
-    Guid? CelebrationId,
-    string? TaskUrl);
-
 var runForecastBackfill = args.Any(a => string.Equals(a, "--backfill-forecast", StringComparison.OrdinalIgnoreCase));
 
 var builder = WebApplication.CreateBuilder(args);
@@ -1767,5 +1753,19 @@ static async Task<IResult> SendUnreadCountAsync(
 }
 
 app.Run();
+
+record CalendarEventVm(
+    string Id,
+    Guid SeriesId,
+    string Title,
+    DateTimeOffset Start,
+    DateTimeOffset End,
+    bool AllDay,
+    string Category,
+    string? Location,
+    bool IsRecurring,
+    bool IsCelebration,
+    Guid? CelebrationId,
+    string? TaskUrl);
 
 public partial class Program { }


### PR DESCRIPTION
## Summary
- move the CalendarEventVm record declaration to the end of Program.cs so top-level statements come first

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3575df328832993ce8ae2e3ad14ea