### PR TITLE
Handle empty quick-add titles

### DIFF
--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -169,6 +169,12 @@ namespace ProjectManagement.Pages.Dashboard
             if (uid == null) return Unauthorized();
 
             TodoQuickParser.Parse(NewTitle, out var clean, out var dueLocal, out var prio);
+            clean = clean.Trim();
+            if (string.IsNullOrEmpty(clean))
+            {
+                TempData["Error"] = "Task title cannot be empty.";
+                return RedirectToPage();
+            }
 
             try
             {

--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -124,6 +124,12 @@ namespace ProjectManagement.Pages.Tasks
             var uid = _users.GetUserId(User);
             if (string.IsNullOrWhiteSpace(NewTitle) || uid == null) return Back();
             TodoQuickParser.Parse(NewTitle, out var clean, out var dueLocal, out var prio);
+            clean = clean.Trim();
+            if (string.IsNullOrEmpty(clean))
+            {
+                TempData["Error"] = "Task title cannot be empty.";
+                return Back();
+            }
             try
             {
                 await _todo.CreateAsync(uid, clean, dueLocal, prio);

--- a/ProjectManagement.Tests/TasksPageTests.cs
+++ b/ProjectManagement.Tests/TasksPageTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Pages.Tasks;
+using ProjectManagement.Services;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public class TasksPageTests
+{
+    [Fact]
+    public async Task OnPostAddAsync_OnlyQuickTokens_SetsErrorAndSkipsCreate()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new ApplicationDbContext(options);
+
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var userManager = new UserManager<ApplicationUser>(
+            new UserStore<ApplicationUser>(context),
+            Options.Create(new IdentityOptions()),
+            new PasswordHasher<ApplicationUser>(),
+            Array.Empty<IUserValidator<ApplicationUser>>(),
+            Array.Empty<IPasswordValidator<ApplicationUser>>(),
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            serviceProvider,
+            NullLogger<UserManager<ApplicationUser>>.Instance);
+
+        var todo = new RecordingTodoService();
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "user-1")
+            }, "TestAuth"))
+        };
+
+        var page = new IndexModel(context, todo, userManager)
+        {
+            PageContext = new PageContext(new ActionContext(
+                httpContext,
+                new RouteData(),
+                new ActionDescriptor()))
+        };
+
+        page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
+
+        var result = await page.OnPostAddAsync("tomorrow !high");
+
+        Assert.IsType<RedirectToPageResult>(result);
+        Assert.True(page.TempData.ContainsKey("Error"));
+        Assert.Equal("Task title cannot be empty.", page.TempData["Error"]);
+        Assert.False(todo.CreateCalled);
+    }
+
+    private sealed class RecordingTodoService : ITodoService
+    {
+        public bool CreateCalled { get; private set; }
+
+        public Task<TodoWidgetResult> GetWidgetAsync(string ownerId, int take = 20)
+            => throw new NotImplementedException();
+
+        public Task<TodoItem> CreateAsync(string ownerId, string title, DateTimeOffset? dueAtLocal = null,
+            TodoPriority priority = TodoPriority.Normal, bool pinned = false)
+        {
+            CreateCalled = true;
+            return Task.FromResult(new TodoItem());
+        }
+
+        public Task<bool> ToggleDoneAsync(string ownerId, Guid id, bool done)
+            => throw new NotImplementedException();
+
+        public Task<bool> EditAsync(string ownerId, Guid id, string? title = null, DateTimeOffset? dueAtLocal = null,
+            TodoPriority? priority = null, bool? pinned = null)
+            => throw new NotImplementedException();
+
+        public Task<bool> DeleteAsync(string ownerId, Guid id)
+            => throw new NotImplementedException();
+
+        public Task<int> ClearCompletedAsync(string ownerId)
+            => throw new NotImplementedException();
+
+        public Task<bool> ReorderAsync(string ownerId, IList<Guid> orderedIds)
+            => throw new NotImplementedException();
+
+        public Task MarkDoneAsync(string ownerId, IList<Guid> ids)
+            => throw new NotImplementedException();
+
+        public Task DeleteManyAsync(string ownerId, IList<Guid> ids)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary
- trim quick-add titles after parsing and block submissions that become empty
- surface a validation error on both the tasks index and dashboard quick-add forms when the title is empty
- add a regression test ensuring token-only quick-add input is rejected

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e40909d4708329aba9de228cd4c3e3