### PR TITLE
Add IST-aware todo widget metrics

### DIFF
--- a/Services/ITodoService.cs
+++ b/Services/ITodoService.cs
@@ -25,5 +25,7 @@ namespace ProjectManagement.Services
         public IList<TodoItem> Items { get; set; } = new List<TodoItem>();
         public int OverdueCount { get; set; }
         public int DueTodayCount { get; set; }
+        public int Next7DaysCount { get; set; }
+        public double OnTimePercent { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extend the todo widget result with upcoming count and on-time completion fields
- calculate overdue, today, and upcoming counts using IST day boundaries
- compute a 14-day on-time percentage and cover the new metrics with unit tests

## Testing
- dotnet test ProjectManagement.sln --filter TodoServiceTests *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f2f0c8748329bdc7b7cf91e5be79