### PR TITLE
Style dashboard events drawer trigger as card

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -44,13 +44,25 @@
     <partial name="_TodoWidget" model="Model.TodoWidget" />
     <button
       type="button"
-      class="btn btn-outline-primary w-100 mt-3"
+      class="dashboard-events-card pm-card pm-shadow w-100 mt-3"
       data-drawer-toggle
       data-drawer-target="dashboard-events"
       aria-controls="dashboard-events"
       aria-haspopup="dialog"
+      aria-label="View upcoming events"
     >
-      View upcoming events
+      <div class="pm-card-body d-flex align-items-center gap-3">
+        <span class="pm-card-icon" aria-hidden="true">
+          <i class="bi bi-calendar-event"></i>
+        </span>
+        <div class="text-start">
+          <h3 class="pm-card-title h6 mb-0">Upcoming events</h3>
+          <p class="pm-card-subtitle mb-0">See what's coming up next.</p>
+        </div>
+        <span class="ms-auto text-primary" aria-hidden="true">
+          <i class="bi bi-arrow-right-short fs-4"></i>
+        </span>
+      </div>
     </button>
   </div>
 </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -199,6 +199,39 @@ body {
     margin-bottom: 0;
 }
 
+.dashboard-events-card {
+    display: block;
+    padding: 0;
+    border: 0;
+    background: none;
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+    transition: transform .2s ease, box-shadow .2s ease;
+}
+
+.dashboard-events-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 30px -20px rgba(15, 23, 42, .25);
+}
+
+.dashboard-events-card:focus {
+    outline: none;
+}
+
+.dashboard-events-card:focus-visible {
+    outline: 2px solid var(--pm-primary);
+    outline-offset: 4px;
+}
+
+.dashboard-events-card:active {
+    transform: translateY(0);
+}
+
+.dashboard-events-card .pm-card-body {
+    width: 100%;
+}
+
 .procurement-metrics {
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- restyle the dashboard events drawer trigger as a pm-card button with descriptive icon and copy
- add dashboard card helper styles to remove default button chrome while preserving focus and hover states

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e381a2e38083298080e6bbd6d4fd8c