### PR TITLE
Widen ongoing analytics bar charts

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -127,7 +127,11 @@
 
 @media (min-width: 992px) {
   .analytics-panel .analytics-layout__row--top {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    /* SECTION: Wider layout for mixed chart rows */
+    grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+    align-items: stretch;
+    column-gap: 1.75rem;
+    /* END SECTION */
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the desktop grid for the ongoing analytics header row so the donut column stays compact while the bar-chart column can stretch across the remaining width

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aa386fc4c8329b73ce080dc08ba89)