### PR TITLE
Refine dashboard task reminders

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -16,30 +16,7 @@
   <div class="alert alert-warning py-2"><i class="bi bi-exclamation-triangle-fill me-2"></i>@err</div>
 }
 
-@if (Model.TodoWidget != null && (Model.TodoWidget.OverdueCount > 0 || Model.TodoWidget.DueTodayCount > 0))
-{
-  <div class="alert alert-warning d-flex align-items-center py-2" role="alert">
-    <i class="bi bi-exclamation-triangle-fill me-2"></i>
-    <div class="small">
-      You have
-      @if (Model.TodoWidget.OverdueCount > 0)
-      {
-        <strong>@Model.TodoWidget.OverdueCount overdue</strong>
-      }
-      @if (Model.TodoWidget.OverdueCount > 0 && Model.TodoWidget.DueTodayCount > 0)
-      {
-        @:and
-      }
-      @if (Model.TodoWidget.DueTodayCount > 0)
-      {
-        <strong>@Model.TodoWidget.DueTodayCount due today</strong>
-      }
-      tasks. <a asp-page="/Tasks/Index" class="ms-1">Review</a>
-    </div>
-  </div>
-}
-
-@{
+@{ 
   var dashboardMainColumnClass = Model.ShowMyProjectsWidget ? "col-12 col-lg-8 col-xl-8" : "col-12";
 }
 

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -18,6 +18,21 @@
             ? "upcoming"
             : "today";
 
+    var hasAttentionState = overdueCount > 0 || dueTodayCount > 0;
+    var attentionClass = overdueCount > 0
+        ? " todo-widget--attention todo-widget--attention-overdue"
+        : dueTodayCount > 0
+            ? " todo-widget--attention todo-widget--attention-today"
+            : string.Empty;
+
+    var attentionHeading = overdueCount > 0 ? "Overdue tasks" : "Due today";
+    var attentionMessage = overdueCount > 0
+        ? $"You have {overdueCount} task{(overdueCount == 1 ? string.Empty : "s")} waiting for action."
+        : dueTodayCount > 0
+            ? $"You have {dueTodayCount} task{(dueTodayCount == 1 ? string.Empty : "s")} scheduled for today."
+            : string.Empty;
+    var attentionIcon = overdueCount > 0 ? "bi-exclamation-octagon-fill" : "bi-exclamation-circle-fill";
+
     var routeValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     foreach (var queryParameter in ViewContext.HttpContext.Request.Query)
     {
@@ -27,7 +42,7 @@
     routeValues["tab"] = defaultTab;
 }
 
-<div class="card shadow-sm todo-widget">
+<div class="card shadow-sm todo-widget@attentionClass">
     <div class="card-header mission-panel__header d-flex flex-wrap align-items-center justify-content-between gap-3 py-2">
         <div class="d-flex flex-wrap align-items-center gap-3">
             <span class="mission-panel__title fw-semibold">To-Do</span>
@@ -52,6 +67,19 @@
     </div>
 
     <div class="card-body">
+        @if (hasAttentionState && !string.IsNullOrEmpty(attentionMessage))
+        {
+            <div class="todo-widget__attention-line" role="status">
+                <span class="todo-widget__attention-icon" aria-hidden="true">
+                    <i class="bi @attentionIcon"></i>
+                </span>
+                <div class="todo-widget__attention-copy">
+                    <p class="todo-widget__attention-heading small mb-0 fw-semibold">@attentionHeading</p>
+                    <p class="todo-widget__attention-text small mb-0">@attentionMessage</p>
+                </div>
+            </div>
+        }
+
         <form method="post" asp-page="/Dashboard/Index" asp-page-handler="Add" class="mb-2">
             @Html.AntiForgeryToken()
             <input name="NewTitle" class="form-control form-control-sm" placeholder="Add a task…" maxlength="160" required aria-label="Task title" />

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -15,6 +15,52 @@
   box-shadow: var(--mission-panel-shadow);
 }
 
+.todo-widget--attention {
+  --mission-panel-border: rgba(255, 193, 7, .45);
+  --mission-panel-shadow: 0 24px 42px -32px rgba(255, 193, 7, .8);
+  --mission-panel-header-bg: linear-gradient(135deg, rgba(255, 193, 7, .2), rgba(255, 255, 255, .8));
+}
+
+.todo-widget--attention-overdue {
+  --mission-panel-border: rgba(220, 53, 69, .4);
+  --mission-panel-shadow: 0 28px 48px -30px rgba(220, 53, 69, .55);
+  --mission-panel-header-bg: linear-gradient(135deg, rgba(220, 53, 69, .15), rgba(255, 193, 7, .18));
+}
+
+.todo-widget__attention-line {
+  display: flex;
+  align-items: flex-start;
+  gap: .65rem;
+  padding: .65rem .85rem;
+  border-radius: .75rem;
+  background: rgba(255, 193, 7, .15);
+  border: 1px solid rgba(255, 193, 7, .35);
+  color: #6b4600;
+  margin-bottom: 1rem;
+}
+
+.todo-widget--attention-overdue .todo-widget__attention-line {
+  background: rgba(220, 53, 69, .1);
+  border-color: rgba(220, 53, 69, .4);
+  color: #7c1620;
+}
+
+.todo-widget__attention-icon {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, .6);
+  box-shadow: inset 0 0 0 1px currentColor;
+  font-size: 1rem;
+}
+
+.todo-widget__attention-copy {
+  flex: 1;
+}
+
 .mission-panel__header {
   background: var(--mission-panel-header-bg);
   border-bottom: 1px solid rgba(13, 110, 253, .15);


### PR DESCRIPTION
## Summary
- remove the full-width dashboard alert and keep task reminders scoped to the To-Do widget
- add an attention state inside the To-Do widget that surfaces overdue or due-today task counts with contextual messaging
- refresh the widget styles so the new attention state stands out without overwhelming the rest of the dashboard

## Testing
- `dotnet test` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171a37c9e48329a2d61a99ca246f7a)