### PR TITLE
Remove sticky behavior from task lane headers

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -274,10 +274,6 @@
   flex: 0 1 auto;
 }
 
-#taskListContainer {
-  --tasks-lane-sticky-offset: 10.75rem;
-}
-
 .tasks-lane {
   position: relative;
   margin-top: 1.5rem;
@@ -288,26 +284,11 @@
 }
 
 .tasks-lane-header {
-  position: sticky;
-  top: calc(var(--pm-sticky-offset, 0) + var(--tasks-lane-sticky-offset, 9.75rem));
-  z-index: 4;
   padding-top: 0.35rem;
   padding-bottom: 0.35rem;
   margin-bottom: 0.65rem;
-  background: var(--bs-body-bg, #fff);
   display: flex;
   align-items: center;
-}
-
-.tasks-lane-header::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: -1.5rem;
-  right: -1.5rem;
-  background: var(--bs-body-bg, #fff);
-  z-index: -1;
 }
 
 .tasks-lane-pill {
@@ -373,17 +354,6 @@
 .tasks-lane-empty,
 .tasks-lane .todo-list {
   padding-left: 0.25rem;
-}
-
-@media (max-width: 767.98px) {
-  #taskListContainer {
-    --tasks-lane-sticky-offset: 12.25rem;
-  }
-
-  .tasks-lane-header::after {
-    left: -1rem;
-    right: -1rem;
-  }
 }
 
 .todo-list {


### PR DESCRIPTION
## Summary
- remove the sticky positioning styles from task lane headers so they scroll naturally
- drop the associated pseudo-element and offset variables that only supported the sticky layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e538390f508329addeca121571b156