### PR TITLE
Improve ongoing analytics layout

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -13,9 +13,9 @@
 <section class="analytics-panel analytics-panel--ongoing" aria-label="Ongoing projects analytics">
     <!-- SECTION: Ongoing analytics layout -->
     <div class="analytics-layout">
+        <div class="analytics-grid analytics-grid--ongoing">
 
-        <!-- Row 1: category + stage distribution -->
-        <div class="analytics-layout__row analytics-layout__row--top">
+            <!-- Card: category distribution -->
             <article class="analytics-card">
                 <header class="analytics-card__header">
                     <h2 class="analytics-card__title">Ongoing projects by category</h2>
@@ -31,6 +31,7 @@
                 </div>
             </article>
 
+            <!-- Card: stage distribution -->
             <article class="analytics-card">
                 <header class="analytics-card__header">
                     <h2 class="analytics-card__title">Ongoing projects by current stage</h2>
@@ -45,10 +46,8 @@
                     </div>
                 </div>
             </article>
-        </div>
 
-        <!-- Row 2: time-in-stage -->
-        <div class="analytics-layout__row">
+            <!-- Card: time-in-stage -->
             <article class="analytics-card analytics-card--wide">
                 <header class="analytics-card__header">
                     <h2 class="analytics-card__title">Average time spent in each stage</h2>
@@ -65,8 +64,8 @@
                     </div>
                 </div>
             </article>
-        </div>
 
+        </div>
     </div>
     <!-- END SECTION -->
 </section>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -125,6 +125,34 @@
   gap: 1.5rem;
 }
 
+/* SECTION: Analytics grid utilities */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.analytics-grid--ongoing {
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.35fr);
+}
+
+.analytics-card--wide {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 991.98px) {
+  .analytics-grid,
+  .analytics-grid--ongoing {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .analytics-card--wide {
+    grid-column: auto;
+  }
+}
+/* END SECTION */
+
 @media (min-width: 992px) {
   .analytics-panel .analytics-layout__row--top {
     /* SECTION: Wider layout for mixed chart rows */
@@ -141,10 +169,6 @@
   box-shadow: 0 18px 30px -26px rgba(15, 23, 42, 0.35);
   border: 1px solid var(--pm-border);
   padding: 1rem 1.25rem 1.25rem;
-}
-
-.analytics-card--wide {
-  grid-column: 1 / -1;
 }
 
 .analytics-card__header {


### PR DESCRIPTION
## Summary
- restructure the ongoing analytics partial to use a shared grid container so the bottom card can span the full width
- add reusable analytics grid utility styles so wide cards naturally stretch on desktop and collapse on smaller screens

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab11750d483298948294f2e5f2a6a)