### PR TITLE
Add post-completion project overview layout

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -11,13 +11,11 @@
 @{
     var project = Model.Project;
     var pageTitle = project?.Name ?? "Project";
-    var isAdmin = User.IsInRole("Admin");
-    var isHoD = User.IsInRole("HoD");
-    var isProjectOfficer = User.IsInRole("Project Officer");
-    var isThisProjectsPo = isProjectOfficer &&
-        string.Equals(Model.Project?.LeadPoUserId, Model.CurrentUserId, StringComparison.Ordinal);
-    var isThisProjectsHod = isHoD &&
-        string.Equals(Model.Project?.HodUserId, Model.CurrentUserId, StringComparison.Ordinal);
+    var roles = Model.Roles;
+    var isAdmin = roles.IsAdmin;
+    var isHoD = roles.IsHoD;
+    var isThisProjectsPo = roles.IsAssignedProjectOfficer;
+    var isThisProjectsHod = roles.IsAssignedHoD;
     var planState = Model.PlanEdit?.State ?? new PlanEditorStateVm();
     var planLocked = planState.IsLocked;
     var hasMyDraft = planState.HasMyDraft;
@@ -27,40 +25,6 @@
     var completedStages = Model.Timeline.CompletedCount;
     var totalStages = Model.Timeline.TotalStages;
     var progressMax = totalStages == 0 ? 1 : totalStages;
-    var canManagePhotos = isAdmin || isThisProjectsPo || isThisProjectsHod;
-    var coverPhoto = Model.CoverPhoto;
-    var coverVersion = Model.CoverPhotoVersion ?? coverPhoto?.Version;
-    var additionalPhotos = Model.Photos.Where(p => coverPhoto == null || p.Id != coverPhoto.Id).ToList();
-    Func<ProjectPhoto, string, int?, string> photoUrl = (photo, size, version) =>
-        Url.Page("/Projects/Photos/View", new { id = Model.Project!.Id, photoId = photo.Id, size, v = version })!;
-    var coverXs = coverPhoto != null ? photoUrl(coverPhoto, "xs", coverVersion) : null;
-    var coverSm = coverPhoto != null ? photoUrl(coverPhoto, "sm", coverVersion) : null;
-    var coverMd = coverPhoto != null ? photoUrl(coverPhoto, "md", coverVersion) : null;
-    var coverXl = coverPhoto != null ? photoUrl(coverPhoto, "xl", coverVersion) : null;
-    var coverSrcSet = coverPhoto != null
-        ? string.Join(", ", new[]
-        {
-            $"{coverXs} 400w",
-            $"{coverSm} 800w",
-            $"{coverMd} 1200w",
-            $"{coverXl} 1600w"
-        })
-        : null;
-    var previewPhotos = additionalPhotos.Take(4).ToList();
-    var remainingPhotos = Math.Max(0, additionalPhotos.Count - previewPhotos.Count);
-    string? galleryModalId = null;
-    ProjectPhotoLightboxViewModel? galleryModalModel = null;
-    if (additionalPhotos.Any())
-    {
-        galleryModalId = $"project-gallery-modal-{Model.Project!.Id}";
-        galleryModalModel = new ProjectPhotoLightboxViewModel(
-            Model.Project!.Id,
-            project?.Name ?? "Project",
-            Model.Photos,
-            coverPhoto?.Id,
-            Model.CoverPhotoVersion ?? coverPhoto?.Version,
-            galleryModalId);
-    }
     ViewData["Title"] = pageTitle;
     var remarksConfigJson = JsonSerializer.Serialize(Model.RemarksPanel, new JsonSerializerOptions(JsonSerializerDefaults.Web));
 }
@@ -136,14 +100,17 @@
         </div>
     }
 
-    <div class="alert alert-warning d-flex align-items-center justify-content-between@(Model.HasBackfill ? string.Empty : " d-none")"
-         role="alert"
-         data-backfill-banner>
-        <div>
-            <strong>Action needed:</strong> Some earlier stages were auto-completed and need dates or costs.
+    @if (!Model.LifecycleSummary.ShowPostCompletionView)
+    {
+        <div class="alert alert-warning d-flex align-items-center justify-content-between@(Model.HasBackfill ? string.Empty : " d-none")"
+             role="alert"
+             data-backfill-banner>
+            <div>
+                <strong>Action needed:</strong> Some earlier stages were auto-completed and need dates or costs.
+            </div>
+            <button type="button" class="btn btn-sm btn-warning text-dark" data-action="open-backfill">Backfill now</button>
         </div>
-        <button type="button" class="btn btn-sm btn-warning text-dark" data-action="open-backfill">Backfill now</button>
-    </div>
+    }
 
     @if (project?.HodUserId == null || project?.LeadPoUserId == null)
     {
@@ -171,7 +138,7 @@
         </div>
     }
 
-    @if (planState.HasPendingSubmission)
+    @if (!Model.LifecycleSummary.ShowPostCompletionView && planState.HasPendingSubmission)
     {
         <div class="alert alert-info d-flex align-items-center justify-content-between" role="alert">
             <div>
@@ -205,129 +172,15 @@
         </div>
     }
 
+    @if (Model.LifecycleSummary.ShowPostCompletionView)
+    {
+        <partial name="_ProjectPostCompletion" model="Model" />
+    }
+    else
+    {
     <div class="row g-3 mb-4">
         <div class="col-lg-8 d-flex flex-column gap-3">
-            <div class="card pm-card">
-                <div class="card-header pm-card-header">
-                    <div class="pm-card-heading">
-                        <span class="pm-card-icon" aria-hidden="true">
-                            <i class="bi bi-layout-text-window"></i>
-                        </span>
-                        <div>
-                            <h2 class="pm-card-title h5 mb-0">Project overview</h2>
-                            <p class="pm-card-subtitle mb-0">Description and key project facts</p>
-                        </div>
-                    </div>
-                    @if (canManagePhotos || isThisProjectsPo || isAdmin || isHoD)
-                    {
-                        <div class="pm-card-menu dropdown">
-                            <button class="btn pm-card-menu-toggle"
-                                    type="button"
-                                    data-bs-toggle="dropdown"
-                                    aria-expanded="false"
-                                    aria-label="Project overview actions">
-                                <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
-                            </button>
-                            <ul class="dropdown-menu dropdown-menu-end">
-                                @if (canManagePhotos)
-                                {
-                                    <li>
-                                        <a class="dropdown-item d-flex align-items-center gap-2"
-                                           asp-page="/Projects/Photos/Index"
-                                           asp-route-id="@Model.Project!.Id">
-                                            <i class="bi bi-sliders" aria-hidden="true"></i>
-                                            <span>Manage photos</span>
-                                        </a>
-                                    </li>
-                                }
-                                @if (isThisProjectsPo)
-                                {
-                                    <li>
-                                        <a class="dropdown-item"
-                                           asp-page="/Projects/Meta/Request"
-                                           asp-route-id="@Model.Project!.Id">Request change</a>
-                                    </li>
-                                }
-                                @if (isAdmin || isHoD)
-                                {
-                                    <li>
-                                        <a class="dropdown-item"
-                                           asp-page="/Projects/Meta/Edit"
-                                           asp-route-id="@Model.Project!.Id">Edit details</a>
-                                    </li>
-                                }
-                            </ul>
-                        </div>
-                    }
-                </div>
-                <div class="card-body pm-card-body">
-                    <div class="row g-4 align-items-start">
-                        <div class="col-12 col-lg-5 col-xl-4">
-                            <div class="project-photo-cover">
-                                <div class="ratio ratio-4x3 w-100">
-                                    @if (coverPhoto != null)
-                                    {
-                                        <picture>
-                                            <source type="image/webp"
-                                                    srcset="@coverSrcSet"
-                                                    sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw" />
-                                            <img class="w-100 h-100 object-fit-cover rounded border"
-                                                 width="360"
-                                                 height="270"
-                                                 src="@coverXs"
-                                                 srcset="@coverSrcSet"
-                                                 sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw"
-                                                 alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
-                                        </picture>
-                                    }
-                                    else
-                                    {
-                                        <div class="d-flex align-items-center justify-content-center w-100 h-100 rounded border bg-light text-muted">
-                                            <span>No cover photo</span>
-                                        </div>
-                                    }
-                                </div>
-                                @if (!string.IsNullOrWhiteSpace(coverPhoto?.Caption))
-                                {
-                                    <div class="mt-2 text-muted small">@coverPhoto.Caption</div>
-                                }
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-7 col-xl-8">
-                            <dl class="row mb-0">
-                                <dt class="col-sm-4">Category</dt>
-                                <dd class="col-sm-8">
-                                    @if (Model.CategoryPath.Any())
-                                    {
-                                        <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
-                                    }
-                                    else
-                                    {
-                                        <span>—</span>
-                                    }
-                                </dd>
-
-                                <dt class="col-sm-4">Sponsoring Unit</dt>
-                                <dd class="col-sm-8">@(Model.Project?.SponsoringUnit?.Name ?? "—")</dd>
-
-                                <dt class="col-sm-4">Sponsoring Line Dte</dt>
-                                <dd class="col-sm-8">@(Model.Project?.SponsoringLineDirectorate?.Name ?? "—")</dd>
-
-                                <dt class="col-sm-4">Head of Department</dt>
-                                <dd class="col-sm-8">@DisplayUser(project?.HodUser)</dd>
-
-                                <dt class="col-sm-4">Project Officer</dt>
-                                <dd class="col-sm-8">@DisplayUser(project?.LeadPoUser)</dd>
-                            </dl>
-                        </div>
-                        <div class="col-12">
-                            <h3 class="h6 mb-2">Project description</h3>
-                            <div class="project-overview__description">@(!string.IsNullOrWhiteSpace(project?.Description) ? project.Description : "—")</div>
-                        </div>
-                    </div>
-
-                </div>
-            </div>
+            <partial name="_ProjectOverviewCard" model="Model" />
             <partial name="_ProjectProcurementAtAGlance" model="Model.Procurement" />
 
             <div class="card pm-card">
@@ -624,111 +477,7 @@
                     }
                 </div>
             </div>
-            <div class="card pm-card">
-                <div class="card-body pm-card-body">
-                    <div class="project-gallery" data-gallery data-gallery-project="@Model.Project!.Id" data-gallery-modal-id="@(galleryModalId ?? string.Empty)">
-                        <div class="project-gallery__header">
-                            <h3 class="h6 mb-2">Gallery</h3>
-                            <p class="text-muted small mb-0">Browse project highlights without leaving the page.</p>
-                        </div>
-                        @if (additionalPhotos.Any())
-                        {
-                            <div class="project-gallery__grid" role="list">
-                                @for (var i = 0; i < previewPhotos.Count; i++)
-                                {
-                                    var photo = previewPhotos[i];
-                                    var thumbUrl = photoUrl(photo, "sm", photo.Version);
-                                    var mediumUrl = photoUrl(photo, "md", photo.Version);
-                                    var largeUrl = photoUrl(photo, "xl", photo.Version);
-                                    var thumbSrcSet = string.Join(", ", new[]
-                                    {
-                                        $"{thumbUrl} 1x",
-                                        $"{mediumUrl} 1.5x",
-                                        $"{largeUrl} 2x"
-                                    });
-                                    var captionText = string.IsNullOrWhiteSpace(photo.Caption) ? null : photo.Caption;
-                                    var altText = captionText ?? $"{project?.Name ?? "Project"} photo";
-                                    <a class="project-gallery__item"
-                                       role="listitem"
-                                       href="@largeUrl"
-                                       data-gallery-trigger
-                                       data-gallery-photo-id="@photo.Id"
-                                       data-gallery-full="@largeUrl"
-                                       data-gallery-srcset="@thumbSrcSet"
-                                       data-gallery-caption="@captionText"
-                                       data-gallery-alt="@altText"
-                                       aria-label="View photo @(i + 1) of @additionalPhotos.Count@(captionText is null ? string.Empty : $": {captionText}")">
-                                        <div class="project-gallery__media">
-                                            <picture>
-                                                <source type="image/webp" srcset="@thumbSrcSet" />
-                                                <img class="project-gallery__img"
-                                                     loading="lazy"
-                                                     width="320"
-                                                     height="240"
-                                                     src="@thumbUrl"
-                                                     srcset="@thumbSrcSet"
-                                                     alt="@altText" />
-                                            </picture>
-                                        </div>
-                                        <div class="project-gallery__overlay" aria-hidden="true">
-                                            <span class="project-gallery__overlay-text">@(captionText ?? "View photo")</span>
-                                        </div>
-                                    </a>
-                                }
-
-                                <a class="project-gallery__item project-gallery__item--cta"
-                                   role="listitem"
-                                   href="@Url.Page("/Projects/Photos/Index", new { id = Model.Project!.Id })"
-                                   data-gallery-open
-                                   aria-controls="@galleryModalId"
-                                   aria-label="View the full project photo gallery">
-                                    <div class="project-gallery__cta-body">
-                                        <span class="project-gallery__cta-icon" aria-hidden="true">&#128247;</span>
-                                        <span class="project-gallery__cta-text">View gallery</span>
-                                        @if (remainingPhotos > 0)
-                                        {
-                                            <span class="project-gallery__cta-meta">+@remainingPhotos more</span>
-                                        }
-                                    </div>
-                                </a>
-                            </div>
-                        }
-                        else
-                        {
-                            var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
-                            var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
-                            <div class="project-photo-empty border rounded bg-light-subtle text-center"
-                                 role="region"
-                                 aria-labelledby="@emptyStateHeadingId"
-                                 aria-describedby="@emptyStateDescriptionId">
-                                <div class="project-photo-empty-body">
-                                    <span class="project-photo-empty-icon" aria-hidden="true">
-                                        <i class="bi bi-images"></i>
-                                    </span>
-                                    <h3 id="@emptyStateHeadingId" class="h6 fw-semibold mb-2">No photos yet</h3>
-                                    <p id="@emptyStateDescriptionId" class="mb-3 text-muted">
-                                        Add a cover or gallery photo to help everyone recognise this project at a glance.
-                                    </p>
-                                    @if (canManagePhotos)
-                                    {
-                                        <a class="btn btn-primary"
-                                           asp-page="/Projects/Photos/Index"
-                                           asp-route-id="@Model.Project!.Id"
-                                           aria-label="Upload the first project photo">
-                                            Upload photo
-                                        </a>
-                                    }
-                                </div>
-                            </div>
-                        }
-                    </div>
-                </div>
-            </div>
-            @if (additionalPhotos.Any())
-            {
-                <partial name="_ProjectPhotoLightbox" model="galleryModalModel" />
-            }
-        </div>
+            <partial name="_ProjectGalleryCard" model="Model" />
         <div class="col-lg-4 d-flex flex-column gap-3">
             @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
             {
@@ -1269,6 +1018,7 @@
             </div>
         </div>
     </div>
+    }
 
     <partial name="Projects/_BackfillModal" model="Model.Backfill" />
     <partial name="_StageDirectApplyModal" />

--- a/Pages/Projects/_ProjectGalleryCard.cshtml
+++ b/Pages/Projects/_ProjectGalleryCard.cshtml
@@ -1,0 +1,7 @@
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+<div class="card pm-card">
+    <div class="card-body pm-card-body">
+        <partial name="_ProjectGalleryContent" model="Model" />
+    </div>
+</div>

--- a/Pages/Projects/_ProjectGalleryContent.cshtml
+++ b/Pages/Projects/_ProjectGalleryContent.cshtml
@@ -1,0 +1,134 @@
+@using System
+@using ProjectManagement.Models
+@using ProjectManagement.ViewModels
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+@{
+    var project = Model.Project;
+    var roles = Model.Roles;
+    var isAdmin = roles.IsAdmin;
+    var isThisProjectsPo = roles.IsAssignedProjectOfficer;
+    var isThisProjectsHod = roles.IsAssignedHoD;
+    var canManagePhotos = isAdmin || isThisProjectsPo || isThisProjectsHod;
+    var media = Model.MediaSummary;
+    var previewPhotos = media.PreviewPhotos;
+    var additionalCount = media.AdditionalPhotoCount;
+    var remainingPhotos = media.RemainingPhotoCount;
+    var hasAdditionalPhotos = media.HasAdditionalPhotos;
+    Func<ProjectPhoto, string, int?, string> photoUrl = (photo, size, version) =>
+        Url.Page("/Projects/Photos/View", new { id = Model.Project!.Id, photoId = photo.Id, size, v = version ?? photo.Version })!;
+    string? galleryModalId = null;
+    ProjectPhotoLightboxViewModel? galleryModalModel = null;
+    if (hasAdditionalPhotos)
+    {
+        galleryModalId = $"project-gallery-modal-{Model.Project!.Id}";
+        galleryModalModel = new ProjectPhotoLightboxViewModel(
+            Model.Project!.Id,
+            project?.Name ?? "Project",
+            Model.Photos,
+            Model.CoverPhoto?.Id,
+            Model.CoverPhotoVersion ?? Model.CoverPhoto?.Version,
+            galleryModalId);
+    }
+}
+
+<div class="project-gallery" data-gallery data-gallery-project="@Model.Project!.Id" data-gallery-modal-id="@(galleryModalId ?? string.Empty)">
+    <div class="project-gallery__header">
+        <h3 class="h6 mb-2">Gallery</h3>
+        <p class="text-muted small mb-0">Browse project highlights without leaving the page.</p>
+    </div>
+    @if (hasAdditionalPhotos)
+    {
+        <div class="project-gallery__grid" role="list">
+            @for (var i = 0; i < previewPhotos.Count; i++)
+            {
+                var photo = previewPhotos[i];
+                var thumbUrl = photoUrl(photo, "sm", photo.Version);
+                var mediumUrl = photoUrl(photo, "md", photo.Version);
+                var largeUrl = photoUrl(photo, "xl", photo.Version);
+                var thumbSrcSet = string.Join(", ", new[]
+                {
+                    $"{thumbUrl} 1x",
+                    $"{mediumUrl} 1.5x",
+                    $"{largeUrl} 2x"
+                });
+                var captionText = string.IsNullOrWhiteSpace(photo.Caption) ? null : photo.Caption;
+                var altText = captionText ?? $"{project?.Name ?? "Project"} photo";
+                <a class="project-gallery__item"
+                   role="listitem"
+                   href="@largeUrl"
+                   data-gallery-trigger
+                   data-gallery-photo-id="@photo.Id"
+                   data-gallery-full="@largeUrl"
+                   data-gallery-srcset="@thumbSrcSet"
+                   data-gallery-caption="@captionText"
+                   data-gallery-alt="@altText"
+                   aria-label="View photo @(i + 1) of @additionalCount@(captionText is null ? string.Empty : $": {captionText}")">
+                    <div class="project-gallery__media">
+                        <picture>
+                            <source type="image/webp" srcset="@thumbSrcSet" />
+                            <img class="project-gallery__img"
+                                 loading="lazy"
+                                 width="320"
+                                 height="240"
+                                 src="@thumbUrl"
+                                 srcset="@thumbSrcSet"
+                                 alt="@altText" />
+                        </picture>
+                    </div>
+                    <div class="project-gallery__overlay" aria-hidden="true">
+                        <span class="project-gallery__overlay-text">@(captionText ?? "View photo")</span>
+                    </div>
+                </a>
+            }
+
+            <a class="project-gallery__item project-gallery__item--cta"
+               role="listitem"
+               href="@Url.Page("/Projects/Photos/Index", new { id = Model.Project!.Id })"
+               data-gallery-open
+               aria-controls="@galleryModalId"
+               aria-label="View the full project photo gallery">
+                <div class="project-gallery__cta-body">
+                    <span class="project-gallery__cta-icon" aria-hidden="true">&#128247;</span>
+                    <span class="project-gallery__cta-text">View gallery</span>
+                    @if (remainingPhotos > 0)
+                    {
+                        <span class="project-gallery__cta-meta">+@remainingPhotos more</span>
+                    }
+                </div>
+            </a>
+        </div>
+    }
+    else
+    {
+        var emptyStateHeadingId = $"project-photo-empty-title-{Model.Project?.Id ?? 0}";
+        var emptyStateDescriptionId = $"{emptyStateHeadingId}-desc";
+        <div class="project-photo-empty border rounded bg-light-subtle text-center"
+             role="region"
+             aria-labelledby="@emptyStateHeadingId"
+             aria-describedby="@emptyStateDescriptionId">
+            <div class="project-photo-empty-body">
+                <span class="project-photo-empty-icon" aria-hidden="true">
+                    <i class="bi bi-images"></i>
+                </span>
+                <h3 id="@emptyStateHeadingId" class="h6 fw-semibold mb-2">No photos yet</h3>
+                <p id="@emptyStateDescriptionId" class="mb-3 text-muted">
+                    Add a cover or gallery photo to help everyone recognise this project at a glance.
+                </p>
+                @if (canManagePhotos)
+                {
+                    <a class="btn btn-primary"
+                       asp-page="/Projects/Photos/Index"
+                       asp-route-id="@Model.Project!.Id"
+                       aria-label="Upload the first project photo">
+                        Upload photo
+                    </a>
+                }
+            </div>
+        </div>
+    }
+</div>
+@if (galleryModalModel is not null)
+{
+    <partial name="_ProjectPhotoLightbox" model="galleryModalModel" />
+}

--- a/Pages/Projects/_ProjectOverviewCard.cshtml
+++ b/Pages/Projects/_ProjectOverviewCard.cshtml
@@ -1,0 +1,179 @@
+@using System
+@using ProjectManagement.Models
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+@{
+    var project = Model.Project;
+    var roles = Model.Roles;
+    var isAdmin = roles.IsAdmin;
+    var isHoD = roles.IsHoD;
+    var isThisProjectsPo = roles.IsAssignedProjectOfficer;
+    var isThisProjectsHod = roles.IsAssignedHoD;
+    var canManagePhotos = isAdmin || isThisProjectsPo || isThisProjectsHod;
+    var coverPhoto = Model.MediaSummary.CoverPhoto ?? Model.CoverPhoto;
+    var coverVersion = Model.MediaSummary.CoverPhotoVersion ?? Model.CoverPhotoVersion ?? coverPhoto?.Version;
+    Func<ProjectPhoto, string, int?, string> photoUrl = (photo, size, version) =>
+        Url.Page("/Projects/Photos/View", new { id = Model.Project!.Id, photoId = photo.Id, size, v = version ?? photo.Version })!;
+    var coverXs = coverPhoto != null ? photoUrl(coverPhoto, "xs", coverVersion) : null;
+    var coverSm = coverPhoto != null ? photoUrl(coverPhoto, "sm", coverVersion) : null;
+    var coverMd = coverPhoto != null ? photoUrl(coverPhoto, "md", coverVersion) : null;
+    var coverXl = coverPhoto != null ? photoUrl(coverPhoto, "xl", coverVersion) : null;
+    var coverSrcSet = coverPhoto != null
+        ? string.Join(", ", new[]
+        {
+            $"{coverXs} 400w",
+            $"{coverSm} 800w",
+            $"{coverMd} 1200w",
+            $"{coverXl} 1600w"
+        })
+        : null;
+}
+
+<div class="card pm-card">
+    <div class="card-header pm-card-header">
+        <div class="pm-card-heading">
+            <span class="pm-card-icon" aria-hidden="true">
+                <i class="bi bi-layout-text-window"></i>
+            </span>
+            <div>
+                <h2 class="pm-card-title h5 mb-0">Project overview</h2>
+                <p class="pm-card-subtitle mb-0">Description and key project facts</p>
+            </div>
+        </div>
+        @if (canManagePhotos || isThisProjectsPo || isAdmin || isHoD)
+        {
+            <div class="pm-card-menu dropdown">
+                <button class="btn pm-card-menu-toggle"
+                        type="button"
+                        data-bs-toggle="dropdown"
+                        aria-expanded="false"
+                        aria-label="Project overview actions">
+                    <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end">
+                    @if (canManagePhotos)
+                    {
+                        <li>
+                            <a class="dropdown-item d-flex align-items-center gap-2"
+                               asp-page="/Projects/Photos/Index"
+                               asp-route-id="@Model.Project!.Id">
+                                <i class="bi bi-sliders" aria-hidden="true"></i>
+                                <span>Manage photos</span>
+                            </a>
+                        </li>
+                    }
+                    @if (isThisProjectsPo)
+                    {
+                        <li>
+                            <a class="dropdown-item"
+                               asp-page="/Projects/Meta/Request"
+                               asp-route-id="@Model.Project!.Id">Request change</a>
+                        </li>
+                    }
+                    @if (isAdmin || isHoD)
+                    {
+                        <li>
+                            <a class="dropdown-item"
+                               asp-page="/Projects/Meta/Edit"
+                               asp-route-id="@Model.Project!.Id">Edit details</a>
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
+    </div>
+    <div class="card-body pm-card-body">
+        <div class="row g-4 align-items-start">
+            <div class="col-12 col-lg-5 col-xl-4">
+                <div class="project-photo-cover">
+                    <div class="ratio ratio-4x3 w-100">
+                        @if (coverPhoto != null)
+                        {
+                            <picture>
+                                <source type="image/webp"
+                                        srcset="@coverSrcSet"
+                                        sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw" />
+                                <img class="w-100 h-100 object-fit-cover rounded border"
+                                     width="360"
+                                     height="270"
+                                     src="@coverXs"
+                                     srcset="@coverSrcSet"
+                                     sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw"
+                                     alt="@(string.IsNullOrWhiteSpace(coverPhoto.Caption) ? $"{project?.Name} cover photo" : coverPhoto.Caption)" />
+                            </picture>
+                        }
+                        else
+                        {
+                            <div class="d-flex align-items-center justify-content-center w-100 h-100 rounded border bg-light text-muted">
+                                <span>No cover photo</span>
+                            </div>
+                        }
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(coverPhoto?.Caption))
+                    {
+                        <div class="mt-2 text-muted small">@coverPhoto.Caption</div>
+                    }
+                </div>
+            </div>
+            <div class="col-12 col-lg-7 col-xl-8">
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Category</dt>
+                    <dd class="col-sm-8">
+                        @if (Model.CategoryPath.Any())
+                        {
+                            <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
+                        }
+                        else
+                        {
+                            <span>—</span>
+                        }
+                    </dd>
+
+                    <dt class="col-sm-4">Sponsoring Unit</dt>
+                    <dd class="col-sm-8">@(Model.Project?.SponsoringUnit?.Name ?? "—")</dd>
+
+                    <dt class="col-sm-4">Sponsoring Line Dte</dt>
+                    <dd class="col-sm-8">@(Model.Project?.SponsoringLineDirectorate?.Name ?? "—")</dd>
+
+                    <dt class="col-sm-4">Head of Department</dt>
+                    <dd class="col-sm-8">@FormatUser(project?.HodUser)</dd>
+
+                    <dt class="col-sm-4">Project Officer</dt>
+                    <dd class="col-sm-8">@FormatUser(project?.LeadPoUser)</dd>
+                </dl>
+            </div>
+            <div class="col-12">
+                <h3 class="h6 mb-2">Project description</h3>
+                <div class="project-overview__description">@(!string.IsNullOrWhiteSpace(project?.Description) ? project.Description : "—")</div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+@functions {
+    private static string FormatUser(ApplicationUser? user)
+    {
+        if (user is null)
+        {
+            return "—";
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.FullName))
+        {
+            return user.FullName!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.UserName))
+        {
+            return user.UserName!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.Email))
+        {
+            return user.Email!;
+        }
+
+        return "—";
+    }
+}

--- a/Pages/Projects/_ProjectPostCompletion.cshtml
+++ b/Pages/Projects/_ProjectPostCompletion.cshtml
@@ -1,0 +1,415 @@
+@using System
+@using System.Globalization
+@using System.Linq
+@using System.Text.Json
+@using ProjectManagement.Models
+@using ProjectManagement.Models.Remarks
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+@{
+    var project = Model.Project;
+    var lifecycle = Model.LifecycleSummary;
+    var media = Model.MediaSummary;
+    var documentSummary = Model.DocumentSummary;
+    var tot = Model.TotSummary;
+    var remarkSummary = Model.RemarkSummary;
+    var roles = Model.Roles;
+    var isAdmin = roles.IsAdmin;
+    var isHoD = roles.IsHoD;
+    var isThisProjectsPo = roles.IsAssignedProjectOfficer;
+    var isThisProjectsHod = roles.IsAssignedHoD;
+    var remarksConfigJson = JsonSerializer.Serialize(Model.RemarksPanel, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    var lifecycleVariant = lifecycle.Status switch
+    {
+        ProjectLifecycleStatus.Completed => "success",
+        ProjectLifecycleStatus.Cancelled => "danger",
+        _ => "secondary"
+    };
+    var totVariant = !tot.HasTotRecord
+        ? "secondary"
+        : tot.Status switch
+        {
+            ProjectTotStatus.Completed => "success",
+            ProjectTotStatus.InProgress => "info",
+            ProjectTotStatus.NotRequired => "secondary",
+            _ => "secondary"
+        };
+    var tabPrefix = $"project-media-{Model.Project?.Id ?? 0}";
+    var photosTabId = $"{tabPrefix}-photos";
+    var docsTabId = $"{tabPrefix}-documents";
+}
+
+<div class="row g-3 mb-4">
+    <div class="col-lg-8 d-flex flex-column gap-3">
+        <div class="card pm-card">
+            <div class="card-header pm-card-header">
+                <div class="pm-card-heading">
+                    <span class="pm-card-icon" aria-hidden="true">
+                        <i class="bi bi-flag"></i>
+                    </span>
+                    <div>
+                        <h2 class="pm-card-title h5 mb-0">Lifecycle summary</h2>
+                        <p class="pm-card-subtitle mb-0">Project status after completion.</p>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center gap-2">
+                    @if (!string.IsNullOrWhiteSpace(lifecycle.BadgeText))
+                    {
+                        <span class="badge text-bg-secondary">@lifecycle.BadgeText</span>
+                    }
+                </div>
+            </div>
+            <div class="card-body pm-card-body d-flex flex-column gap-3">
+                <div>
+                    <span class="badge text-bg-@lifecycleVariant">@lifecycle.StatusLabel</span>
+                    @if (!string.IsNullOrWhiteSpace(lifecycle.PrimaryDetail))
+                    {
+                        <p class="mt-2 mb-0">@lifecycle.PrimaryDetail</p>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(lifecycle.SecondaryDetail))
+                    {
+                        <p class="text-muted mb-0">@lifecycle.SecondaryDetail</p>
+                    }
+                </div>
+                @if (lifecycle.Facts.Any())
+                {
+                    <dl class="row small mb-0">
+                        @foreach (var fact in lifecycle.Facts)
+                        {
+                            <dt class="col-sm-4">@fact.Label</dt>
+                            <dd class="col-sm-8">@fact.Value</dd>
+                        }
+                    </dl>
+                }
+            </div>
+        </div>
+
+        <partial name="_ProjectOverviewCard" model="Model" />
+
+        <div class="card pm-card">
+            <div class="card-header pm-card-header">
+                <div class="pm-card-heading">
+                    <span class="pm-card-icon" aria-hidden="true">
+                        <i class="bi bi-collection"></i>
+                    </span>
+                    <div>
+                        <h3 class="pm-card-title h5 mb-0">Project media</h3>
+                        <p class="pm-card-subtitle mb-0">Archived photos and documents.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body pm-card-body">
+                <ul class="nav nav-tabs mb-3" id="@tabPrefix" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active"
+                                id="@photosTabId-tab"
+                                data-bs-toggle="tab"
+                                data-bs-target="#@photosTabId"
+                                type="button"
+                                role="tab"
+                                aria-controls="@photosTabId"
+                                aria-selected="true">
+                            Photos (@media.PhotoCount)
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link"
+                                id="@docsTabId-tab"
+                                data-bs-toggle="tab"
+                                data-bs-target="#@docsTabId"
+                                type="button"
+                                role="tab"
+                                aria-controls="@docsTabId"
+                                aria-selected="false">
+                            Documents (@documentSummary.PublishedCount)
+                        </button>
+                    </li>
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade show active"
+                         id="@photosTabId"
+                         role="tabpanel"
+                         aria-labelledby="@photosTabId-tab">
+                        <partial name="_ProjectGalleryContent" model="Model" />
+                    </div>
+                    <div class="tab-pane fade"
+                         id="@docsTabId"
+                         role="tabpanel"
+                         aria-labelledby="@docsTabId-tab">
+                        <div class="d-flex flex-column gap-2">
+                            @if (documentSummary.PublishedCount > 0)
+                            {
+                                <p class="mb-0">Published documents: <strong>@documentSummary.PublishedCount</strong></p>
+                            }
+                            else
+                            {
+                                <p class="text-muted mb-0">No published documents for this project.</p>
+                            }
+                            @if (documentSummary.HasPending && Model.IsDocumentApprover)
+                            {
+                                <p class="mb-0 text-muted">Pending approval requests: @documentSummary.PendingCount</p>
+                            }
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-sm btn-outline-secondary"
+                                   asp-page="/Projects/Documents/Index"
+                                   asp-route-id="@Model.Project!.Id">Open documents workspace</a>
+                                @if (Model.IsDocumentApprover)
+                                {
+                                    <a class="btn btn-sm btn-outline-secondary"
+                                       asp-page="/Projects/Documents/Approvals/Index"
+                                       asp-route-id="@Model.Project!.Id">Review approvals</a>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4 d-flex flex-column gap-3">
+        <div class="card pm-card">
+            <div class="card-header pm-card-header">
+                <div class="pm-card-heading">
+                    <span class="pm-card-icon" aria-hidden="true">
+                        <i class="bi bi-diagram-3"></i>
+                    </span>
+                    <div>
+                        <h3 class="pm-card-title h6 mb-0">Transfer of Technology</h3>
+                        <p class="pm-card-subtitle mb-0">Status and milestones.</p>
+                    </div>
+                </div>
+                <span class="badge text-bg-@totVariant">@tot.StatusLabel</span>
+            </div>
+            <div class="card-body pm-card-body d-flex flex-column gap-2">
+                <p class="mb-0">@tot.Summary</p>
+                @if (tot.Facts.Any())
+                {
+                    <dl class="row small mb-0">
+                        @foreach (var fact in tot.Facts)
+                        {
+                            <dt class="col-sm-5">@fact.Label</dt>
+                            <dd class="col-sm-7">@fact.Value</dd>
+                        }
+                    </dl>
+                }
+                @if (!string.IsNullOrWhiteSpace(tot.Remarks))
+                {
+                    <div class="alert alert-secondary mb-0" role="status">@tot.Remarks</div>
+                }
+            </div>
+        </div>
+
+        @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
+        {
+            <div class="card pm-card">
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-inbox"></i>
+                        </span>
+                        <div>
+                            <h3 class="pm-card-title h6 mb-0">Document requests</h3>
+                            <p class="pm-card-subtitle mb-0">Newest submissions awaiting your decision.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body pm-card-body d-flex flex-column gap-3">
+                    @foreach (var request in Model.DocumentPendingRequests)
+                    {
+                        <div class="border rounded p-3">
+                            <div class="d-flex justify-content-between align-items-start gap-2">
+                                <div>
+                                    <div class="fw-semibold">@request.Title</div>
+                                    <div class="text-muted small">@request.StageDisplayName · @request.RequestTypeLabel</div>
+                                    <div class="text-muted small">@request.RequestedSummary</div>
+                                    <div class="text-muted small">@request.FileName (@request.FileSizeDisplay)</div>
+                                </div>
+                                <span class="badge text-bg-warning">Pending</span>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2 mt-3">
+                                <form method="post"
+                                      class="d-inline"
+                                      asp-page="/Projects/Documents/Approvals/Review"
+                                      asp-page-handler="Approve"
+                                      asp-route-id="@Model.Project!.Id"
+                                      asp-route-requestId="@request.RequestId">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="Input.RequestId" value="@request.RequestId" />
+                                    <input type="hidden" name="Input.RowVersion" value="@request.RowVersion" />
+                                    <button type="submit" class="btn btn-sm btn-success">Approve</button>
+                                </form>
+                                <form method="post"
+                                      class="d-inline"
+                                      asp-page="/Projects/Documents/Approvals/Review"
+                                      asp-page-handler="Reject"
+                                      asp-route-id="@Model.Project!.Id"
+                                      asp-route-requestId="@request.RequestId">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="Input.RequestId" value="@request.RequestId" />
+                                    <input type="hidden" name="Input.RowVersion" value="@request.RowVersion" />
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Reject</button>
+                                </form>
+                                <a class="btn btn-sm btn-outline-secondary"
+                                   asp-page="/Projects/Documents/Approvals/Review"
+                                   asp-route-id="@Model.Project!.Id"
+                                   asp-route-requestId="@request.RequestId">Review</a>
+                            </div>
+                        </div>
+                    }
+                    <a class="btn btn-sm btn-outline-secondary align-self-start"
+                       asp-page="/Projects/Documents/Approvals/Index"
+                       asp-route-id="@Model.Project!.Id">View all requests</a>
+                </div>
+            </div>
+        }
+
+        @if (Model.MetaChangeRequest is { } metaRequest)
+        {
+            if (isHoD || isAdmin)
+            {
+                <div class="card pm-card">
+                    <div class="card-header pm-card-header">
+                        <div class="pm-card-heading">
+                            <span class="pm-card-icon" aria-hidden="true">
+                                <i class="bi bi-arrow-repeat"></i>
+                            </span>
+                            <div>
+                                <h3 class="pm-card-title h6 mb-0">Pending metadata update</h3>
+                                <p class="pm-card-subtitle mb-0">Review project detail change requests.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-body pm-card-body">
+                        <p class="mb-1"><strong>@metaRequest.RequestedBy</strong> requested changes on @metaRequest.RequestedOn.ToLocalTime().ToString("dd MMM yyyy").</p>
+                        <p class="text-muted mb-3">@metaRequest.Summary</p>
+                        <div class="d-flex gap-2">
+                            <a class="btn btn-sm btn-primary"
+                               asp-page="/Projects/Meta/Decide"
+                               asp-route-id="@Model.Project!.Id"
+                               asp-route-requestId="@metaRequest.RequestId">Review request</a>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               asp-page="/Projects/Meta/View"
+                               asp-route-id="@Model.Project!.Id"
+                               asp-route-requestId="@metaRequest.RequestId">View details</a>
+                        </div>
+                    </div>
+                </div>
+            }
+        }
+
+        <div class="card pm-card">
+            <div class="card-header pm-card-header">
+                <div class="pm-card-heading">
+                    <span class="pm-card-icon" aria-hidden="true">
+                        <i class="bi bi-chat-dots"></i>
+                    </span>
+                    <div>
+                        <h3 class="pm-card-title h6 mb-0">Remarks</h3>
+                        <p class="pm-card-subtitle mb-0">Latest conversation highlights.</p>
+                    </div>
+                </div>
+                <span class="badge text-bg-secondary">@remarkSummary.TotalCount total</span>
+            </div>
+            <div class="card-body pm-card-body d-flex flex-column gap-3">
+                <div class="small text-muted">
+                    Internal: @remarkSummary.InternalCount · External: @remarkSummary.ExternalCount
+                </div>
+                @if (remarkSummary.LastActivityUtc is DateTime lastActivity)
+                {
+                    var lastTime = lastActivity.ToLocalTime().ToString("dd MMM yyyy, HH:mm", CultureInfo.InvariantCulture);
+                    var roleLabel = FormatRole(remarkSummary.LastRemarkActorRole);
+                    var typeLabel = FormatRemarkType(remarkSummary.LastRemarkType);
+                    <div class="text-muted small">Last remark on @lastTime@(!string.IsNullOrWhiteSpace(roleLabel) ? $" · {roleLabel}" : string.Empty)@(!string.IsNullOrWhiteSpace(typeLabel) ? $" · {typeLabel}" : string.Empty).</div>
+                    if (!string.IsNullOrWhiteSpace(remarkSummary.LastRemarkPreview))
+                    {
+                        <blockquote class="blockquote mb-0 small text-muted">@remarkSummary.LastRemarkPreview</blockquote>
+                    }
+                }
+                <div class="remarks-panel" data-remarks-panel data-config='@remarksConfigJson'>
+                    @if (Model.RemarksPanel.ShowComposer)
+                    {
+                        <form class="remarks-composer" data-remarks-composer>
+                            @Html.AntiForgeryToken()
+                            <div class="d-flex flex-column gap-3">
+                                <div>
+                                    <label for="remark-body" class="form-label fw-semibold mb-1">Add a remark</label>
+                                    <textarea id="remark-body" class="form-control" rows="3" maxlength="4000" data-remarks-body required></textarea>
+                                    <div class="form-text">Maximum 4000 characters.</div>
+                                    @if (!string.IsNullOrWhiteSpace(Model.RemarksPanel.ActorDisplayName))
+                                    {
+                                        <div class="small text-muted mt-1">Posting as @Model.RemarksPanel.ActorDisplayName</div>
+                                    }
+                                </div>
+                                <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                    <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
+                                        <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
+                                        @if (Model.RemarksPanel.AllowExternal)
+                                        {
+                                            <button type="button" class="btn btn-outline-secondary" data-remarks-composer-option="External" aria-pressed="false">External</button>
+                                        }
+                                    </div>
+                                    <div class="remarks-composer-external d-flex flex-wrap align-items-end gap-2 d-none" data-remarks-external-fields>
+                                        <div>
+                                            <label for="remark-event-date" class="form-label mb-1 small">Event date</label>
+                                            <input type="date" id="remark-event-date" class="form-control form-control-sm" data-remarks-event-date value="@Model.RemarksPanel.Today" max="@Model.RemarksPanel.Today" />
+                                        </div>
+                                        <div>
+                                            <label for="remark-stage" class="form-label mb-1 small">Stage <span class="text-muted">(optional)</span></label>
+                                            <select id="remark-stage" class="form-select form-select-sm" data-remarks-stage>
+                                                <option value="">Not linked</option>
+                                                @foreach (var stage in Model.RemarksPanel.StageOptions)
+                                                {
+                                                    <option value="@stage.Value">@stage.Label</option>
+                                                }
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="d-flex flex-column flex-sm-row gap-2 align-items-sm-center justify-content-between">
+                                    <div class="small" data-remarks-feedback></div>
+                                    <div class="d-flex gap-2 ms-sm-auto">
+                                        <button type="reset" class="btn btn-sm btn-outline-secondary" data-remarks-reset>Clear</button>
+                                        <button type="submit" class="btn btn-primary btn-sm" data-remarks-submit>Post remark</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </form>
+                    }
+                    else
+                    {
+                        <div class="alert alert-info border-info-subtle bg-info-subtle text-dark" role="status">
+                            Remarks can only be posted by the assigned project team and leadership.
+                        </div>
+                    }
+                    <div class="remarks-list" data-remarks-list>
+                        <div class="text-muted" data-remarks-empty>Loading remarks…</div>
+                        <div class="vstack gap-3" data-remarks-items></div>
+                        <a class="btn btn-outline-secondary btn-sm align-self-start" asp-page="/Projects/Remarks/Index" asp-route-projectId="@Model.Project!.Id">View all remarks</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@functions {
+    private static string FormatRole(RemarkActorRole? role) => role switch
+    {
+        RemarkActorRole.ProjectOfficer => "PO",
+        RemarkActorRole.HeadOfDepartment => "HoD",
+        RemarkActorRole.Commandant => "Comdt",
+        RemarkActorRole.Administrator => "Admin",
+        RemarkActorRole.Mco => "MCO",
+        RemarkActorRole.ProjectOffice => "Project Office",
+        RemarkActorRole.MainOffice => "Main Office",
+        RemarkActorRole.Ta => "TA",
+        _ => string.Empty
+    };
+
+    private static string FormatRemarkType(RemarkType? type) => type switch
+    {
+        RemarkType.External => "External",
+        RemarkType.Internal => "Internal",
+        _ => string.Empty
+    };
+}

--- a/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
+++ b/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Remarks;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Services.Stages;
+using ProjectManagement.ViewModels;
+using Xunit;
+using ProjectsOverviewModel = ProjectManagement.Pages.Projects.OverviewModel;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectOverviewLifecycleTests
+{
+    [Fact]
+    public async Task Overview_WhenProjectActive_DoesNotShowPostCompletionView()
+    {
+        await using var db = CreateContext();
+        await SeedProjectAsync(db, projectId: 1);
+
+        var clock = new FixedClock(DateTimeOffset.UtcNow);
+        var overview = CreateOverviewPage(db, clock);
+        ConfigurePageContext(overview);
+
+        var result = await overview.OnGetAsync(1, CancellationToken.None);
+
+        Assert.IsType<PageResult>(result);
+        Assert.False(overview.LifecycleSummary.ShowPostCompletionView);
+        Assert.Equal(ProjectLifecycleStatus.Active, overview.LifecycleSummary.Status);
+        Assert.Equal(0, overview.MediaSummary.PhotoCount);
+        Assert.Equal(0, overview.DocumentSummary.PublishedCount);
+        Assert.False(overview.TotSummary.HasTotRecord);
+        Assert.Equal("Not tracked", overview.TotSummary.StatusLabel);
+        Assert.Equal(0, overview.RemarkSummary.TotalCount);
+    }
+
+    [Fact]
+    public async Task Overview_WhenProjectCompleted_BuildsPostCompletionSummaries()
+    {
+        await using var db = CreateContext();
+        await SeedCompletedProjectAsync(db, projectId: 2);
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 8, 0, 0, TimeSpan.Zero));
+        var overview = CreateOverviewPage(db, clock);
+        ConfigurePageContext(overview);
+
+        var result = await overview.OnGetAsync(2, CancellationToken.None);
+
+        Assert.IsType<PageResult>(result);
+        Assert.True(overview.LifecycleSummary.ShowPostCompletionView);
+        Assert.Equal(ProjectLifecycleStatus.Completed, overview.LifecycleSummary.Status);
+        Assert.Contains("completed on", overview.LifecycleSummary.PrimaryDetail!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(overview.LifecycleSummary.Facts, fact => fact.Label == "Completed on");
+        Assert.Equal(2, overview.MediaSummary.PhotoCount);
+        Assert.True(overview.MediaSummary.HasAdditionalPhotos);
+        Assert.Equal(1, overview.DocumentSummary.PublishedCount);
+        Assert.Equal(1, overview.RemarkSummary.TotalCount);
+        Assert.Equal(RemarkType.Internal, overview.RemarkSummary.LastRemarkType);
+        Assert.Equal(ProjectTotStatus.Completed, overview.TotSummary.Status);
+        Assert.Contains("Transfer of Technology completed", overview.TotSummary.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task SeedProjectAsync(ApplicationDbContext db, int projectId)
+    {
+        db.Projects.Add(new Project
+        {
+            Id = projectId,
+            Name = $"Project {projectId}",
+            CreatedByUserId = "creator",
+            CreatedAt = new DateTime(2024, 1, 1),
+            RowVersion = new byte[] { 1 }
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedCompletedProjectAsync(ApplicationDbContext db, int projectId)
+    {
+        var project = new Project
+        {
+            Id = projectId,
+            Name = "Completed Project",
+            CreatedByUserId = "creator",
+            CreatedAt = new DateTime(2023, 3, 10),
+            LifecycleStatus = ProjectLifecycleStatus.Completed,
+            CompletedOn = new DateOnly(2024, 4, 5),
+            CompletedYear = 2024,
+            RowVersion = new byte[] { 2 }
+        };
+        db.Projects.Add(project);
+
+        db.ProjectPhotos.AddRange(
+            new ProjectPhoto
+            {
+                Id = 10,
+                ProjectId = projectId,
+                StorageKey = "photos/2/10.png",
+                OriginalFileName = "cover.png",
+                ContentType = "image/png",
+                Width = 800,
+                Height = 600,
+                Ordinal = 1,
+                Caption = "Cover",
+                IsCover = true,
+                Version = 2,
+                CreatedUtc = DateTime.UtcNow,
+                UpdatedUtc = DateTime.UtcNow
+            },
+            new ProjectPhoto
+            {
+                Id = 11,
+                ProjectId = projectId,
+                StorageKey = "photos/2/11.png",
+                OriginalFileName = "additional.png",
+                ContentType = "image/png",
+                Width = 800,
+                Height = 600,
+                Ordinal = 2,
+                Caption = "Preview",
+                Version = 1,
+                CreatedUtc = DateTime.UtcNow,
+                UpdatedUtc = DateTime.UtcNow
+            });
+
+        db.ProjectDocuments.Add(new ProjectDocument
+        {
+            Id = 20,
+            ProjectId = projectId,
+            Title = "Completion Report",
+            StorageKey = "docs/2/20.pdf",
+            OriginalFileName = "report.pdf",
+            ContentType = "application/pdf",
+            FileSize = 1024,
+            Status = ProjectDocumentStatus.Published,
+            FileStamp = 1,
+            UploadedByUserId = "uploader",
+            UploadedAtUtc = DateTimeOffset.UtcNow
+        });
+
+        db.Remarks.Add(new Remark
+        {
+            ProjectId = projectId,
+            AuthorUserId = "author",
+            AuthorRole = RemarkActorRole.ProjectOfficer,
+            Type = RemarkType.Internal,
+            Body = "Final walkthrough completed.",
+            EventDate = new DateOnly(2024, 4, 5),
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = projectId,
+            Status = ProjectTotStatus.Completed,
+            StartedOn = new DateOnly(2023, 8, 1),
+            CompletedOn = new DateOnly(2024, 3, 15),
+            Remarks = "Knowledge transfer complete."
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static ProjectsOverviewModel CreateOverviewPage(ApplicationDbContext db, IClock clock)
+    {
+        var procure = new ProjectProcurementReadService(db);
+        var timeline = new ProjectTimelineReadService(db, clock);
+        var planRead = new PlanReadService(db);
+        var planCompare = new PlanCompareService(db);
+        var userManager = CreateUserManager(db);
+        var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel);
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<ILookupNormalizer, UpperInvariantLookupNormalizer>()
+            .BuildServiceProvider();
+
+        return new UserManager<ApplicationUser>(
+            new UserStore<ApplicationUser>(db),
+            Options.Create(new IdentityOptions()),
+            new PasswordHasher<ApplicationUser>(),
+            Array.Empty<IUserValidator<ApplicationUser>>(),
+            Array.Empty<IPasswordValidator<ApplicationUser>>(),
+            services.GetRequiredService<ILookupNormalizer>(),
+            new IdentityErrorDescriber(),
+            services,
+            NullLogger<UserManager<ApplicationUser>>.Instance);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static void ConfigurePageContext(PageModel page, ClaimsPrincipal? user = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        var tempDataProvider = new InMemoryTempDataProvider();
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton<ITempDataProvider>(tempDataProvider)
+            .BuildServiceProvider();
+        httpContext.User = user ?? new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "page-user")
+        }, "Test"));
+
+        var actionContext = new ActionContext(httpContext, new(), new ActionDescriptor());
+        page.PageContext = new PageContext(actionContext)
+        {
+            ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        };
+        page.TempData = new TempDataDictionary(httpContext, tempDataProvider);
+        page.Url = new SimpleUrlHelper(page.PageContext);
+    }
+
+    private sealed class InMemoryTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => new Dictionary<string, object?>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+        }
+    }
+}

--- a/ViewModels/ProjectDocumentSummaryViewModel.cs
+++ b/ViewModels/ProjectDocumentSummaryViewModel.cs
@@ -1,0 +1,12 @@
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectDocumentSummaryViewModel
+{
+    public static readonly ProjectDocumentSummaryViewModel Empty = new();
+
+    public int TotalCount { get; init; }
+    public int PublishedCount { get; init; }
+    public int PendingCount { get; init; }
+
+    public bool HasPending => PendingCount > 0;
+}

--- a/ViewModels/ProjectLifecycleSummaryViewModel.cs
+++ b/ViewModels/ProjectLifecycleSummaryViewModel.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectLifecycleSummaryViewModel
+{
+    public static readonly ProjectLifecycleSummaryViewModel Empty = new();
+
+    public bool ShowPostCompletionView { get; init; }
+    public ProjectLifecycleStatus Status { get; init; } = ProjectLifecycleStatus.Active;
+    public string StatusLabel { get; init; } = "Active";
+    public bool IsLegacy { get; init; }
+    public string? PrimaryDetail { get; init; }
+    public string? SecondaryDetail { get; init; }
+    public string? BadgeText { get; init; }
+    public IReadOnlyList<LifecycleFact> Facts { get; init; } = Array.Empty<LifecycleFact>();
+
+    public sealed record LifecycleFact(string Label, string Value);
+}

--- a/ViewModels/ProjectMediaSummaryViewModel.cs
+++ b/ViewModels/ProjectMediaSummaryViewModel.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectMediaSummaryViewModel
+{
+    public static readonly ProjectMediaSummaryViewModel Empty = new();
+    public const int DefaultPreviewCount = 4;
+
+    public int PhotoCount { get; init; }
+    public int AdditionalPhotoCount { get; init; }
+    public int RemainingPhotoCount { get; init; }
+    public ProjectPhoto? CoverPhoto { get; init; }
+    public int? CoverPhotoVersion { get; init; }
+    public string? CoverPhotoUrl { get; init; }
+    public IReadOnlyList<ProjectPhoto> PreviewPhotos { get; init; } = Array.Empty<ProjectPhoto>();
+    public int DocumentCount { get; init; }
+    public int PendingDocumentCount { get; init; }
+
+    public bool HasPhotos => PhotoCount > 0;
+    public bool HasAdditionalPhotos => AdditionalPhotoCount > 0;
+    public bool HasDocuments => DocumentCount > 0;
+    public bool HasPendingDocuments => PendingDocumentCount > 0;
+}

--- a/ViewModels/ProjectRemarkSummaryViewModel.cs
+++ b/ViewModels/ProjectRemarkSummaryViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+using ProjectManagement.Models.Remarks;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectRemarkSummaryViewModel
+{
+    public static readonly ProjectRemarkSummaryViewModel Empty = new();
+
+    public int InternalCount { get; init; }
+    public int ExternalCount { get; init; }
+    public int TotalCount => InternalCount + ExternalCount;
+    public bool HasRemarks => TotalCount > 0;
+    public DateTime? LastActivityUtc { get; init; }
+    public int? LastRemarkId { get; init; }
+    public RemarkType? LastRemarkType { get; init; }
+    public RemarkActorRole? LastRemarkActorRole { get; init; }
+    public string? LastRemarkPreview { get; init; }
+}

--- a/ViewModels/ProjectRolesViewModel.cs
+++ b/ViewModels/ProjectRolesViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectRolesViewModel
+{
+    public static readonly ProjectRolesViewModel Empty = new();
+
+    public bool IsAdmin { get; init; }
+    public bool IsHoD { get; init; }
+    public bool IsProjectOfficer { get; init; }
+    public bool IsAssignedProjectOfficer { get; init; }
+    public bool IsAssignedHoD { get; init; }
+}

--- a/ViewModels/ProjectTotSummaryViewModel.cs
+++ b/ViewModels/ProjectTotSummaryViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectTotSummaryViewModel
+{
+    public static readonly ProjectTotSummaryViewModel Empty = new();
+
+    public bool HasTotRecord { get; init; }
+    public ProjectTotStatus Status { get; init; } = ProjectTotStatus.NotStarted;
+    public string StatusLabel { get; init; } = "Not started";
+    public string Summary { get; init; } = string.Empty;
+    public string? Remarks { get; init; }
+    public IReadOnlyList<TotFact> Facts { get; init; } = Array.Empty<TotFact>();
+
+    public sealed record TotFact(string Label, string Value);
+}


### PR DESCRIPTION
## Summary
- add a post-completion branch in the project overview to show lifecycle badges, media tabs, ToT summary, and remarks when applicable
- enrich the overview page model with lifecycle, media, document, remark, and ToT metadata for the new layout
- introduce reusable partials and tests covering active versus completed overview scenarios

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5f9a658248329adcb65af8d01db6c