### PR TITLE
Fix TotId mapping in ProjectDocumentRequest migration metadata

### DIFF
--- a/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.Designer.cs
+++ b/Migrations/20251008034359_20251015120000_AddProjectLifecycleAndTot.Designer.cs
@@ -1629,6 +1629,9 @@ namespace ProjectManagement.Migrations
                     b.Property<int?>("StageId")
                         .HasColumnType("integer");
 
+                    b.Property<int?>("TotId")
+                        .HasColumnType("integer");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .ValueGeneratedOnAdd()

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1629,6 +1629,9 @@ namespace ProjectManagement.Migrations
                     b.Property<int?>("StageId")
                         .HasColumnType("integer");
 
+                    b.Property<int?>("TotId")
+                        .HasColumnType("integer");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .ValueGeneratedOnAdd()


### PR DESCRIPTION
## Summary
- add the missing TotId property mapping to the ProjectDocumentRequest model in the AddProjectLifecycleAndTot migration snapshot
- keep the ApplicationDbContext model snapshot in sync so EF Core can build the model when applying migrations

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6633bd3e883298d70d01f8385ad56