### PR TITLE
Add todo widget percent clamp script

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -94,3 +94,7 @@
     </div>
   </div>
 </div>
+
+@section Scripts {
+  <script src="~/js/todo-widget.js" asp-append-version="true" defer></script>
+}

--- a/wwwroot/js/todo-widget.js
+++ b/wwwroot/js/todo-widget.js
@@ -1,0 +1,41 @@
+// wwwroot/js/todo-widget.js
+
+(function () {
+  const RING_SELECTOR = '.mission-ring[data-percent]';
+
+  function clampPercent(value) {
+    if (Number.isNaN(value)) return null;
+    if (!Number.isFinite(value)) return null;
+    return Math.min(100, Math.max(0, value));
+  }
+
+  function applyRing(root) {
+    if (!root) return;
+    const rings = root.matches?.(RING_SELECTOR) ? [root] : root.querySelectorAll(RING_SELECTOR);
+    rings.forEach((ring) => {
+      const raw = ring.getAttribute('data-percent');
+      if (raw == null) return;
+      const parsed = Number.parseFloat(raw);
+      const clamped = clampPercent(parsed);
+      if (clamped == null) return;
+      ring.style.setProperty('--p', String(clamped));
+    });
+  }
+
+  function init(root) {
+    applyRing(root || document);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => init());
+  } else {
+    init();
+  }
+
+  document.addEventListener('htmx:afterSwap', (event) => {
+    const target = event.detail && event.detail.target;
+    if (target instanceof HTMLElement) {
+      init(target);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a CSP-safe todo widget script that clamps the mission ring percentage and writes it to the CSS variable
- load the new script from the dashboard to keep the mission ring in sync with the server value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3f8df180c8329b28d479821a6a17e