### PR TITLE
Fix mission ring percent fallback

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -193,7 +193,7 @@
 .mission-ring {
   --mission-ring-size: 7.5rem;
   --mission-ring-thickness: 12px;
-  --mission-ring-percent: attr(data-percent percentage, 0%);
+  --mission-ring-percent-attr: 0%;
   display: grid;
   place-items: center;
   gap: .2rem;
@@ -203,7 +203,13 @@
   position: relative;
   border-radius: 50%;
   color: inherit;
-  background: conic-gradient(var(--mission-panel-ring-fill) var(--mission-ring-percent, 0%), var(--mission-panel-ring-track) 0);
+  background: conic-gradient(var(--mission-panel-ring-fill) var(--mission-ring-percent, var(--mission-ring-percent-attr, 0%)), var(--mission-panel-ring-track) 0);
+}
+
+@supports (width: attr(data-percent percentage)) {
+  .mission-ring {
+    --mission-ring-percent-attr: attr(data-percent percentage, 0%);
+  }
 }
 
 .mission-ring::after {

--- a/wwwroot/js/todo-widget.js
+++ b/wwwroot/js/todo-widget.js
@@ -2,6 +2,7 @@
 
 (function () {
   const RING_SELECTOR = '.mission-ring[data-percent]';
+  const RING_PERCENT_PROPERTY = '--mission-ring-percent';
 
   function clampPercent(value) {
     if (Number.isNaN(value)) return null;
@@ -18,7 +19,7 @@
       const parsed = Number.parseFloat(raw);
       const clamped = clampPercent(parsed);
       if (clamped == null) return;
-      ring.style.setProperty('--p', String(clamped));
+      ring.style.setProperty(RING_PERCENT_PROPERTY, `${clamped}%`);
     });
   }
 


### PR DESCRIPTION
## Summary
- update the todo widget to write the --mission-ring-percent custom property from the computed percentage
- adjust the mission ring styling to fall back to the JavaScript-provided percentage while keeping typed attr() support when available

## Testing
- dotnet run --urls http://0.0.0.0:5000 *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e405d6cff0832987b6e1e92f5987c9