### PR TITLE
Fix todo dropdown clipping inside scroll container

### DIFF
--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -141,6 +141,10 @@
   overflow: visible;
 }
 
+.todo-widget .pm-scroll.dropdown-open {
+  overflow: visible;
+}
+
 .todo-list .list-group-item {
   padding: 0;
   border: 0;

--- a/wwwroot/js/todo-widget.js
+++ b/wwwroot/js/todo-widget.js
@@ -3,6 +3,22 @@
 (function () {
   const RING_SELECTOR = '.mission-ring[data-percent]';
   const RING_PERCENT_PROPERTY = '--mission-ring-percent';
+  const SCROLL_CONTAINER_SELECTOR = '.pm-scroll';
+
+  function getScrollContainer(element) {
+    if (!element) return null;
+    const widget = element.closest('.todo-widget');
+    if (!widget) return null;
+    return widget.querySelector(SCROLL_CONTAINER_SELECTOR);
+  }
+
+  function toggleDropdownState(event, isOpen) {
+    const target = event?.target;
+    if (!(target instanceof HTMLElement)) return;
+    const scroller = getScrollContainer(target);
+    if (!scroller) return;
+    scroller.classList.toggle('dropdown-open', isOpen);
+  }
 
   function clampPercent(value) {
     if (Number.isNaN(value)) return null;
@@ -38,5 +54,13 @@
     if (target instanceof HTMLElement) {
       init(target);
     }
+  });
+
+  document.addEventListener('show.bs.dropdown', (event) => {
+    toggleDropdownState(event, true);
+  });
+
+  document.addEventListener('hidden.bs.dropdown', (event) => {
+    toggleDropdownState(event, false);
   });
 })();


### PR DESCRIPTION
## Summary
- allow the todo widget scroll container to relax overflow when a dropdown is open
- hook Bootstrap dropdown show/hidden events to toggle the new state class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55a5b10908329b83a7fea0866de76