### PR TITLE
Adjust todo widget overflow to fix dropdown clipping

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1430,7 +1430,11 @@ h6:first-child {
 .badge { letter-spacing: .2px; }
 
 /* Scroll area helper for dashboard widgets */
-.pm-scroll{ max-height:340px; overflow:auto }
+.pm-scroll {
+  max-height: 340px;
+  overflow-y: auto;
+  overflow-x: visible;
+}
 
 /* Keep dropdowns above any cards/sections on the dashboard */
 .dashboard .dropdown-menu,

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -150,7 +150,7 @@
   border-radius: 0.75rem;
   background-color: var(--bs-body-bg, #fff);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .06);
-  overflow: hidden;
+  overflow: visible;
   transition: background-color .18s ease, box-shadow .18s ease, transform .18s ease, opacity .18s ease;
 }
 


### PR DESCRIPTION
## Summary
- allow todo rows to render overflow so accent bars and menus are no longer clipped
- keep the dashboard pm-scroll helper vertically scrollable while allowing horizontal overflow for dropdowns

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5290173248329a6664aa8ca8da69f