### PR TITLE
Refactor project media tabs script into module

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -1098,6 +1098,7 @@
 
 @section Scripts {
     <script type="module" src="~/js/gallery-lightbox.js" asp-append-version="true"></script>
+    <script type="module" src="~/js/pages/projects/media-tabs.js" asp-append-version="true"></script>
     <script src="~/js/projects/remarks-panel.js" asp-append-version="true"></script>
     <script src="~/js/projects/overview.js" asp-append-version="true"></script>
     <script src="~/js/projects/plan-edit.js" asp-append-version="true"></script>

--- a/Pages/Projects/_ProjectMediaTabs.cshtml
+++ b/Pages/Projects/_ProjectMediaTabs.cshtml
@@ -513,30 +513,3 @@
     </div>
 </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        var tabButtons = document.querySelectorAll('[data-media-tab-button]');
-        if (!tabButtons || tabButtons.length === 0) {
-            return;
-        }
-        var filterForm = document.querySelector('[data-media-filter-form]');
-        if (!filterForm) {
-            return;
-        }
-        var tabInput = filterForm.querySelector('[data-media-tab-input]');
-        tabButtons.forEach(function (button) {
-            button.addEventListener('shown.bs.tab', function (event) {
-                if (!tabInput) {
-                    return;
-                }
-                var target = event.target;
-                if (target && target.getAttribute) {
-                    var key = target.getAttribute('data-media-tab');
-                    if (key) {
-                        tabInput.value = key;
-                    }
-                }
-            });
-        });
-    });
-</script>

--- a/wwwroot/js/pages/projects/media-tabs.js
+++ b/wwwroot/js/pages/projects/media-tabs.js
@@ -1,0 +1,36 @@
+function initMediaTabs() {
+    const tabButtons = document.querySelectorAll('[data-media-tab-button]');
+    if (!tabButtons || tabButtons.length === 0) {
+        return;
+    }
+
+    const filterForm = document.querySelector('[data-media-filter-form]');
+    if (!filterForm) {
+        return;
+    }
+
+    const tabInput = filterForm.querySelector('[data-media-tab-input]');
+    if (!tabInput) {
+        return;
+    }
+
+    tabButtons.forEach((button) => {
+        button.addEventListener('shown.bs.tab', (event) => {
+            const target = event.target;
+            if (!target || typeof target.getAttribute !== 'function') {
+                return;
+            }
+
+            const key = target.getAttribute('data-media-tab');
+            if (key) {
+                tabInput.value = key;
+            }
+        });
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMediaTabs);
+} else {
+    initMediaTabs();
+}


### PR DESCRIPTION
## Summary
- move the project media tab handling logic into a dedicated ES module under wwwroot/js/pages/projects/media-tabs.js
- load the new module from the Project Overview page instead of relying on the inline script

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65a6caa9883298f65e951d5a5b390