### PR TITLE
Fix dashboard category aggregations

### DIFF
--- a/Services/Dashboard/ProjectPulseService.cs
+++ b/Services/Dashboard/ProjectPulseService.cs
@@ -88,9 +88,14 @@ public sealed class ProjectPulseService : IProjectPulseService
             .AsNoTracking()
             .Where(p => !p.IsDeleted && !p.IsArchived && p.LifecycleStatus == ProjectLifecycleStatus.Completed)
             .GroupBy(p => p.Category != null ? p.Category.Name : "Uncategorized")
-            .Select(g => new LabelValue(g.Key, g.Count()))
-            .OrderByDescending(x => x.Value)
+            .Select(g => new
+            {
+                Label = g.Key,
+                Count = g.Count()
+            })
+            .OrderByDescending(x => x.Count)
             .ThenBy(x => x.Label)
+            .Select(x => new LabelValue(x.Label, x.Count))
             .ToListAsync(cancellationToken);
 
         return completedSeries;
@@ -102,9 +107,14 @@ public sealed class ProjectPulseService : IProjectPulseService
             .AsNoTracking()
             .Where(p => !p.IsDeleted && !p.IsArchived)
             .GroupBy(p => p.TechnicalCategory != null ? p.TechnicalCategory.Name : "Unclassified")
-            .Select(g => new LabelValue(g.Key, g.Count()))
-            .OrderByDescending(x => x.Value)
+            .Select(g => new
+            {
+                Label = g.Key,
+                Count = g.Count()
+            })
+            .OrderByDescending(x => x.Count)
             .ThenBy(x => x.Label)
+            .Select(x => new LabelValue(x.Label, x.Count))
             .ToListAsync(cancellationToken);
 
         return technicalSeries;


### PR DESCRIPTION
## Summary
- ensure the dashboard aggregation queries sort/group results before projecting into `LabelValue` records so EF Core can translate the SQL fully
- keep the user-facing data unchanged while avoiding the runtime `InvalidOperationException`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691838d987e0832986ac3cada35ce634)