### PR TITLE
Fix test helpers after media aggregator changes

### DIFF
--- a/ProjectManagement.Tests/ProjectMediaAggregatorTests.cs
+++ b/ProjectManagement.Tests/ProjectMediaAggregatorTests.cs
@@ -56,7 +56,7 @@ public sealed class ProjectMediaAggregatorTests
 
         // Assert
         var documentTab = result.Tabs.Single(t => t.Key == ProjectMediaTabViewModel.DocumentsKey).Documents!;
-        Assert.Equal(new[] { 1, 2 }, documentTab.Groups.Single().Items.Select(i => i.Row.DocumentId));
+        Assert.Equal(new int?[] { 1, 2 }, documentTab.Groups.Single().Items.Select(i => i.Row.DocumentId));
 
         var photoTab = result.Tabs.Single(t => t.Key == ProjectMediaTabViewModel.PhotosKey).Photos!;
         Assert.Equal(new[] { 4, 3, 5 }, photoTab.PreviewTiles.Select(t => t.Photo.Id));

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -407,7 +407,8 @@ public sealed class ProjectPhotoPageTests
         var userManager = CreateUserManager(db);
         var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
         var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
-        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle);
+        var mediaAggregator = new ProjectMediaAggregator();
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator);
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)
@@ -666,53 +667,6 @@ public sealed class ProjectPhotoPageTests
         public ClaimsPrincipal User { get; }
 
         public string? UserId { get; }
-    }
-
-    private sealed class SimpleUrlHelper : IUrlHelper
-    {
-        public SimpleUrlHelper(ActionContext context)
-        {
-            ActionContext = context;
-        }
-
-        public ActionContext ActionContext { get; }
-
-        public string? Action(UrlActionContext actionContext) => throw new NotImplementedException();
-
-        public string? Content(string? contentPath) => contentPath;
-
-        public bool IsLocalUrl(string? url) => true;
-
-        public string? Link(string? routeName, object? values) => throw new NotImplementedException();
-
-        public string? RouteUrl(UrlRouteContext routeContext) => throw new NotImplementedException();
-
-        public string? RouteUrl(string? routeName, object? values, string? protocol, string? host, string? fragment) => throw new NotImplementedException();
-
-        public string? RouteUrl(string? routeName, object? values) => throw new NotImplementedException();
-
-        public string? RouteUrl(string? routeName, object? values, string? protocol, string? host) => throw new NotImplementedException();
-
-        public string? Page(string? pageName, string? pageHandler, object? values, string? protocol, string? host, string? fragment)
-        {
-            return $"/Pages{pageName}?{values}";
-        }
-
-        public string? Page(string? pageName, string? pageHandler, object? values, string? protocol) => throw new NotImplementedException();
-
-        public string? Page(string? pageName, string? pageHandler, object? values) => throw new NotImplementedException();
-
-        public string? Page(string? pageName, string? pageHandler, object? values, string? protocol, string? host) => throw new NotImplementedException();
-
-        public string? Page(string? pageName, object? values) => Page(pageName, null, values, null, null, null);
-
-        public string? RouteUrl(string? routeName, object? values, string? protocol) => throw new NotImplementedException();
-
-        public string? Action(string? action, string? controller, object? values, string? protocol, string? host, string? fragment) => throw new NotImplementedException();
-
-        public string? Action(string? action, string? controller, object? values) => throw new NotImplementedException();
-
-        public string? Action(string? action, string? controller, object? values, string? protocol) => throw new NotImplementedException();
     }
 
     private sealed class FixedClock : IClock

--- a/ProjectManagement.Tests/SimpleUrlHelper.cs
+++ b/ProjectManagement.Tests/SimpleUrlHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace ProjectManagement.Tests;
+
+internal sealed class SimpleUrlHelper : IUrlHelper
+{
+    public SimpleUrlHelper(ActionContext context)
+    {
+        ActionContext = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public ActionContext ActionContext { get; }
+
+    public string? Action(UrlActionContext actionContext) => throw new NotImplementedException();
+
+    public string? Action(string? action, string? controller, object? values, string? protocol, string? host, string? fragment)
+        => throw new NotImplementedException();
+
+    public string? Action(string? action, string? controller, object? values, string? protocol)
+        => throw new NotImplementedException();
+
+    public string? Action(string? action, string? controller, object? values)
+        => throw new NotImplementedException();
+
+    public string? Action(string? action, string? controller)
+        => throw new NotImplementedException();
+
+    public string? Content(string? contentPath) => contentPath;
+
+    public bool IsLocalUrl(string? url) => true;
+
+    public string? Link(string? routeName, object? values) => throw new NotImplementedException();
+
+    public string? RouteUrl(UrlRouteContext routeContext) => throw new NotImplementedException();
+
+    public string? RouteUrl(string? routeName, object? values, string? protocol, string? host, string? fragment)
+        => throw new NotImplementedException();
+
+    public string? RouteUrl(string? routeName, object? values, string? protocol, string? host)
+        => throw new NotImplementedException();
+
+    public string? RouteUrl(string? routeName, object? values, string? protocol)
+        => throw new NotImplementedException();
+
+    public string? RouteUrl(string? routeName, object? values)
+        => throw new NotImplementedException();
+
+    public string? Page(string? pageName, string? pageHandler, object? values, string? protocol, string? host, string? fragment)
+        => $"/Pages{pageName}?{values}";
+
+    public string? Page(string? pageName, string? pageHandler, object? values, string? protocol)
+        => throw new NotImplementedException();
+
+    public string? Page(string? pageName, string? pageHandler, object? values)
+        => throw new NotImplementedException();
+
+    public string? Page(string? pageName, string? pageHandler)
+        => throw new NotImplementedException();
+
+    public string? Page(string? pageName, object? values)
+        => Page(pageName, null, values, null, null, null);
+}


### PR DESCRIPTION
## Summary
- add a reusable SimpleUrlHelper for tests and update photo page tests to consume it
- fix project media aggregator tests to compare nullable document IDs
- update overview page test setup to provide the media aggregator dependency

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e65eae31f08329a7edc5f003220512