### PR TITLE
Simplify FFC simulator country strip styling

### DIFF
--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -240,12 +240,9 @@
 .ffc-country-strip {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
-  background: #ffffff;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  font-size: 0.8rem;
+  gap: 0.15rem;
+  padding: 0;
+  font-size: 0.75rem;
   color: #0f172a;
   white-space: nowrap;
 }
@@ -254,19 +251,19 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.2rem 0.4rem;
+  padding: 0;
   border: 0;
   background: transparent;
-  border-radius: 999px;
+  border-radius: 0;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
+  line-height: 1.2;
+  transition: color 0.15s ease;
 }
 
 .ffc-country-chip:hover,
 .ffc-country-chip:focus-visible {
-  background: #f5f3ff;
   color: #312e81;
   outline: none;
 }


### PR DESCRIPTION
## Summary
- restyle the FFC simulator country strip into a compact single-line row without chip borders
- keep country counts emphasized while preserving interactive behavior for map focus

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691958e4de048329b20bcd9495f019c7)