### PR TITLE
Improve dashboard widget layout consistency

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -20,8 +20,8 @@
         <div class="ffc-simulator-map-widget__header">
             <div>
                 <p class="ffc-simulator-map-widget__eyebrow text-uppercase mb-1">FFC simulators</p>
-                <h2 id="ffc-simulator-map-title" class="h5 mb-1">Installed & delivered footprint</h2>
-                <p class="text-secondary small mb-0">Countries with completed deliveries are highlighted with live counts.</p>
+                <h2 id="ffc-simulator-map-title" class="dashboard-widget-title mb-1">Installed & delivered footprint</h2>
+                <p class="text-secondary small mb-0 dashboard-widget-subtitle">Countries with completed deliveries are highlighted with live counts.</p>
             </div>
             <div class="ffc-simulator-map-widget__stats" aria-label="FFC delivery totals">
                 <div class="ffc-simulator-map-widget__stat">

--- a/Areas/Dashboard/Components/OpsSignals/_Widget.cshtml
+++ b/Areas/Dashboard/Components/OpsSignals/_Widget.cshtml
@@ -9,7 +9,21 @@
     string SerializeList<T>(IEnumerable<T>? data) => JsonSerializer.Serialize(data ?? Array.Empty<T>());
 }
 
-<section class="ops-signals" aria-label="Activity snapshot">
+<section class="ops-signals pm-card pm-shadow" aria-label="Activity snapshot">
+  @* SECTION: Header *@
+  <header class="ops-signals__header">
+    <div class="ops-signals__title">
+      <span class="ops-signals__badge" aria-hidden="true">
+        <i class="bi bi-graph-up"></i>
+      </span>
+      <div>
+        <h2 class="dashboard-widget-title mb-1">Ops signals</h2>
+        <p class="dashboard-widget-subtitle mb-0">Live operational metrics</p>
+      </div>
+    </div>
+  </header>
+  @* END SECTION *@
+
   <div class="ops-signals__grid">
     @foreach (var t in Model.Tiles)
     {

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -59,7 +59,7 @@
     <partial name="_TodoWidget" model="Model.TodoWidget" />
     <button
       type="button"
-      class="dashboard-events-card dashboard-events-card--floating pm-card pm-shadow w-100 mt-3 mt-lg-0"
+      class="dashboard-events-card dashboard-events-card--floating pm-card pm-shadow w-100"
       data-drawer-toggle
       data-drawer-target="dashboard-events"
       aria-controls="dashboard-events"
@@ -71,8 +71,8 @@
           <i class="bi bi-calendar-event"></i>
         </span>
         <div class="text-start">
-          <h3 class="pm-card-title h6 mb-0">Upcoming events</h3>
-          <p class="pm-card-subtitle mb-0">See what's coming up next.</p>
+          <h3 class="pm-card-title dashboard-widget-title mb-1">Upcoming events</h3>
+          <p class="pm-card-subtitle dashboard-widget-subtitle mb-0">See what's coming up next.</p>
         </div>
         <span class="ms-auto text-primary" aria-hidden="true">
           <i class="bi bi-arrow-right-short fs-4"></i>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2233,6 +2233,46 @@ summary::marker {
     width: 100%;
 }
 
+/* SECTION: Dashboard layout refinements */
+.dashboard-main-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.dashboard-sidebar {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.dashboard-events-card--floating {
+    position: static;
+    top: auto;
+    right: auto;
+    width: 100%;
+}
+
+.dashboard-events-card .pm-card-body {
+    align-items: center;
+    border: 1px solid var(--pm-border);
+    border-radius: 1rem;
+    background: var(--pm-card);
+}
+
+.dashboard-widget-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--pm-text, #0f172a);
+}
+
+.dashboard-widget-subtitle {
+    font-size: 0.9rem;
+    color: var(--pm-text-secondary, #64748b);
+}
+
 /* SECTION: Dashboard - My projects */
 .dashboard-my-projects {
     display: flex;
@@ -2481,21 +2521,6 @@ summary::marker {
 @media (max-width: 767.98px) {
     .dashboard-my-projects__list {
         grid-template-columns: 1fr;
-    }
-}
-
-@media (min-width: 992px) {
-    .dashboard-events-card--floating {
-        position: absolute;
-        top: 0;
-        right: calc(-1 * (100% + 1.5rem));
-        width: 18rem;
-    }
-}
-
-@media (min-width: 1200px) {
-    .dashboard-events-card--floating {
-        right: calc(-1 * (100% + 2.5rem));
     }
 }
 

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -2,7 +2,38 @@
 .ops-signals {
   --ops-gap-xs: 8px;
   --ops-gap-sm: 12px;
-  margin-top: var(--ops-gap-sm);
+  --ops-card-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  background: var(--pm-card, #fff);
+  border: 1px solid var(--pm-border, #e5e7eb);
+  border-radius: var(--ops-card-radius);
+  box-shadow: var(--pm-shadow, 0 8px 30px rgba(15, 23, 42, 0.08));
+}
+
+.ops-signals__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.ops-signals__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ops-signals__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--pm-primary, #2d6cdf) 12%, #eef2ff);
+  color: var(--pm-primary, #2d6cdf);
+  font-size: 1.25rem;
 }
 
 .ops-signals__grid {


### PR DESCRIPTION
## Summary
- Keep the upcoming events card within the sidebar and align its typography with other dashboard widgets
- Add shared dashboard spacing plus title/subtitle styles for consistent widget padding and margins
- Refresh OpsSignals and FFC map headers to match the updated card styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691972cab79c83299e6f6f7968aa0639)