### PR TITLE
Add remark scope handling across API, UI, and tests

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -867,6 +867,16 @@
                                         </div>
                                         <div class="d-flex flex-column gap-2 w-100 align-items-lg-end">
                                             <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-between justify-content-lg-end w-100" role="toolbar" aria-label="Filter remarks">
+                                                @if (Model.RemarksPanel.ScopeOptions.Count > 1)
+                                                {
+                                                    <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by scope" data-remarks-scope-group>
+                                                        <button type="button" class="btn btn-outline-primary active" data-remarks-scope="all" aria-pressed="true">All scopes</button>
+                                                        @foreach (var scope in Model.RemarksPanel.ScopeOptions)
+                                                        {
+                                                            <button type="button" class="btn btn-outline-primary" data-remarks-scope="@scope.Canonical" aria-pressed="false">@scope.Label</button>
+                                                        }
+                                                    </div>
+                                                }
                                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -978,6 +988,16 @@
                                             }
                                         </div>
                                         <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                            @if (Model.RemarksPanel.ScopeOptions.Count > 1)
+                                            {
+                                                <div class="btn-group btn-group-sm" role="group" aria-label="Remark scope" data-remarks-composer-scope>
+                                                    @foreach (var scope in Model.RemarksPanel.ScopeOptions)
+                                                    {
+                                                        var isDefaultScope = string.Equals(scope.Canonical, Model.RemarksPanel.DefaultScope, StringComparison.OrdinalIgnoreCase);
+                                                        <button type="button" class="btn btn-outline-secondary@(isDefaultScope ? " active" : string.Empty)" data-remarks-composer-scope-option="@scope.Canonical" aria-pressed="@(isDefaultScope ? "true" : "false")">@scope.Label</button>
+                                                    }
+                                                </div>
+                                            }
                                             <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
                                                 <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
                                                 @if (Model.RemarksPanel.AllowExternal)

--- a/Pages/Projects/Remarks/Index.cshtml
+++ b/Pages/Projects/Remarks/Index.cshtml
@@ -44,6 +44,16 @@
                         </div>
                         <div class="d-flex flex-column gap-2 align-items-lg-end w-100 w-lg-auto">
                             <div class="d-flex flex-wrap flex-lg-nowrap gap-2 justify-content-between justify-content-lg-end" role="toolbar" aria-label="Filter remarks">
+                                @if (Model.RemarksPanel.ScopeOptions.Count > 1)
+                                {
+                                    <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by scope" data-remarks-scope-group>
+                                        <button type="button" class="btn btn-outline-primary active" data-remarks-scope="all" aria-pressed="true">All scopes</button>
+                                        @foreach (var scope in Model.RemarksPanel.ScopeOptions)
+                                        {
+                                            <button type="button" class="btn btn-outline-primary" data-remarks-scope="@scope.Canonical" aria-pressed="false">@scope.Label</button>
+                                        }
+                                    </div>
+                                }
                                 <div class="btn-group btn-group-sm pm-remarks-filter" role="group" aria-label="Filter remarks by type" data-remarks-type-group>
                                     <button type="button" class="btn btn-outline-primary active" data-remarks-type="all" aria-pressed="true">All</button>
                                     <button type="button" class="btn btn-outline-primary" data-remarks-type="Internal" aria-pressed="false">Internal</button>
@@ -81,6 +91,16 @@
                                     }
                                 </div>
                                 <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                    @if (Model.RemarksPanel.ScopeOptions.Count > 1)
+                                    {
+                                        <div class="btn-group btn-group-sm" role="group" aria-label="Remark scope" data-remarks-composer-scope>
+                                            @foreach (var scope in Model.RemarksPanel.ScopeOptions)
+                                            {
+                                                var isDefaultScope = string.Equals(scope.Canonical, Model.RemarksPanel.DefaultScope, StringComparison.OrdinalIgnoreCase);
+                                                <button type="button" class="btn btn-outline-secondary@(isDefaultScope ? " active" : string.Empty)" data-remarks-composer-scope-option="@scope.Canonical" aria-pressed="@(isDefaultScope ? "true" : "false")">@scope.Label</button>
+                                            }
+                                        </div>
+                                    }
                                     <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
                                         <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
                                         @if (Model.RemarksPanel.AllowExternal)

--- a/Pages/Projects/_ProjectPostCompletion.cshtml
+++ b/Pages/Projects/_ProjectPostCompletion.cshtml
@@ -301,6 +301,16 @@
                                     }
                                 </div>
                                 <div class="remarks-composer-options d-flex flex-wrap align-items-center gap-2">
+                                    @if (Model.RemarksPanel.ScopeOptions.Count > 1)
+                                    {
+                                        <div class="btn-group btn-group-sm" role="group" aria-label="Remark scope" data-remarks-composer-scope>
+                                            @foreach (var scope in Model.RemarksPanel.ScopeOptions)
+                                            {
+                                                var isDefaultScope = string.Equals(scope.Canonical, Model.RemarksPanel.DefaultScope, StringComparison.OrdinalIgnoreCase);
+                                                <button type="button" class="btn btn-outline-secondary@(isDefaultScope ? " active" : string.Empty)" data-remarks-composer-scope-option="@scope.Canonical" aria-pressed="@(isDefaultScope ? "true" : "false")">@scope.Label</button>
+                                            }
+                                        </div>
+                                    }
                                     <div class="btn-group btn-group-sm" role="group" aria-label="Remark audience" data-remarks-composer-type>
                                         <button type="button" class="btn btn-outline-secondary active" data-remarks-composer-option="Internal" aria-pressed="true">Internal</button>
                                         @if (Model.RemarksPanel.AllowExternal)

--- a/ProjectManagement.Tests/RemarkApiTests.cs
+++ b/ProjectManagement.Tests/RemarkApiTests.cs
@@ -83,6 +83,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "<b>Hello</b>",
             eventDate = new DateOnly(2024, 10, 1),
             stageRef = StageCodes.FS
@@ -93,6 +94,7 @@ public class RemarkApiTests
         Assert.NotNull(created);
         Assert.Equal("user-po", created!.AuthorUserId);
         Assert.Equal("<b>Hello</b>", created.Body);
+        Assert.Equal(RemarkScope.General, created.Scope);
         Assert.False(string.IsNullOrWhiteSpace(created.RowVersion));
 
         var list = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks", SerializerOptions);
@@ -101,6 +103,7 @@ public class RemarkApiTests
         Assert.Single(list.Items);
         Assert.Equal("user-po", list.Items[0].AuthorUserId);
         Assert.Equal("<b>Hello</b>", list.Items[0].Body);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
     }
 
     [Fact]
@@ -115,6 +118,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Ping @[Mention Target](user:mention-user)",
             eventDate = new DateOnly(2024, 9, 15),
             stageRef = StageCodes.FS
@@ -126,6 +130,7 @@ public class RemarkApiTests
         Assert.Contains("remark-mention", created!.Body, StringComparison.Ordinal);
         Assert.Single(created.Mentions);
         Assert.Equal("mention-user", created.Mentions[0].Id);
+        Assert.Equal(RemarkScope.General, created.Scope);
 
         var list = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks", SerializerOptions);
         Assert.NotNull(list);
@@ -133,6 +138,7 @@ public class RemarkApiTests
         Assert.Single(list.Items[0].Mentions);
         Assert.Equal("mention-user", list.Items[0].Mentions[0].Id);
         Assert.Equal("Mention Target", list.Items[0].Mentions[0].DisplayName);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
     }
 
     [Fact]
@@ -148,6 +154,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Fallback PO remark",
             eventDate = today,
             stageRef = StageCodes.FS
@@ -158,6 +165,7 @@ public class RemarkApiTests
         Assert.NotNull(created);
         Assert.Equal("po-fallback", created!.AuthorUserId);
         Assert.Equal(RemarkActorRole.ProjectOfficer, created.AuthorRole);
+        Assert.Equal(RemarkScope.General, created.Scope);
 
         var list = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks", SerializerOptions);
         Assert.NotNull(list);
@@ -165,6 +173,7 @@ public class RemarkApiTests
         Assert.Single(list.Items);
         Assert.Equal("po-fallback", list.Items[0].AuthorUserId);
         Assert.Equal(RemarkActorRole.ProjectOfficer, list.Items[0].AuthorRole);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
     }
 
     [Fact]
@@ -180,6 +189,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Fallback HoD remark",
             eventDate = today,
             stageRef = StageCodes.FS,
@@ -191,6 +201,7 @@ public class RemarkApiTests
         Assert.NotNull(created);
         Assert.Equal("hod-fallback", created!.AuthorUserId);
         Assert.Equal(RemarkActorRole.HeadOfDepartment, created.AuthorRole);
+        Assert.Equal(RemarkScope.General, created.Scope);
 
         var list = await client.GetFromJsonAsync<RemarkListResponseDto>(
             $"/api/projects/{projectId}/remarks?actorRole={Uri.EscapeDataString(RemarkActorRole.HeadOfDepartment.ToString())}",
@@ -200,6 +211,7 @@ public class RemarkApiTests
         Assert.Single(list.Items);
         Assert.Equal(RemarkActorRole.HeadOfDepartment, list.Items[0].AuthorRole);
         Assert.Equal("hod-fallback", list.Items[0].AuthorUserId);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
     }
 
     [Fact]
@@ -214,6 +226,7 @@ public class RemarkApiTests
         var createResponse = await authorClient.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Author remark",
             eventDate = new DateOnly(2024, 10, 3),
             stageRef = StageCodes.FS
@@ -236,6 +249,7 @@ public class RemarkApiTests
         Assert.Equal(1, list!.Total);
         Assert.Single(list.Items);
         Assert.Equal("author-owner", list.Items[0].AuthorUserId);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
     }
 
     [Fact]
@@ -250,6 +264,7 @@ public class RemarkApiTests
         var createResponse = await authorClient.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Seed remark",
             eventDate = new DateOnly(2024, 10, 4),
             stageRef = StageCodes.FS
@@ -269,6 +284,7 @@ public class RemarkApiTests
         var createAttempt = await viewerClient.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Viewer attempt",
             eventDate = new DateOnly(2024, 10, 4),
             stageRef = StageCodes.FS
@@ -282,6 +298,7 @@ public class RemarkApiTests
         var editAttempt = await viewerClient.PutAsJsonAsync($"/api/projects/{projectId}/remarks/{created!.Id}", new
         {
             body = "Edited body",
+            scope = RemarkScope.General,
             eventDate = created.EventDate,
             stageRef = created.StageRef,
             rowVersion = created.RowVersion
@@ -304,6 +321,7 @@ public class RemarkApiTests
         var create = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Initial",
             eventDate = DateOnly.FromDateTime(DateTime.UtcNow.Date),
             stageRef = StageCodes.FS
@@ -319,6 +337,7 @@ public class RemarkApiTests
         var update = await client.PutAsJsonAsync($"/api/projects/{projectId}/remarks/{created.Id}", new
         {
             body = "Updated",
+            scope = RemarkScope.General,
             eventDate = DateOnly.FromDateTime(DateTime.UtcNow.Date),
             stageRef = StageCodes.FS,
             rowVersion,
@@ -342,6 +361,7 @@ public class RemarkApiTests
         var create = await authorClient.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = "Body",
             eventDate = new DateOnly(2024, 9, 30),
             stageRef = StageCodes.FS
@@ -383,6 +403,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = remarkBody,
             eventDate = today,
             stageRef = StageCodes.FS,
@@ -394,16 +415,19 @@ public class RemarkApiTests
         Assert.NotNull(created);
         Assert.Equal(userId, created!.AuthorUserId);
         Assert.Equal(remarkBody, created.Body);
+        Assert.Equal(RemarkScope.General, created.Scope);
 
         var list = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks?actorRole={Uri.EscapeDataString(canonicalRole)}", SerializerOptions);
         Assert.NotNull(list);
         Assert.Equal(1, list!.Total);
         Assert.Single(list.Items);
         Assert.Equal(created.Id, list.Items[0].Id);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
 
         var updateResponse = await client.PutAsJsonAsync($"/api/projects/{projectId}/remarks/{created.Id}", new
         {
             body = $"Updated remark for {canonicalRole}",
+            scope = RemarkScope.General,
             eventDate = today,
             stageRef = StageCodes.FS,
             rowVersion = created.RowVersion,
@@ -414,6 +438,7 @@ public class RemarkApiTests
         var updated = await updateResponse.Content.ReadFromJsonAsync<RemarkResponseDto>(SerializerOptions);
         Assert.NotNull(updated);
         Assert.Equal($"Updated remark for {canonicalRole}", updated!.Body);
+        Assert.Equal(RemarkScope.General, updated.Scope);
 
         var deleteRequest = new
         {
@@ -451,6 +476,7 @@ public class RemarkApiTests
         var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = targetBody,
             eventDate = today,
             stageRef = StageCodes.FS,
@@ -462,6 +488,7 @@ public class RemarkApiTests
         var otherResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
         {
             type = RemarkType.Internal,
+            scope = RemarkScope.General,
             body = otherBody,
             eventDate = today,
             stageRef = StageCodes.FS,
@@ -479,6 +506,60 @@ public class RemarkApiTests
         Assert.Single(list.Items);
         Assert.Equal(targetBody, list.Items[0].Body);
         Assert.Equal(expectedRole, list.Items[0].AuthorRole);
+        Assert.Equal(RemarkScope.General, list.Items[0].Scope);
+    }
+
+    [Fact]
+    public async Task ListRemarks_FilterByScope_Succeeds()
+    {
+        using var factory = new RemarkApiFactory();
+        var projectId = 9900;
+        var client = await CreateClientForUserAsync(factory, "scope-po", "Scope Tester", "Project Officer");
+        await SeedProjectAsync(factory, projectId, leadPoUserId: "scope-po");
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+        var totResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
+        {
+            type = RemarkType.Internal,
+            scope = RemarkScope.TransferOfTechnology,
+            body = "ToT remark",
+            eventDate = today,
+            stageRef = StageCodes.FS
+        });
+
+        Assert.Equal(HttpStatusCode.Created, totResponse.StatusCode);
+        var totCreated = await totResponse.Content.ReadFromJsonAsync<RemarkResponseDto>(SerializerOptions);
+        Assert.NotNull(totCreated);
+        Assert.Equal(RemarkScope.TransferOfTechnology, totCreated!.Scope);
+
+        var generalResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
+        {
+            type = RemarkType.Internal,
+            scope = RemarkScope.General,
+            body = "General remark",
+            eventDate = today,
+            stageRef = StageCodes.FS
+        });
+
+        Assert.Equal(HttpStatusCode.Created, generalResponse.StatusCode);
+        var generalCreated = await generalResponse.Content.ReadFromJsonAsync<RemarkResponseDto>(SerializerOptions);
+        Assert.NotNull(generalCreated);
+        Assert.Equal(RemarkScope.General, generalCreated!.Scope);
+
+        var totList = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks?scope=tot", SerializerOptions);
+        Assert.NotNull(totList);
+        Assert.Equal(1, totList!.Total);
+        Assert.Single(totList.Items);
+        Assert.Equal("ToT remark", totList.Items[0].Body);
+        Assert.Equal(RemarkScope.TransferOfTechnology, totList.Items[0].Scope);
+
+        var generalList = await client.GetFromJsonAsync<RemarkListResponseDto>($"/api/projects/{projectId}/remarks?scope=General", SerializerOptions);
+        Assert.NotNull(generalList);
+        Assert.Equal(1, generalList!.Total);
+        Assert.Single(generalList.Items);
+        Assert.Equal("General remark", generalList.Items[0].Body);
+        Assert.Equal(RemarkScope.General, generalList.Items[0].Scope);
     }
 
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
@@ -628,6 +709,7 @@ public class RemarkApiTests
         public int Id { get; init; }
         public int ProjectId { get; init; }
         public RemarkType Type { get; init; }
+        public RemarkScope Scope { get; init; }
         public RemarkActorRole AuthorRole { get; init; }
         public string AuthorUserId { get; init; } = string.Empty;
         public string AuthorDisplayName { get; init; } = string.Empty;

--- a/Services/Projects/ProjectRemarksPanelService.cs
+++ b/Services/Projects/ProjectRemarksPanelService.cs
@@ -59,6 +59,19 @@ public sealed class ProjectRemarksPanelService
             })
             .ToList();
 
+        var scopeOptions = new List<ProjectRemarksPanelViewModel.RemarkScopeOption>
+        {
+            new(RemarkScope.General.ToString(), "General", RemarkScope.General.ToString())
+        };
+
+        if (project.Tot is not null)
+        {
+            scopeOptions.Add(new ProjectRemarksPanelViewModel.RemarkScopeOption(
+                RemarkScope.TransferOfTechnology.ToString(),
+                "ToT",
+                RemarkScope.TransferOfTechnology.ToString()));
+        }
+
         var today = DateOnly.FromDateTime(IstClock.ToIst(_clock.UtcNow.UtcDateTime))
             .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
@@ -70,6 +83,8 @@ public sealed class ProjectRemarksPanelService
                 ProjectId = project.Id,
                 StageOptions = stageOptions,
                 RoleOptions = roleOptions,
+                ScopeOptions = scopeOptions,
+                DefaultScope = RemarkScope.General.ToString(),
                 Today = today
             };
         }
@@ -137,6 +152,8 @@ public sealed class ProjectRemarksPanelService
             ActorHasOverride = canOverride,
             StageOptions = stageOptions,
             RoleOptions = roleOptions,
+            ScopeOptions = scopeOptions,
+            DefaultScope = RemarkScope.General.ToString(),
             Today = today,
             ViewerOnly = viewerOnly
         };

--- a/Services/Remarks/IRemarkService.cs
+++ b/Services/Remarks/IRemarkService.cs
@@ -29,6 +29,7 @@ public sealed record CreateRemarkRequest(
     int ProjectId,
     RemarkActorContext Actor,
     RemarkType Type,
+    RemarkScope Scope,
     string Body,
     DateOnly EventDate,
     string? StageRef,
@@ -39,6 +40,7 @@ public sealed record ListRemarksRequest(
     int ProjectId,
     RemarkActorContext Actor,
     RemarkType? Type = null,
+    RemarkScope? Scope = null,
     RemarkActorRole? AuthorRole = null,
     string? StageRef = null,
     DateOnly? FromDate = null,
@@ -53,6 +55,7 @@ public sealed record RemarkListResult(int TotalCount, IReadOnlyList<Remark> Item
 public sealed record EditRemarkRequest(
     RemarkActorContext Actor,
     string Body,
+    RemarkScope Scope,
     DateOnly EventDate,
     string? StageRef,
     string? StageNameSnapshot,

--- a/Services/Remarks/RemarkService.cs
+++ b/Services/Remarks/RemarkService.cs
@@ -90,6 +90,7 @@ public sealed class RemarkService : IRemarkService
             AuthorUserId = request.Actor.UserId,
             AuthorRole = request.Actor.ActorRole,
             Type = request.Type,
+            Scope = request.Scope,
             Body = processedBody.Body,
             EventDate = request.EventDate,
             StageRef = stage.StageRef,
@@ -152,6 +153,11 @@ public sealed class RemarkService : IRemarkService
         if (request.AuthorRole.HasValue)
         {
             query = query.Where(r => r.AuthorRole == request.AuthorRole.Value);
+        }
+
+        if (request.Scope.HasValue)
+        {
+            query = query.Where(r => r.Scope == request.Scope.Value);
         }
 
         if (!string.IsNullOrWhiteSpace(request.StageRef))
@@ -227,6 +233,7 @@ public sealed class RemarkService : IRemarkService
         var stage = await NormalizeStageAsync(remark.ProjectId, request.StageRef, request.StageNameSnapshot, cancellationToken);
 
         remark.Body = processedBody.Body;
+        remark.Scope = request.Scope;
         remark.EventDate = request.EventDate;
         remark.StageRef = stage.StageRef;
         remark.StageNameSnapshot = stage.StageNameSnapshot;
@@ -647,6 +654,7 @@ public sealed class RemarkService : IRemarkService
             RemarkId = remark.Id,
             Action = action,
             SnapshotType = remark.Type,
+            SnapshotScope = remark.Scope,
             SnapshotAuthorRole = remark.AuthorRole,
             SnapshotAuthorUserId = remark.AuthorUserId,
             SnapshotEventDate = remark.EventDate,

--- a/ViewModels/ProjectRemarksPanelViewModel.cs
+++ b/ViewModels/ProjectRemarksPanelViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ProjectManagement.Infrastructure;
+using ProjectManagement.Models.Remarks;
 
 namespace ProjectManagement.ViewModels;
 
@@ -38,11 +39,17 @@ public sealed class ProjectRemarksPanelViewModel
 
     public string TimeZone { get; init; } = "Asia/Kolkata";
 
+    public string DefaultScope { get; init; } = RemarkScope.General.ToString();
+
     public IReadOnlyList<RemarkRoleOption> RoleOptions { get; init; } = Array.Empty<RemarkRoleOption>();
 
     public IReadOnlyList<RemarkStageOption> StageOptions { get; init; } = Array.Empty<RemarkStageOption>();
 
+    public IReadOnlyList<RemarkScopeOption> ScopeOptions { get; init; } = Array.Empty<RemarkScopeOption>();
+
     public sealed record RemarkRoleOption(string Value, string Label, string Canonical);
 
     public sealed record RemarkStageOption(string Value, string Label);
+
+    public sealed record RemarkScopeOption(string Value, string Label, string Canonical);
 }

--- a/wwwroot/js/projects/remarks-panel.test.js
+++ b/wwwroot/js/projects/remarks-panel.test.js
@@ -39,6 +39,7 @@ function makeRemark(overrides = {}) {
         authorDisplayName: 'Alice Bob',
         authorUserId: 'user-123',
         type: 'Internal',
+        scope: 'General',
         body: '<p>Test remark</p>',
         eventDate: null,
         stageRef: null,
@@ -100,6 +101,7 @@ test('saveEdit serializes mentions using the stored mapping', async () => {
         id: 1,
         projectId: 1,
         type: 'Internal',
+        scope: 'General',
         authorRole: '',
         authorUserId: 'author-1',
         authorDisplayName: 'Author One',
@@ -170,6 +172,7 @@ test('saveEdit serializes mentions using the stored mapping', async () => {
 
     assert.ok(requestBody);
     assert.equal(requestBody.body, '@[John Doe](user:user-1)');
+    assert.equal(requestBody.scope, 'General');
 });
 
 test('buildRemarkElement applies role accent classes for canonical roles', () => {


### PR DESCRIPTION
## Summary
- add scope propagation to remark API contracts and service queries, including request parsing and audit snapshots
- expose scope options/defaults in remarks panel view model and razor views so users can compose/filter general vs ToT remarks
- extend client scripts and automated tests to submit, render, and verify scope-aware behaviour, plus cover new ToT scenarios in service/API tests

## Testing
- npm test
- dotnet test *(fails: `dotnet: command not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e623849aa883299c14532d7a636303