### PR TITLE
Set default holiday date to today

### DIFF
--- a/Pages/Settings/Holidays/Create.cshtml.cs
+++ b/Pages/Settings/Holidays/Create.cshtml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,8 @@ public class CreateModel : PageModel
 
     public void OnGet()
     {
+        Input ??= new InputModel();
+        Input.Date = DateOnly.FromDateTime(DateTime.Today);
     }
 
     public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- initialize the holiday creation form with today's date to streamline current-year entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d8264030832991aa5abead10f879