### PR TITLE
Fix FFC map modal

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -72,7 +72,7 @@
         data-ffc-map-modal
         data-reset-on-close="false"
     >
-        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-dialog modal-xxl modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header align-items-start">
                     <div>
@@ -96,7 +96,7 @@
                     </div>
                 </div>
                 <div class="modal-body p-0">
-                    <div class="ffc-simulator-map-modal__frame-wrapper ratio ratio-4x3">
+                    <div class="ffc-simulator-map-modal__frame-wrapper">
                         <iframe
                             class="ffc-simulator-map-modal__frame"
                             title="Full FFC simulator delivery map"

--- a/Program.cs
+++ b/Program.cs
@@ -600,6 +600,9 @@ app.Use(async (ctx, next) =>
         ctx.Request.Path.StartsWithSegments("/files", StringComparison.OrdinalIgnoreCase);
 
     var isDocumentPreviewContext = isDocumentViewer || isDocumentPreview || isAttachmentResponse;
+    var isDashboardFfcMap = ctx.Request.Path.StartsWithSegments(
+        "/ProjectOfficeReports/FFC/Map",
+        StringComparison.OrdinalIgnoreCase);
 
     if (isDocumentPreviewContext)
     {
@@ -620,10 +623,12 @@ app.Use(async (ctx, next) =>
             : string.Empty;
         var styleUnsafeInline = app.Environment.IsDevelopment() ? " 'unsafe-inline'" : string.Empty;
 
+        var frameAncestorsDirective = isDashboardFfcMap ? "frame-ancestors 'self'; " : "frame-ancestors 'none'; ";
+
         h["Content-Security-Policy"] =
             "default-src 'self'; " +
             "base-uri 'self'; " +
-            "frame-ancestors 'none'; " +
+            frameAncestorsDirective +
             $"frame-src 'self' data: blob:{devSourcesSuffix}; " +
             $"img-src 'self' data: blob:{devSourcesSuffix}; " +
             $"script-src 'self'{devSourcesSuffix}; " +

--- a/wwwroot/css/widgets/ffc-simulator-map-modal.css
+++ b/wwwroot/css/widgets/ffc-simulator-map-modal.css
@@ -3,6 +3,10 @@
   border-bottom: 1px solid rgba(15, 23, 42, 0.1);
 }
 
+.ffc-simulator-map-modal .modal-body {
+  padding: 0;
+}
+
 .ffc-simulator-map-modal__eyebrow {
   letter-spacing: 0.08em;
   font-weight: 600;
@@ -10,14 +14,17 @@
 }
 
 .ffc-simulator-map-modal__frame-wrapper {
-  min-height: 60vh;
+  width: 100%;
+  min-height: min(75vh, 900px);
   background: linear-gradient(135deg, #ede9fe, #eef2ff);
+  display: flex;
 }
 
 .ffc-simulator-map-modal__frame {
   border: 0;
   width: 100%;
   height: 100%;
+  flex: 1 1 auto;
 }
 
 @media (min-width: 992px) {
@@ -26,6 +33,10 @@
   }
 
   .ffc-simulator-map-modal .modal-content {
+    height: 100%;
+  }
+
+  .ffc-simulator-map-modal .modal-body {
     height: 100%;
   }
 


### PR DESCRIPTION
## Summary
- allow the dashboard FFC map modal to embed the full FFC map page by relaxing the frame-ancestors directive for that route only
- enlarge the modal dialog and frame so the interactive map has more room on larger screens

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c5d59ce88329a3c04735f27fed60)