### PR TITLE
Adjust dashboard column layout to 9-3 split

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -36,11 +36,11 @@
 }
 
 <div class="row g-3 dashboard mt-1">
-  <div class="col-lg-8">
+  <div class="col-lg-9">
     <h2 class="h5 fw-semibold mb-2">Dashboard</h2>
     <p class="text-secondary">This is a placeholder. Add role-specific widgets here.</p>
   </div>
-  <div class="col-lg-4 dashboard-sidebar">
+  <div class="col-lg-3 dashboard-sidebar">
     <partial name="_TodoWidget" model="Model.TodoWidget" />
     <button
       type="button"


### PR DESCRIPTION
## Summary
- adjust the dashboard layout to use a 9:3 column split so the main content gets more width while the sidebar stays aligned

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fb9f47d08329981d231e0f27d440