### PR TITLE
Add holiday badges to calendar views

### DIFF
--- a/wwwroot/css/calendar.css
+++ b/wwwroot/css/calendar.css
@@ -84,6 +84,20 @@
   font-size: var(--pm-font-size-xxs, .75rem);
   font-weight: 600;
 }
+.fc .fc-daygrid-day-top {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+}
+.fc .fc-daygrid-day-top .fc-daygrid-day-number {
+  padding-right: 0;
+}
+.fc .fc-daygrid-day-top .pm-holiday-badge {
+  margin-left: 0;
+}
+.fc .fc-timegrid-col-top .pm-holiday-badge {
+  margin-left: .35rem;
+}
 
 /* Ensure text inherits our dark color everywhere */
 .fc .fc-event,

--- a/wwwroot/js/calendar.test.js
+++ b/wwwroot/js/calendar.test.js
@@ -150,9 +150,13 @@ test('calendar highlights admin holidays during initial load', async () => {
     const calendarEl = window.document.getElementById('calendar');
     const holidayCell = calendarEl.querySelector('.fc-daygrid-day[data-date="2024-12-25"]');
     assert.ok(holidayCell.classList.contains('pm-holiday'));
+    const holidayBadge = holidayCell.querySelector('.pm-holiday-badge');
+    assert.ok(holidayBadge, 'holiday cell should receive badge');
+    assert.equal(holidayBadge.textContent, 'Holiday: Founders Day');
 
     const nonHolidayCell = calendarEl.querySelector('.fc-daygrid-day[data-date="2024-12-26"]');
     assert.ok(!nonHolidayCell.classList.contains('pm-holiday'));
+    assert.equal(nonHolidayCell.querySelector('.pm-holiday-badge'), null);
 
     const numberEl = holidayCell.querySelector('.fc-daygrid-day-number');
     assert.equal(numberEl.getAttribute('title'), 'Holiday: Founders Day');


### PR DESCRIPTION
## Summary
- add a shared badge synchronizer so holiday badges render in grid, time, and list cells without duplicates
- tweak calendar styling so badges sit next to day numbers in grid views while preserving list layout
- extend calendar tests to cover holiday badge rendering and ensure non-holiday cells stay unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3dec74a148329b8544a00c8bcf220