### PR TITLE
Refresh holiday styling in calendar

### DIFF
--- a/wwwroot/css/calendar.css
+++ b/wwwroot/css/calendar.css
@@ -43,23 +43,34 @@
 .fc .fc-daygrid-day-frame.pm-holiday,
 .fc .fc-col-header-cell.pm-holiday,
 .fc .fc-list-day.pm-holiday {
-  background-image: linear-gradient(135deg, rgba(250,204,21,.16), rgba(253,224,71,.08));
+  background-image: linear-gradient(135deg, rgba(248,113,113,.16), rgba(254,226,226,.18));
+  box-shadow: inset 3px 0 0 rgba(248,113,113,.3);
 }
 .fc .fc-timegrid-col.pm-holiday .fc-timegrid-col-frame,
 .fc .fc-timegrid-col-frame.pm-holiday {
-  background-image: linear-gradient(180deg, rgba(250,204,21,.12), rgba(253,224,71,.05));
+  background-image: linear-gradient(180deg, rgba(248,113,113,.12), rgba(254,226,226,.08));
+  box-shadow: inset 3px 0 0 rgba(248,113,113,.28);
 }
-.fc .fc-daygrid-day.pm-holiday .fc-daygrid-day-number {
-  background-color: rgba(234,179,8,.15);
+.fc .fc-daygrid-day.pm-holiday .fc-daygrid-day-number,
+.fc .pm-holiday .fc-daygrid-day-number {
+  background-color: rgba(254,226,226,.85);
   border-radius: .5rem;
-  color: #b45309;
-  box-shadow: inset 0 0 0 1px rgba(217,119,6,.35);
+  color: #7f1d1d;
+  box-shadow: inset 0 0 0 2px rgba(248,113,113,.55);
+}
+@media (prefers-contrast: more) {
+  .fc .pm-holiday .fc-daygrid-day-number {
+    background-color: #fee2e2;
+    color: #450a0a;
+    box-shadow: inset 0 0 0 3px #b91c1c;
+    text-shadow: 0 1px 0 rgba(255,255,255,.45);
+  }
 }
 .fc .fc-col-header-cell.pm-holiday .fc-col-header-cell-cushion,
 .fc .fc-col-header-cell-cushion.pm-holiday,
 .fc .fc-list-day.pm-holiday .fc-list-day-cushion,
 .fc .fc-list-day-cushion.pm-holiday {
-  color: #92400e;
+  color: #7f1d1d;
   font-weight: 600;
 }
 .pm-holiday-badge {
@@ -68,8 +79,8 @@
   padding: .15rem .45rem;
   margin-left: .5rem;
   border-radius: 999px;
-  background-color: rgba(250,204,21,.18);
-  color: #854d0e;
+  background-color: rgba(254,226,226,.7);
+  color: #991b1b;
   font-size: var(--pm-font-size-xxs, .75rem);
   font-weight: 600;
 }
@@ -182,6 +193,7 @@
 #categoryFilters .btn[data-cat="Birthday"]::before   { content:"• "; color:#ec4899; }
 #categoryFilters .btn[data-cat="Anniversary"]::before{ content:"• "; color:#14b8a6; }
 #categoryFilters .btn[data-cat="Other"]::before      { content:"• "; color:#94a3b8; }
+#categoryFilters .btn[data-cat="Holiday"]::before    { content:"• "; color:#ef4444; }
 
 /* Legend dots */
 .legend-dot {
@@ -198,7 +210,8 @@
 .legend-dot.pm-cat-anniversary{ background:#14b8a6; }
 .legend-dot.pm-cat-celebration{ background:#f472b6; }
 .legend-dot.pm-cat-other      { background:#94a3b8; }
-.legend-dot.pm-holiday        { background:#eab308; }
+.legend-dot.pm-cat-holiday,
+.legend-dot.pm-holiday        { background:#ef4444; box-shadow:0 0 0 2px rgba(248,113,113,.35); }
 
 .fc-event.pm-recurring::after {
   content: "\21BB";
@@ -212,4 +225,9 @@
   nav, header, footer, #categoryFilters, #btnNewEvent, #btnPrev, #btnNext, [data-view], #btnToday { display: none !important; }
   #calendar { box-shadow: none; border: none; }
   .fc .fc-toolbar { display: none; }
+  .fc .pm-holiday .fc-daygrid-day-number {
+    background: transparent !important;
+    box-shadow: inset 0 0 0 1px #b91c1c;
+    color: #111827;
+  }
 }


### PR DESCRIPTION
## Summary
- add a red-tinted holiday highlight with stronger contrast across month, week, and list views
- ensure holiday date numbers have a high-contrast variant and update holiday badges and legend swatches
- keep print layouts readable with simplified holiday rings

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3d2cc8f608329b78633aa480600c0