### PR TITLE
Fix todo dropdown stacking so menus overlay due badges

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -101,7 +101,7 @@
 
                                 @if (!string.IsNullOrEmpty(badge))
                                 {
-                                    <span class="badge rounded-pill bg-light text-dark border">@badge</span>
+                                    <span class="badge todo-badge rounded-pill bg-light text-dark border">@badge</span>
                                 }
                             </div>
 

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -159,7 +159,7 @@
   background-color: var(--bs-body-bg, #fff);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, .06);
   overflow: visible;
-  transition: background-color .18s ease, box-shadow .18s ease, transform .18s ease, opacity .18s ease;
+  transition: background-color .18s ease, box-shadow .18s ease, opacity .18s ease;
 }
 
 .todo-row::before {
@@ -192,7 +192,6 @@
 .todo-row:focus-within {
   background-color: var(--todo-row-hover-bg);
   box-shadow: 0 14px 32px -24px rgba(15, 23, 42, .4);
-  transform: translateY(-1px);
 }
 
 .todo-row:focus-within {
@@ -248,6 +247,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.todo-widget .todo-badge {
+  position: relative;
+  z-index: 0;
 }
 
 .todo-kebab {


### PR DESCRIPTION
## Summary
- remove the hover transform on todo rows so dropdown menus can escape the row stacking context
- tag the due-date badge in the widget and ensure it stays on the base layer so menus render above it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55c077c6c8329840113f66f3f775e