### PR TITLE
Fix visit edit upload token

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml
@@ -171,7 +171,13 @@ else
                         <h2 class="visit-form-card__title">Upload additional photos</h2>
                         <p class="visit-form-card__subtitle">Drop in multiple images at once. Captions will apply to the entire batch.</p>
                     </div>
-                    <form method="post" enctype="multipart/form-data" asp-page-handler="Upload" asp-route-id="@Model.PhotoGallery.VisitId" class="visit-form" data-visits-disable-on-submit>
+                    <form method="post"
+                          enctype="multipart/form-data"
+                          asp-page-handler="Upload"
+                          asp-route-id="@Model.PhotoGallery.VisitId"
+                          class="visit-form"
+                          data-visits-disable-on-submit>
+                        @Html.AntiForgeryToken()
                         <input type="hidden" name="id" value="@Model.PhotoGallery.VisitId" />
                         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
                         <div class="visit-form-grid visit-form-grid--single">


### PR DESCRIPTION
## Summary
- add an explicit anti-forgery token to the upload form on the visit edit page so uploads succeed while the page remains protected
- keep the existing form configuration but format it to emphasize the separate attributes for clarity

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691709e648d0832988f8f8d0781202ef)