### PR TITLE
Add PDC snapshot column to dashboard My Projects widget

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -88,58 +88,144 @@
         <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
           <h2 id="dashboard-my-projects-title" class="h5 fw-semibold mb-0">My Projects</h2>
         </div>
-        @if (Model.HasMyProjects)
-        {
-          @foreach (var projectSection in Model.MyProjectSections)
-          {
-            <div class="dashboard-my-projects__section">
-              <h3 class="dashboard-my-projects__section-title text-uppercase text-secondary fw-semibold small mb-2">
-                @projectSection.Title
-              </h3>
-              <div class="dashboard-my-projects__list" role="list">
-                @foreach (var project in projectSection.Items)
+        <div class="row g-3 dashboard-my-projects__layout">
+          <div class="col-12 col-xl-9">
+            @* SECTION: My Projects listing *@
+            @if (Model.HasMyProjects)
+            {
+              <div class="dashboard-my-projects__projects pm-card pm-shadow h-100">
+                @foreach (var projectSection in Model.MyProjectSections)
                 {
-                  <a
-                    asp-page="/Projects/Overview"
-                    asp-route-id="@project.ProjectId"
-                    class="dashboard-project-card"
-                    role="listitem"
-                  >
-                    <div class="dashboard-project-card__cover" aria-hidden="true">
-                      @if (!string.IsNullOrEmpty(project.CoverImageUrl))
+                  <div class="dashboard-my-projects__section">
+                    <h3 class="dashboard-my-projects__section-title text-uppercase text-secondary fw-semibold small mb-2">
+                      @projectSection.Title
+                    </h3>
+                    <div class="dashboard-my-projects__list" role="list">
+                      @foreach (var project in projectSection.Items)
                       {
-                        <img
-                          src="@project.CoverImageUrl"
-                          alt=""
-                          loading="lazy"
-                        />
-                      }
-                      else
-                      {
-                        <span class="dashboard-project-card__cover-placeholder">No cover</span>
+                        <a
+                          asp-page="/Projects/Overview"
+                          asp-route-id="@project.ProjectId"
+                          class="dashboard-project-card"
+                          role="listitem"
+                        >
+                          <div class="dashboard-project-card__cover" aria-hidden="true">
+                            @if (!string.IsNullOrEmpty(project.CoverImageUrl))
+                            {
+                              <img
+                                src="@project.CoverImageUrl"
+                                alt=""
+                                loading="lazy"
+                              />
+                            }
+                            else
+                            {
+                              <span class="dashboard-project-card__cover-placeholder">No cover</span>
+                            }
+                          </div>
+                          <div class="dashboard-project-card__content">
+                            <div class="dashboard-project-card__title text-truncate" title="@project.Name">
+                              @project.Name
+                            </div>
+                            <div class="dashboard-project-card__meta text-truncate">
+                              @(string.IsNullOrWhiteSpace(project.Category) ? "No category" : project.Category)
+                            </div>
+                          </div>
+                          <span class="dashboard-project-card__chevron" aria-hidden="true">
+                            <i class="bi bi-arrow-right-short"></i>
+                          </span>
+                        </a>
                       }
                     </div>
-                    <div class="dashboard-project-card__content">
-                      <div class="dashboard-project-card__title text-truncate" title="@project.Name">
-                        @project.Name
-                      </div>
-                      <div class="dashboard-project-card__meta text-truncate">
-                        @(string.IsNullOrWhiteSpace(project.Category) ? "No category" : project.Category)
-                      </div>
-                    </div>
-                    <span class="dashboard-project-card__chevron" aria-hidden="true">
-                      <i class="bi bi-arrow-right-short"></i>
-                    </span>
-                  </a>
+                  </div>
                 }
               </div>
+            }
+            else if (Model.ShowEmptyMyProjectsMessage)
+            {
+              <p class="text-secondary small mb-0">You are not currently assigned to any projects.</p>
+            }
+            @* END SECTION *@
+          </div>
+          <div class="col-12 col-xl-3">
+            @* SECTION: My Projects PDC summary *@
+            <div class="dashboard-my-projects__pdc-card pm-card pm-shadow h-100">
+              <div class="dashboard-my-projects__pdc-header d-flex flex-column gap-1">
+                <p class="text-uppercase text-secondary fw-semibold small mb-0">Ongoing stage PDC</p>
+                <p class="text-muted small mb-0">Live PDC status for projects shown on the left.</p>
+              </div>
+              @if (Model.HasMyProjects)
+              {
+                var pdcProjects = Model.MyProjectSections.SelectMany(section => section.Items).ToList();
+                if (pdcProjects.Count > 0)
+                {
+                  <ul class="dashboard-my-projects__pdc-list list-unstyled mb-0" role="list">
+                    @foreach (var project in pdcProjects)
+                    {
+                      var stage = project.StageSummary;
+                      <li class="dashboard-my-projects__pdc-item" role="listitem">
+                        <div class="d-flex justify-content-between align-items-start gap-2">
+                          <div class="dashboard-my-projects__pdc-label text-truncate">
+                            <div class="fw-semibold text-truncate" title="@project.Name">@project.Name</div>
+                            <div class="text-muted small text-truncate">
+                              @if (stage is not null)
+                              {
+                                @:Stage: @stage.StageName (@stage.StageCode)
+                              }
+                              else
+                              {
+                                <span class="text-muted">Stage data unavailable</span>
+                              }
+                            </div>
+                          </div>
+                          <div class="text-end">
+                            @if (stage?.PlannedDue is { } plannedDue)
+                            {
+                              var badgeClass = stage.IsOverdue ? "text-bg-danger" : "text-bg-success";
+                              <span class=$"badge rounded-pill {badgeClass}">
+                                @plannedDue.ToString("dd-MMM-yyyy")
+                              </span>
+                              <div class="dashboard-my-projects__pdc-meta small">
+                                @if (stage.DaysToPdc.HasValue)
+                                {
+                                  if (stage.IsOverdue)
+                                  {
+                                    <span class="text-danger">Overdue by @stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s")</span>
+                                  }
+                                  else
+                                  {
+                                    <span class="text-success">@stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s") to PDC</span>
+                                  }
+                                }
+                              </div>
+                            }
+                            else if (stage is not null)
+                            {
+                              <span class="badge rounded-pill text-bg-secondary">PDC not set</span>
+                            }
+                            else
+                            {
+                              <span class="badge rounded-pill text-bg-secondary">Unavailable</span>
+                            }
+                          </div>
+                        </div>
+                      </li>
+                    }
+                  </ul>
+                }
+                else
+                {
+                  <p class="text-secondary small mb-0">No projects available for PDC tracking.</p>
+                }
+              }
+              else
+              {
+                <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
+              }
             </div>
-          }
-        }
-        else if (Model.ShowEmptyMyProjectsMessage)
-        {
-          <p class="text-secondary small mb-0">You are not currently assigned to any projects.</p>
-        }
+            @* END SECTION *@
+          </div>
+        </div>
       </section>
     </div>
   }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2233,9 +2233,21 @@ summary::marker {
     width: 100%;
 }
 
+/* SECTION: Dashboard - My projects */
 .dashboard-my-projects {
     display: flex;
     flex-direction: column;
+}
+
+.dashboard-my-projects__layout {
+    align-items: stretch;
+}
+
+.dashboard-my-projects__projects {
+    border: 1px solid var(--pm-border);
+    border-radius: 1rem;
+    background-color: var(--pm-card);
+    padding: 1rem 1.25rem;
 }
 
 .dashboard-my-projects__section + .dashboard-my-projects__section {
@@ -2244,8 +2256,26 @@ summary::marker {
 
 .dashboard-my-projects__list {
     display: grid;
-    grid-template-columns: repeat(1, minmax(0, 1fr));
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(15.5rem, 1fr);
     gap: 1rem;
+    overflow-x: auto;
+    padding-bottom: .35rem;
+    scrollbar-width: thin;
+}
+
+.dashboard-my-projects__list::-webkit-scrollbar {
+    height: 8px;
+}
+
+.dashboard-my-projects__list::-webkit-scrollbar-thumb {
+    background-color: rgba(15, 23, 42, .15);
+    border-radius: 999px;
+}
+
+.dashboard-my-projects__list::-webkit-scrollbar-track {
+    background-color: rgba(15, 23, 42, .06);
+    border-radius: 999px;
 }
 
 .dashboard-project-card {
@@ -2328,19 +2358,50 @@ summary::marker {
     flex-shrink: 0;
 }
 
+.dashboard-my-projects__pdc-card {
+    border: 1px solid var(--pm-border);
+    border-radius: 1rem;
+    background-color: var(--pm-card);
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+}
+
+.dashboard-my-projects__pdc-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: .5rem;
+}
+
+.dashboard-my-projects__pdc-item {
+    padding-bottom: .75rem;
+    border-bottom: 1px solid var(--pm-border);
+}
+
+.dashboard-my-projects__pdc-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.dashboard-my-projects__pdc-meta {
+    margin-top: .35rem;
+}
+
 .dashboard-my-projects__section-title {
     letter-spacing: .4px;
 }
 
-@media (min-width: 768px) {
+@media (max-width: 1199.98px) {
     .dashboard-my-projects__list {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-auto-columns: minmax(14rem, 75%);
     }
 }
 
 @media (min-width: 1200px) {
     .dashboard-my-projects__list {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-auto-columns: minmax(16rem, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- restructure the dashboard My Projects widget into a 9:3 layout with a dedicated PDC column
- compute current stage PDC summaries for assigned projects using existing stage ordering logic
- add styling for the single-row project list and the PDC status panel

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196410ccac83299a16bd24ebd70333)