### PR TITLE
Remove sticky header styling from tasks page

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -2,9 +2,9 @@
 /* Compact, modern task list styling */
 
 .tasks-header {
-  position: sticky;
-  top: var(--pm-sticky-offset, 0);
-  z-index: 10;
+  position: static;
+  top: auto;
+  z-index: auto;
   background: var(--bs-body-bg, #fff);
   padding: 0.75rem 0 0.5rem;
   display: flex;


### PR DESCRIPTION
## Summary
- update tasks page stylesheet to use static positioning for the header
- disable the sticky offset/z-index so the header scrolls normally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54158e95483299defc46bf4a86092