### PR TITLE
Add Transfer of Technology management UI and service

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -484,6 +484,7 @@
             </div>
             <partial name="_ProjectGalleryCard" model="Model" />
         <div class="col-lg-4 d-flex flex-column gap-3">
+            <partial name="_ProjectTotPanel" model="Model" />
             @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
             {
                 <div class="card pm-card">

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -82,6 +82,7 @@ namespace ProjectManagement.Pages.Projects
         public ProjectDocumentSummaryViewModel DocumentSummary { get; private set; } = ProjectDocumentSummaryViewModel.Empty;
         public ProjectRemarkSummaryViewModel RemarkSummary { get; private set; } = ProjectRemarkSummaryViewModel.Empty;
         public ProjectTotSummaryViewModel TotSummary { get; private set; } = ProjectTotSummaryViewModel.Empty;
+        public bool CanManageTot { get; private set; }
 
         [BindProperty(SupportsGet = true)]
         public string? DocumentStageFilter { get; set; }
@@ -206,6 +207,8 @@ namespace ProjectManagement.Pages.Projects
                 IsAssignedProjectOfficer = isThisProjectsPo,
                 IsAssignedHoD = isThisProjectsHod
             };
+
+            CanManageTot = isAdmin || isHoD || isThisProjectsPo || isThisProjectsHod;
 
             var todayLocalDate = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(_clock.UtcNow.UtcDateTime, TimeZoneHelper.GetIst()));
 

--- a/Pages/Projects/Tot/Edit.cshtml
+++ b/Pages/Projects/Tot/Edit.cshtml
@@ -1,0 +1,100 @@
+@page "{id:int}"
+@using ProjectManagement.Models
+@model ProjectManagement.Pages.Projects.Tot.EditModel
+@{
+    var projectName = Model.Project?.Name ?? "Project";
+    ViewData["Title"] = $"Transfer of Technology · {projectName}";
+}
+
+<div class="container-xxl py-4">
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-page="/Projects/Index">Projects</a></li>
+            <li class="breadcrumb-item"><a asp-page="/Projects/Overview" asp-route-id="@Model.Project?.Id">@projectName</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Transfer of Technology</li>
+        </ol>
+    </nav>
+
+    <div class="row g-4">
+        <div class="col-lg-8">
+            <div class="card pm-card">
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-diagram-3"></i>
+                        </span>
+                        <div>
+                            <h1 class="pm-card-title h5 mb-0">Update Transfer of Technology</h1>
+                            <p class="pm-card-subtitle mb-0">Track ToT status, milestones, and remarks.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body pm-card-body">
+                    <form method="post" class="d-flex flex-column gap-3">
+                        <input asp-for="Input.ProjectId" type="hidden" />
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+                        <div>
+                            <label asp-for="Input.Status" class="form-label">Current status</label>
+                            <select asp-for="Input.Status" class="form-select" asp-items="Model.StatusOptions"></select>
+                            <span asp-validation-for="Input.Status" class="text-danger"></span>
+                        </div>
+
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label asp-for="Input.StartedOn" class="form-label">Start date</label>
+                                <input asp-for="Input.StartedOn" class="form-control" type="date" />
+                                <div class="form-text">Required when ToT is in progress or completed.</div>
+                                <span asp-validation-for="Input.StartedOn" class="text-danger"></span>
+                            </div>
+                            <div class="col-md-6">
+                                <label asp-for="Input.CompletedOn" class="form-label">Completion date</label>
+                                <input asp-for="Input.CompletedOn" class="form-control" type="date" />
+                                <div class="form-text">Required when ToT is completed.</div>
+                                <span asp-validation-for="Input.CompletedOn" class="text-danger"></span>
+                            </div>
+                        </div>
+
+                        <div>
+                            <label asp-for="Input.Remarks" class="form-label">Remarks</label>
+                            <textarea asp-for="Input.Remarks" class="form-control" rows="3" maxlength="2000"></textarea>
+                            <span asp-validation-for="Input.Remarks" class="text-danger"></span>
+                        </div>
+
+                        <div class="d-flex flex-wrap gap-2">
+                            <button type="submit" class="btn btn-primary">Save changes</button>
+                            <a class="btn btn-outline-secondary" asp-page="/Projects/Overview" asp-route-id="@Model.Project?.Id">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <div class="card pm-card">
+                <div class="card-header pm-card-header">
+                    <div class="pm-card-heading">
+                        <span class="pm-card-icon" aria-hidden="true">
+                            <i class="bi bi-info-circle"></i>
+                        </span>
+                        <div>
+                            <h2 class="pm-card-title h6 mb-0">Guidance</h2>
+                            <p class="pm-card-subtitle mb-0">Date requirements by status.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body pm-card-body">
+                    <ul class="list-unstyled mb-0 small">
+                        <li class="mb-2"><strong>Not required</strong>: Leave both dates empty.</li>
+                        <li class="mb-2"><strong>Not started</strong>: Leave both dates empty until ToT begins.</li>
+                        <li class="mb-2"><strong>In progress</strong>: Provide the start date; completion must stay empty.</li>
+                        <li><strong>Completed</strong>: Provide both start and completion dates; completion cannot be earlier than the start.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Tot/Edit.cshtml.cs
+++ b/Pages/Projects/Tot/Edit.cshtml.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.ViewModels;
+
+namespace ProjectManagement.Pages.Projects.Tot;
+
+[Authorize]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly ProjectTotService _totService;
+    private readonly ILogger<EditModel> _logger;
+
+    public EditModel(ApplicationDbContext db, UserManager<ApplicationUser> users, ProjectTotService totService, ILogger<EditModel> logger)
+    {
+        _db = db;
+        _users = users;
+        _totService = totService;
+        _logger = logger;
+    }
+
+    public Project? Project { get; private set; }
+    public ProjectRolesViewModel Roles { get; private set; } = ProjectRolesViewModel.Empty;
+    public bool CanManageTot { get; private set; }
+    public IReadOnlyList<SelectListItem> StatusOptions { get; private set; } = Array.Empty<SelectListItem>();
+
+    [BindProperty]
+    public UpdateTotInput Input { get; set; } = new();
+
+    public sealed class UpdateTotInput
+    {
+        public int ProjectId { get; set; }
+
+        public ProjectTotStatus Status { get; set; } = ProjectTotStatus.NotStarted;
+
+        public DateOnly? StartedOn { get; set; }
+
+        public DateOnly? CompletedOn { get; set; }
+
+        public string? Remarks { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    {
+        var project = await LoadProjectAsync(id, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!CanManageTot)
+        {
+            return Forbid();
+        }
+
+        Input ??= new UpdateTotInput();
+        Input.ProjectId = project.Id;
+        Input.Status = project.Tot?.Status ?? ProjectTotStatus.NotStarted;
+        Input.StartedOn = project.Tot?.StartedOn;
+        Input.CompletedOn = project.Tot?.CompletedOn;
+        Input.Remarks = project.Tot?.Remarks;
+
+        StatusOptions = BuildStatusOptions();
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken cancellationToken)
+    {
+        StatusOptions = BuildStatusOptions();
+
+        if (Input is null || Input.ProjectId != id)
+        {
+            return BadRequest();
+        }
+
+        var project = await LoadProjectAsync(id, cancellationToken);
+        if (project is null)
+        {
+            return NotFound();
+        }
+
+        if (!CanManageTot)
+        {
+            return Forbid();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var actorUserId = _users.GetUserId(User);
+        if (string.IsNullOrEmpty(actorUserId))
+        {
+            return Forbid();
+        }
+
+        var request = new ProjectTotUpdateRequest(Input.Status, Input.StartedOn, Input.CompletedOn, Input.Remarks);
+        var result = await _totService.UpdateAsync(id, request, actorUserId, cancellationToken);
+
+        if (result.Status == ProjectTotUpdateStatus.NotFound)
+        {
+            return NotFound();
+        }
+
+        if (!result.IsSuccess)
+        {
+            ModelState.AddModelError(string.Empty, result.ErrorMessage ?? "Unable to update Transfer of Technology details.");
+            return Page();
+        }
+
+        _logger.LogInformation("Project ToT updated. ProjectId={ProjectId}, UserId={UserId}, Status={Status}", id, actorUserId, Input.Status);
+        TempData["Flash"] = "Transfer of Technology details updated.";
+        return RedirectToPage("/Projects/Overview", new { id });
+    }
+
+    private async Task<Project?> LoadProjectAsync(int id, CancellationToken cancellationToken)
+    {
+        var project = await _db.Projects
+            .Include(p => p.Tot)
+            .Include(p => p.HodUser)
+            .Include(p => p.LeadPoUser)
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+        if (project is null)
+        {
+            return null;
+        }
+
+        Project = project;
+
+        var currentUserId = _users.GetUserId(User);
+        var isAdmin = User.IsInRole("Admin");
+        var isHoD = User.IsInRole("HoD");
+        var isProjectOfficer = User.IsInRole("Project Officer");
+        var isAssignedPo = isProjectOfficer && !string.IsNullOrEmpty(project.LeadPoUserId) &&
+            string.Equals(project.LeadPoUserId, currentUserId, StringComparison.Ordinal);
+        var isAssignedHoD = isHoD && !string.IsNullOrEmpty(project.HodUserId) &&
+            string.Equals(project.HodUserId, currentUserId, StringComparison.Ordinal);
+
+        Roles = new ProjectRolesViewModel
+        {
+            IsAdmin = isAdmin,
+            IsHoD = isHoD,
+            IsProjectOfficer = isProjectOfficer,
+            IsAssignedProjectOfficer = isAssignedPo,
+            IsAssignedHoD = isAssignedHoD
+        };
+
+        CanManageTot = isAdmin || isHoD || isAssignedPo || isAssignedHoD;
+
+        return project;
+    }
+
+    private static IReadOnlyList<SelectListItem> BuildStatusOptions() => new List<SelectListItem>
+    {
+        new("Not required", ProjectTotStatus.NotRequired.ToString()),
+        new("Not started", ProjectTotStatus.NotStarted.ToString()),
+        new("In progress", ProjectTotStatus.InProgress.ToString()),
+        new("Completed", ProjectTotStatus.Completed.ToString())
+    };
+}

--- a/Pages/Projects/_ProjectPostCompletion.cshtml
+++ b/Pages/Projects/_ProjectPostCompletion.cshtml
@@ -11,7 +11,6 @@
     var lifecycle = Model.LifecycleSummary;
     var media = Model.MediaSummary;
     var documentSummary = Model.DocumentSummary;
-    var tot = Model.TotSummary;
     var remarkSummary = Model.RemarkSummary;
     var roles = Model.Roles;
     var isAdmin = roles.IsAdmin;
@@ -25,15 +24,6 @@
         ProjectLifecycleStatus.Cancelled => "danger",
         _ => "secondary"
     };
-    var totVariant = !tot.HasTotRecord
-        ? "secondary"
-        : tot.Status switch
-        {
-            ProjectTotStatus.Completed => "success",
-            ProjectTotStatus.InProgress => "info",
-            ProjectTotStatus.NotRequired => "secondary",
-            _ => "secondary"
-        };
     var tabPrefix = $"project-media-{Model.Project?.Id ?? 0}";
     var photosTabId = $"{tabPrefix}-photos";
     var docsTabId = $"{tabPrefix}-documents";
@@ -167,37 +157,7 @@
         </div>
     </div>
     <div class="col-lg-4 d-flex flex-column gap-3">
-        <div class="card pm-card">
-            <div class="card-header pm-card-header">
-                <div class="pm-card-heading">
-                    <span class="pm-card-icon" aria-hidden="true">
-                        <i class="bi bi-diagram-3"></i>
-                    </span>
-                    <div>
-                        <h3 class="pm-card-title h6 mb-0">Transfer of Technology</h3>
-                        <p class="pm-card-subtitle mb-0">Status and milestones.</p>
-                    </div>
-                </div>
-                <span class="badge text-bg-@totVariant">@tot.StatusLabel</span>
-            </div>
-            <div class="card-body pm-card-body d-flex flex-column gap-2">
-                <p class="mb-0">@tot.Summary</p>
-                @if (tot.Facts.Any())
-                {
-                    <dl class="row small mb-0">
-                        @foreach (var fact in tot.Facts)
-                        {
-                            <dt class="col-sm-5">@fact.Label</dt>
-                            <dd class="col-sm-7">@fact.Value</dd>
-                        }
-                    </dl>
-                }
-                @if (!string.IsNullOrWhiteSpace(tot.Remarks))
-                {
-                    <div class="alert alert-secondary mb-0" role="status">@tot.Remarks</div>
-                }
-            </div>
-        </div>
+        <partial name="_ProjectTotPanel" model="Model" />
 
         @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
         {

--- a/Pages/Projects/_ProjectTotPanel.cshtml
+++ b/Pages/Projects/_ProjectTotPanel.cshtml
@@ -1,0 +1,64 @@
+@using System.Linq
+@using ProjectManagement.Models
+@model ProjectManagement.Pages.Projects.OverviewModel
+
+@{
+    var tot = Model.TotSummary;
+    var hasTot = tot.HasTotRecord;
+    var badgeVariant = hasTot
+        ? tot.Status switch
+        {
+            ProjectTotStatus.Completed => "success",
+            ProjectTotStatus.InProgress => "info",
+            ProjectTotStatus.NotRequired => "secondary",
+            _ => "secondary"
+        }
+        : "secondary";
+    var canManageTot = Model.CanManageTot;
+}
+
+<div class="card pm-card">
+    <div class="card-header pm-card-header">
+        <div class="pm-card-heading">
+            <span class="pm-card-icon" aria-hidden="true">
+                <i class="bi bi-diagram-3"></i>
+            </span>
+            <div>
+                <h3 class="pm-card-title h6 mb-0">Transfer of Technology</h3>
+                <p class="pm-card-subtitle mb-0">Status and milestones.</p>
+            </div>
+        </div>
+        <div class="pm-card-actions d-flex align-items-center gap-2">
+            <span class="badge text-bg-@badgeVariant">@tot.StatusLabel</span>
+            @if (canManageTot && Model.Project is { } project)
+            {
+                <a class="btn btn-sm btn-outline-secondary"
+                   asp-page="/Projects/Tot/Edit"
+                   asp-route-id="@project.Id">
+                    Update
+                </a>
+            }
+        </div>
+    </div>
+    <div class="card-body pm-card-body d-flex flex-column gap-2">
+        <p class="mb-0">@tot.Summary</p>
+        @if (tot.Facts.Any())
+        {
+            <dl class="row small mb-0">
+                @foreach (var fact in tot.Facts)
+                {
+                    <dt class="col-sm-5">@fact.Label</dt>
+                    <dd class="col-sm-7">@fact.Value</dd>
+                }
+            </dl>
+        }
+        @if (!string.IsNullOrWhiteSpace(tot.Remarks))
+        {
+            <div class="alert alert-secondary mb-0" role="status">@tot.Remarks</div>
+        }
+        @if (!hasTot)
+        {
+            <p class="text-muted small mb-0">Set up ToT tracking to capture milestones and remarks.</p>
+        }
+    </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -192,6 +192,7 @@ builder.Services.AddScoped<ProjectFactsReadService>();
 builder.Services.AddScoped<ProjectProcurementReadService>();
 builder.Services.AddScoped<ProjectTimelineReadService>();
 builder.Services.AddScoped<ProjectLifecycleService>();
+builder.Services.AddScoped<ProjectTotService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<ProjectRemarksPanelService>();
 builder.Services.AddScoped<IRemarkService, RemarkService>();

--- a/ProjectManagement.Tests/ProjectTotServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectTotServiceTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Projects;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class ProjectTotServiceTests
+{
+    [Fact]
+    public async Task UpdateAsync_WhenProjectMissing_ReturnsNotFound()
+    {
+        await using var db = CreateContext();
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            42,
+            new ProjectTotUpdateRequest(ProjectTotStatus.NotStarted, null, null, null),
+            "actor");
+
+        Assert.Equal(ProjectTotUpdateStatus.NotFound, result.Status);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenSetToNotRequired_ClearsDatesAndRemarks()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 1,
+            Name = "Alpha",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator"
+        });
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = 1,
+            Status = ProjectTotStatus.InProgress,
+            StartedOn = new DateOnly(2024, 2, 1),
+            CompletedOn = new DateOnly(2024, 3, 15),
+            Remarks = "Some note"
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            1,
+            new ProjectTotUpdateRequest(ProjectTotStatus.NotRequired, null, null, null),
+            "actor");
+
+        Assert.True(result.IsSuccess);
+        var tot = await db.ProjectTots.SingleAsync(t => t.ProjectId == 1);
+        Assert.Equal(ProjectTotStatus.NotRequired, tot.Status);
+        Assert.Null(tot.StartedOn);
+        Assert.Null(tot.CompletedOn);
+        Assert.Null(tot.Remarks);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InProgressWithoutStart_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 5,
+            Name = "Beta",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator"
+        });
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = 5,
+            Status = ProjectTotStatus.NotStarted
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            5,
+            new ProjectTotUpdateRequest(ProjectTotStatus.InProgress, null, null, null),
+            "actor");
+
+        Assert.Equal(ProjectTotUpdateStatus.ValidationFailed, result.Status);
+        Assert.Equal("Start date is required when ToT is in progress.", result.ErrorMessage);
+
+        var tot = await db.ProjectTots.SingleAsync(t => t.ProjectId == 5);
+        Assert.Equal(ProjectTotStatus.NotStarted, tot.Status);
+        Assert.Null(tot.StartedOn);
+        Assert.Null(tot.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CompletedRequiresDates_TrimsRemarks()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 7,
+            Name = "Gamma",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator"
+        });
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = 7,
+            Status = ProjectTotStatus.InProgress,
+            StartedOn = new DateOnly(2024, 2, 1)
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            7,
+            new ProjectTotUpdateRequest(
+                ProjectTotStatus.Completed,
+                new DateOnly(2024, 2, 1),
+                new DateOnly(2024, 5, 20),
+                " Completed successfully "
+            ),
+            "actor");
+
+        Assert.True(result.IsSuccess);
+        var tot = await db.ProjectTots.SingleAsync(t => t.ProjectId == 7);
+        Assert.Equal(ProjectTotStatus.Completed, tot.Status);
+        Assert.Equal(new DateOnly(2024, 2, 1), tot.StartedOn);
+        Assert.Equal(new DateOnly(2024, 5, 20), tot.CompletedOn);
+        Assert.Equal("Completed successfully", tot.Remarks);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CompletedWithFutureDate_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 11,
+            Name = "Delta",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator"
+        });
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = 11,
+            Status = ProjectTotStatus.NotStarted
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            11,
+            new ProjectTotUpdateRequest(
+                ProjectTotStatus.Completed,
+                new DateOnly(2024, 9, 1),
+                new DateOnly(2025, 1, 1),
+                null),
+            "actor");
+
+        Assert.Equal(ProjectTotUpdateStatus.ValidationFailed, result.Status);
+        Assert.Equal("Completion date cannot be in the future.", result.ErrorMessage);
+
+        var tot = await db.ProjectTots.SingleAsync(t => t.ProjectId == 11);
+        Assert.Equal(ProjectTotStatus.NotStarted, tot.Status);
+        Assert.Null(tot.StartedOn);
+        Assert.Null(tot.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CompletedWithEndBeforeStart_ReturnsValidationError()
+    {
+        await using var db = CreateContext();
+        db.Projects.Add(new Project
+        {
+            Id = 15,
+            Name = "Epsilon",
+            CreatedAt = new DateTime(2024, 1, 1),
+            CreatedByUserId = "creator"
+        });
+        db.ProjectTots.Add(new ProjectTot
+        {
+            ProjectId = 15,
+            Status = ProjectTotStatus.NotStarted
+        });
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 10, 8, 6, 0, 0, TimeSpan.Zero));
+        var service = new ProjectTotService(db, clock);
+
+        var result = await service.UpdateAsync(
+            15,
+            new ProjectTotUpdateRequest(
+                ProjectTotStatus.Completed,
+                new DateOnly(2024, 5, 10),
+                new DateOnly(2024, 5, 5),
+                null),
+            "actor");
+
+        Assert.Equal(ProjectTotUpdateStatus.ValidationFailed, result.Status);
+        Assert.Equal("Completion date cannot be earlier than the start date.", result.ErrorMessage);
+
+        var tot = await db.ProjectTots.SingleAsync(t => t.ProjectId == 15);
+        Assert.Equal(ProjectTotStatus.NotStarted, tot.Status);
+        Assert.Null(tot.StartedOn);
+        Assert.Null(tot.CompletedOn);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; }
+    }
+}

--- a/Services/Projects/ProjectTotService.cs
+++ b/Services/Projects/ProjectTotService.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services;
+using ProjectManagement.Utilities;
+
+namespace ProjectManagement.Services.Projects;
+
+public sealed class ProjectTotService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IClock _clock;
+
+    public ProjectTotService(ApplicationDbContext db, IClock clock)
+    {
+        _db = db;
+        _clock = clock;
+    }
+
+    public async Task<ProjectTotUpdateResult> UpdateAsync(
+        int projectId,
+        ProjectTotUpdateRequest request,
+        string actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(actorUserId))
+        {
+            throw new ArgumentException("A valid user is required to update Transfer of Technology details.", nameof(actorUserId));
+        }
+
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var project = await _db.Projects
+            .Include(p => p.Tot)
+            .FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken);
+
+        if (project is null)
+        {
+            return ProjectTotUpdateResult.NotFound();
+        }
+
+        var todayLocal = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(
+            _clock.UtcNow.UtcDateTime,
+            TimeZoneHelper.GetIst()));
+
+        var trimmedRemarks = string.IsNullOrWhiteSpace(request.Remarks)
+            ? null
+            : request.Remarks.Trim();
+
+        if (trimmedRemarks is { Length: > 2000 })
+        {
+            return ProjectTotUpdateResult.ValidationFailed("Remarks must be 2000 characters or fewer.");
+        }
+
+        switch (request.Status)
+        {
+            case ProjectTotStatus.NotRequired:
+            {
+                if (request.StartedOn.HasValue || request.CompletedOn.HasValue)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed(
+                        "Start and completion dates must be empty when ToT is not required.");
+                }
+                break;
+            }
+            case ProjectTotStatus.NotStarted:
+            {
+                if (request.StartedOn.HasValue || request.CompletedOn.HasValue)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed(
+                        "Start and completion dates must be empty until ToT is in progress.");
+                }
+                break;
+            }
+            case ProjectTotStatus.InProgress:
+            {
+                if (request.StartedOn is null)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Start date is required when ToT is in progress.");
+                }
+
+                if (request.StartedOn.Value > todayLocal)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Start date cannot be in the future.");
+                }
+
+                if (request.CompletedOn.HasValue)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed(
+                        "Completion date must be empty until ToT is completed.");
+                }
+
+                break;
+            }
+            case ProjectTotStatus.Completed:
+            {
+                if (request.StartedOn is null)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Start date is required when ToT is completed.");
+                }
+
+                if (request.CompletedOn is null)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Completion date is required when ToT is completed.");
+                }
+
+                if (request.CompletedOn.Value < request.StartedOn.Value)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed(
+                        "Completion date cannot be earlier than the start date.");
+                }
+
+                if (request.StartedOn.Value > todayLocal)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Start date cannot be in the future.");
+                }
+
+                if (request.CompletedOn.Value > todayLocal)
+                {
+                    return ProjectTotUpdateResult.ValidationFailed("Completion date cannot be in the future.");
+                }
+
+                break;
+            }
+            default:
+            {
+                return ProjectTotUpdateResult.ValidationFailed("Invalid ToT status specified.");
+            }
+        }
+
+        var tot = project.Tot;
+        if (tot is null)
+        {
+            tot = new ProjectTot
+            {
+                ProjectId = projectId
+            };
+            project.Tot = tot;
+            _db.ProjectTots.Add(tot);
+        }
+
+        tot.Status = request.Status;
+        tot.Remarks = trimmedRemarks;
+
+        switch (request.Status)
+        {
+            case ProjectTotStatus.NotRequired:
+            case ProjectTotStatus.NotStarted:
+                tot.StartedOn = null;
+                tot.CompletedOn = null;
+                break;
+            case ProjectTotStatus.InProgress:
+                tot.StartedOn = request.StartedOn;
+                tot.CompletedOn = null;
+                break;
+            case ProjectTotStatus.Completed:
+                tot.StartedOn = request.StartedOn;
+                tot.CompletedOn = request.CompletedOn;
+                break;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return ProjectTotUpdateResult.Success();
+    }
+}

--- a/Services/Projects/ProjectTotUpdateResult.cs
+++ b/Services/Projects/ProjectTotUpdateResult.cs
@@ -1,0 +1,29 @@
+using System;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.Projects;
+
+public enum ProjectTotUpdateStatus
+{
+    Success = 0,
+    NotFound = 1,
+    ValidationFailed = 2
+}
+
+public sealed record ProjectTotUpdateRequest(
+    ProjectTotStatus Status,
+    DateOnly? StartedOn,
+    DateOnly? CompletedOn,
+    string? Remarks);
+
+public sealed record ProjectTotUpdateResult(ProjectTotUpdateStatus Status, string? ErrorMessage = null)
+{
+    public bool IsSuccess => Status == ProjectTotUpdateStatus.Success;
+
+    public static ProjectTotUpdateResult Success() => new(ProjectTotUpdateStatus.Success);
+
+    public static ProjectTotUpdateResult NotFound() => new(ProjectTotUpdateStatus.NotFound);
+
+    public static ProjectTotUpdateResult ValidationFailed(string message) =>
+        new(ProjectTotUpdateStatus.ValidationFailed, message);
+}


### PR DESCRIPTION
## Summary
- add a shared Transfer of Technology panel to the overview page in both active and post-completion layouts
- introduce a ToT edit workflow and backend service that validates status/date transitions and persists remarks
- cover the ToT service with unit tests and register it for dependency injection

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6134bc66c8329b287e57f6d870189