### PR TITLE
Include holidays in dashboard upcoming events

### DIFF
--- a/Pages/Dashboard/_UpcomingEventsWidget.cshtml
+++ b/Pages/Dashboard/_UpcomingEventsWidget.cshtml
@@ -14,7 +14,7 @@
 @foreach (var ev in events)
 {
   <li class="small mb-3">
-    <div class="fw-semibold">@ev.Title</div>
+    <div class="fw-semibold@(ev.IsHoliday ? " text-danger" : string.Empty)">@ev.Title</div>
     <div class="text-secondary">@ev.When</div>
   </li>
 }


### PR DESCRIPTION
## Summary
- include holidays occurring within the upcoming 30 day window in the dashboard widget
- flag holiday rows for red styling and expose the holiday indicator in the view model
- add coverage to ensure holidays appear in the upcoming events list

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e58487308329ae3590ffdb4aa7bb