### PR TITLE
Refine task list row layout and feedback

### DIFF
--- a/Pages/Tasks/Index.cshtml
+++ b/Pages/Tasks/Index.cshtml
@@ -4,9 +4,18 @@
 @{
     ViewData["Title"] = "My Tasks";
     string? toastUndoId = null;
+    string? toastMessage = null;
+    string? toastVariant = null;
     if (TempData["UndoId"] is string undo && Guid.TryParse(undo, out var undoGuid))
     {
         toastUndoId = undoGuid.ToString();
+        toastMessage = "Task marked done.";
+        toastVariant = "undo";
+    }
+    else if (TempData["ToastMessage"] is string flash && !string.IsNullOrWhiteSpace(flash))
+    {
+        toastMessage = flash;
+        toastVariant = "success";
     }
 }
 
@@ -149,8 +158,9 @@
      aria-atomic="true"
      aria-hidden="true"
      hidden
-     data-toast-auto-message="@(toastUndoId is not null ? "Task marked done." : null)"
-     data-toast-auto-id="@toastUndoId">
+     data-toast-auto-message="@toastMessage"
+     data-toast-auto-id="@toastUndoId"
+     data-toast-auto-variant="@toastVariant">
   <div class="pm-toast__body">
     <span class="pm-toast__message" data-toast-role="message"></span>
     <div class="pm-toast__actions">

--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -29,7 +29,7 @@ namespace ProjectManagement.Pages.Tasks
         }
 
         public record Row(Guid Id, string Title, TodoPriority Priority, bool IsPinned,
-                          TodoStatus Status, DateTimeOffset? DueAtUtc, DateTimeOffset? CompletedUtc);
+                          TodoStatus Status, DateTimeOffset CreatedUtc, DateTimeOffset? DueAtUtc, DateTimeOffset? CompletedUtc);
         public record Group(string Title, Row[] Items);
         public Group[] Groups { get; set; } = Array.Empty<Group>();
 
@@ -74,7 +74,7 @@ namespace ProjectManagement.Pages.Tasks
                 .ThenBy(x => x.DueAtUtc)
                 .ThenBy(x => x.OrderIndex)
                 .ThenBy(x => x.CreatedUtc)
-                .Select(x => new Row(x.Id, x.Title, x.Priority, x.IsPinned, x.Status, x.DueAtUtc, x.CompletedUtc))
+                .Select(x => new Row(x.Id, x.Title, x.Priority, x.IsPinned, x.Status, x.CreatedUtc, x.DueAtUtc, x.CompletedUtc))
                 .ToListAsync();
 
             // Group client-side (fast enough for a single user’s page)
@@ -133,6 +133,7 @@ namespace ProjectManagement.Pages.Tasks
             try
             {
                 await _todo.CreateAsync(uid, clean, dueLocal, prio);
+                TempData["ToastMessage"] = "Task added.";
             }
             catch (InvalidOperationException ex)
             {

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -1,10 +1,27 @@
 @using ProjectManagement.Models
 @using ProjectManagement.Helpers
+@using ProjectManagement.Infrastructure
 @using System.Linq
 @model ProjectManagement.Pages.Tasks.IndexModel
 
 @functions {
-    string Dot(TodoPriority p) => p == TodoPriority.High ? "todo-dot-high" : p == TodoPriority.Low ? "todo-dot-low" : "todo-dot-normal";
+    private static readonly TimeZoneInfo Ist = IstClock.TimeZone;
+
+    string FormatCreatedMeta(DateTimeOffset createdUtc)
+    {
+        var local = TimeZoneInfo.ConvertTime(createdUtc, Ist);
+        return $"Created {local:dd MMM yyyy h:mm tt}";
+    }
+
+    string? FormatDueMeta(DateTimeOffset? dueUtc)
+    {
+        if (dueUtc is null) return null;
+        var local = TimeZoneInfo.ConvertTime(dueUtc.Value, Ist);
+        var hasExplicitTime = !(local.Hour == 23 && local.Minute == 59 && local.Second == 59);
+        return hasExplicitTime
+            ? $"Due {local:dd MMM yyyy h:mm tt}"
+            : $"Due {local:dd MMM yyyy}";
+    }
 }
 
 @{
@@ -78,61 +95,92 @@ else
             {
                 <ul class="list-group todo-list" data-lane="@laneKey">
                     @foreach (var t in grp.Items)
+                    {
+    var formId = $"f-{t.Id}";
+    var chip = TodoViewHelpers.DueBadge(t.DueAtUtc);
+    var createdMeta = FormatCreatedMeta(t.CreatedUtc);
+    var dueMeta = FormatDueMeta(t.DueAtUtc);
+    var pinMeta = t.IsPinned ? "Pinned task" : string.Empty;
+    var priorityMeta = t.Priority switch
+    {
+        TodoPriority.High => "High priority",
+        TodoPriority.Low => "Low priority",
+        _ => string.Empty
+    };
+    var showPriorityIndicator = !string.IsNullOrEmpty(priorityMeta);
+
+<li class="list-group-item todo-row @(t.Status == TodoStatus.Done ? "done" : string.Empty)"
+    data-id="@t.Id"
+    draggable="@(Model.Tab == "completed" ? "false" : "true")"
+    data-priority="@t.Priority"
+    data-status="@(t.Status == TodoStatus.Done ? "done" : null)">
+    <div class="task-row">
+        <div class="task-row__grip">
+            <span class="task-row__handle text-muted draggable-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
+            <div class="form-check mb-0 task-row__select">
+                <input class="form-check-input task-select" type="checkbox" id="select-@t.Id" name="ids" value="@t.Id" title="Select task" />
+                <label class="visually-hidden" for="select-@t.Id">Select @t.Title</label>
+            </div>
+            <form method="post" asp-page-handler="Toggle" class="m-0 p-0 js-toggle-done-form task-row__done-form" data-success-message="Task marked done.">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@t.Id" />
+                <input class="form-check-input js-done-checkbox"
+                       type="checkbox"
+                       name="done"
+                       value="true"
+                       @(t.Status == TodoStatus.Done ? "checked" : string.Empty)
+                       title="Mark done"
+                       aria-label="Mark done" />
+                <input type="hidden" name="done" value="false" />
+            </form>
+            @if (showPriorityIndicator)
+            {
+                <span class="task-row__priority task-row__priority--@t.Priority.ToString().ToLowerInvariant()" title="@priorityMeta" aria-hidden="true"></span>
+            }
+        </div>
+
+        <div class="task-row__body">
+            <form id="@formId" method="post" asp-page-handler="Edit" class="task-row__title-form">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="id" value="@t.Id" />
+                <input name="title" class="form-control form-control-sm border-0 ps-0 todo-title task-row__title" value="@t.Title" maxlength="160" aria-label="Title" />
+            </form>
+            <div class="task-row__meta">
+                @if (!string.IsNullOrEmpty(createdMeta))
                 {
-                    var formId = $"f-{t.Id}";
-                    var chip = TodoViewHelpers.DueBadge(t.DueAtUtc);
+                    <span class="task-row__meta-item" data-meta="@createdMeta"><span class="visually-hidden">@createdMeta</span></span>
+                }
+                @if (!string.IsNullOrEmpty(dueMeta))
+                {
+                    <span class="task-row__meta-item" data-meta="@dueMeta"><span class="visually-hidden">@dueMeta</span></span>
+                }
+                @if (!string.IsNullOrEmpty(pinMeta))
+                {
+                    <span class="task-row__meta-item" data-meta="@pinMeta"><span class="visually-hidden">@pinMeta</span></span>
+                }
+                @if (!string.IsNullOrEmpty(priorityMeta))
+                {
+                    <span class="task-row__meta-item" data-meta="@priorityMeta"><span class="visually-hidden">@priorityMeta</span></span>
+                }
+            </div>
+        </div>
 
-                <li class="list-group-item d-flex align-items-start justify-content-between py-2 todo-row @(t.Status == TodoStatus.Done ? "done" : "")" data-id="@t.Id" draggable="@(Model.Tab == "completed" ? "false" : "true")" data-priority="@t.Priority">
-                    <div class="d-flex align-items-center gap-2 flex-grow-1">
-                        <span class="text-muted draggable-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
-
-                        <div class="form-check mb-0">
-                            <input class="form-check-input task-select" type="checkbox" id="select-@t.Id" name="ids" value="@t.Id" title="Select task" />
-                            <label class="visually-hidden" for="select-@t.Id">Select @t.Title</label>
-                        </div>
-
-                        <form method="post" asp-page-handler="Toggle" class="m-0 p-0 js-toggle-done-form" data-success-message="Task marked done.">
-                            @Html.AntiForgeryToken()
-                            <input type="hidden" name="id" value="@t.Id" />
-                            <!-- CHECKBOX FIRST -->
-                            <input class="form-check-input js-done-checkbox"
-                                   type="checkbox"
-                                   name="done"
-                                   value="true"
-                                   @(t.Status == TodoStatus.Done ? "checked" : "")
-                                   title="Mark done"
-                                   aria-label="Mark done" />
-                            <!-- HIDDEN FALLBACK AFTER -->
-                            <input type="hidden" name="done" value="false" />
-                        </form>
-
-                        <span class="todo-dot @(Dot(t.Priority))" title="@t.Priority"></span>
-
-                        <form id="@formId" method="post" asp-page-handler="Edit" class="flex-grow-1">
-                            @Html.AntiForgeryToken()
-                            <input type="hidden" name="id" value="@t.Id" />
-                            <input name="title" class="form-control form-control-sm border-0 ps-0 todo-title" value="@t.Title" maxlength="160" aria-label="Title" />
-                        </form>
-
-                        @if (!string.IsNullOrEmpty(chip))
-                        {
-                            <span class="badge rounded-pill bg-light text-dark border">@chip</span>
-                        }
-                    </div>
-
-                    <div class="d-flex align-items-center gap-3">
-                        <div class="row-actions d-none">
-                            <button form="@formId" type="submit" class="btn btn-link btn-sm p-0">Save</button>
-                            <button type="reset" form="@formId" class="btn btn-link btn-sm p-0 text-muted">Cancel</button>
-                        </div>
-
-                        <div class="dropdown">
-                            <button type="button" class="btn todo-kebab dropdown-toggle"
-                                    data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport"
-                                    aria-expanded="false" aria-label="More actions">
-                                <i class="bi bi-three-dots"></i>
-                            </button>
-                            <ul class="dropdown-menu todo-menu dropdown-menu-end">
+        <div class="task-row__actions">
+            @if (!string.IsNullOrEmpty(chip))
+            {
+                <button type="button" class="btn btn-sm btn-link task-row__due" title="@(dueMeta ?? chip)">@chip</button>
+            }
+            <div class="row-actions d-none task-row__inline-actions">
+                <button form="@formId" type="submit" class="btn btn-link btn-sm p-0">Save</button>
+                <button type="reset" form="@formId" class="btn btn-link btn-sm p-0 text-muted">Cancel</button>
+            </div>
+            <div class="dropdown">
+                <button type="button" class="btn todo-kebab dropdown-toggle"
+                        data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport"
+                        aria-expanded="false" aria-label="More actions">
+                    <i class="bi bi-three-dots"></i>
+                </button>
+                <ul class="dropdown-menu todo-menu dropdown-menu-end">
                                 <li>
                                     <form method="post" asp-page-handler="Pin" class="m-0 p-0">
                                         @Html.AntiForgeryToken()
@@ -209,7 +257,7 @@ else
                         </div>
                     </div>
                 </li>
-                }
+                    }
                 </ul>
             }
         </section>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1429,34 +1429,8 @@ h6:first-child {
 .form-control-sm, .form-select-sm { padding-top: .25rem; padding-bottom: .25rem; }
 .badge { letter-spacing: .2px; }
 
-/* Widget row compactness */
-.todo-list .list-group-item { padding: .35rem .6rem; }
-.todo-actions .btn { padding: 0; width: var(--pm-btn-icon); height: var(--pm-btn-icon); display: inline-flex; align-items: center; justify-content: center; }
-
 /* Scroll area helper for dashboard widgets */
 .pm-scroll{ max-height:340px; overflow:auto }
-
-/* Priority dots */
-.todo-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
-.todo-dot-low { background: #6c757d; }
-.todo-dot-normal { background: #0d6efd; }
-.todo-dot-high { background: #dc3545; }
-
-/* Truncation helper for titles so icons never wrap */
-.todo-title { max-width: 420px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Kebab: icon-only ghost button (no rectangular chrome) */
-.todo-kebab{
-  width:28px;height:28px;padding:0;border:0;border-radius:50%;
-  background:transparent;display:inline-flex;align-items:center;justify-content:center
-}
-.todo-kebab:hover{ background:rgba(0,0,0,.06) }
-.todo-kebab:active{ background:rgba(0,0,0,.12) }
-.todo-kebab:focus{ outline:none; box-shadow:0 0 0 .2rem rgba(13,110,253,.25) }
-
-/* Remove Bootstrap caret triangles that cause odd « artefacts */
-.todo-kebab.dropdown-toggle::after,
-.dropstart .todo-kebab.dropdown-toggle::before{ display:none !important }
 
 /* Keep dropdowns above any cards/sections on the dashboard */
 .dashboard .dropdown-menu,
@@ -1477,12 +1451,6 @@ h6:first-child {
 
 /* Base menu tweaks */
 .dropdown-menu{ font-size:var(--pm-font-size-base) }
-
-.todo-row.done .todo-title { text-decoration: line-through; color: #6c757d; }
-.todo-row.done { opacity: .85; }
-
-.draggable-handle{cursor:grab}
-
 
 /* ---------- Project photo gallery ---------- */
 html.has-expanded-project-photo-editor,

--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -176,13 +176,21 @@
   background: var(--bs-primary, #0d6efd);
 }
 
-#taskListContainer.compact .todo-list .list-group-item {
-  padding-top: 0.45rem;
-  padding-bottom: 0.45rem;
+#taskListContainer.compact .todo-row {
+  padding-block: 0.4rem;
+  padding-inline: 0.75rem;
 }
 
-#taskListContainer.compact .todo-title {
+#taskListContainer.compact .task-row {
+  gap: 0.75rem;
+}
+
+#taskListContainer.compact .task-row__title {
   font-size: var(--pm-font-size-tight, 0.9rem);
+}
+
+#taskListContainer.compact .task-row__meta {
+  font-size: var(--pm-font-size-xxs, 0.7rem);
 }
 
 #taskListContainer {
@@ -298,27 +306,37 @@
 }
 
 .todo-list {
-  --pm-gap: 0.6rem;
   --todo-row-hover-bg: rgba(13, 110, 253, .08);
-  --todo-row-hover-border: rgba(13, 110, 253, .2);
+  --todo-row-hover-border: rgba(13, 110, 253, .18);
+  --todo-row-shadow: 0 16px 40px -30px rgba(13, 110, 253, .45);
+  display: grid;
+  gap: 0.5rem;
+  padding-left: 0;
 }
 
 .todo-list .list-group-item {
-  position: relative;
-  padding-top: 0.6rem;
-  padding-bottom: 0.6rem;
-  border-left: 0;
-  background-clip: padding-box;
-  transition: background-color .18s ease, box-shadow .18s ease, border-color .18s ease;
+  padding: 0;
+  border: 0;
+  background: transparent;
 }
 
-.todo-list .list-group-item::before {
+.todo-row {
+  position: relative;
+  display: block;
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  background-color: var(--bs-body-bg, #fff);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .06);
+  transition: background-color .18s ease, box-shadow .18s ease, transform .18s ease, opacity .18s ease;
+}
+
+.todo-row::before {
   content: "";
   position: absolute;
-  top: -1px;
-  bottom: -1px;
-  left: -1px;
-  width: 0.4rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  width: 0.25rem;
   border-radius: 999px;
   background: var(--todo-priority-color, transparent);
   opacity: var(--todo-priority-opacity, 0);
@@ -326,82 +344,251 @@
   pointer-events: none;
 }
 
-.todo-list .list-group-item[data-priority] {
+.todo-row[data-priority] {
   --todo-priority-opacity: 1;
 }
 
-.todo-list .list-group-item[data-priority="High"] {
+.todo-row[data-priority="High"] {
   --todo-priority-color: #e03131;
 }
 
-.todo-list .list-group-item[data-priority="Normal"] {
-  --todo-priority-color: #1c7ed6;
-}
-
-.todo-list .list-group-item[data-priority="Low"] {
+.todo-row[data-priority="Low"] {
   --todo-priority-color: #2f9e44;
 }
 
-.todo-list .list-group-item:hover,
-.todo-list .list-group-item:focus-within {
+.todo-row:hover,
+.todo-row:focus-within {
   background-color: var(--todo-row-hover-bg);
-  box-shadow: inset 0 0 0 1px var(--todo-row-hover-border);
+  box-shadow: 0 14px 32px -24px rgba(15, 23, 42, .4);
+  transform: translateY(-1px);
 }
 
-.todo-list .list-group-item:focus-within {
+.todo-row:focus-within {
   outline: 0;
+  box-shadow: 0 0 0 1px var(--todo-row-hover-border), 0 14px 32px -24px rgba(15, 23, 42, .35);
 }
 
-.draggable-handle {
-  cursor: grab;
+.task-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
 }
 
-.todo-title {
+.task-row__grip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.task-row__handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+}
+
+.task-row__grip .form-check {
+  margin-bottom: 0;
+}
+
+.task-row__select .form-check-input,
+.task-row__done-form .form-check-input {
+  margin: 0;
+  cursor: pointer;
+}
+
+.task-row__done-form {
+  display: inline-flex;
+  align-items: center;
+}
+
+.task-row__priority {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  margin-left: 0.25rem;
+}
+
+.task-row__priority--high {
+  color: #e03131;
+}
+
+.task-row__priority--low {
+  color: #2f9e44;
+}
+
+.task-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.task-row__title-form {
+  display: flex;
+  width: 100%;
+}
+
+.task-row__title {
+  padding-left: 0;
+  padding-right: 0;
+  background: transparent;
+  box-shadow: none;
   font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.todo-title.done {
-  text-decoration: line-through;
-  opacity: .6;
+.task-row__title:focus {
+  box-shadow: none;
 }
 
-.todo-chip {
-  font-size: var(--pm-font-size-xs);
-  padding: .2rem .5rem;
+.task-row__meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: var(--pm-font-size-xxs, 0.75rem);
+  color: var(--bs-secondary-color);
+  opacity: 0;
+  max-height: 0;
+  transform: translateY(-2px);
+  pointer-events: none;
+  overflow: hidden;
+  transition: opacity .2s ease, transform .2s ease, max-height .2s ease;
+}
+
+.todo-row:hover .task-row__meta,
+.todo-row:focus-within .task-row__meta {
+  opacity: 1;
+  max-height: 2.5rem;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.task-row__meta-item {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.task-row__meta-item::before {
+  content: attr(data-meta);
+}
+
+.task-row__meta-item:not(:last-child)::after {
+  content: "\2022";
+  margin-left: 0.5rem;
+  margin-right: 0.25rem;
+  opacity: 0.6;
+}
+
+.task-row__actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.task-row__inline-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task-row__inline-actions .btn {
+  font-size: var(--pm-font-size-compact, 0.85rem);
+  padding: 0;
+}
+
+.task-row__due {
+  padding: 0.125rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(13, 110, 253, .12);
+  color: var(--bs-primary, #0d6efd);
+  text-decoration: none;
+  border: 0;
+  line-height: 1.2;
+}
+
+.task-row__due:hover,
+.task-row__due:focus-visible {
+  background-color: rgba(13, 110, 253, .18);
+  color: var(--bs-primary, #0d6efd);
+  text-decoration: none;
+}
+
+.task-row__due:focus-visible {
+  outline: 2px solid rgba(13, 110, 253, .3);
+  outline-offset: 2px;
 }
 
 .todo-kebab {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
   border: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
-  padding: .125rem .25rem;
+  color: inherit;
+  transition: background-color .18s ease, color .18s ease;
 }
 
-.row-actions .btn {
-  font-size: var(--pm-font-size-compact);
+.todo-kebab:hover,
+.todo-kebab:focus-visible {
+  background-color: rgba(15, 23, 42, .08);
+  color: inherit;
 }
 
+.todo-kebab:focus-visible {
+  outline: 2px solid rgba(13, 110, 253, .35);
+  outline-offset: 2px;
+}
 
-/* Done state styling (instant visual feedback) */
-.todo-list li[data-status="done"] input.todo-title {
+.todo-kebab.dropdown-toggle::after,
+.dropstart .todo-kebab.dropdown-toggle::before {
+  display: none !important;
+}
+
+.task-row__grip .draggable-handle {
+  cursor: grab;
+}
+
+.todo-row[data-status="done"] .task-row__title,
+.todo-row:has(.js-done-checkbox:checked) .task-row__title {
   text-decoration: line-through;
   opacity: .6;
 }
 
-.todo-list li[data-status="done"] .todo-dot {
-  opacity: .4;
+.todo-row[data-status="done"] {
+  opacity: .85;
 }
 
-/* Fallback: style based on checkbox state without extra classes */
-.js-done-checkbox:checked ~ form input.todo-title {
-  text-decoration: line-through;
-  opacity: .6;
+.todo-row.vanish {
+  animation: todo-row-complete .32s ease forwards;
 }
 
-/* Subtle vanish animation for items being completed in non-completed tabs */
-.todo-list li.vanish {
-  opacity: 0;
-  transform: translateX(6px);
-  transition: opacity .18s ease, transform .18s ease;
+@keyframes todo-row-complete {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  40% {
+    opacity: 0.7;
+    transform: translateX(4px);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(18px);
+  }
 }
 
 /* Mission panel (dashboard to-do widget) */
@@ -559,13 +746,19 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .todo-list .list-group-item,
+  .todo-row,
+  .task-row__meta,
+  .task-row__due,
+  .todo-row.vanish,
   .mission-panel__link,
   .mission-panel__kpi,
   .mission-ring,
   .pm-scroll::-webkit-scrollbar-thumb,
   .pm-scroll::-webkit-scrollbar-thumb:hover {
     transition-duration: .001ms;
+  }
+  .todo-row.vanish {
+    animation: none;
   }
 }
 
@@ -578,6 +771,31 @@ body[data-bs-theme="dark"] .todo-widget {
   --mission-scroll-thumb: rgba(125, 170, 255, .55);
   --todo-row-hover-bg: rgba(13, 110, 253, .22);
   --todo-row-hover-border: rgba(125, 170, 255, .4);
+}
+
+body[data-bs-theme="dark"] .todo-row {
+  background-color: rgba(17, 22, 36, .85);
+  box-shadow: inset 0 0 0 1px rgba(125, 170, 255, .16);
+}
+
+body[data-bs-theme="dark"] .todo-row:hover,
+body[data-bs-theme="dark"] .todo-row:focus-within {
+  box-shadow: 0 18px 38px -28px rgba(8, 18, 44, .65);
+}
+
+body[data-bs-theme="dark"] .task-row__meta {
+  color: rgba(226, 232, 240, .8);
+}
+
+body[data-bs-theme="dark"] .task-row__due {
+  background-color: rgba(125, 170, 255, .18);
+  color: #9bbdff;
+}
+
+body[data-bs-theme="dark"] .task-row__due:hover,
+body[data-bs-theme="dark"] .task-row__due:focus-visible {
+  background-color: rgba(125, 170, 255, .28);
+  color: #c7dcff;
 }
 
 body[data-bs-theme="dark"] .mission-panel__link {

--- a/wwwroot/js/tasks-page.js
+++ b/wwwroot/js/tasks-page.js
@@ -122,8 +122,10 @@
 
     const autoMessage = root.dataset.toastAutoMessage;
     const autoId = root.dataset.toastAutoId;
+    const autoVariant = root.dataset.toastAutoVariant;
     if (autoMessage) {
-      show({ message: autoMessage, undoId: autoId || '' });
+      const autoDismiss = autoVariant === 'undo' ? false : true;
+      show({ message: autoMessage, undoId: autoId || '', autoDismiss });
     }
 
     return {
@@ -600,7 +602,7 @@
             }
 
             if (doneChecked && toastApi && typeof toastApi.show === 'function') {
-              toastApi.show({ message, undoId });
+              toastApi.show({ message, undoId, autoDismiss: false });
             } else if (!doneChecked && toastApi && typeof toastApi.hide === 'function') {
               toastApi.hide();
             }


### PR DESCRIPTION
## Summary
- reorganize the task list item markup into distinct grip/body/action columns, reveal metadata on hover, and move the due chip into a quiet action button
- refresh the task list styling on an 8px grid, add hover lift and completion animation, and remove overlapping site.css overrides
- surface a post-add success toast by wiring TempData through to the existing toast component and JS handler

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e49664e2c4832981980ad5dd59e1f0