### PR TITLE
Support viewer-only access in project remarks panel

### DIFF
--- a/Services/Projects/ProjectRemarksPanelService.cs
+++ b/Services/Projects/ProjectRemarksPanelService.cs
@@ -84,10 +84,12 @@ public sealed class ProjectRemarksPanelService
 
         if (remarkRoleSet.Count == 0)
         {
+            const RemarkActorRole fallbackRole = RemarkActorRole.ProjectOfficer;
+
             if (!string.IsNullOrWhiteSpace(project.LeadPoUserId)
                 && string.Equals(project.LeadPoUserId, user.Id, StringComparison.Ordinal))
             {
-                remarkRoleSet.Add(RemarkActorRole.ProjectOfficer);
+                remarkRoleSet.Add(fallbackRole);
             }
 
             if (!string.IsNullOrWhiteSpace(project.HodUserId)
@@ -99,7 +101,7 @@ public sealed class ProjectRemarksPanelService
             if (remarkRoleSet.Count == 0
                 && ProjectAccessGuard.CanViewProject(project, userPrincipal, user.Id))
             {
-                remarkRoleSet.Add(RemarkActorRole.ProjectOfficer);
+                remarkRoleSet.Add(fallbackRole);
                 viewerOnly = true;
             }
         }
@@ -135,7 +137,8 @@ public sealed class ProjectRemarksPanelService
             ActorHasOverride = canOverride,
             StageOptions = stageOptions,
             RoleOptions = roleOptions,
-            Today = today
+            Today = today,
+            ViewerOnly = viewerOnly
         };
     }
 

--- a/ViewModels/ProjectRemarksPanelViewModel.cs
+++ b/ViewModels/ProjectRemarksPanelViewModel.cs
@@ -30,6 +30,8 @@ public sealed class ProjectRemarksPanelViewModel
 
     public bool ActorHasOverride { get; init; }
 
+    public bool ViewerOnly { get; init; }
+
     public string Today { get; init; } = DateOnly.FromDateTime(IstClock.ToIst(DateTime.UtcNow)).ToString("yyyy-MM-dd");
 
     public int PageSize { get; init; } = 20;

--- a/wwwroot/js/projects/remarks-panel.js
+++ b/wwwroot/js/projects/remarks-panel.js
@@ -325,6 +325,7 @@
             this.currentUserId = this.config.currentUserId || null;
             this.actorHasOverride = !!this.config.actorHasOverride;
             this.allowExternal = !!this.config.allowExternal;
+            this.viewerOnly = !!this.config.viewerOnly;
             const parsedPageSize = Number.parseInt(this.config.pageSize, 10);
             this.pageSize = Number.isFinite(parsedPageSize) && parsedPageSize > 0 ? parsedPageSize : 20;
             this.timeZone = this.config.timeZone || 'Asia/Kolkata';
@@ -951,7 +952,7 @@
             const targetPage = Number.isFinite(requestedPage) && requestedPage > 0 ? requestedPage : 1;
             const wasInitialised = this.state.initialised;
 
-            if (!this.actorRole) {
+            if (!this.actorRole && !this.viewerOnly) {
                 if (!append) {
                     this.state.items = [];
                     this.state.page = targetPage;
@@ -1761,6 +1762,10 @@
                 return 'You do not have permission for this action.';
             }
 
+            if (this.viewerOnly) {
+                return 'You do not have permission for this action.';
+            }
+
             if (this.actorHasOverride) {
                 return '';
             }
@@ -1780,6 +1785,10 @@
 
         canEditRemark(remark) {
             if (remark.isDeleted) {
+                return false;
+            }
+
+            if (this.viewerOnly) {
                 return false;
             }
 


### PR DESCRIPTION
## Summary
- propagate the viewer-only fallback when building the project remarks panel so users who can only view still receive an actor role
- surface the viewer-only flag to the client and adjust the remarks panel script to keep the list active while disabling compose and moderation actions

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e528b540ec83298f938bf296d92632