### PR TITLE
Fix dropdown stacking on My Tasks rows

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -449,6 +449,16 @@
   box-shadow: 0 0 0 1px var(--todo-row-hover-border), 0 14px 32px -24px rgba(15, 23, 42, .35);
 }
 
+.todo-row--dropdown-open {
+  transform: none !important;
+  z-index: 20;
+}
+
+.todo-row--dropdown-open:hover,
+.todo-row--dropdown-open:focus-within {
+  transform: none !important;
+}
+
 .task-row {
   display: flex;
   align-items: stretch;

--- a/wwwroot/js/todo.js
+++ b/wwwroot/js/todo.js
@@ -15,6 +15,7 @@
 
       const originalParent = menu.parentNode;
       const originalNextSibling = menu.nextSibling;
+      const todoRow = btn.closest('.todo-row');
 
       bootstrap.Dropdown.getOrCreateInstance(btn, {
         popperConfig: {
@@ -28,12 +29,18 @@
       });
 
       btn.addEventListener('show.bs.dropdown', () => {
+        if (todoRow) {
+          todoRow.classList.add('todo-row--dropdown-open');
+        }
         if (menu.parentNode !== document.body) {
           document.body.appendChild(menu);
         }
       });
 
       btn.addEventListener('hidden.bs.dropdown', () => {
+        if (todoRow) {
+          todoRow.classList.remove('todo-row--dropdown-open');
+        }
         if (!originalParent) return;
 
         if (originalNextSibling && originalNextSibling.parentNode === originalParent) {


### PR DESCRIPTION
## Summary
- add a CSS override so task rows with an open dropdown stay fixed and above surrounding content
- toggle a helper class from the dropdown show/hide lifecycle in todo.js

## Testing
- dotnet run *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e52fc049448329bcb490b1700a9203