### PR TITLE
Fix test setup null warnings and assert usage

### DIFF
--- a/ProjectManagement.Tests/DashboardPageTests.cs
+++ b/ProjectManagement.Tests/DashboardPageTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using ProjectManagement.Data;
@@ -58,6 +59,8 @@ namespace ProjectManagement.Tests
             });
             await context.SaveChangesAsync();
 
+            using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
             var userManager = new UserManager<ApplicationUser>(
                 new UserStore<ApplicationUser>(context),
                 Options.Create(new IdentityOptions()),
@@ -66,7 +69,7 @@ namespace ProjectManagement.Tests
                 Array.Empty<IPasswordValidator<ApplicationUser>>(),
                 new UpperInvariantLookupNormalizer(),
                 new IdentityErrorDescriber(),
-                null,
+                serviceProvider,
                 NullLogger<UserManager<ApplicationUser>>.Instance);
 
             var todo = new StubTodoService();
@@ -115,6 +118,8 @@ namespace ProjectManagement.Tests
             });
             await context.SaveChangesAsync();
 
+            using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
             var userManager = new UserManager<ApplicationUser>(
                 new UserStore<ApplicationUser>(context),
                 Options.Create(new IdentityOptions()),
@@ -123,7 +128,7 @@ namespace ProjectManagement.Tests
                 Array.Empty<IPasswordValidator<ApplicationUser>>(),
                 new UpperInvariantLookupNormalizer(),
                 new IdentityErrorDescriber(),
-                null,
+                serviceProvider,
                 NullLogger<UserManager<ApplicationUser>>.Instance);
 
             var todo = new StubTodoService();

--- a/ProjectManagement.Tests/EventEndpointTests.cs
+++ b/ProjectManagement.Tests/EventEndpointTests.cs
@@ -131,7 +131,7 @@ namespace ProjectManagement.Tests
             Assert.True(response.IsSuccessStatusCode, body);
             var items = JsonSerializer.Deserialize<List<CalendarEventVm>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             Assert.NotNull(items);
-            var match = Assert.Contains(items!, i => i.SeriesId == ev.Id && i.AllDay && i.Start == start);
+            var match = Assert.Single(items!.Where(i => i.SeriesId == ev.Id && i.AllDay && i.Start == start));
             Assert.False(match.IsCelebration);
             Assert.Equal($"/calendar/events/{ev.Id}/task", match.TaskUrl);
         }


### PR DESCRIPTION
## Summary
- provide a real service provider when constructing UserManager in dashboard page tests to avoid nullability warnings
- adjust recurring events test to locate the matching event with Assert.Single instead of capturing the result of Assert.Contains

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fa0d9a4883298c76cf1794f9ca77