### PR TITLE
Ensure ProjectDocumentRequest snapshot includes TotId

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1629,9 +1629,6 @@ namespace ProjectManagement.Migrations
                     b.Property<int?>("StageId")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("TotId")
-                        .HasColumnType("integer");
-
                     b.Property<string>("Status")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
@@ -1648,6 +1645,9 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
+                    b.Property<int?>("TotId")
+                        .HasColumnType("integer");
+
                     b.HasKey("Id");
 
                     b.HasIndex("DocumentId")
@@ -1657,6 +1657,8 @@ namespace ProjectManagement.Migrations
 
                     b.HasIndex("ProjectId");
 
+                    b.HasIndex("ProjectId", "Status");
+
                     b.HasIndex("ProjectId", "TotId");
 
                     b.HasIndex("RequestedByUserId");
@@ -1664,8 +1666,6 @@ namespace ProjectManagement.Migrations
                     b.HasIndex("ReviewedByUserId");
 
                     b.HasIndex("StageId");
-
-                    b.HasIndex("ProjectId", "Status");
 
                     b.ToTable("ProjectDocumentRequests");
                 });


### PR DESCRIPTION
## Summary
- refresh the ProjectDocumentRequest entity snapshot so the TotId scalar property is declared before TotId-based indexes

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6697a03bc83299f16b58bf777b2b4