### PR TITLE
Remove desktop column gap from tasks layout

### DIFF
--- a/wwwroot/css/tasks.css
+++ b/wwwroot/css/tasks.css
@@ -25,7 +25,6 @@
 
 @media (min-width: 992px) {
   .tasks-layout {
-    column-gap: 2rem;
     align-items: stretch;
   }
 


### PR DESCRIPTION
## Summary
- remove the manual column gap from the tasks layout at the large breakpoint so the two columns stay within 100%

## Testing
- dotnet run *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e547d485ac83299947d50a1066ec1b