### PR TITLE
Enable viewer fallback for project remark reads

### DIFF
--- a/Services/Remarks/IRemarkService.cs
+++ b/Services/Remarks/IRemarkService.cs
@@ -19,7 +19,11 @@ public interface IRemarkService
     Task<IReadOnlyList<RemarkAudit>> GetRemarkAuditAsync(int remarkId, RemarkActorContext actor, CancellationToken cancellationToken = default);
 }
 
-public sealed record RemarkActorContext(string UserId, RemarkActorRole ActorRole, IReadOnlyCollection<RemarkActorRole> Roles);
+public sealed record RemarkActorContext(
+    string UserId,
+    RemarkActorRole ActorRole,
+    IReadOnlyCollection<RemarkActorRole> Roles,
+    bool IsViewerOnly = false);
 
 public sealed record CreateRemarkRequest(
     int ProjectId,

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -990,6 +990,32 @@
                 });
 
                 if (!response.ok) {
+                    if (response.status === 403) {
+                        if (!append) {
+                            this.state.items = [];
+                            this.state.page = targetPage;
+                            this.state.total = 0;
+                            this.state.totalPages = 1;
+                            this.state.hasMore = false;
+                            if (this.listContainer) {
+                                this.listContainer.innerHTML = '';
+                            }
+
+                            if (this.emptyState) {
+                                this.emptyState.classList.remove('d-none');
+                                this.emptyState.textContent = 'This remark is no longer available for your account.';
+                            }
+
+                            if (this.paginationContainer) {
+                                this.paginationContainer.innerHTML = '';
+                                this.paginationContainer.classList.add('d-none');
+                            }
+                        }
+
+                        this.state.initialised = true;
+                        return false;
+                    }
+
                     const problem = await this.readProblemDetails(response);
                     this.toastHandler(problem || 'Unable to load remarks.', 'danger');
                     this.state.initialised = false;


### PR DESCRIPTION
## Summary
- allow remark list and audit endpoints to fall back to a viewer context when the caller can view the project
- surface the same viewer fallback inside the project remarks panel so the drawer stays read-only
- handle 403 responses client-side with an inline message and cover the regression with new API tests

## Testing
- `dotnet test ProjectManagement.sln --filter FullyQualifiedName~RemarkApiTests` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e523d0e7508329b1d5f3b984f5ca40