### PR TITLE
Fix Project Pulse widget charts and remove idle category

### DIFF
--- a/Areas/Dashboard/Components/ProjectPulse/ProjectPulseVm.cs
+++ b/Areas/Dashboard/Components/ProjectPulse/ProjectPulseVm.cs
@@ -11,8 +11,6 @@ public sealed class ProjectPulseVm
 
     public int Ongoing { get; init; }
 
-    public int Idle { get; init; }
-
     public AllProjectsCard All { get; init; } = new();
 
     public CompletedCard Done { get; init; } = new();
@@ -41,4 +39,4 @@ public sealed record OngoingCard(
 public sealed record AnalyticsCard(
     string CtaUrl = "/Reports/Projects/Analytics");
 
-public sealed record StatusBucket(int Completed, int Ongoing, int Idle);
+public sealed record StatusBucket(int Completed, int Ongoing);

--- a/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml
+++ b/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml
@@ -21,10 +21,6 @@
         <span class="ppulse-chip__label">Ongoing</span>
         <span class="ppulse-chip__val">@Model.Ongoing</span>
       </li>
-      <li>
-        <span class="ppulse-chip__label">Idle</span>
-        <span class="ppulse-chip__val">@Model.Idle</span>
-      </li>
     </ul>
   </header>
   @* END SECTION *@

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -166,6 +166,7 @@
 </div>
 
 @section Scripts {
+  <script src="~/lib/chart.js/chart.umd.js" asp-append-version="true"></script>
   <script type="module" src="~/js/widgets/project-pulse.js" asp-append-version="true"></script>
   <script src="~/js/todo-widget.js" asp-append-version="true" defer></script>
 }

--- a/Services/Dashboard/ProjectPulseService.cs
+++ b/Services/Dashboard/ProjectPulseService.cs
@@ -49,8 +49,6 @@ public sealed class ProjectPulseService
         var total = projects.Count;
         var completed = projects.Count(p => p.Status == ProjectLifecycleStatus.Completed);
         var ongoing = projects.Count(p => p.Status != ProjectLifecycleStatus.Completed && !p.IsArchived);
-        var idle = Math.Max(0, total - (completed + ongoing));
-
         var weeklyBuckets = BuildStatusBuckets(projects, weekWindows);
         var completedSeries = BuildCompletedSeries(projects, weekWindows);
         var activeSeries = BuildActiveSeries(projects, weekWindows);
@@ -67,7 +65,6 @@ public sealed class ProjectPulseService
             Total = total,
             Completed = completed,
             Ongoing = ongoing,
-            Idle = idle,
             All = new AllProjectsCard(total, weeklyBuckets, RepositoryLink),
             Done = new CompletedCard(completed, completedSeries, CompletedLink),
             Doing = new OngoingCard(ongoing, overdue, activeSeries, OngoingLink),
@@ -116,8 +113,7 @@ public sealed class ProjectPulseService
                 p.CreatedOn < endExclusive &&
                 (p.CompletedOn == null || p.CompletedOn.Value >= endExclusive) &&
                 !p.IsArchived);
-            var idle = Math.Max(0, totalToWeek - (completedToWeek + ongoingToWeek));
-            buckets.Add(new StatusBucket(completedToWeek, ongoingToWeek, idle));
+            buckets.Add(new StatusBucket(completedToWeek, ongoingToWeek));
         }
 
         return buckets;

--- a/wwwroot/js/widgets/project-pulse.js
+++ b/wwwroot/js/widgets/project-pulse.js
@@ -43,7 +43,6 @@
     const labels = buckets.map((_, index) => index + 1);
     const completed = buckets.map((bucket) => bucket.completed ?? bucket.Completed ?? 0);
     const ongoing = buckets.map((bucket) => bucket.ongoing ?? bucket.Ongoing ?? 0);
-    const idle = buckets.map((bucket) => bucket.idle ?? bucket.Idle ?? 0);
     const ctx = canvas.getContext('2d');
 
     new Chart(ctx, {
@@ -52,8 +51,7 @@
         labels,
         datasets: [
           { data: completed, borderWidth: 0, backgroundColor: '#16a34a', stack: 'ppulse' },
-          { data: ongoing, borderWidth: 0, backgroundColor: '#2563eb', stack: 'ppulse' },
-          { data: idle, borderWidth: 0, backgroundColor: '#9ca3af', stack: 'ppulse' }
+          { data: ongoing, borderWidth: 0, backgroundColor: '#2563eb', stack: 'ppulse' }
         ]
       },
       options: {


### PR DESCRIPTION
## Summary
- load Chart.js on the dashboard so the Project Pulse inline charts can initialize correctly
- remove the unused idle project category from the Project Pulse view model, service, view, and stacked-bar dataset so the data reflects only real statuses

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e815d3cc832983f4a38d0440f0b7)