### PR TITLE
Add compact country chip strip to simulator map widget

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -12,6 +12,8 @@
         .OrderByDescending(country => country.Total)
         .ThenBy(country => country.Name)
         .ToList();
+    var topCountries = sortedCountries.Take(5).ToList();
+    var remainingCount = sortedCountries.Count - topCountries.Count;
 }
 <section class="ffc-simulator-map-widget pm-card pm-shadow" aria-labelledby="ffc-simulator-map-title">
     <div class="pm-card-body">
@@ -55,29 +57,35 @@
                 ></div>
                 <div class="ffc-simulator-map__status" data-map-status>Loading delivery footprint…</div>
             </div>
-            @* SECTION: Below-map country list *@
-            <div class="ffc-simulator-map__list" aria-label="FFC simulator activity by country">
-                <table class="table mb-0 align-middle">
-                    <thead>
-                        <tr>
-                            <th scope="col" class="text-uppercase small fw-semibold text-secondary">Country</th>
-                            <th scope="col" class="text-uppercase small fw-semibold text-secondary text-end">Installed</th>
-                            <th scope="col" class="text-uppercase small fw-semibold text-secondary text-end">Delivered</th>
-                            <th scope="col" class="text-uppercase small fw-semibold text-secondary text-end">Total</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var country in sortedCountries)
+            @* SECTION: Below-map country chip strip *@
+            <div class="ffc-simulator-map__country-strip" aria-label="FFC simulator activity by country">
+                <div class="ffc-country-strip" role="list">
+                    @for (var index = 0; index < topCountries.Count; index++)
+                    {
+                        var country = topCountries[index];
+                        if (index > 0)
                         {
-                            <tr data-country-row="@country.Iso3" tabindex="0">
-                                <td class="text-truncate" title="@country.Name">@country.Name</td>
-                                <td class="text-end">@country.Installed</td>
-                                <td class="text-end">@country.Delivered</td>
-                                <td class="text-end fw-semibold">@country.Total</td>
-                            </tr>
+                            <span class="ffc-country-sep" aria-hidden="true">·</span>
                         }
-                    </tbody>
-                </table>
+                        <button
+                            type="button"
+                            class="ffc-country-chip"
+                            data-country-chip="@country.Iso3"
+                            title="@country.Name"
+                            role="listitem"
+                        >
+                            <span class="ffc-country-chip__name">@country.Name</span>
+                            <span class="ffc-country-chip__total">(<strong>@country.Total</strong>)</span>
+                        </button>
+                    }
+                    @if (remainingCount > 0)
+                    {
+                        <span class="ffc-country-sep" aria-hidden="true">·</span>
+                        <a class="ffc-country-chip ffc-country-chip--more" href="@fullMapUrl">
+                            … and @remainingCount more
+                        </a>
+                    }
+                </div>
             </div>
         }
         else

--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -231,62 +231,63 @@
   display: none;
 }
 
-/* SECTION: Country list */
-.ffc-simulator-map__list {
+/* SECTION: Country chip strip */
+.ffc-simulator-map__country-strip {
   margin-top: 1.25rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 0.75rem;
-  background: #ffffff;
-  overflow: hidden;
+  overflow-x: auto;
 }
 
-.ffc-simulator-map__list table {
-  width: 100%;
-  margin: 0;
-  border-collapse: collapse;
-  font-size: 0.85rem;
-}
-
-.ffc-simulator-map__list thead {
-  background: #f8fafc;
-  color: #475569;
-}
-
-.ffc-simulator-map__list th,
-.ffc-simulator-map__list td {
-  padding: 0.55rem 0.85rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.04);
-}
-
-.ffc-simulator-map__list tbody {
-  display: block;
-  max-height: 200px;
-  overflow: auto;
-}
-
-.ffc-simulator-map__list thead tr {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr 1fr 1fr;
-}
-
-.ffc-simulator-map__list tbody tr {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr 1fr 1fr;
+.ffc-country-strip {
+  display: inline-flex;
   align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  background: #ffffff;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  font-size: 0.8rem;
+  color: #0f172a;
+  white-space: nowrap;
+}
+
+.ffc-country-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  border: 0;
+  background: transparent;
+  border-radius: 999px;
+  color: inherit;
+  text-decoration: none;
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.ffc-simulator-map__list tbody tr:last-child td {
-  border-bottom: 0;
-}
-
-.ffc-simulator-map__list tbody tr:hover {
+.ffc-country-chip:hover,
+.ffc-country-chip:focus-visible {
   background: #f5f3ff;
+  color: #312e81;
+  outline: none;
 }
 
-.ffc-simulator-map__list tbody tr:focus-visible {
-  outline: 2px solid #5b21b6;
-  outline-offset: -2px;
+.ffc-country-chip__name {
+  max-width: 11rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ffc-country-chip__total strong {
+  font-weight: 800;
+}
+
+.ffc-country-chip--more {
+  padding-left: 0.35rem;
+  padding-right: 0.35rem;
+}
+
+.ffc-country-sep {
+  color: #94a3b8;
 }
 /* END SECTION */

--- a/wwwroot/js/widgets/ffc-simulator-map.js
+++ b/wwwroot/js/widgets/ffc-simulator-map.js
@@ -339,23 +339,23 @@
           });
         });
 
-        var listRows = host.querySelectorAll('[data-country-row]');
-        if (listRows.length) {
-          listRows.forEach(function (row) {
-            var iso = row.getAttribute('data-country-row');
-            row.addEventListener('mouseenter', function () {
+        var listItems = host.querySelectorAll('[data-country-chip]');
+        if (listItems.length) {
+          listItems.forEach(function (itemEl) {
+            var iso = itemEl.getAttribute('data-country-chip');
+            itemEl.addEventListener('mouseenter', function () {
               showCountryTooltip(iso);
             });
-            row.addEventListener('focus', function () {
+            itemEl.addEventListener('focus', function () {
               showCountryTooltip(iso);
             });
-            row.addEventListener('mouseleave', function () {
+            itemEl.addEventListener('mouseleave', function () {
               scheduleHideTooltip();
             });
-            row.addEventListener('blur', function () {
+            itemEl.addEventListener('blur', function () {
               scheduleHideTooltip();
             });
-            row.addEventListener('click', function (e) {
+            itemEl.addEventListener('click', function (e) {
               e.preventDefault();
               var item = state[iso];
               if (!item) {


### PR DESCRIPTION
## Summary
- replace the dashboard country table with a compact chip strip that emphasizes totals and shows only the top countries
- style the chip strip for a single-line, low-noise presentation with subtle hover states
- wire chip interactions to existing map highlighting, tooltip display, and centering behavior

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691941d4ffcc8329ae2e2a66338c714a)