### PR TITLE
Add spacing above FFC simulator map widget

### DIFF
--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -3,6 +3,7 @@
   border: 0;
   border-radius: 1rem;
   background: linear-gradient(135deg, #ffffff 0%, #f5f3ff 55%, #ede9fe 100%);
+  margin-top: 1.5rem;
 }
 
 .ffc-simulator-map-widget .pm-card-body {


### PR DESCRIPTION
## Summary
- add top margin to the FFC simulator map widget to separate it from preceding dashboard content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919753c2f4883298a9b3cd9769a2020)