### PR TITLE
Update upcoming events header text

### DIFF
--- a/Pages/Dashboard/_UpcomingEventsWidget.cshtml
+++ b/Pages/Dashboard/_UpcomingEventsWidget.cshtml
@@ -2,7 +2,7 @@
 
 <div class="card mb-3 mt-3">
   <div class="card-header d-flex justify-content-between align-items-center">
-    <span class="small fw-semibold">Next 5 events</span>
+    <span class="small fw-semibold">Upcoming events</span>
     <a asp-page="/Calendar/Index" class="small">View full calendar</a>
   </div>
   <ul class="list-group list-group-flush">


### PR DESCRIPTION
## Summary
- replace the dashboard upcoming events widget header text to read "Upcoming events"

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3714537148329bc916c661c527059