### PR TITLE
Fix missing ProjectDue dashboard widget partial

### DIFF
--- a/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
+++ b/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
@@ -1,0 +1,4 @@
+@model ProjectManagement.Areas.Dashboard.Components.ProjectPulse.ProjectPulseVm
+
+@* SECTION: Compatibility bridge *@
+@await Html.PartialAsync("Areas/Dashboard/Components/ProjectPulse/_Widget", Model)


### PR DESCRIPTION
## Summary
- add a compatibility partial at `Areas/Dashboard/Components/ProjectDue/_Widget.cshtml` so legacy locations resolve to the existing Project Pulse widget

## Testing
- dotnet build *(fails: `dotnet` command not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d5369bf88329a21f67d5b8ea67aa)