### PR TITLE
Implement sticky tasks header and compact toggle

### DIFF
--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -21,7 +21,56 @@
   </ol>
 </nav>
 
-<h4 class="mb-3">My Tasks</h4>
+<div class="tasks-header mb-3">
+  <div class="tasks-header__bar">
+    <div class="tasks-header__title-group">
+      <h4 class="tasks-header__title mb-0">My Tasks</h4>
+      <span class="tasks-header__count" aria-label="Total tasks">@Model.TotalItems</span>
+    </div>
+    <div class="tasks-header__actions">
+      <button type="button"
+              class="btn btn-sm btn-outline-secondary tasks-compact-toggle"
+              data-compact="false"
+              aria-pressed="false">
+        <span class="tasks-compact-toggle__icon" aria-hidden="true"></span>
+        <span class="tasks-compact-toggle__label">Compact view</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="tasks-filter-stack">
+    <div class="tasks-filter-card">
+      <form method="get" class="tasks-filter-card__form">
+        <div class="tasks-filter-card__group tasks-filter-card__group--selects">
+          <select class="form-select form-select-sm" name="tab">
+            <option value="all" selected="@(Model.Tab=="all")">All</option>
+            <option value="today" selected="@(Model.Tab=="today")">Today</option>
+            <option value="upcoming" selected="@(Model.Tab=="upcoming")">Upcoming</option>
+            <option value="completed" selected="@(Model.Tab=="completed")">Completed</option>
+          </select>
+          <select class="form-select form-select-sm" name="PageSize">
+            <option value="10" selected="@(Model.PageSize==10)">10</option>
+            <option value="25" selected="@(Model.PageSize==25)">25</option>
+            <option value="50" selected="@(Model.PageSize==50)">50</option>
+          </select>
+        </div>
+        <div class="tasks-filter-card__group tasks-filter-card__group--search">
+          <input class="form-control form-control-sm" name="q" value="@Model.Q" placeholder="Search" />
+        </div>
+        <div class="tasks-filter-card__group tasks-filter-card__group--actions">
+          <button class="btn btn-sm btn-outline-primary">Apply</button>
+          <a class="btn btn-sm btn-outline-secondary" asp-page="Index">Reset</a>
+        </div>
+      </form>
+    </div>
+
+    <form method="post" asp-page-handler="Add" class="tasks-add-form input-group input-group-sm pm-form-max-520">
+      @Html.AntiForgeryToken()
+      <input class="form-control" name="NewTitle" placeholder="Add a task…" maxlength="160" required />
+      <button class="btn btn-primary">Add</button>
+    </form>
+  </div>
+</div>
 
 @if (TempData["Error"] is string err && !string.IsNullOrWhiteSpace(err))
 {
@@ -39,29 +88,6 @@
     </form>
   </noscript>
 }
-
-<form method="get" class="d-flex flex-wrap gap-2 align-items-center mb-3">
-  <select class="form-select form-select-sm w-auto" name="tab">
-    <option value="all" selected="@(Model.Tab=="all")">All</option>
-    <option value="today" selected="@(Model.Tab=="today")">Today</option>
-    <option value="upcoming" selected="@(Model.Tab=="upcoming")">Upcoming</option>
-    <option value="completed" selected="@(Model.Tab=="completed")">Completed</option>
-  </select>
-  <input class="form-control form-control-sm w-auto" name="q" value="@Model.Q" placeholder="Search">
-  <select class="form-select form-select-sm w-auto" name="PageSize">
-    <option value="10" selected="@(Model.PageSize==10)">10</option>
-    <option value="25" selected="@(Model.PageSize==25)">25</option>
-    <option value="50" selected="@(Model.PageSize==50)">50</option>
-  </select>
-  <button class="btn btn-sm btn-primary">Apply</button>
-  <a class="btn btn-sm btn-outline-secondary" asp-page="Index">Reset</a>
-</form>
-
-<form method="post" asp-page-handler="Add" class="input-group input-group-sm mb-2 pm-form-max-520">
-  @Html.AntiForgeryToken()
-  <input class="form-control" name="NewTitle" placeholder="Add a task…" maxlength="160" required />
-  <button class="btn btn-primary">Add</button>
-</form>
 
 <div id="bulkSelectionToolbar" class="alert alert-secondary py-2 px-3 d-none" role="region" aria-live="polite">
   <div class="d-flex flex-wrap align-items-center gap-2">

--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -1,6 +1,190 @@
 /* wwwroot/css/tasks.css */
 /* Compact, modern task list styling */
 
+.tasks-header {
+  position: sticky;
+  top: var(--pm-sticky-offset, 0);
+  z-index: 10;
+  background: var(--bs-body-bg, #fff);
+  padding: 0.75rem 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, .06);
+}
+
+.tasks-header__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tasks-header__title-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.tasks-header__title {
+  font-weight: 600;
+}
+
+.tasks-header__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.25rem 0.65rem;
+  font-size: var(--pm-font-size-tight, 0.875rem);
+  font-weight: 600;
+  border-radius: 999px;
+  background: var(--bs-primary-bg-subtle, rgba(13, 110, 253, .12));
+  color: var(--bs-primary-text-emphasis, #0a58ca);
+  border: 1px solid rgba(13, 110, 253, .2);
+}
+
+.tasks-header__actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tasks-filter-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.tasks-filter-card {
+  border: 1px solid rgba(13, 110, 253, .18);
+  border-radius: 0.75rem 0.75rem 0 0;
+  background: linear-gradient(135deg, rgba(13, 110, 253, .08), rgba(111, 66, 193, .05));
+  box-shadow: 0 8px 22px -18px rgba(13, 110, 253, .9);
+  padding: 0.85rem 1rem;
+}
+
+.tasks-filter-card__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.tasks-filter-card__group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tasks-filter-card__group--selects {
+  flex-wrap: wrap;
+}
+
+.tasks-filter-card__group--selects .form-select {
+  min-width: 8.5rem;
+}
+
+.tasks-filter-card__group--search {
+  flex: 1 1 200px;
+}
+
+.tasks-filter-card__group--search .form-control {
+  width: 100%;
+}
+
+.tasks-filter-card__group--actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tasks-add-form {
+  border: 1px solid rgba(13, 110, 253, .18);
+  border-top: 0;
+  border-radius: 0 0 0.75rem 0.75rem;
+  overflow: hidden;
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 12px 24px -20px rgba(13, 110, 253, .75);
+  margin-top: -1px;
+  width: 100%;
+}
+
+.tasks-add-form .form-control {
+  border: 0;
+  box-shadow: none;
+  padding-block: 0.5rem;
+}
+
+.tasks-add-form .form-control:focus {
+  box-shadow: none;
+}
+
+.tasks-add-form .btn {
+  border: 0;
+  border-radius: 0;
+}
+
+.tasks-add-form .btn:focus {
+  box-shadow: none;
+}
+
+.tasks-compact-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  transition: background-color .18s ease, color .18s ease, border-color .18s ease;
+}
+
+.tasks-compact-toggle__icon {
+  position: relative;
+  width: 1.5rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: rgba(13, 110, 253, .12);
+  border: 1px solid rgba(13, 110, 253, .25);
+}
+
+.tasks-compact-toggle__icon::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0.2rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: rgba(13, 110, 253, .8);
+  transform: translateY(-50%);
+  transition: transform .18s ease, background-color .18s ease;
+}
+
+.tasks-compact-toggle[data-compact="true"] {
+  color: var(--bs-primary, #0d6efd);
+  border-color: rgba(13, 110, 253, .35);
+  background-color: rgba(13, 110, 253, .08);
+}
+
+.tasks-compact-toggle[data-compact="true"] .tasks-compact-toggle__icon {
+  background: rgba(13, 110, 253, .18);
+  border-color: rgba(13, 110, 253, .45);
+}
+
+.tasks-compact-toggle[data-compact="true"] .tasks-compact-toggle__icon::before {
+  transform: translate(0.55rem, -50%);
+  background: var(--bs-primary, #0d6efd);
+}
+
+#taskListContainer.compact .todo-list .list-group-item {
+  padding-top: 0.45rem;
+  padding-bottom: 0.45rem;
+}
+
+#taskListContainer.compact .todo-title {
+  font-size: var(--pm-font-size-tight, 0.9rem);
+}
+
 .todo-list {
   --pm-gap: 0.6rem;
   --todo-row-hover-bg: rgba(13, 110, 253, .08);

--- a/wwwroot/js/tasks-page.js
+++ b/wwwroot/js/tasks-page.js
@@ -488,6 +488,48 @@
     });
   }
 
+  function initCompactToggle() {
+    const toggle = qs('.tasks-compact-toggle');
+    const container = document.getElementById('taskListContainer');
+    if (!toggle || !container) return;
+
+    const STORAGE_KEY = 'pm.tasks.compact';
+
+    function saveState(value) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false');
+      } catch (_) {
+        /* no-op */
+      }
+    }
+
+    function readStoredState() {
+      try {
+        return window.localStorage.getItem(STORAGE_KEY);
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function applyState(isCompact) {
+      container.classList.toggle('compact', isCompact);
+      toggle.dataset.compact = isCompact ? 'true' : 'false';
+      toggle.setAttribute('aria-pressed', isCompact ? 'true' : 'false');
+      toggle.classList.toggle('is-active', isCompact);
+      saveState(isCompact);
+    }
+
+    const stored = readStoredState();
+    const initial = stored === 'true' || (stored === null && toggle.dataset.compact === 'true');
+    applyState(initial);
+
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      const current = toggle.dataset.compact === 'true';
+      applyState(!current);
+    });
+  }
+
   // ---- 0) Auto-submit done/undo checkboxes ----
   function initDoneAutosubmit(toastApi) {
     const nativeSubmit = HTMLFormElement.prototype.submit;
@@ -581,6 +623,7 @@
       initDragReorder();
       initBulkSelection();
       initKeyboardNav();
+      initCompactToggle();
     });
   } else {
     const toast = initTaskToast();
@@ -589,5 +632,6 @@
     initDragReorder();
     initBulkSelection();
     initKeyboardNav();
+    initCompactToggle();
   }
 })();


### PR DESCRIPTION
## Summary
- wrap the tasks heading, count badge, and filters in a sticky header with a refreshed layout
- introduce a styled filter card with aligned quick-add form and a compact view toggle
- add supporting CSS and JavaScript so the compact toggle updates the task list presentation and persists state

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48bae2af48329917a4bf9d3a89529