### PR TITLE
Improve FFC map pin readability

### DIFF
--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -93,37 +93,52 @@
 
 .ffc-simulator-map__pin {
   --pin-size: 40px;
-  width: var(--pin-size);
-  height: var(--pin-size);
-  border-radius: var(--pin-size);
-  background: radial-gradient(circle at 35% 35%, #ede9fe, #8b5cf6);
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
+  --pin-fill: #fef9c3;
+  --pin-border: #f59e0b;
+  --pin-text: #1f2937;
+  --pin-shadow: 0 10px 22px rgba(217, 119, 6, 0.25);
   position: relative;
-  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.65);
+  width: var(--pin-size);
+  height: calc(var(--pin-size) * 1.35);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  filter: drop-shadow(var(--pin-shadow));
 }
 
 .ffc-simulator-map__pin::after {
   content: '';
   position: absolute;
-  bottom: calc(var(--pin-size) * -0.2);
+  bottom: calc(var(--pin-size) * 0.08);
   left: 50%;
-  width: calc(var(--pin-size) * 0.35);
-  height: calc(var(--pin-size) * 0.35);
+  width: calc(var(--pin-size) * 0.42);
+  height: calc(var(--pin-size) * 0.42);
+  background: var(--pin-fill);
+  border: 2px solid var(--pin-border);
   transform: translateX(-50%) rotate(45deg);
-  background: inherit;
+  border-top-color: transparent;
+  border-left-color: transparent;
   border-bottom-left-radius: 999px;
   border-bottom-right-radius: 999px;
-  box-shadow: inherit;
+}
+
+.ffc-simulator-map__pin-head {
+  width: 100%;
+  height: calc(var(--pin-size) * 0.9);
+  background: radial-gradient(circle at 35% 35%, #fff7d6, var(--pin-fill));
+  border: 2px solid var(--pin-border);
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pin-text);
+  font-weight: 700;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .ffc-simulator-map__pin-count {
   display: inline-block;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   letter-spacing: 0.01em;
 }
 

--- a/wwwroot/js/widgets/ffc-simulator-map.js
+++ b/wwwroot/js/widgets/ffc-simulator-map.js
@@ -91,16 +91,19 @@
   function createPin(count) {
     var safeCount = typeof count === 'number' && !Number.isNaN(count) ? count : 0;
     var digitCount = String(Math.abs(safeCount)).length;
-    var size = 38 + Math.min(Math.max(digitCount - 1, 0) * 6, 12);
+    var size = 34 + Math.min(Math.max(digitCount - 1, 0) * 6, 12);
+    var height = Math.round(size * 1.35);
     var html = '' +
       '<div class="ffc-simulator-map__pin" style="--pin-size:' + size + 'px">' +
-      '  <span class="ffc-simulator-map__pin-count">' + safeCount + '</span>' +
+      '  <div class="ffc-simulator-map__pin-head">' +
+      '    <span class="ffc-simulator-map__pin-count">' + safeCount + '</span>' +
+      '  </div>' +
       '</div>';
     return L.divIcon({
       html: html,
       className: '',
-      iconSize: [size, size + 14],
-      iconAnchor: [size / 2, size + 10]
+      iconSize: [size, height],
+      iconAnchor: [size / 2, height - 4]
     });
   }
 


### PR DESCRIPTION
## Summary
- replace FFC simulator map markers with teardrop-style pins sized for multi-digit counts
- restyle pin colors and shadows for improved readability and contrast on the map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691939eee9048329b71646e0992d4833)