### PR TITLE
Align dashboard widget spacing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2192,6 +2192,12 @@ summary::marker {
     margin-bottom: 0;
 }
 
+/* SECTION: Dashboard widget spacing */
+.dashboard-main-content > * + * {
+    margin-top: 1.25rem;
+}
+/* END SECTION */
+
 .dashboard-events-card {
     display: block;
     padding: 0;

--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -3,7 +3,7 @@
   border: 0;
   border-radius: 1rem;
   background: linear-gradient(135deg, #ffffff 0%, #f5f3ff 55%, #ede9fe 100%);
-  margin-top: 1.5rem;
+  margin-top: 0;
 }
 
 .ffc-simulator-map-widget .pm-card-body {

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -2,7 +2,7 @@
 .ops-signals {
   --ops-gap-xs: 8px;
   --ops-gap-sm: 12px;
-  margin-top: var(--ops-gap-sm);
+  margin-top: 0;
 }
 
 .ops-signals__grid {


### PR DESCRIPTION
## Summary
- add consistent vertical spacing between stacked dashboard widgets
- remove per-widget top margins so cards share the same rhythm

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197930ba948329969c55f13811d84a)