### PR TITLE
Filter deleted tasks from task index

### DIFF
--- a/Pages/Tasks/Index.cshtml.cs
+++ b/Pages/Tasks/Index.cshtml.cs
@@ -44,7 +44,8 @@ namespace ProjectManagement.Pages.Tasks
         public async Task OnGetAsync()
         {
             var uid = _users.GetUserId(User);
-            var q = _db.TodoItems.AsNoTracking().Where(x => x.OwnerId == uid);
+            var q = _db.TodoItems.AsNoTracking()
+                .Where(x => x.OwnerId == uid && x.DeletedUtc == null);
 
             if (!string.IsNullOrWhiteSpace(Q))
             {


### PR DESCRIPTION
## Summary
- ensure the base TodoItems query ignores entries with DeletedUtc set before applying tab filters
- keep completed tab results scoped to non-deleted done tasks

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4baf2b5188329a8de56878f38bd99