### PR TITLE
Expand analytics layout width

### DIFF
--- a/Pages/Analytics/Index.cshtml
+++ b/Pages/Analytics/Index.cshtml
@@ -31,7 +31,7 @@
     data-projects-index-url="@Url.Page("/Projects/Index")"
     data-project-overview-url="@Url.Page("/Projects/Overview")"
   >
-    <div class="analytics-layout" aria-label="Project analytics views">
+    <div class="analytics-layout analytics-layout--shell" aria-label="Project analytics views">
       <aside class="analytics-left-rail" aria-label="Analytics modes">
         <!-- Left navigation for analytics modes -->
         <nav class="analytics-left-nav" aria-label="Analytics views">

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -27,6 +27,20 @@
   margin-top: 1.15rem;
 }
 
+/* SECTION: Analytics shell widths */
+.analytics-layout--shell {
+  width: min(1360px, 100%);
+  max-width: none;
+  margin-inline: auto;
+}
+
+@media (min-width: 1600px) {
+  .analytics-layout--shell {
+    width: min(1480px, calc(100% - 3rem));
+  }
+}
+/* END SECTION */
+
 @media (max-width: 991.98px) {
   .analytics-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add a shell-specific modifier for the analytics layout so the navigation and cards can stretch further across large viewports
- apply the modifier in the analytics index markup to pick up the wider shell styling without affecting nested layouts

## Testing
- dotnet build *(fails: `dotnet: command not found` in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abdf7b3308329b012217c2a7fdec2)