### PR TITLE
Revamp Project Pulse widget with inline charts

### DIFF
--- a/Areas/Dashboard/Components/ProjectPulse/ProjectPulseVm.cs
+++ b/Areas/Dashboard/Components/ProjectPulse/ProjectPulseVm.cs
@@ -6,23 +6,26 @@ namespace ProjectManagement.Areas.Dashboard.Components.ProjectPulse;
 // SECTION: Widget view model
 public sealed class ProjectPulseVm
 {
-    // SECTION: KPI tiles
-    public int Total { get; init; }
-    public int Completed { get; init; }
-    public int Ongoing { get; init; }
-    public int Idle { get; init; }
+    // SECTION: Header KPIs
+    public int TotalProjects { get; init; }
+    public int CompletedCount { get; init; }
+    public int OngoingCount { get; init; }
+    public int IdleCount { get; init; }
+    public int AvailableForProliferationCount { get; init; }
     // END SECTION
 
-    // SECTION: Trend micro-charts
-    public IReadOnlyList<int> CompletedByMonth { get; init; } = Array.Empty<int>();
-    public IReadOnlyList<int> OngoingByMonth { get; init; } = Array.Empty<int>();
-    public IReadOnlyList<int> NewByMonth { get; init; } = Array.Empty<int>();
+    // SECTION: Chart data
+    public IReadOnlyList<LabelValue> CompletedByProjectCategory { get; init; } = Array.Empty<LabelValue>();
+    public IReadOnlyList<LabelValue> OngoingByStage { get; init; } = Array.Empty<LabelValue>();
+    public IReadOnlyList<LabelValue> AllByTechnicalCategory { get; init; } = Array.Empty<LabelValue>();
     // END SECTION
 
-    // SECTION: Deep links
-    public string RepositoryUrl { get; init; } = "/Projects";
-    public string CompletedUrl { get; init; } = "/Projects?status=Completed";
-    public string OngoingUrl { get; init; } = "/Projects?status=Ongoing";
-    public string AnalyticsUrl { get; init; } = "/Reports/Projects/Analytics";
+    // SECTION: View flags
+    public bool Condensed { get; init; }
     // END SECTION
 }
+// END SECTION
+
+// SECTION: Shared chart label/value pair
+public sealed record LabelValue(string Label, int Value);
+// END SECTION

--- a/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml
+++ b/Areas/Dashboard/Components/ProjectPulse/_Widget.cshtml
@@ -1,93 +1,107 @@
 @model ProjectManagement.Areas.Dashboard.Components.ProjectPulse.ProjectPulseVm
+@using System.Collections.Generic
+@using System.Text.Json
 
-<section class="pm-pulse" aria-labelledby="pm-pulse-title">
-  @* SECTION: Header summary *@
-  <header class="pm-pulse__header">
-    <h2 id="pm-pulse-title" class="pm-pulse__title">Project pulse</h2>
-    <ul class="pm-pulse__summary" role="list">
-      <li>
-        <span class="pm-pulse__k">Total</span>
-        <span class="pm-pulse__v">@Model.Total</span>
+@* SECTION: Serialization helpers *@
+@{
+    var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    string Serialize<T>(IReadOnlyList<T> source) => JsonSerializer.Serialize(source, jsonOptions);
+    var widgetClass = Model.Condensed ? "ppulse ppulse--condensed" : "ppulse";
+}
+@* END SECTION *@
+
+<section class="@widgetClass" data-project-pulse>
+  @* SECTION: Header *@
+  <header class="ppulse__head">
+    <div class="ppulse__title">
+      <i class="bi bi-activity" aria-hidden="true"></i>
+      <h2 class="h5 mb-0">Project pulse</h2>
+    </div>
+    <ul class="ppulse__kpis" aria-label="Project metrics">
+      <li class="ppulse__pill">
+        <span class="ppulse__pill-label">Total</span>
+        <span class="ppulse__pill-value">@Model.TotalProjects</span>
       </li>
-      <li>
-        <span class="pm-pulse__k">Completed</span>
-        <span class="pm-pulse__v">@Model.Completed</span>
+      <li class="ppulse__pill">
+        <span class="ppulse__pill-label">Completed</span>
+        <span class="ppulse__pill-value">@Model.CompletedCount</span>
       </li>
-      <li>
-        <span class="pm-pulse__k">Ongoing</span>
-        <span class="pm-pulse__v">@Model.Ongoing</span>
+      <li class="ppulse__pill">
+        <span class="ppulse__pill-label">Ongoing</span>
+        <span class="ppulse__pill-value">@Model.OngoingCount</span>
       </li>
-      <li>
-        <span class="pm-pulse__k">Idle</span>
-        <span class="pm-pulse__v">@Model.Idle</span>
+      <li class="ppulse__pill">
+        <span class="ppulse__pill-label">Idle</span>
+        <span class="ppulse__pill-value">@Model.IdleCount</span>
+      </li>
+      <li
+        class="ppulse__pill ppulse__pill--accent"
+        title="Completed and eligible, not yet proliferated"
+      >
+        <span class="ppulse__pill-label">Available for proliferation</span>
+        <span class="ppulse__pill-value">@Model.AvailableForProliferationCount</span>
       </li>
     </ul>
   </header>
   @* END SECTION *@
 
-  @* SECTION: Widget grid *@
-  <div class="pm-pulse__grid">
-    <article class="pm-pulse__card">
-      <div class="pm-pulse__meta">
-        <span class="pm-pulse__label">Completed</span>
-        <span class="pm-pulse__number">@Model.Completed</span>
+  @* SECTION: Cards *@
+  <div class="ppulse__grid">
+    <article class="ppulse__card" aria-labelledby="ppulse-card-completed">
+      <div class="ppulse__card-head">
+        <h3 id="ppulse-card-completed">Completed <small>@Model.CompletedCount</small></h3>
       </div>
-      <div class="pm-pulse__spark">
-        <canvas
-          width="220"
-          height="40"
-          data-spark="line"
-          data-points="@string.Join(',', Model.CompletedByMonth)"></canvas>
+      <div
+        class="ppulse__chart"
+        data-chart="pie"
+        data-series='@Html.Raw(Serialize(Model.CompletedByProjectCategory))'
+      >
+        <canvas aria-hidden="true"></canvas>
       </div>
-      <footer class="pm-pulse__footer">
-        <a class="pm-pulse__link" href="@Model.CompletedUrl" aria-label="View completed projects">View completed</a>
-      </footer>
+      <div class="ppulse__card-foot">
+        <a class="ppulse__link" asp-page="/Projects/CompletedSummary/Index">View completed →</a>
+      </div>
     </article>
 
-    <article class="pm-pulse__card">
-      <div class="pm-pulse__meta">
-        <span class="pm-pulse__label">Ongoing</span>
-        <span class="pm-pulse__number">@Model.Ongoing</span>
+    <article class="ppulse__card" aria-labelledby="ppulse-card-ongoing">
+      <div class="ppulse__card-head">
+        <h3 id="ppulse-card-ongoing">Ongoing <small>@Model.OngoingCount</small></h3>
       </div>
-      <div class="pm-pulse__spark">
-        <canvas
-          width="220"
-          height="40"
-          data-spark="bar"
-          data-points="@string.Join(',', Model.OngoingByMonth)"></canvas>
+      <div
+        class="ppulse__chart"
+        data-chart="line"
+        data-series='@Html.Raw(Serialize(Model.OngoingByStage))'
+      >
+        <canvas aria-hidden="true"></canvas>
       </div>
-      <footer class="pm-pulse__footer">
-        <a class="pm-pulse__link" href="@Model.OngoingUrl" aria-label="View ongoing projects">View ongoing</a>
-      </footer>
+      <div class="ppulse__card-foot">
+        <a class="ppulse__link" asp-page="/Projects/Ongoing/Index">View ongoing →</a>
+      </div>
     </article>
 
-    <article class="pm-pulse__card">
-      <div class="pm-pulse__meta">
-        <span class="pm-pulse__label">All projects</span>
-        <span class="pm-pulse__number">@Model.Total</span>
+    <article class="ppulse__card" aria-labelledby="ppulse-card-all">
+      <div class="ppulse__card-head">
+        <h3 id="ppulse-card-all">All projects <small>@Model.TotalProjects</small></h3>
       </div>
-      <div class="pm-pulse__spark">
-        <canvas
-          width="220"
-          height="40"
-          data-spark="area"
-          data-points="@string.Join(',', Model.NewByMonth)"></canvas>
+      <div
+        class="ppulse__chart"
+        data-chart="bar"
+        data-series='@Html.Raw(Serialize(Model.AllByTechnicalCategory))'
+      >
+        <canvas aria-hidden="true"></canvas>
       </div>
-      <footer class="pm-pulse__footer">
-        <a class="pm-pulse__link" href="@Model.RepositoryUrl" aria-label="Explore repository">Explore repository</a>
-      </footer>
+      <div class="ppulse__card-foot">
+        <a class="ppulse__link" asp-page="/Projects/Index">Explore repository →</a>
+      </div>
     </article>
 
-    <aside class="pm-pulse__cta" aria-label="Project analytics deep dive">
-      <div class="pm-pulse__cta-body">
-        <h3 class="pm-pulse__cta-title">Deep dive</h3>
-        <p class="pm-pulse__cta-copy">Trends, drill-downs and downloads.</p>
+    <aside class="ppulse__cta" aria-labelledby="ppulse-card-cta">
+      <div class="ppulse__cta-body">
+        <h3 id="ppulse-card-cta">Deep dive</h3>
+        <p>Trends, drill-downs, and downloads.</p>
+        <a class="btn btn-primary" asp-page="/Analytics/Index">Open analytics</a>
       </div>
-      <a class="btn btn-primary pm-pulse__cta-btn" href="@Model.AnalyticsUrl">Open analytics</a>
     </aside>
   </div>
   @* END SECTION *@
 </section>
-
-<link rel="stylesheet" href="~/css/widgets/project-pulse.css" asp-append-version="true" />
-<script type="module" src="~/js/widgets/project-pulse.js" asp-append-version="true"></script>

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -166,7 +166,7 @@
 </div>
 
 @section Scripts {
-  <script src="~/lib/chart.js/chart.umd.js" asp-append-version="true"></script>
-  <script type="module" src="~/js/widgets/project-pulse.js" asp-append-version="true"></script>
+  <script src="~/lib/chart.js/chart.umd.js" asp-append-version="true" defer></script>
+  <script src="~/js/widgets/project-pulse.js" asp-append-version="true" defer></script>
   <script src="~/js/todo-widget.js" asp-append-version="true" defer></script>
 }

--- a/wwwroot/css/widgets/project-pulse.css
+++ b/wwwroot/css/widgets/project-pulse.css
@@ -1,140 +1,213 @@
-/* SECTION: Widget shell */
-.pm-pulse {
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
-  padding: 14px;
+/* SECTION: Theme tokens */
+.ppulse {
+  --pp-bg: #ffffff;
+  --pp-border: #e5e7eb;
+  --pp-surface: #f8fafc;
+  --pp-text: #0f172a;
+  --pp-muted: #6b7280;
+  --pp-pill-bg: #f1f5f9;
+  --pp-pill-accent-bg: #dbeafe;
+  --pp-pill-accent-text: #1d4ed8;
+  --pp-radius: 16px;
+  --pp-gap: 1rem;
+  --pp-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
+  --pp-chart-h: 160px;
 }
 
-.pm-pulse__header {
+[data-theme="dark"] .ppulse {
+  --pp-bg: #0f172a;
+  --pp-border: #1e293b;
+  --pp-surface: #16213c;
+  --pp-text: #f8fafc;
+  --pp-muted: #94a3b8;
+  --pp-pill-bg: #1e293b;
+  --pp-pill-accent-bg: rgba(45, 108, 223, 0.25);
+  --pp-pill-accent-text: #93c5fd;
+  --pp-shadow: 0 25px 60px rgba(2, 6, 23, 0.45);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .ppulse {
+    --pp-bg: #0f172a;
+    --pp-border: #1e293b;
+    --pp-surface: #16213c;
+    --pp-text: #f8fafc;
+    --pp-muted: #94a3b8;
+    --pp-pill-bg: #1e293b;
+    --pp-pill-accent-bg: rgba(45, 108, 223, 0.25);
+    --pp-pill-accent-text: #93c5fd;
+    --pp-shadow: 0 25px 60px rgba(2, 6, 23, 0.45);
+  }
+}
+/* END SECTION */
+
+/* SECTION: Wrapper */
+.ppulse {
+  background: var(--pp-bg);
+  border: 1px solid var(--pp-border);
+  border-radius: var(--pp-radius);
+  box-shadow: var(--pp-shadow);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ppulse--condensed {
+  --pp-chart-h: 120px;
+  padding: 1rem;
+}
+/* END SECTION */
+
+/* SECTION: Header */
+.ppulse__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 8px 10px;
+  gap: 1rem;
   flex-wrap: wrap;
-  gap: 10px;
 }
 
-.pm-pulse__title {
-  font-size: 1rem;
-  margin: 0;
-  color: #0b1220;
+.ppulse__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--pp-text);
 }
 
-.pm-pulse__summary {
-  display: flex;
-  gap: 14px;
+.ppulse__title i {
+  font-size: 1.25rem;
+  color: #22c55e;
+}
+
+.ppulse__kpis {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
+  display: flex;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-.pm-pulse__k {
-  font-size: 0.72rem;
-  color: #6b7280;
-  margin-right: 6px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+.ppulse__pill {
+  background: var(--pp-pill-bg);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 120px;
 }
 
-.pm-pulse__v {
-  font-weight: 600;
-  color: #111827;
+.ppulse__pill-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pp-muted);
 }
+
+.ppulse__pill-value {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--pp-text);
+}
+
+.ppulse__pill--accent {
+  background: var(--pp-pill-accent-bg);
+  color: var(--pp-pill-accent-text);
+  border: 1px solid rgba(29, 78, 216, 0.2);
+}
+
+.ppulse__pill--accent .ppulse__pill-value {
+  color: var(--pp-pill-accent-text);
+}
+/* END SECTION */
 
 /* SECTION: Grid */
-.pm-pulse__grid {
+.ppulse__grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--pp-gap);
 }
 
 @media (max-width: 1200px) {
-  .pm-pulse__grid {
+  .ppulse__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 700px) {
-  .pm-pulse__grid {
+@media (max-width: 720px) {
+  .ppulse__grid {
     grid-template-columns: 1fr;
   }
 }
+/* END SECTION */
 
 /* SECTION: Cards */
-.pm-pulse__card {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 10px;
+.ppulse__card,
+.ppulse__cta {
+  border-radius: 18px;
+  border: 1px solid var(--pp-border);
+  background: var(--pp-surface);
+  padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  min-height: 120px;
-  background-color: #fff;
+  gap: 0.85rem;
+  min-height: 100%;
 }
 
-.pm-pulse__meta {
+.ppulse__card-head h3 {
+  font-size: 1rem;
+  margin: 0;
+  color: var(--pp-text);
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  gap: 0.35rem;
 }
 
-.pm-pulse__label {
-  font-size: 0.78rem;
-  color: #6b7280;
+.ppulse__card-head small {
+  font-size: 0.8rem;
+  color: var(--pp-muted);
 }
 
-.pm-pulse__number {
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  color: #0b1220;
+.ppulse__chart {
+  position: relative;
+  height: var(--pp-chart-h);
 }
 
-.pm-pulse__spark {
-  height: 40px;
+.ppulse__chart canvas {
+  width: 100% !important;
+  height: 100% !important;
 }
 
-.pm-pulse__footer {
-  display: flex;
-  justify-content: flex-end;
+.ppulse__card-foot {
+  margin-top: auto;
 }
 
-.pm-pulse__link {
-  font-size: 0.85rem;
-  text-decoration: none;
+.ppulse__link {
+  font-weight: 600;
   color: #2563eb;
+  text-decoration: none;
 }
 
-.pm-pulse__link:hover,
-.pm-pulse__link:focus-visible {
+.ppulse__link:hover,
+.ppulse__link:focus-visible {
   text-decoration: underline;
 }
 
-/* SECTION: CTA */
-.pm-pulse__cta {
-  border: 1px dashed #dbe3f8;
-  background: linear-gradient(180deg, #f5f8ff, #eef2ff);
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
+.ppulse__cta {
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.12));
+  border-style: dashed;
   justify-content: space-between;
 }
 
-.pm-pulse__cta-title {
-  margin: 0 0 4px 0;
-  font-size: 1.1rem;
-  color: #0f172a;
+.ppulse__cta-body h3 {
+  margin: 0 0 0.35rem 0;
+  color: var(--pp-text);
 }
 
-.pm-pulse__cta-copy {
-  margin: 0 0 10px 0;
-  color: #4b5563;
-  font-size: 0.9rem;
+.ppulse__cta-body p {
+  margin: 0 0 0.75rem 0;
+  color: var(--pp-muted);
 }
-
-.pm-pulse__cta-btn {
-  align-self: flex-start;
-}
+/* END SECTION */


### PR DESCRIPTION
## Summary
- add the new Project Pulse view model, widget markup, and dashboard wiring for the four-card experience with a dedicated "Available for proliferation" KPI
- extend the ProjectPulseService aggregation logic to build category, stage, and technical chart series plus the proliferation eligibility count
- provide refreshed styling and a Chart.js bootstrapper for the widget, keeping the assets modular and CSP-friendly

## Testing
- ⚠️ `dotnet build ProjectManagement.sln` *(fails: `dotnet` CLI is not available in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918357ae4a883299e4d626904a52ef7)