### PR TITLE
Add lifecycle actions to project overview

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -100,6 +100,11 @@
         </div>
     }
 
+    @if (Model.LifecycleActions.HasActions)
+    {
+        <partial name="_ProjectLifecycleActions" model="Model" />
+    }
+
     @if (!Model.LifecycleSummary.ShowPostCompletionView)
     {
         <div class="alert alert-warning d-flex align-items-center justify-content-between@(Model.HasBackfill ? string.Empty : " d-none")"

--- a/Pages/Projects/_ProjectLifecycleActions.cshtml
+++ b/Pages/Projects/_ProjectLifecycleActions.cshtml
@@ -1,0 +1,92 @@
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+@{
+    var project = Model.Project;
+    var actions = Model.LifecycleActions;
+    var hasCompletionForm = actions.CanMarkCompleted;
+    var hasEndorseForm = actions.CanEndorseCompletedDate;
+    var hasCancelForm = actions.CanCancel;
+}
+
+<div class="card pm-card mb-3">
+    <div class="card-header pm-card-header">
+        <div class="pm-card-heading">
+            <span class="pm-card-icon" aria-hidden="true">
+                <i class="bi bi-check2-square"></i>
+            </span>
+            <div>
+                <h2 class="pm-card-title h6 mb-0">Lifecycle actions</h2>
+                <p class="pm-card-subtitle mb-0">Update the project lifecycle status and key dates.</p>
+            </div>
+        </div>
+    </div>
+    <div class="card-body pm-card-body">
+        <div class="row g-4">
+            @if (hasCompletionForm)
+            {
+                <div class="col-lg-4">
+                    <h3 class="h6 mb-2">Mark completed</h3>
+                    <form method="post" asp-page-handler="Complete" asp-route-id="@project.Id" class="d-flex flex-column gap-3">
+                        <input asp-for="CompleteProjectInput.ProjectId" type="hidden" />
+                        <div class="mb-0">
+                            <label asp-for="CompleteProjectInput.CompletedYear" class="form-label">Completion year (optional)</label>
+                            <input asp-for="CompleteProjectInput.CompletedYear" type="number" class="form-control" min="1900" max="2099" />
+                            <div class="form-text">Provide the year the project completed if the exact date is not known.</div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-primary btn-sm">Save completion</button>
+                        </div>
+                    </form>
+                </div>
+            }
+
+            @if (hasEndorseForm)
+            {
+                <div class="col-lg-4">
+                    <h3 class="h6 mb-2">Endorse completion date</h3>
+                    <form method="post" asp-page-handler="Endorse" asp-route-id="@project.Id" class="d-flex flex-column gap-3">
+                        <input asp-for="EndorseCompletionInput.ProjectId" type="hidden" />
+                        <div class="mb-0">
+                            <label asp-for="EndorseCompletionInput.CompletedOn" class="form-label">Completion date</label>
+                            <input asp-for="EndorseCompletionInput.CompletedOn" type="date" class="form-control" />
+                            <div class="form-text">Set the exact date the project finished to finalise completion.</div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-success btn-sm">Endorse date</button>
+                        </div>
+                    </form>
+                </div>
+            }
+
+            @if (hasCancelForm)
+            {
+                <div class="col-lg-4">
+                    <h3 class="h6 mb-2">Cancel project</h3>
+                    <form method="post" asp-page-handler="Cancel" asp-route-id="@project.Id" class="d-flex flex-column gap-3">
+                        <input asp-for="CancelProjectInput.ProjectId" type="hidden" />
+                        <div class="mb-0">
+                            <label asp-for="CancelProjectInput.CancelledOn" class="form-label">Cancellation date</label>
+                            <input asp-for="CancelProjectInput.CancelledOn" type="date" class="form-control" />
+                        </div>
+                        <div class="mb-0">
+                            <label asp-for="CancelProjectInput.Reason" class="form-label">Reason</label>
+                            <textarea asp-for="CancelProjectInput.Reason" class="form-control" rows="3" maxlength="512"></textarea>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-danger btn-sm">Cancel project</button>
+                        </div>
+                    </form>
+                </div>
+            }
+
+            @if (!hasCompletionForm && !hasEndorseForm && !hasCancelForm)
+            {
+                <div class="col-12">
+                    <div class="alert alert-secondary mb-0" role="status">
+                        No lifecycle actions are currently available for this project.
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -191,6 +191,7 @@ builder.Services.AddScoped<ProjectFactsService>();
 builder.Services.AddScoped<ProjectFactsReadService>();
 builder.Services.AddScoped<ProjectProcurementReadService>();
 builder.Services.AddScoped<ProjectTimelineReadService>();
+builder.Services.AddScoped<ProjectLifecycleService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<ProjectRemarksPanelService>();
 builder.Services.AddScoped<IRemarkService, RemarkService>();

--- a/ProjectManagement.Tests/ProjectLifecycleServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectLifecycleServiceTests.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectLifecycleServiceTests
+{
+    [Fact]
+    public async Task MarkCompleted_WhenActive_SetsLifecycleAndLogs()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Alpha",
+            CreatedAt = new DateTime(2024, 1, 10),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.MarkCompletedAsync(1, "actor", 2024);
+
+        Assert.True(result.IsSuccess);
+        var project = await db.Projects.SingleAsync(p => p.Id == 1);
+        Assert.Equal(ProjectLifecycleStatus.Completed, project.LifecycleStatus);
+        Assert.Equal(2024, project.CompletedYear);
+        Assert.Null(project.CompletedOn);
+        Assert.Null(project.CancelledOn);
+        Assert.Null(project.CancelReason);
+
+        var entry = Assert.Single(audit.Logs);
+        Assert.Equal("Project.LifecycleCompleted", entry.Action);
+        Assert.Equal("actor", entry.UserId);
+        Assert.Equal("2024", entry.Data["CompletionYear"]);
+    }
+
+    [Fact]
+    public async Task MarkCompleted_WithOutOfRangeYear_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 5,
+            Name = "Beta",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.MarkCompletedAsync(5, "actor", 2125);
+
+        Assert.Equal(ProjectLifecycleOperationStatus.ValidationFailed, result.Status);
+        Assert.Equal("Completion year must be between 1900 and 2024.", result.ErrorMessage);
+        var project = await db.Projects.SingleAsync(p => p.Id == 5);
+        Assert.Equal(ProjectLifecycleStatus.Active, project.LifecycleStatus);
+        Assert.Null(project.CompletedYear);
+        Assert.Empty(audit.Logs);
+    }
+
+    [Fact]
+    public async Task MarkCompleted_WhenAlreadyEndorsed_ReturnsInvalidStatus()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 7,
+            Name = "Gamma",
+            CreatedAt = new DateTime(2023, 5, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Completed,
+            CompletedYear = 2023,
+            CompletedOn = new DateOnly(2023, 9, 15)
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.MarkCompletedAsync(7, "actor", 2024);
+
+        Assert.Equal(ProjectLifecycleOperationStatus.InvalidStatus, result.Status);
+        Assert.Equal("Project must be active or awaiting endorsement to update completion details.", result.ErrorMessage);
+        var project = await db.Projects.SingleAsync(p => p.Id == 7);
+        Assert.Equal(2023, project.CompletedYear);
+        Assert.Equal(new DateOnly(2023, 9, 15), project.CompletedOn);
+        Assert.Empty(audit.Logs);
+    }
+
+    [Fact]
+    public async Task EndorseCompletion_WhenValid_SetsDateYearAndLogs()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 10,
+            Name = "Delta",
+            CreatedAt = new DateTime(2023, 1, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Completed,
+            CompletedYear = 2023
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.EndorseCompletionAsync(10, "actor", new DateOnly(2023, 12, 15));
+
+        Assert.True(result.IsSuccess);
+        var project = await db.Projects.SingleAsync(p => p.Id == 10);
+        Assert.Equal(new DateOnly(2023, 12, 15), project.CompletedOn);
+        Assert.Equal(2023, project.CompletedYear);
+
+        var entry = Assert.Single(audit.Logs);
+        Assert.Equal("Project.LifecycleCompletionEndorsed", entry.Action);
+        Assert.Equal("2023-12-15", entry.Data["CompletionDate"]);
+        Assert.Equal("2023", entry.Data["CompletionYear"]);
+    }
+
+    [Fact]
+    public async Task EndorseCompletion_WhenYearMissing_ReturnsInvalidStatus()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 11,
+            Name = "Epsilon",
+            CreatedAt = new DateTime(2023, 1, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Completed
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.EndorseCompletionAsync(11, "actor", new DateOnly(2023, 8, 20));
+
+        Assert.Equal(ProjectLifecycleOperationStatus.InvalidStatus, result.Status);
+        Assert.Equal("Set a completion year before endorsing an exact date.", result.ErrorMessage);
+        var project = await db.Projects.SingleAsync(p => p.Id == 11);
+        Assert.Null(project.CompletedOn);
+        Assert.Null(project.CompletedYear);
+        Assert.Empty(audit.Logs);
+    }
+
+    [Fact]
+    public async Task CancelProject_WhenActive_SetsFieldsAndLogs()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 20,
+            Name = "Zeta",
+            CreatedAt = new DateTime(2023, 6, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Active,
+            CompletedYear = 2023
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.CancelProjectAsync(20, "actor", new DateOnly(2024, 4, 2), " Budget withdrawn ");
+
+        Assert.True(result.IsSuccess);
+        var project = await db.Projects.SingleAsync(p => p.Id == 20);
+        Assert.Equal(ProjectLifecycleStatus.Cancelled, project.LifecycleStatus);
+        Assert.Equal(new DateOnly(2024, 4, 2), project.CancelledOn);
+        Assert.Equal("Budget withdrawn", project.CancelReason);
+        Assert.Null(project.CompletedYear);
+        Assert.Null(project.CompletedOn);
+
+        var entry = Assert.Single(audit.Logs);
+        Assert.Equal("Project.LifecycleCancelled", entry.Action);
+        Assert.Equal("Budget withdrawn", entry.Data["Reason"]);
+        Assert.Equal("2024-04-02", entry.Data["CancelledOn"]);
+    }
+
+    [Fact]
+    public async Task CancelProject_WithMissingReason_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 21,
+            Name = "Eta",
+            CreatedAt = new DateTime(2023, 6, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.CancelProjectAsync(21, "actor", new DateOnly(2024, 4, 2), " ");
+
+        Assert.Equal(ProjectLifecycleOperationStatus.ValidationFailed, result.Status);
+        Assert.Equal("Cancellation reason is required.", result.ErrorMessage);
+        var project = await db.Projects.SingleAsync(p => p.Id == 21);
+        Assert.Equal(ProjectLifecycleStatus.Active, project.LifecycleStatus);
+        Assert.Null(project.CancelledOn);
+        Assert.Empty(audit.Logs);
+    }
+
+    [Fact]
+    public async Task CancelProject_WithFutureDate_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 22,
+            Name = "Theta",
+            CreatedAt = new DateTime(2023, 6, 1),
+            CreatedByUserId = "creator",
+            LifecycleStatus = ProjectLifecycleStatus.Active
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var audit = new TestAuditService();
+        var service = new ProjectLifecycleService(db, audit, clock);
+
+        var result = await service.CancelProjectAsync(22, "actor", new DateOnly(2025, 1, 1), "Reason");
+
+        Assert.Equal(ProjectLifecycleOperationStatus.ValidationFailed, result.Status);
+        Assert.Equal("Cancellation date cannot be in the future.", result.ErrorMessage);
+        var project = await db.Projects.SingleAsync(p => p.Id == 22);
+        Assert.Null(project.CancelledOn);
+        Assert.Empty(audit.Logs);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; }
+    }
+
+    private sealed class TestAuditService : IAuditService
+    {
+        public List<AuditEntry> Logs { get; } = new();
+
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, HttpContext? http = null)
+        {
+            var snapshot = data is null
+                ? new Dictionary<string, string?>()
+                : data.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Logs.Add(new AuditEntry(action, userId, snapshot));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record AuditEntry(string Action, string? UserId, IDictionary<string, string?> Data);
+}

--- a/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
+++ b/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
@@ -183,7 +183,8 @@ public sealed class ProjectOverviewLifecycleTests
         var planCompare = new PlanCompareService(db);
         var userManager = CreateUserManager(db);
         var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
-        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel);
+        var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle);
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)
@@ -241,5 +242,11 @@ public sealed class ProjectOverviewLifecycleTests
         public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
         {
         }
+    }
+
+    private sealed class NoOpAuditService : IAuditService
+    {
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, HttpContext? http = null)
+            => Task.CompletedTask;
     }
 }

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -406,7 +406,8 @@ public sealed class ProjectPhotoPageTests
         var planCompare = new PlanCompareService(db);
         var userManager = CreateUserManager(db);
         var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
-        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel);
+        var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle);
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)
@@ -716,5 +717,11 @@ public sealed class ProjectPhotoPageTests
         }
 
         public DateTimeOffset UtcNow { get; }
+    }
+
+    private sealed class NoOpAuditService : IAuditService
+    {
+        public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, HttpContext? http = null)
+            => Task.CompletedTask;
     }
 }

--- a/Services/AuditEvents.cs
+++ b/Services/AuditEvents.cs
@@ -68,6 +68,41 @@ public static class Audit
             return new AuditEvent("Project.PhotoReordered", userId, data);
         }
 
+        public static AuditEvent ProjectLifecycleMarkedCompleted(int projectId, string userId, int? completionYear)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["ProjectId"] = projectId.ToString(),
+                ["CompletionYear"] = completionYear?.ToString(CultureInfo.InvariantCulture)
+            };
+
+            return new AuditEvent("Project.LifecycleCompleted", userId, data);
+        }
+
+        public static AuditEvent ProjectLifecycleCompletionEndorsed(int projectId, string userId, DateOnly completionDate, int? completionYear)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["ProjectId"] = projectId.ToString(),
+                ["CompletionDate"] = completionDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                ["CompletionYear"] = completionYear?.ToString(CultureInfo.InvariantCulture)
+            };
+
+            return new AuditEvent("Project.LifecycleCompletionEndorsed", userId, data);
+        }
+
+        public static AuditEvent ProjectLifecycleCancelled(int projectId, string userId, DateOnly cancelledOn, string reason)
+        {
+            var data = new Dictionary<string, string?>
+            {
+                ["ProjectId"] = projectId.ToString(),
+                ["CancelledOn"] = cancelledOn.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                ["Reason"] = reason
+            };
+
+            return new AuditEvent("Project.LifecycleCancelled", userId, data);
+        }
+
         public static AuditEvent ProjectDocumentRequested(int projectId, int requestId, string userId, ProjectDocumentRequestType type, int? documentId)
         {
             var data = new Dictionary<string, string?>

--- a/Services/Projects/ProjectLifecycleOperationResult.cs
+++ b/Services/Projects/ProjectLifecycleOperationResult.cs
@@ -1,0 +1,22 @@
+namespace ProjectManagement.Services.Projects;
+
+public enum ProjectLifecycleOperationStatus
+{
+    Success,
+    NotFound,
+    InvalidStatus,
+    ValidationFailed
+}
+
+public sealed record ProjectLifecycleOperationResult(ProjectLifecycleOperationStatus Status, string? ErrorMessage = null)
+{
+    public bool IsSuccess => Status == ProjectLifecycleOperationStatus.Success;
+
+    public static ProjectLifecycleOperationResult Success() => new(ProjectLifecycleOperationStatus.Success);
+
+    public static ProjectLifecycleOperationResult NotFound() => new(ProjectLifecycleOperationStatus.NotFound);
+
+    public static ProjectLifecycleOperationResult InvalidStatus(string message) => new(ProjectLifecycleOperationStatus.InvalidStatus, message);
+
+    public static ProjectLifecycleOperationResult ValidationFailed(string message) => new(ProjectLifecycleOperationStatus.ValidationFailed, message);
+}

--- a/Services/Projects/ProjectLifecycleService.cs
+++ b/Services/Projects/ProjectLifecycleService.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Utilities;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectLifecycleService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IAuditService _audit;
+    private readonly IClock _clock;
+
+    public ProjectLifecycleService(ApplicationDbContext db, IAuditService audit, IClock clock)
+    {
+        _db = db;
+        _audit = audit;
+        _clock = clock;
+    }
+
+    public async Task<ProjectLifecycleOperationResult> MarkCompletedAsync(
+        int projectId,
+        string actorUserId,
+        int? provisionalYear,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(actorUserId))
+        {
+            throw new ArgumentException("A valid user is required to update the lifecycle.", nameof(actorUserId));
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return ProjectLifecycleOperationResult.NotFound();
+        }
+
+        var canUpdateExistingCompletion = project.LifecycleStatus == ProjectLifecycleStatus.Completed && project.CompletedOn is null;
+        var isActive = project.LifecycleStatus == ProjectLifecycleStatus.Active;
+
+        if (!isActive && !canUpdateExistingCompletion)
+        {
+            return ProjectLifecycleOperationResult.InvalidStatus("Project must be active or awaiting endorsement to update completion details.");
+        }
+
+        if (provisionalYear.HasValue)
+        {
+            var year = provisionalYear.Value;
+            var todayLocal = TimeZoneInfo.ConvertTimeFromUtc(_clock.UtcNow.UtcDateTime, TimeZoneHelper.GetIst());
+            var maxYear = todayLocal.Year;
+            if (year < 1900 || year > maxYear)
+            {
+                return ProjectLifecycleOperationResult.ValidationFailed($"Completion year must be between 1900 and {maxYear}.");
+            }
+        }
+
+        project.LifecycleStatus = ProjectLifecycleStatus.Completed;
+        project.CompletedYear = provisionalYear;
+        if (isActive)
+        {
+            project.CompletedOn = null;
+        }
+        project.CancelledOn = null;
+        project.CancelReason = null;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        await Audit.Events.ProjectLifecycleMarkedCompleted(
+                project.Id,
+                actorUserId,
+                provisionalYear)
+            .WriteAsync(_audit);
+
+        return ProjectLifecycleOperationResult.Success();
+    }
+
+    public async Task<ProjectLifecycleOperationResult> EndorseCompletionAsync(
+        int projectId,
+        string actorUserId,
+        DateOnly completionDate,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(actorUserId))
+        {
+            throw new ArgumentException("A valid user is required to update the lifecycle.", nameof(actorUserId));
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return ProjectLifecycleOperationResult.NotFound();
+        }
+
+        if (project.LifecycleStatus != ProjectLifecycleStatus.Completed)
+        {
+            return ProjectLifecycleOperationResult.InvalidStatus("Only completed projects can be endorsed with a final date.");
+        }
+
+        if (!project.CompletedYear.HasValue)
+        {
+            return ProjectLifecycleOperationResult.InvalidStatus("Set a completion year before endorsing an exact date.");
+        }
+
+        var todayLocal = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(_clock.UtcNow.UtcDateTime, TimeZoneHelper.GetIst()));
+        if (completionDate > todayLocal)
+        {
+            return ProjectLifecycleOperationResult.ValidationFailed("Completion date cannot be in the future.");
+        }
+
+        project.CompletedOn = completionDate;
+        project.CompletedYear = completionDate.Year;
+        project.CancelledOn = null;
+        project.CancelReason = null;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        await Audit.Events.ProjectLifecycleCompletionEndorsed(
+                project.Id,
+                actorUserId,
+                completionDate,
+                project.CompletedYear)
+            .WriteAsync(_audit);
+
+        return ProjectLifecycleOperationResult.Success();
+    }
+
+    public async Task<ProjectLifecycleOperationResult> CancelProjectAsync(
+        int projectId,
+        string actorUserId,
+        DateOnly cancelledOn,
+        string cancelReason,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(actorUserId))
+        {
+            throw new ArgumentException("A valid user is required to update the lifecycle.", nameof(actorUserId));
+        }
+
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+        if (project is null)
+        {
+            return ProjectLifecycleOperationResult.NotFound();
+        }
+
+        if (project.LifecycleStatus == ProjectLifecycleStatus.Cancelled)
+        {
+            return ProjectLifecycleOperationResult.InvalidStatus("Project is already cancelled.");
+        }
+
+        if (project.LifecycleStatus == ProjectLifecycleStatus.Completed)
+        {
+            return ProjectLifecycleOperationResult.InvalidStatus("Completed projects cannot be cancelled.");
+        }
+
+        var todayLocal = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(_clock.UtcNow.UtcDateTime, TimeZoneHelper.GetIst()));
+        if (cancelledOn > todayLocal)
+        {
+            return ProjectLifecycleOperationResult.ValidationFailed("Cancellation date cannot be in the future.");
+        }
+
+        var trimmedReason = cancelReason?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedReason))
+        {
+            return ProjectLifecycleOperationResult.ValidationFailed("Cancellation reason is required.");
+        }
+
+        if (trimmedReason.Length > 512)
+        {
+            return ProjectLifecycleOperationResult.ValidationFailed("Cancellation reason must be 512 characters or fewer.");
+        }
+
+        project.LifecycleStatus = ProjectLifecycleStatus.Cancelled;
+        project.CancelledOn = cancelledOn;
+        project.CancelReason = trimmedReason;
+        project.CompletedOn = null;
+        project.CompletedYear = null;
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        await Audit.Events.ProjectLifecycleCancelled(
+                project.Id,
+                actorUserId,
+                cancelledOn,
+                trimmedReason)
+            .WriteAsync(_audit);
+
+        return ProjectLifecycleOperationResult.Success();
+    }
+}

--- a/ViewModels/ProjectLifecycleActionsViewModel.cs
+++ b/ViewModels/ProjectLifecycleActionsViewModel.cs
@@ -1,0 +1,27 @@
+using System;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class ProjectLifecycleActionsViewModel
+{
+    public static readonly ProjectLifecycleActionsViewModel Empty = new();
+
+    public ProjectLifecycleStatus Status { get; init; } = ProjectLifecycleStatus.Active;
+
+    public bool CanMarkCompleted { get; init; }
+
+    public bool CanEndorseCompletedDate { get; init; }
+
+    public bool CanCancel { get; init; }
+
+    public int? CompletedYear { get; init; }
+
+    public DateOnly? CompletedOn { get; init; }
+
+    public DateOnly? CancelledOn { get; init; }
+
+    public string? CancelReason { get; init; }
+
+    public bool HasActions => CanMarkCompleted || CanEndorseCompletedDate || CanCancel;
+}


### PR DESCRIPTION
## Summary
- add lifecycle action forms to the project overview so authorised users can complete, endorse, or cancel projects while persisting lifecycle fields
- introduce a lifecycle domain service with new audit events, register it in DI, and surface a view model + partial for lifecycle controls
- add unit coverage for lifecycle transitions and update existing overview/photo tests for the new dependency

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6104f822c832987d99f6bf630837d