### PR TITLE
Fix project pulse partial view path

### DIFF
--- a/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
+++ b/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
@@ -2,6 +2,6 @@
 
 @* SECTION: Compatibility bridge *@
 @await Html.PartialAsync(
-    "~/Areas/Dashboard/Components/ProjectPulse/_Widget",
+    "~/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml",
     Model
 )

--- a/Pages/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
+++ b/Pages/Areas/Dashboard/Components/ProjectDue/_Widget.cshtml
@@ -2,7 +2,7 @@
 
 @* SECTION: Legacy compatibility shim *@
 @await Html.PartialAsync(
-    "~/Areas/Dashboard/Components/ProjectPulse/_Widget",
+    "~/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml",
     Model
 )
 @* END SECTION *@

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -96,7 +96,7 @@
           {
             @* SECTION: Project Pulse widget partial *@
             @await Html.PartialAsync(
-              "~/Areas/Dashboard/Components/ProjectPulse/_Widget",
+              "~/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml",
               Model.ProjectPulse
             )
             @* END SECTION *@


### PR DESCRIPTION
## Summary
- update every reference to the Project Pulse widget so it points to the concrete `.cshtml` file, allowing the Razor view engine to resolve the partial reliably
- keep the compatibility wrappers for the legacy widget while directing them to the corrected path

## Testing
- `dotnet build` *(fails: dotnet command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d9171aa48329b708557ac4b00442)