### PR TITLE
Create combined My Projects and PDC widget

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -84,16 +84,24 @@
   @if (Model.ShowMyProjectsWidget)
   {
     <div class="col-12">
-      <section class="dashboard-my-projects" aria-labelledby="dashboard-my-projects-title">
-        <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
-          <h2 id="dashboard-my-projects-title" class="h5 fw-semibold mb-0">My Projects</h2>
-        </div>
-        <div class="row g-3 dashboard-my-projects__layout">
-          <div class="col-12 col-xl-9">
+      <section
+        class="dashboard-card myproj-stage-widget dashboard-my-projects"
+        aria-labelledby="dashboard-my-projects-title"
+      >
+        @* SECTION: My Projects + Stage PDC header *@
+        <header class="myproj-stage-widget__header">
+          <h2 id="dashboard-my-projects-title" class="myproj-stage-widget__title">My projects</h2>
+          <p class="myproj-stage-widget__subtitle mb-0">Stage &amp; PDC</p>
+        </header>
+        @* END SECTION *@
+
+        @* SECTION: My Projects + Stage PDC split widget *@
+        <div class="myproj-stage-widget__body">
+          <div class="myproj-stage-widget__projects" data-role="myproj-projects-pane">
             @* SECTION: My Projects listing *@
             @if (Model.HasMyProjects)
             {
-              <div class="dashboard-my-projects__projects pm-card pm-shadow h-100">
+              <div class="dashboard-my-projects__projects">
                 @foreach (var projectSection in Model.MyProjectSections)
                 {
                   <div class="dashboard-my-projects__section">
@@ -108,6 +116,7 @@
                           asp-route-id="@project.ProjectId"
                           class="dashboard-project-card"
                           role="listitem"
+                          data-project-id="@project.ProjectId"
                         >
                           <div class="dashboard-project-card__cover" aria-hidden="true">
                             @if (!string.IsNullOrEmpty(project.CoverImageUrl))
@@ -147,85 +156,90 @@
             }
             @* END SECTION *@
           </div>
-          <div class="col-12 col-xl-3">
-            @* SECTION: My Projects PDC summary *@
-            <div class="dashboard-my-projects__pdc-card pm-card pm-shadow h-100">
-              <div class="dashboard-my-projects__pdc-header d-flex flex-column gap-1">
-                <p class="text-uppercase text-secondary fw-semibold small mb-0">Ongoing stage PDC</p>
-                <p class="text-muted small mb-0">Live PDC status for projects shown on the left.</p>
-              </div>
-              @if (Model.HasMyProjects)
+
+          <div class="myproj-stage-widget__divider" aria-hidden="true"></div>
+
+          <aside class="myproj-stage-widget__pdc" data-role="myproj-pdc-pane" aria-label="Ongoing stage PDC">
+            <div class="dashboard-my-projects__pdc-header d-flex flex-column gap-1">
+              <p class="text-uppercase text-secondary fw-semibold small mb-0">Ongoing stage PDC</p>
+              <p class="text-muted small mb-0">Live PDC status for projects shown on the left.</p>
+            </div>
+            @if (Model.HasMyProjects)
+            {
+              var pdcProjects = Model.MyProjectSections.SelectMany(section => section.Items).ToList();
+              if (pdcProjects.Count > 0)
               {
-                var pdcProjects = Model.MyProjectSections.SelectMany(section => section.Items).ToList();
-                if (pdcProjects.Count > 0)
-                {
-                  <ul class="dashboard-my-projects__pdc-list list-unstyled mb-0" role="list">
-                    @foreach (var project in pdcProjects)
-                    {
-                      var stage = project.StageSummary;
-                      <li class="dashboard-my-projects__pdc-item" role="listitem">
-                        <div class="d-flex justify-content-between align-items-start gap-2">
-                          <div class="dashboard-my-projects__pdc-label text-truncate">
-                            <div class="fw-semibold text-truncate" title="@project.Name">@project.Name</div>
-                            <div class="text-muted small text-truncate">
-                              @if (stage is not null)
-                              {
-                                @:Stage: @stage.StageName (@stage.StageCode)
-                              }
-                              else
-                              {
-                                <span class="text-muted">Stage data unavailable</span>
-                              }
-                            </div>
-                          </div>
-                          <div class="text-end">
-                            @if (stage?.PlannedDue is { } plannedDue)
+                <ul class="dashboard-my-projects__pdc-list list-unstyled mb-0" role="list">
+                  @foreach (var project in pdcProjects)
+                  {
+                    var stage = project.StageSummary;
+                    <li
+                      class="dashboard-my-projects__pdc-item myproj-stage-widget__pdc-row"
+                      data-project-id="@project.ProjectId"
+                      role="listitem"
+                      tabindex="0"
+                    >
+                      <div class="d-flex justify-content-between align-items-start gap-2">
+                        <div class="dashboard-my-projects__pdc-label text-truncate">
+                          <div class="fw-semibold text-truncate" title="@project.Name">@project.Name</div>
+                          <div class="text-muted small text-truncate">
+                            @if (stage is not null)
                             {
-                              var badgeClass = stage.IsOverdue ? "text-bg-danger" : "text-bg-success";
-                              <span class=$"badge rounded-pill {badgeClass}">
-                                @plannedDue.ToString("dd-MMM-yyyy")
-                              </span>
-                              <div class="dashboard-my-projects__pdc-meta small">
-                                @if (stage.DaysToPdc.HasValue)
-                                {
-                                  if (stage.IsOverdue)
-                                  {
-                                    <span class="text-danger">Overdue by @stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s")</span>
-                                  }
-                                  else
-                                  {
-                                    <span class="text-success">@stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s") to PDC</span>
-                                  }
-                                }
-                              </div>
-                            }
-                            else if (stage is not null)
-                            {
-                              <span class="badge rounded-pill text-bg-secondary">PDC not set</span>
+                              @:Stage: @stage.StageName (@stage.StageCode)
                             }
                             else
                             {
-                              <span class="badge rounded-pill text-bg-secondary">Unavailable</span>
+                              <span class="text-muted">Stage data unavailable</span>
                             }
                           </div>
                         </div>
-                      </li>
-                    }
-                  </ul>
-                }
-                else
-                {
-                  <p class="text-secondary small mb-0">No projects available for PDC tracking.</p>
-                }
+                        <div class="text-end">
+                          @if (stage?.PlannedDue is { } plannedDue)
+                          {
+                            var badgeClass = stage.IsOverdue ? "text-bg-danger" : "text-bg-success";
+                            <span class=$"badge rounded-pill {badgeClass}">
+                              @plannedDue.ToString("dd-MMM-yyyy")
+                            </span>
+                            <div class="dashboard-my-projects__pdc-meta small">
+                              @if (stage.DaysToPdc.HasValue)
+                              {
+                                if (stage.IsOverdue)
+                                {
+                                  <span class="text-danger">Overdue by @stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s")</span>
+                                }
+                                else
+                                {
+                                  <span class="text-success">@stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s") to PDC</span>
+                                }
+                              }
+                            </div>
+                          }
+                          else if (stage is not null)
+                          {
+                            <span class="badge rounded-pill text-bg-secondary">PDC not set</span>
+                          }
+                          else
+                          {
+                            <span class="badge rounded-pill text-bg-secondary">Unavailable</span>
+                          }
+                        </div>
+                      </div>
+                    </li>
+                  }
+                </ul>
               }
               else
               {
-                <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
+                <p class="text-secondary small mb-0">No projects available for PDC tracking.</p>
               }
-            </div>
-            @* END SECTION *@
-          </div>
+            }
+            else
+            {
+              <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
+            }
+          </aside>
         </div>
+        @* END SECTION *@
       </section>
     </div>
   }
@@ -267,4 +281,5 @@
   <script src="~/lib/leaflet/1.9.4/leaflet.js" asp-append-version="true" defer></script>
   <script src="~/js/widgets/ffc-simulator-map.js" asp-append-version="true" defer></script>
   <script src="~/js/todo-widget.js" asp-append-version="true" defer></script>
+  <script type="module" src="~/js/dashboard/myproj-stage-widget.js" asp-append-version="true"></script>
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2392,6 +2392,80 @@ summary::marker {
     letter-spacing: .4px;
 }
 
+/* SECTION: Dashboard - My projects + Stage PDC widget */
+.myproj-stage-widget {
+    border-radius: 1.25rem;
+    box-shadow: var(--pm-shadow);
+    background: var(--pm-card);
+    padding: 1.25rem 1.5rem 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.myproj-stage-widget__header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: baseline;
+    margin-bottom: .75rem;
+    font-size: var(--pm-font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--pm-muted);
+}
+
+.myproj-stage-widget__title {
+    justify-self: flex-start;
+}
+
+.myproj-stage-widget__subtitle {
+    justify-self: flex-end;
+}
+
+.myproj-stage-widget__body {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.myproj-stage-widget__projects {
+    flex: 1.6;
+    min-width: 0;
+}
+
+.myproj-stage-widget__pdc {
+    flex: 1;
+    min-width: 0;
+}
+
+.myproj-stage-widget__divider {
+    width: 1px;
+    background: linear-gradient(to bottom, transparent, rgba(15, 23, 42, .06), transparent);
+}
+
+.myproj-stage-widget__pdc-row.is-active {
+    background: rgba(37, 99, 235, .06);
+    border-radius: .75rem;
+}
+
+.myproj-stage-widget__pdc-row.is-active .pdc-row__title,
+.myproj-stage-widget__pdc-row.is-active .dashboard-my-projects__pdc-label .fw-semibold {
+    font-weight: 600;
+}
+
+.dashboard-project-card.is-active {
+    border-color: rgba(45, 108, 223, .65);
+    box-shadow: 0 24px 36px -26px rgba(45, 108, 223, .45);
+    background-color: rgba(37, 99, 235, .04);
+}
+
+@media (max-width: 992px) {
+    .myproj-stage-widget__body {
+        flex-direction: column;
+    }
+
+    .myproj-stage-widget__divider {
+        display: none;
+    }
+}
+
 @media (max-width: 1199.98px) {
     .dashboard-my-projects__list {
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/wwwroot/js/dashboard/myproj-stage-widget.js
+++ b/wwwroot/js/dashboard/myproj-stage-widget.js
@@ -1,0 +1,75 @@
+// SECTION: My Projects + Stage PDC interactive linking
+(function () {
+    document.addEventListener('DOMContentLoaded', () => {
+        const widget = document.querySelector('.myproj-stage-widget');
+        if (!widget) {
+            return;
+        }
+
+        const projectCards = widget.querySelectorAll('[data-project-id].dashboard-project-card');
+        const pdcRows = widget.querySelectorAll('.myproj-stage-widget__pdc-row[data-project-id]');
+
+        if (!projectCards.length || !pdcRows.length) {
+            return;
+        }
+
+        const pdcById = new Map();
+        pdcRows.forEach((row) => {
+            pdcById.set(row.dataset.projectId, row);
+        });
+
+        const cardById = new Map();
+        projectCards.forEach((card) => {
+            cardById.set(card.dataset.projectId, card);
+        });
+
+        function setActive(projectId, options = { scrollToCard: false }) {
+            pdcRows.forEach((row) => {
+                row.classList.toggle('is-active', row.dataset.projectId === projectId);
+            });
+
+            projectCards.forEach((card) => {
+                card.classList.toggle('is-active', card.dataset.projectId === projectId);
+            });
+
+            if (options.scrollToCard) {
+                const card = cardById.get(projectId);
+                if (card) {
+                    card.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+                }
+            }
+        }
+
+        function activateFromRow(row, shouldScroll = false) {
+            const id = row.dataset.projectId;
+            if (!id) {
+                return;
+            }
+
+            setActive(id, { scrollToCard: shouldScroll });
+        }
+
+        projectCards.forEach((card) => {
+            const id = card.dataset.projectId;
+            card.addEventListener('mouseenter', () => setActive(id));
+            card.addEventListener('focus', () => setActive(id));
+        });
+
+        pdcRows.forEach((row) => {
+            row.addEventListener('click', () => activateFromRow(row, true));
+            row.addEventListener('mouseenter', () => activateFromRow(row));
+            row.addEventListener('focus', () => activateFromRow(row));
+            row.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    activateFromRow(row, true);
+                }
+            });
+        });
+
+        const initialActiveId = pdcRows[0]?.dataset.projectId;
+        if (initialActiveId) {
+            setActive(initialActiveId);
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- merge the My Projects cards and Ongoing Stage PDC list into a unified split dashboard card with shared header and data attributes
- add styling for the split layout, divider, active highlights, and responsive stacking
- introduce a dashboard script that syncs hover/click/focus states between project cards and PDC rows and scrolls cards into view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196e0fa08c83298979ad33d6a5b2db)