### PR TITLE
Fix todo widget route values type

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -2,6 +2,8 @@
 @using ProjectManagement.Helpers
 @using Microsoft.AspNetCore.Routing
 @using System.Linq
+@using System.Collections.Generic
+@using System
 @model ProjectManagement.Services.TodoWidgetResult
 
 @{
@@ -16,12 +18,10 @@
             ? "upcoming"
             : "today";
 
-    var routeValues = new RouteValueDictionary();
+    var routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     foreach (var queryParameter in ViewContext.HttpContext.Request.Query)
     {
-        routeValues[queryParameter.Key] = queryParameter.Value.Count > 1
-            ? queryParameter.Value.ToArray()
-            : queryParameter.Value.ToString();
+        routeValues[queryParameter.Key] = queryParameter.Value.ToString();
     }
 
     routeValues["tab"] = defaultTab;


### PR DESCRIPTION
## Summary
- update the todo widget to build route values with a string dictionary that is compatible with asp-all-route-data
- ensure the route dictionary preserves query string values and sets the default tab

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4798d41a88329b7879186d83a67b9