### PR TITLE
Ensure todo widget script loads after dynamic render

### DIFF
--- a/wwwroot/js/init.js
+++ b/wwwroot/js/init.js
@@ -1,20 +1,67 @@
 // wwwroot/js/init.js
 
 (function () {
-  function loadTodo() {
-    if (!document.querySelector('.todo-list')) return;
-    const script = document.currentScript;
-    const src = script?.dataset.todoSrc || '/js/todo.js';
+  const TODO_FLAG = '__todoLoaded';
+  const scriptEl = document.currentScript;
+  const todoSrc = scriptEl?.dataset.todoSrc || '/js/todo.js';
+  let observer;
+
+  function stopWatching() {
+    if (observer) {
+      observer.disconnect();
+      observer = undefined;
+    }
+    document.removeEventListener('htmx:afterSwap', handleDynamicUpdate);
+  }
+
+  function injectTodoScript() {
+    window[TODO_FLAG] = true;
     const s = document.createElement('script');
-    s.src = src;
+    s.src = todoSrc;
     s.defer = true;
     document.head.appendChild(s);
   }
 
+  function ensureTodoLoaded() {
+    if (window[TODO_FLAG]) {
+      return true;
+    }
+
+    if (!document.querySelector('.todo-list')) {
+      return false;
+    }
+
+    injectTodoScript();
+    stopWatching();
+    return true;
+  }
+
+  function handleDynamicUpdate() {
+    if (ensureTodoLoaded()) {
+      stopWatching();
+    }
+  }
+
+  function startWatching() {
+    if (observer || window[TODO_FLAG]) {
+      return;
+    }
+
+    observer = new MutationObserver(handleDynamicUpdate);
+    observer.observe(document.body, { childList: true, subtree: true });
+    document.addEventListener('htmx:afterSwap', handleDynamicUpdate);
+  }
+
+  function init() {
+    if (!ensureTodoLoaded()) {
+      startWatching();
+    }
+  }
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => { loadTodo(); });
+    document.addEventListener('DOMContentLoaded', init);
   } else {
-    loadTodo();
+    init();
   }
 })();
 


### PR DESCRIPTION
## Summary
- add a guard flag to prevent double loading of the todo helper script
- observe DOM mutations and HTMX swaps to inject `/js/todo.js` when the todo list widget is rendered dynamically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4d38884fc8329bb20802eac2d638c