### PR TITLE
Add modal access to full FFC map from dashboard

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -29,7 +29,14 @@
                     <strong>@Model.TotalProjects</strong>
                 </div>
             </div>
-            <a asp-area="ProjectOfficeReports" asp-page="/FFC/Map" class="btn btn-outline-primary btn-sm">View full map</a>
+            <button
+                type="button"
+                class="btn btn-outline-primary btn-sm"
+                data-bs-toggle="modal"
+                data-bs-target="#ffcSimulatorFullMapModal"
+            >
+                View full map
+            </button>
         </div>
         @if (Model.HasData)
         {
@@ -55,5 +62,53 @@
             <p class="text-secondary small mb-0 mt-3">FFC simulator delivery data is not available right now.</p>
         }
     </div>
+    @* SECTION: Full map modal *@
+    <div
+        class="modal fade ffc-simulator-map-modal"
+        id="ffcSimulatorFullMapModal"
+        tabindex="-1"
+        aria-labelledby="ffcSimulatorFullMapModalTitle"
+        aria-hidden="true"
+        data-ffc-map-modal
+        data-reset-on-close="false"
+    >
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header align-items-start">
+                    <div>
+                        <p class="ffc-simulator-map-modal__eyebrow text-uppercase mb-1">FFC simulators</p>
+                        <h1 id="ffcSimulatorFullMapModalTitle" class="h5 mb-0">Installed & delivered footprint</h1>
+                        <p class="text-secondary small mb-0">
+                            Explore the full interactive map without leaving your dashboard. Use the "Open in new tab" link for a dedicated page view.
+                        </p>
+                    </div>
+                    <div class="d-flex align-items-center gap-2 ms-3">
+                        <a
+                            asp-area="ProjectOfficeReports"
+                            asp-page="/FFC/Map"
+                            class="btn btn-outline-secondary btn-sm"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Open in new tab
+                        </a>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close full map"></button>
+                    </div>
+                </div>
+                <div class="modal-body p-0">
+                    <div class="ffc-simulator-map-modal__frame-wrapper ratio ratio-4x3">
+                        <iframe
+                            class="ffc-simulator-map-modal__frame"
+                            title="Full FFC simulator delivery map"
+                            data-ffc-map-frame
+                            data-src="@Url.Page("/ProjectOfficeReports/FFC/Map")"
+                            loading="lazy"
+                        ></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    @* END SECTION *@
 </section>
 @* END SECTION *@

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="~/css/widgets/ops-signals.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/lib/leaflet/1.9.4/leaflet.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/css/widgets/ffc-simulator-map.css" asp-append-version="true" />
+  <link rel="stylesheet" href="~/css/widgets/ffc-simulator-map-modal.css" asp-append-version="true" />
   <link rel="stylesheet" href="~/css/todo-widget.css" asp-append-version="true" />
 }
 
@@ -180,5 +181,6 @@
   <script type="module" src="~/js/widgets/ops-signals.js" asp-append-version="true"></script>
   <script src="~/lib/leaflet/1.9.4/leaflet.js" asp-append-version="true" defer></script>
   <script src="~/js/widgets/ffc-simulator-map.js" asp-append-version="true" defer></script>
+  <script src="~/js/widgets/ffc-simulator-map-modal.js" asp-append-version="true" defer></script>
   <script src="~/js/todo-widget.js" asp-append-version="true" defer></script>
 }

--- a/wwwroot/css/widgets/ffc-simulator-map-modal.css
+++ b/wwwroot/css/widgets/ffc-simulator-map-modal.css
@@ -1,0 +1,37 @@
+/* SECTION: FFC simulator map modal */
+.ffc-simulator-map-modal .modal-header {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.ffc-simulator-map-modal__eyebrow {
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.ffc-simulator-map-modal__frame-wrapper {
+  min-height: 60vh;
+  background: linear-gradient(135deg, #ede9fe, #eef2ff);
+}
+
+.ffc-simulator-map-modal__frame {
+  border: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@media (min-width: 992px) {
+  .ffc-simulator-map-modal .modal-dialog {
+    height: calc(100vh - 3rem);
+  }
+
+  .ffc-simulator-map-modal .modal-content {
+    height: 100%;
+  }
+
+  .ffc-simulator-map-modal__frame-wrapper {
+    min-height: unset;
+    height: 100%;
+  }
+}
+/* END SECTION */

--- a/wwwroot/js/widgets/ffc-simulator-map-modal.js
+++ b/wwwroot/js/widgets/ffc-simulator-map-modal.js
@@ -1,0 +1,34 @@
+// SECTION: FFC simulator map modal loader
+(function () {
+  var modal = document.querySelector('[data-ffc-map-modal]');
+  if (!modal) {
+    return;
+  }
+
+  var frame = modal.querySelector('[data-ffc-map-frame]');
+  if (!frame) {
+    return;
+  }
+
+  var frameSrc = frame.getAttribute('data-src');
+  if (!frameSrc) {
+    return;
+  }
+
+  var hydrateFrame = function () {
+    if (frame.getAttribute('src')) {
+      return;
+    }
+    frame.setAttribute('src', frameSrc);
+  };
+
+  modal.addEventListener('show.bs.modal', hydrateFrame);
+
+  var resetOnClose = modal.getAttribute('data-reset-on-close') === 'true';
+  if (resetOnClose) {
+    modal.addEventListener('hidden.bs.modal', function () {
+      frame.removeAttribute('src');
+    });
+  }
+})();
+// END SECTION


### PR DESCRIPTION
## Summary
- add a Bootstrap modal to the FFC simulator widget so the "View full map" CTA opens inline instead of navigating away
- load the full map inside a lazy iframe, include a direct link fallback, and add dedicated styling for the modal layout
- register a lightweight script to hydrate the iframe on demand and include the new assets on the dashboard page

## Testing
- `dotnet test` *(fails: `dotnet` command is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c3dcee8c8329b1627f12d7e72004)