### PR TITLE
Add legacy project creation workflow

### DIFF
--- a/Pages/Projects/Create.cshtml
+++ b/Pages/Projects/Create.cshtml
@@ -94,20 +94,44 @@
         <div class="card mb-4">
             <div class="card-header">Current Status (optional)</div>
             <div class="card-body">
-                <div class="form-check form-switch mb-2">
-                    <input class="form-check-input" type="checkbox" id="IsOngoing" asp-for="Input.IsOngoing" />
-                    <label class="form-check-label" for="IsOngoing">Project already in progress</label>
-                </div>
-                <div id="OngoingFields" class="row g-3 visually-hidden">
-                    <div class="col-md-6">
-                        <label asp-for="Input.LastStageCompleted" class="form-label">Last stage completed</label>
-                        <select asp-for="Input.LastStageCompleted" class="form-select" asp-items="Model.StageOptions"></select>
-                        <span asp-validation-for="Input.LastStageCompleted" class="text-danger"></span>
+                <div class="row g-3">
+                    <div class="col-lg-6">
+                        <div class="form-check form-switch mb-2">
+                            <input class="form-check-input" type="checkbox" id="IsOngoing" asp-for="Input.IsOngoing" />
+                            <label class="form-check-label" for="IsOngoing">Project already in progress</label>
+                        </div>
+                        <div id="OngoingFields" class="row g-3 visually-hidden">
+                            <div class="col-md-12">
+                                <label asp-for="Input.LastStageCompleted" class="form-label">Last stage completed</label>
+                                <select asp-for="Input.LastStageCompleted" class="form-select" asp-items="Model.StageOptions"></select>
+                                <span asp-validation-for="Input.LastStageCompleted" class="text-danger"></span>
+                            </div>
+                            <div class="col-md-12">
+                                <label asp-for="Input.LastStageCompletedOn" class="form-label">Completed on</label>
+                                <input asp-for="Input.LastStageCompletedOn" type="date" class="form-control" />
+                                <span asp-validation-for="Input.LastStageCompletedOn" class="text-danger"></span>
+                            </div>
+                        </div>
                     </div>
-                    <div class="col-md-6">
-                        <label asp-for="Input.LastStageCompletedOn" class="form-label">Completed on</label>
-                        <input asp-for="Input.LastStageCompletedOn" type="date" class="form-control" />
-                        <span asp-validation-for="Input.LastStageCompletedOn" class="text-danger"></span>
+                    <div class="col-lg-6">
+                        <div class="form-check form-switch mb-2">
+                            <input class="form-check-input" type="checkbox" id="IsLegacy" asp-for="Input.IsLegacy" />
+                            <label class="form-check-label" for="IsLegacy">Project is a legacy record</label>
+                        </div>
+                        <div id="LegacyFields" class="row g-3@(Model.Input?.IsLegacy == true ? string.Empty : " visually-hidden")">
+                            <div class="col-md-12">
+                                <label asp-for="Input.LegacyCompletedOn" class="form-label">Completion date</label>
+                                <input asp-for="Input.LegacyCompletedOn" type="date" class="form-control" />
+                                <div class="form-text">Provide the exact completion date, or leave blank and record the year.</div>
+                                <span asp-validation-for="Input.LegacyCompletedOn" class="text-danger"></span>
+                            </div>
+                            <div class="col-md-12">
+                                <label asp-for="Input.LegacyCompletedYear" class="form-label">Completion year</label>
+                                <input asp-for="Input.LegacyCompletedYear" type="number" class="form-control" min="1900" max="2099" />
+                                <div class="form-text">If the exact date is unknown, capture the calendar year only.</div>
+                                <span asp-validation-for="Input.LegacyCompletedYear" class="text-danger"></span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/wwwroot/js/projects/create.js
+++ b/wwwroot/js/projects/create.js
@@ -1,6 +1,8 @@
 (function () {
   const isOngoing = document.getElementById('IsOngoing');
   const ongoingFields = document.getElementById('OngoingFields');
+  const isLegacy = document.getElementById('IsLegacy');
+  const legacyFields = document.getElementById('LegacyFields');
   const categorySelect = document.querySelector('[name="Input.CategoryId"]');
   const subCategorySelect = document.getElementById('SubCategoryId');
 
@@ -11,6 +13,23 @@
 
     const active = Boolean(isOngoing && isOngoing.checked);
     ongoingFields.classList.toggle('visually-hidden', !active);
+  }
+
+  function toggleLegacy() {
+    if (!legacyFields) {
+      return;
+    }
+
+    const active = Boolean(isLegacy && isLegacy.checked);
+    legacyFields.classList.toggle('visually-hidden', !active);
+
+    if (isOngoing) {
+      if (active) {
+        isOngoing.checked = false;
+      }
+      isOngoing.disabled = active;
+      toggleOngoing();
+    }
   }
 
   async function loadSubCategories(categoryId, selectedValue) {
@@ -58,6 +77,9 @@
 
   isOngoing?.addEventListener('change', toggleOngoing);
   toggleOngoing();
+
+  isLegacy?.addEventListener('change', toggleLegacy);
+  toggleLegacy();
 
   const preselectedSub = subCategorySelect?.dataset.selected || '';
   if (categorySelect && categorySelect.value) {


### PR DESCRIPTION
## Summary
- add a legacy toggle with conditional completion date and year inputs on the project creation form, including client-side behaviour
- validate legacy submissions server-side, set lifecycle/TOT defaults, and seed minimal procurement fact records for legacy projects
- cover active and legacy creation flows plus validation edge cases with new page-model tests

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e60d3ee8248329a46423a330ba7cb9