### PR TITLE
Remove redundant Bootstrap bundle include from calendar page

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -211,8 +211,7 @@
 </div>
 
 @section Scripts {
-  <!-- Order matters: Bootstrap JS → FullCalendar → page script -->
-  <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- Order matters: Bootstrap JS (provided by layout) → FullCalendar → page script -->
 
   <!-- EITHER: single bundle -->
   <script src="~/lib/fullcalendar/bundle/index.global.min.js"></script>


### PR DESCRIPTION
## Summary
- remove the extra Bootstrap bundle import from the calendar page now that it is provided by the shared layout
- clarify the remaining script order comment to note Bootstrap comes from the layout

## Testing
- ⚠️ `ASPNETCORE_URLS=http://0.0.0.0:5000 dotnet run` *(fails: `dotnet` is not installed in the container environment, so the site could not be launched for manual verification)*

------
https://chatgpt.com/codex/tasks/task_e_68e362a9aedc83298e7ed6075edc7ab0