### PR TITLE
Fix tests for media and overview updates

### DIFF
--- a/ProjectManagement.Tests/ProjectMediaAggregatorTests.cs
+++ b/ProjectManagement.Tests/ProjectMediaAggregatorTests.cs
@@ -203,7 +203,7 @@ public sealed class ProjectMediaAggregatorTests
     private static ProjectDocumentRowViewModel CreateDocumentRow(int id, string title, int? totId)
     {
         return new ProjectDocumentRowViewModel(
-            stageCode: "exe",
+            StageCode: "exe",
             StageDisplayName: "Execution",
             DocumentId: id,
             RequestId: null,

--- a/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
+++ b/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
@@ -8,7 +8,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -300,7 +303,8 @@ public sealed class ProjectOverviewLifecycleTests
         var userManager = CreateUserManager(db);
         var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
         var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
-        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle);
+        var mediaAggregator = new ProjectMediaAggregator();
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator);
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)
@@ -376,5 +380,15 @@ public sealed class ProjectOverviewLifecycleTests
     {
         public Task LogAsync(string action, string? message = null, string level = "Info", string? userId = null, string? userName = null, IDictionary<string, string?>? data = null, HttpContext? http = null)
             => Task.CompletedTask;
+    }
+
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTimeOffset now)
+        {
+            UtcNow = now;
+        }
+
+        public DateTimeOffset UtcNow { get; }
     }
 }

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -129,7 +129,7 @@ public sealed class ProjectPhotoPageTests
             var photoService = new ProjectPhotoService(db, clock, new RecordingAudit(), optionsWrapper, uploadRoot, NullLogger<ProjectPhotoService>.Instance);
 
             await using var stream = await CreateImageStreamAsync(1600, 1200);
-            var added = await photoService.AddAsync(6, stream, "cover.png", "image/png", "creator", true, "Cover", CancellationToken.None);
+            var added = await photoService.AddAsync(6, stream, "cover.png", "image/png", "creator", true, "Cover", totId: null, cancellationToken: CancellationToken.None);
 
             var overview = CreateOverviewPage(db, clock);
             ConfigurePageContext(overview);


### PR DESCRIPTION
## Summary
- update overview lifecycle tests to use the new media aggregator dependency and provide a local fixed clock helper
- update project media aggregator tests for the renamed StageCode parameter
- adjust photo page tests to pass the new totId argument when adding photos

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65d6b2a1c83299751e1ca289551a9