### PR TITLE
Adjust task lane header background to match surface color

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -294,7 +294,7 @@
   padding-top: 0.35rem;
   padding-bottom: 0.35rem;
   margin-bottom: 0.65rem;
-  background: var(--bs-body-bg, #fff);
+  background: var(--pm-surface, var(--bs-body-bg, #fff));
   display: flex;
   align-items: center;
 }
@@ -306,7 +306,7 @@
   bottom: 0;
   left: -1.5rem;
   right: -1.5rem;
-  background: var(--bs-body-bg, #fff);
+  background: var(--pm-surface, var(--bs-body-bg, #fff));
   z-index: -1;
 }
 


### PR DESCRIPTION
## Summary
- update the task lane header and sticky extension backgrounds to use the pm surface color token so the sticky bar blends with the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e538390f508329addeca121571b156