### PR TITLE
Restyle FFC map markers

### DIFF
--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -93,38 +93,50 @@
 
 .ffc-simulator-map__pin {
   --pin-size: 40px;
+  --pin-pointer: calc(var(--pin-size) * 0.28);
   --pin-fill: #fef9c3;
   --pin-border: #f59e0b;
   --pin-text: #1f2937;
-  --pin-shadow: 0 10px 22px rgba(217, 119, 6, 0.25);
+  --pin-shadow: 0 10px 18px rgba(217, 119, 6, 0.22);
   position: relative;
   width: var(--pin-size);
-  height: calc(var(--pin-size) * 1.35);
+  height: calc(var(--pin-size) + var(--pin-pointer));
   display: flex;
-  justify-content: center;
-  align-items: flex-start;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding-bottom: var(--pin-pointer);
   filter: drop-shadow(var(--pin-shadow));
 }
 
+.ffc-simulator-map__pin::before,
 .ffc-simulator-map__pin::after {
   content: '';
   position: absolute;
-  bottom: calc(var(--pin-size) * 0.08);
   left: 50%;
-  width: calc(var(--pin-size) * 0.42);
-  height: calc(var(--pin-size) * 0.42);
-  background: var(--pin-fill);
-  border: 2px solid var(--pin-border);
-  transform: translateX(-50%) rotate(45deg);
-  border-top-color: transparent;
-  border-left-color: transparent;
-  border-bottom-left-radius: 999px;
-  border-bottom-right-radius: 999px;
+  width: 0;
+  height: 0;
+  transform: translateX(-50%);
+}
+
+.ffc-simulator-map__pin::before {
+  bottom: 0;
+  border-left: calc(var(--pin-pointer) * 0.9) solid transparent;
+  border-right: calc(var(--pin-pointer) * 0.9) solid transparent;
+  border-top: calc(var(--pin-pointer) * 0.9) solid var(--pin-border);
+}
+
+.ffc-simulator-map__pin::after {
+  bottom: 1px;
+  border-left: calc(var(--pin-pointer) * 0.75) solid transparent;
+  border-right: calc(var(--pin-pointer) * 0.75) solid transparent;
+  border-top: calc(var(--pin-pointer) * 0.75) solid var(--pin-fill);
+  box-shadow: 0 2px 4px rgba(217, 119, 6, 0.12);
 }
 
 .ffc-simulator-map__pin-head {
   width: 100%;
-  height: calc(var(--pin-size) * 0.9);
+  height: var(--pin-size);
   background: radial-gradient(circle at 35% 35%, #fff7d6, var(--pin-fill));
   border: 2px solid var(--pin-border);
   border-radius: 999px;

--- a/wwwroot/js/widgets/ffc-simulator-map.js
+++ b/wwwroot/js/widgets/ffc-simulator-map.js
@@ -92,9 +92,10 @@
     var safeCount = typeof count === 'number' && !Number.isNaN(count) ? count : 0;
     var digitCount = String(Math.abs(safeCount)).length;
     var size = 34 + Math.min(Math.max(digitCount - 1, 0) * 6, 12);
-    var height = Math.round(size * 1.35);
+    var pointer = Math.round(size * 0.28);
+    var height = size + pointer;
     var html = '' +
-      '<div class="ffc-simulator-map__pin" style="--pin-size:' + size + 'px">' +
+      '<div class="ffc-simulator-map__pin" style="--pin-size:' + size + 'px; --pin-pointer:' + pointer + 'px">' +
       '  <div class="ffc-simulator-map__pin-head">' +
       '    <span class="ffc-simulator-map__pin-count">' + safeCount + '</span>' +
       '  </div>' +
@@ -103,7 +104,7 @@
       html: html,
       className: '',
       iconSize: [size, height],
-      iconAnchor: [size / 2, height - 4]
+      iconAnchor: [size / 2, height]
     });
   }
 


### PR DESCRIPTION
## Summary
- update the FFC simulator map pin styling to use a teardrop marker with a clear anchor point
- align marker sizing between CSS and JS with adjustable pointer sizing for consistent anchoring

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193b9559088329b26cb6a9177b828d)