### PR TITLE
Unify dashboard widget spacing

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2192,9 +2192,22 @@ summary::marker {
     margin-bottom: 0;
 }
 
-/* SECTION: Dashboard widget spacing */
+/* SECTION: Dashboard layout spacing */
+.dashboard-main-content,
+.dashboard {
+    --dashboard-section-gap: clamp(1.35rem, 1.5vw, 1.75rem);
+}
+
 .dashboard-main-content > * + * {
-    margin-top: clamp(1.35rem, 1.5vw, 1.75rem);
+    margin-top: var(--dashboard-section-gap);
+}
+
+.dashboard-my-projects {
+    margin-top: var(--dashboard-section-gap);
+}
+
+.row.dashboard {
+    --bs-gutter-y: 0;
 }
 /* END SECTION */
 


### PR DESCRIPTION
## Summary
- add a shared dashboard spacing token and reuse it for vertical gaps between widgets
- remove the dashboard row's vertical gutter so spacing relies on the unified token rather than Bootstrap gutters

## Testing
- not run (CSS change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197d638d9c8329809e69e2c399fd97)