### PR TITLE
Add lifecycle and ToT foundations

### DIFF
--- a/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.Designer.cs
+++ b/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ProjectManagement.Data;
@@ -11,9 +12,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251008034359_20251015120000_AddProjectLifecycleAndTot")]
+    partial class _20251015120000_AddProjectLifecycleAndTot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -238,8 +241,7 @@ namespace ProjectManagement.Migrations
                         .HasColumnType("text");
 
                     b.Property<bool>("ShowCelebrationsInCalendar")
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(true);
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("TwoFactorEnabled")
                         .HasColumnType("boolean");
@@ -538,8 +540,7 @@ namespace ProjectManagement.Migrations
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasDefaultValue("NotStarted");
+                        .HasColumnType("character varying(32)");
 
                     b.HasKey("Id");
 
@@ -1104,8 +1105,7 @@ namespace ProjectManagement.Migrations
                     b.Property<string>("LifecycleStatus")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasDefaultValue("Active");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -2065,8 +2065,7 @@ namespace ProjectManagement.Migrations
                     b.Property<string>("Scope")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasDefaultValue("General");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("StageNameSnapshot")
                         .HasMaxLength(256)
@@ -2172,8 +2171,7 @@ namespace ProjectManagement.Migrations
                     b.Property<string>("SnapshotScope")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasDefaultValue("General");
+                        .HasColumnType("character varying(32)");
 
                     b.Property<string>("SnapshotStageName")
                         .HasMaxLength(256)

--- a/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.cs
+++ b/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class _20251015120000_AddProjectLifecycleAndTot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Scope",
+                table: "Remarks",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "General");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SnapshotScope",
+                table: "RemarkAudits",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "General");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CancelReason",
+                table: "Projects",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "CancelledOn",
+                table: "Projects",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "CompletedOn",
+                table: "Projects",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompletedYear",
+                table: "Projects",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLegacy",
+                table: "Projects",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LifecycleStatus",
+                table: "Projects",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "Active");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotId",
+                table: "ProjectPhotos",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotId",
+                table: "ProjectDocuments",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "ShowCelebrationsInCalendar",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: true);
+
+            migrationBuilder.CreateTable(
+                name: "ProjectTots",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProjectId = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "NotStarted"),
+                    StartedOn = table.Column<DateOnly>(type: "date", nullable: true),
+                    CompletedOn = table.Column<DateOnly>(type: "date", nullable: true),
+                    Remarks = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectTots", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectTots_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.Sql("INSERT INTO \"ProjectTots\" (\"ProjectId\", \"Status\") SELECT \"Id\", 'NotStarted' FROM \"Projects\"");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Remarks_ProjectId_IsDeleted_Scope_CreatedAtUtc",
+                table: "Remarks",
+                columns: new[] { "ProjectId", "IsDeleted", "Scope", "CreatedAtUtc" },
+                descending: new[] { false, false, false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_CompletedYear",
+                table: "Projects",
+                column: "CompletedYear");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_IsLegacy",
+                table: "Projects",
+                column: "IsLegacy");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_LifecycleStatus",
+                table: "Projects",
+                column: "LifecycleStatus");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPhotos_ProjectId_TotId",
+                table: "ProjectPhotos",
+                columns: new[] { "ProjectId", "TotId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectPhotos_TotId",
+                table: "ProjectPhotos",
+                column: "TotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_ProjectId_TotId",
+                table: "ProjectDocuments",
+                columns: new[] { "ProjectId", "TotId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectDocuments_TotId",
+                table: "ProjectDocuments",
+                column: "TotId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectTots_ProjectId",
+                table: "ProjectTots",
+                column: "ProjectId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectDocuments_ProjectTots_TotId",
+                table: "ProjectDocuments",
+                column: "TotId",
+                principalTable: "ProjectTots",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProjectPhotos_ProjectTots_TotId",
+                table: "ProjectPhotos",
+                column: "TotId",
+                principalTable: "ProjectTots",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectDocuments_ProjectTots_TotId",
+                table: "ProjectDocuments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProjectPhotos_ProjectTots_TotId",
+                table: "ProjectPhotos");
+
+            migrationBuilder.DropTable(
+                name: "ProjectTots");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Remarks_ProjectId_IsDeleted_Scope_CreatedAtUtc",
+                table: "Remarks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_CompletedYear",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_IsLegacy",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_LifecycleStatus",
+                table: "Projects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProjectPhotos_ProjectId_TotId",
+                table: "ProjectPhotos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProjectPhotos_TotId",
+                table: "ProjectPhotos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProjectDocuments_ProjectId_TotId",
+                table: "ProjectDocuments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProjectDocuments_TotId",
+                table: "ProjectDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "Scope",
+                table: "Remarks");
+
+            migrationBuilder.DropColumn(
+                name: "SnapshotScope",
+                table: "RemarkAudits");
+
+            migrationBuilder.DropColumn(
+                name: "CancelReason",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "CancelledOn",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "CompletedOn",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "CompletedYear",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "IsLegacy",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "LifecycleStatus",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "TotId",
+                table: "ProjectPhotos");
+
+            migrationBuilder.DropColumn(
+                name: "TotId",
+                table: "ProjectDocuments");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "ShowCelebrationsInCalendar",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+        }
+    }
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -20,6 +20,19 @@ namespace ProjectManagement.Models
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+        public ProjectLifecycleStatus LifecycleStatus { get; set; } = ProjectLifecycleStatus.Active;
+
+        public bool IsLegacy { get; set; }
+
+        public DateOnly? CompletedOn { get; set; }
+
+        public int? CompletedYear { get; set; }
+
+        public DateOnly? CancelledOn { get; set; }
+
+        [MaxLength(512)]
+        public string? CancelReason { get; set; }
+
         [MaxLength(64)]
         public string? CaseFileNumber { get; set; }
 
@@ -78,6 +91,8 @@ namespace ProjectManagement.Models
         public int? CoverPhotoId { get; set; }
 
         public int CoverPhotoVersion { get; set; } = 1;
+
+        public ProjectTot? Tot { get; set; }
 
         [NotMapped]
         public ProjectPhoto? CoverPhoto => CoverPhotoId.HasValue

--- a/Models/ProjectDocument.cs
+++ b/Models/ProjectDocument.cs
@@ -55,6 +55,10 @@ namespace ProjectManagement.Models
         [Range(0, int.MaxValue)]
         public int FileStamp { get; set; }
 
+        public int? TotId { get; set; }
+
+        public ProjectTot? Tot { get; set; }
+
         [Required]
         [MaxLength(450)]
         public string UploadedByUserId { get; set; } = string.Empty;

--- a/Models/ProjectLifecycleStatus.cs
+++ b/Models/ProjectLifecycleStatus.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ProjectManagement.Models
+{
+    public enum ProjectLifecycleStatus
+    {
+        Active = 1,
+        Completed = 2,
+        Cancelled = 3
+    }
+}

--- a/Models/ProjectPhoto.cs
+++ b/Models/ProjectPhoto.cs
@@ -33,6 +33,10 @@ namespace ProjectManagement.Models
         [MaxLength(512)]
         public string? Caption { get; set; }
 
+        public int? TotId { get; set; }
+
+        public ProjectTot? Tot { get; set; }
+
         public bool IsCover { get; set; }
 
         public int Version { get; set; } = 1;

--- a/Models/ProjectTot.cs
+++ b/Models/ProjectTot.cs
@@ -1,0 +1,33 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models
+{
+    public enum ProjectTotStatus
+    {
+        NotRequired = 0,
+        NotStarted = 1,
+        InProgress = 2,
+        Completed = 3
+    }
+
+    public sealed class ProjectTot
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int ProjectId { get; set; }
+
+        public Project Project { get; set; } = null!;
+
+        [Required]
+        public ProjectTotStatus Status { get; set; } = ProjectTotStatus.NotStarted;
+
+        public DateOnly? StartedOn { get; set; }
+
+        public DateOnly? CompletedOn { get; set; }
+
+        [MaxLength(2000)]
+        public string? Remarks { get; set; }
+    }
+}

--- a/Models/Remarks/Remark.cs
+++ b/Models/Remarks/Remark.cs
@@ -24,6 +24,12 @@ namespace ProjectManagement.Models.Remarks
         MainOffice = 8
     }
 
+    public enum RemarkScope
+    {
+        General = 0,
+        TransferOfTechnology = 1
+    }
+
     public enum RemarkAuditAction
     {
         Created = 0,
@@ -47,6 +53,9 @@ namespace ProjectManagement.Models.Remarks
 
         [Required]
         public RemarkType Type { get; set; }
+
+        [Required]
+        public RemarkScope Scope { get; set; } = RemarkScope.General;
 
         [Required]
         [MaxLength(4000)]
@@ -95,6 +104,9 @@ namespace ProjectManagement.Models.Remarks
 
         [Required]
         public RemarkType SnapshotType { get; set; }
+
+        [Required]
+        public RemarkScope SnapshotScope { get; set; }
 
         [Required]
         public RemarkActorRole SnapshotAuthorRole { get; set; }

--- a/ProjectManagement.Tests/TasksPageTests.cs
+++ b/ProjectManagement.Tests/TasksPageTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -168,5 +169,15 @@ public class TasksPageTests
 
         public Task DeleteManyAsync(string ownerId, IList<Guid> ids)
             => throw new NotImplementedException();
+    }
+
+    private sealed class DictionaryTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context)
+            => new Dictionary<string, object?>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add project lifecycle fields and cancellation/completion metadata
- introduce ProjectTot tracking with document/photo associations and remark scope support
- add EF Core migration and adjust tests to compile under .NET 8 tooling

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e5dc9c26d083299913f70878ea091e