### PR TITLE
Align visit photo upload test with toast message

### DIFF
--- a/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
@@ -124,7 +124,7 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
             var redirect = Assert.IsType<RedirectToPageResult>(result);
             Assert.NotNull(redirect.RouteValues);
             Assert.Equal(visit.Id, redirect.RouteValues!["id"]);
-            Assert.Equal("Photo uploaded.", page.TempData["ToastMessage"]);
+            Assert.Equal("1 photo uploaded.", page.TempData["ToastMessage"]);
             Assert.False(page.TempData.ContainsKey("ToastError"));
             Assert.True(page.ModelState.IsValid);
 


### PR DESCRIPTION
## Summary
- update the visit photo integration test to expect the new toast copy that announces the number of uploaded photos

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c784e6288329b177b2af6d8bcc4a)