### PR TITLE
Remove redundant todo row overflow override

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -408,7 +408,6 @@
   border-radius: 0.75rem;
   background-color: var(--bs-body-bg, #fff);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .06);
-  overflow: visible;
   transition: background-color .18s ease, box-shadow .18s ease, transform .18s ease, opacity .18s ease;
 }
 


### PR DESCRIPTION
## Summary
- remove the redundant todo-row overflow override in tasks.css so the lanes use the shared relaxed widget styling

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e52ab96704832986176412a0c725e8