### PR TITLE
Ensure analytics panels fill width

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -155,6 +155,17 @@
   grid-column: 1 / -1;
 }
 
+/* SECTION: Analytics panel width overrides */
+.analytics-panel .analytics-layout {
+  width: 100%;
+}
+
+.analytics-panel .analytics-grid {
+  width: 100%;
+  max-width: none;
+}
+/* END SECTION */
+
 @media (max-width: 991.98px) {
   .analytics-grid,
   .analytics-grid--ongoing {


### PR DESCRIPTION
## Summary
- ensure analytics panel layouts and grids expand to the full available width by overriding legacy width constraints

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691acdac52408329b933014e86a55910)