### PR TITLE
Fix visit photo uploads blocked by unrelated validation errors

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml.cs
@@ -169,7 +169,7 @@ public class EditModel : PageModel
             return Page();
         }
 
-        ClearInputValidationErrors();
+        ClearUploadValidationErrors();
 
         if (!ModelState.IsValid)
         {
@@ -374,15 +374,28 @@ public class EditModel : PageModel
         return User.IsInRole("Project Office") || User.IsInRole("ProjectOffice");
     }
 
-    private void ClearInputValidationErrors()
+    private void ClearUploadValidationErrors()
     {
-        var prefix = nameof(Input);
+        var uploadKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            nameof(Upload),
+            nameof(Uploads),
+            nameof(UploadCaption)
+        };
+
         var keysToRemove = new List<string>();
 
         foreach (var entry in ModelState)
         {
-            if (entry.Key.Equals(prefix, StringComparison.Ordinal) ||
-                entry.Key.StartsWith(prefix + '.', StringComparison.Ordinal))
+            if (!uploadKeys.Contains(entry.Key) &&
+                !(entry.Key.StartsWith(nameof(Input) + '.', StringComparison.Ordinal) ||
+                  entry.Key.Equals(nameof(Input), StringComparison.Ordinal)))
+            {
+                keysToRemove.Add(entry.Key);
+            }
+
+            if (entry.Key.StartsWith(nameof(Input) + '.', StringComparison.Ordinal) ||
+                entry.Key.Equals(nameof(Input), StringComparison.Ordinal))
             {
                 keysToRemove.Add(entry.Key);
             }
@@ -393,7 +406,11 @@ public class EditModel : PageModel
             ModelState.Remove(key);
         }
 
-        ModelState.ClearValidationState(prefix);
+        foreach (var key in uploadKeys)
+        {
+            ModelState.ClearValidationState(key);
+        }
+
         ModelState.ClearValidationState(string.Empty);
     }
 


### PR DESCRIPTION
## Summary
- update the visit edit photo upload handler to clear all non-upload ModelState entries before validating
- rename and expand the ModelState clearing helper so only upload-specific keys remain and are revalidated, preventing stale edit-form errors from blocking uploads

## Testing
- not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d9aeba7c8329aa6fb0ad79589f7c)