### PR TITLE
Add global empty state to task list

### DIFF
--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -1,26 +1,70 @@
 @using ProjectManagement.Models
 @using ProjectManagement.Helpers
+@using System.Linq
 @model ProjectManagement.Pages.Tasks.IndexModel
 
 @functions {
     string Dot(TodoPriority p) => p == TodoPriority.High ? "todo-dot-high" : p == TodoPriority.Low ? "todo-dot-low" : "todo-dot-normal";
 }
 
-@foreach (var grp in Model.Groups)
-{
-    <div class="mb-2 mt-3 small text-uppercase text-muted fw-semibold">@grp.Title</div>
+@{
+    var allGroupsEmpty = Model.Groups.Length == 0 || Model.Groups.All(grp => grp.Items.Length == 0);
+}
 
-    @if (grp.Items.Length == 0)
+@if (allGroupsEmpty)
+{
+    string emptyTitle;
+    string emptyDescription;
+
+    switch (Model.Tab)
     {
-        <div class="text-muted small mb-3">No tasks here.</div>
+        case "today":
+            emptyTitle = "You're clear for Today";
+            emptyDescription = "No tasks scheduled for the rest of today.";
+            break;
+        case "upcoming":
+            emptyTitle = "Nothing on the horizon";
+            emptyDescription = "You don't have any upcoming tasks right now.";
+            break;
+        case "completed":
+            emptyTitle = "No completed tasks yet";
+            emptyDescription = "Mark tasks as done to see them here.";
+            break;
+        default:
+            emptyTitle = "You're all caught up";
+            emptyDescription = "Add a task to get started.";
+            break;
     }
-    else
-    {
-        <ul class="list-group todo-list">
-            @foreach (var t in grp.Items)
+
+    <div class="card border-0 bg-light text-center my-4">
+        <div class="card-body py-5">
+            <h5 class="card-title mb-2">@emptyTitle</h5>
+            <p class="card-text text-muted mb-0">@emptyDescription</p>
+
+            @if (!string.IsNullOrWhiteSpace(Model.Q))
             {
-                var formId = $"f-{t.Id}";
-                var chip = TodoViewHelpers.DueBadge(t.DueAtUtc);
+                <a class="btn btn-sm btn-outline-secondary mt-3" asp-page="Index">Show all tasks</a>
+            }
+        </div>
+    </div>
+}
+else
+{
+    @foreach (var grp in Model.Groups)
+    {
+        <div class="mb-2 mt-3 small text-uppercase text-muted fw-semibold">@grp.Title</div>
+
+        @if (grp.Items.Length == 0)
+        {
+            <div class="text-muted small mb-3">No tasks here.</div>
+        }
+        else
+        {
+            <ul class="list-group todo-list">
+                @foreach (var t in grp.Items)
+                {
+                    var formId = $"f-{t.Id}";
+                    var chip = TodoViewHelpers.DueBadge(t.DueAtUtc);
 
                 <li class="list-group-item d-flex align-items-start justify-content-between py-2 todo-row @(t.Status == TodoStatus.Done ? "done" : "")" data-id="@t.Id" draggable="@(Model.Tab == "completed" ? "false" : "true")" data-priority="@t.Priority">
                     <div class="d-flex align-items-center gap-2 flex-grow-1">
@@ -149,7 +193,8 @@
                         </div>
                     </div>
                 </li>
-            }
-        </ul>
+                }
+            </ul>
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect when all task groups are empty and show a friendly empty-state card
- tailor the message to the active tab and offer a reset search link when filters are applied
- hide per-group empty messages whenever the global empty state is displayed

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e46a9311a483299affe3fcec7b0dd5