### PR TITLE
Add holiday highlighting to calendar views

### DIFF
--- a/wwwroot/css/calendar.css
+++ b/wwwroot/css/calendar.css
@@ -38,6 +38,42 @@
   background-image: linear-gradient(to bottom, rgba(148,163,184,.06), rgba(148,163,184,.06));
 }
 
+/* Holiday accent */
+.fc .fc-daygrid-day.pm-holiday,
+.fc .fc-daygrid-day-frame.pm-holiday,
+.fc .fc-col-header-cell.pm-holiday,
+.fc .fc-list-day.pm-holiday {
+  background-image: linear-gradient(135deg, rgba(250,204,21,.16), rgba(253,224,71,.08));
+}
+.fc .fc-timegrid-col.pm-holiday .fc-timegrid-col-frame,
+.fc .fc-timegrid-col-frame.pm-holiday {
+  background-image: linear-gradient(180deg, rgba(250,204,21,.12), rgba(253,224,71,.05));
+}
+.fc .fc-daygrid-day.pm-holiday .fc-daygrid-day-number {
+  background-color: rgba(234,179,8,.15);
+  border-radius: .5rem;
+  color: #b45309;
+  box-shadow: inset 0 0 0 1px rgba(217,119,6,.35);
+}
+.fc .fc-col-header-cell.pm-holiday .fc-col-header-cell-cushion,
+.fc .fc-col-header-cell-cushion.pm-holiday,
+.fc .fc-list-day.pm-holiday .fc-list-day-cushion,
+.fc .fc-list-day-cushion.pm-holiday {
+  color: #92400e;
+  font-weight: 600;
+}
+.pm-holiday-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: .15rem .45rem;
+  margin-left: .5rem;
+  border-radius: 999px;
+  background-color: rgba(250,204,21,.18);
+  color: #854d0e;
+  font-size: var(--pm-font-size-xxs, .75rem);
+  font-weight: 600;
+}
+
 /* Ensure text inherits our dark color everywhere */
 .fc .fc-event,
 .fc .fc-event-main,
@@ -162,6 +198,7 @@
 .legend-dot.pm-cat-anniversary{ background:#14b8a6; }
 .legend-dot.pm-cat-celebration{ background:#f472b6; }
 .legend-dot.pm-cat-other      { background:#94a3b8; }
+.legend-dot.pm-holiday        { background:#eab308; }
 
 .fc-event.pm-recurring::after {
   content: "\21BB";


### PR DESCRIPTION
## Summary
- fetch holiday data for the active calendar range and keep it cached client-side
- decorate calendar cells, headers, and list rows with a holiday highlight plus accessibility metadata and badges
- add styling and legend support for holidays so they show alongside existing event categories

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3cfb947d8832985ab94f5282bf26a