### PR TITLE
Enhance task lane headers with sticky pills

### DIFF
--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -52,16 +52,32 @@ else
 {
     @foreach (var grp in Model.Groups)
     {
-        <div class="mb-2 mt-3 small text-uppercase text-muted fw-semibold">@grp.Title</div>
+        var laneKey = grp.Title?.Trim().ToLowerInvariant().Replace(' ', '-') ?? "lane";
+        string laneIcon = grp.Title switch
+        {
+            "Overdue" => "bi-exclamation-octagon-fill",
+            "Today" => "bi-sun-fill",
+            "Upcoming" => "bi-calendar-event-fill",
+            "Completed" => "bi-check-circle-fill",
+            _ => "bi-inboxes-fill"
+        };
 
-        @if (grp.Items.Length == 0)
-        {
-            <div class="text-muted small mb-3">No tasks here.</div>
-        }
-        else
-        {
-            <ul class="list-group todo-list">
-                @foreach (var t in grp.Items)
+        <section class="tasks-lane" data-lane="@laneKey">
+            <div class="tasks-lane-header" data-lane="@laneKey">
+                <span class="tasks-lane-pill">
+                    <i class="bi @laneIcon" aria-hidden="true"></i>
+                    <span class="tasks-lane-pill__label">@grp.Title</span>
+                </span>
+            </div>
+
+            @if (grp.Items.Length == 0)
+            {
+                <div class="tasks-lane-empty text-muted small">No tasks here.</div>
+            }
+            else
+            {
+                <ul class="list-group todo-list" data-lane="@laneKey">
+                    @foreach (var t in grp.Items)
                 {
                     var formId = $"f-{t.Id}";
                     var chip = TodoViewHelpers.DueBadge(t.DueAtUtc);
@@ -194,7 +210,8 @@ else
                     </div>
                 </li>
                 }
-            </ul>
-        }
+                </ul>
+            }
+        </section>
     }
 }

--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -185,6 +185,118 @@
   font-size: var(--pm-font-size-tight, 0.9rem);
 }
 
+#taskListContainer {
+  --tasks-lane-sticky-offset: 9.75rem;
+}
+
+.tasks-lane {
+  position: relative;
+  margin-top: 1.5rem;
+}
+
+.tasks-lane:first-of-type {
+  margin-top: 0.5rem;
+}
+
+.tasks-lane-header {
+  position: sticky;
+  top: calc(var(--pm-sticky-offset, 0) + var(--tasks-lane-sticky-offset, 9.75rem));
+  z-index: 4;
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+  margin-bottom: 0.65rem;
+  background: var(--bs-body-bg, #fff);
+  display: flex;
+  align-items: center;
+}
+
+.tasks-lane-header::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1.5rem;
+  right: -1.5rem;
+  background: var(--bs-body-bg, #fff);
+  z-index: -1;
+}
+
+.tasks-lane-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: var(--pm-font-size-tight, 0.82rem);
+  font-weight: 600;
+  letter-spacing: 0.015em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  transition: background-color .18s ease, color .18s ease, border-color .18s ease, box-shadow .18s ease;
+  box-shadow: 0 4px 12px -8px rgba(15, 23, 42, .3);
+}
+
+.tasks-lane-pill i {
+  font-size: 1rem;
+}
+
+.tasks-lane-pill__label {
+  line-height: 1.1;
+}
+
+.tasks-lane-header[data-lane="overdue"] .tasks-lane-pill {
+  background: var(--bs-danger-bg-subtle, rgba(220, 53, 69, .14));
+  border-color: var(--bs-danger-border-subtle, rgba(220, 53, 69, .28));
+  color: var(--bs-danger-text-emphasis, #842029);
+}
+
+.tasks-lane-header[data-lane="today"] .tasks-lane-pill {
+  background: var(--bs-warning-bg-subtle, rgba(255, 193, 7, .2));
+  border-color: var(--bs-warning-border-subtle, rgba(255, 193, 7, .32));
+  color: var(--bs-warning-text-emphasis, #664d03);
+}
+
+.tasks-lane-header[data-lane="upcoming"] .tasks-lane-pill {
+  background: var(--bs-info-bg-subtle, rgba(13, 202, 240, .18));
+  border-color: var(--bs-info-border-subtle, rgba(13, 202, 240, .28));
+  color: var(--bs-info-text-emphasis, #055160);
+}
+
+.tasks-lane-header[data-lane="completed"] .tasks-lane-pill,
+.tasks-lane-header[data-lane="open"] .tasks-lane-pill {
+  background: var(--bs-success-bg-subtle, rgba(25, 135, 84, .16));
+  border-color: var(--bs-success-border-subtle, rgba(25, 135, 84, .28));
+  color: var(--bs-success-text-emphasis, #0f5132);
+}
+
+.tasks-lane .todo-list {
+  margin-bottom: 1.5rem;
+}
+
+.tasks-lane .todo-list:last-child {
+  margin-bottom: 0;
+}
+
+.tasks-lane-empty {
+  margin-bottom: 1.5rem;
+}
+
+.tasks-lane-empty,
+.tasks-lane .todo-list {
+  padding-left: 0.25rem;
+}
+
+@media (max-width: 767.98px) {
+  #taskListContainer {
+    --tasks-lane-sticky-offset: 11rem;
+  }
+
+  .tasks-lane-header::after {
+    left: -1rem;
+    right: -1rem;
+  }
+}
+
 .todo-list {
   --pm-gap: 0.6rem;
   --todo-row-hover-bg: rgba(13, 110, 253, .08);


### PR DESCRIPTION
## Summary
- wrap task group headings in reusable lane pills with contextual icons and sticky headers
- add lane-level data attributes and styling to keep headers visible while scrolling
- extend task stylesheet with pill colors, spacing, and sticky offsets that fit beneath the filter bar

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e49075978c8329ada0732376158673