### PR TITLE
Ensure todo dropdown menus are reparented to body

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -105,7 +105,7 @@
                         </div>
 
                         <div class="dropdown">
-                            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport" data-bs-container="body" aria-expanded="false" aria-label="More actions">
+                            <button type="button" class="btn todo-kebab dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport" aria-expanded="false" aria-label="More actions">
                                 <i class="bi bi-three-dots"></i>
                             </button>
                             <ul class="dropdown-menu todo-menu dropdown-menu-end">

--- a/Pages/Tasks/_TaskList.cshtml
+++ b/Pages/Tasks/_TaskList.cshtml
@@ -179,7 +179,7 @@ else
             </div>
             <div class="dropdown">
                 <button type="button" class="btn todo-kebab dropdown-toggle"
-                        data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport" data-bs-container="body"
+                        data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-display="dynamic" data-bs-boundary="viewport"
                         aria-expanded="false" aria-label="More actions">
                     <i class="bi bi-three-dots"></i>
                 </button>

--- a/wwwroot/js/todo.js
+++ b/wwwroot/js/todo.js
@@ -7,9 +7,16 @@
   // ---------- Dropdowns: render menus in <body> & flip safely ----------
   function initDropdowns() {
     document.querySelectorAll('[data-bs-toggle="dropdown"]').forEach(btn => {
-      // Mount menus to body so scrollable cards don't clip them
+      const parent = btn.parentElement;
+      if (!parent) return;
+
+      const menu = parent.querySelector(':scope > .dropdown-menu') || parent.querySelector('.dropdown-menu');
+      if (!menu) return;
+
+      const originalParent = menu.parentNode;
+      const originalNextSibling = menu.nextSibling;
+
       bootstrap.Dropdown.getOrCreateInstance(btn, {
-        container: document.body,
         popperConfig: {
           strategy: 'fixed',
           modifiers: [
@@ -17,6 +24,22 @@
             { name: 'preventOverflow', options: { boundary: 'viewport' } },
             { name: 'offset', options: { offset: [0, 6] } }
           ]
+        }
+      });
+
+      btn.addEventListener('show.bs.dropdown', () => {
+        if (menu.parentNode !== document.body) {
+          document.body.appendChild(menu);
+        }
+      });
+
+      btn.addEventListener('hidden.bs.dropdown', () => {
+        if (!originalParent) return;
+
+        if (originalNextSibling && originalNextSibling.parentNode === originalParent) {
+          originalParent.insertBefore(menu, originalNextSibling);
+        } else {
+          originalParent.appendChild(menu);
         }
       });
     });


### PR DESCRIPTION
## Summary
- reparent todo dropdown menus to the document body before Popper positioning so menus escape clipping
- keep Popper's fixed strategy and modifiers while managing the DOM move manually
- remove now-unused data-bs-container attributes from todo dropdown markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d6ea76dc8329b8826a834562f291