### PR TITLE
Refactor gallery lightbox payload handling

### DIFF
--- a/Pages/Shared/_ProjectPhotoLightbox.cshtml
+++ b/Pages/Shared/_ProjectPhotoLightbox.cshtml
@@ -1,4 +1,5 @@
 @using System.Linq
+@using System.Text
 @using System.Text.Encodings.Web
 @using System.Text.Json
 @using ProjectManagement.Models
@@ -57,6 +58,7 @@
         .ToList();
 
     var json = JsonSerializer.Serialize(payload, options);
+    var payloadBase64 = System.Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
 }
 
 <div class="modal fade project-gallery-modal" id="@modalId" tabindex="-1" aria-labelledby="@labelId" aria-describedby="@captionId" aria-hidden="true" data-gallery-modal>
@@ -90,7 +92,7 @@
                         </div>
                     </div>
                 </div>
-                <script type="application/json" data-gallery-data>@Html.Raw(json)</script>
+                <div data-gallery-data data-gallery-payload="@payloadBase64" hidden></div>
             </div>
         </div>
     </div>

--- a/wwwroot/js/gallery-lightbox.js
+++ b/wwwroot/js/gallery-lightbox.js
@@ -15,9 +15,31 @@ function initGallery(gallery) {
     return;
   }
 
+  let payloadText = '';
+
+  if (dataEl instanceof HTMLTemplateElement) {
+    payloadText = dataEl.innerHTML ?? '';
+  } else if (dataEl.hasAttribute('data-gallery-payload')) {
+    const encodedPayload = dataEl.getAttribute('data-gallery-payload') ?? '';
+    if (encodedPayload) {
+      try {
+        payloadText = window.atob(encodedPayload);
+      } catch (error) {
+        console.error('Failed to decode gallery data', error);
+        return;
+      }
+    }
+  } else {
+    payloadText = dataEl.textContent ?? '';
+  }
+
+  const jsonText = typeof payloadText === 'string' && payloadText.trim().length > 0
+    ? payloadText
+    : '[]';
+
   let photos = [];
   try {
-    photos = JSON.parse(dataEl.textContent ?? '[]');
+    photos = JSON.parse(jsonText);
   } catch (error) {
     console.error('Failed to parse gallery data', error);
     return;


### PR DESCRIPTION
## Summary
- expose the gallery lightbox payload as a Base64-encoded data attribute so the modal markup no longer needs an inline script tag
- update the gallery lightbox JavaScript to decode payloads from data attributes while retaining support for template/text sources

## Testing
- npm test
- npm run lint:views *(fails: existing inline style guardrail violations)*
- rg '<script' Pages/Shared/_ProjectPhotoLightbox.cshtml -n

------
https://chatgpt.com/codex/tasks/task_e_68e63d0585588329bb837a8a476a8f7f