### PR TITLE
Align ongoing sparkline with active filter

### DIFF
--- a/Services/Dashboard/ProjectPulseService.cs
+++ b/Services/Dashboard/ProjectPulseService.cs
@@ -64,7 +64,8 @@ public sealed class ProjectPulseService : IProjectPulseService
         var snapshots = rows.Select(r => new ProjectPulseSnapshot(
             DateOnly.FromDateTime(r.CreatedAt.Date),
             r.CompletedOn,
-            r.IsArchived)).ToList();
+            r.IsArchived,
+            r.Status)).ToList();
 
         return new ProjectPulseVm
         {
@@ -109,6 +110,7 @@ public sealed class ProjectPulseService : IProjectPulseService
         foreach (var month in months)
         {
             var active = snapshots.Count(p =>
+                p.Status != ProjectLifecycleStatus.Cancelled &&
                 !p.IsArchived &&
                 p.CreatedOn < month.EndExclusive &&
                 (!p.CompletedOn.HasValue || p.CompletedOn.Value >= month.EndExclusive));
@@ -165,7 +167,8 @@ public sealed class ProjectPulseService : IProjectPulseService
     private sealed record ProjectPulseSnapshot(
         DateOnly CreatedOn,
         DateOnly? CompletedOn,
-        bool IsArchived);
+        bool IsArchived,
+        ProjectLifecycleStatus Status);
 
     private sealed record MonthWindow(DateOnly Start, DateOnly EndExclusive);
     // END SECTION


### PR DESCRIPTION
## Summary
- carry each project's lifecycle status into the snapshot used to build the dashboard trend series
- exclude cancelled projects when counting "ongoing" trend data so the sparkline aligns with the headline KPI definition

## Testing
- `dotnet test` *(fails: `dotnet` is not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691804b5184883299c7d6a4b5a0ee8c6)