### PR TITLE
Remove CoE lifecycle chart and wire real subcategory data

### DIFF
--- a/Models/Analytics/CoeAnalyticsVm.cs
+++ b/Models/Analytics/CoeAnalyticsVm.cs
@@ -9,8 +9,6 @@ public sealed class CoeAnalyticsVm
     // SECTION: Chart datasets
     public IReadOnlyList<CoeStageBucketVm> ByStage { get; init; } = Array.Empty<CoeStageBucketVm>();
 
-    public IReadOnlyList<CoeLifecycleBucketVm> ByLifecycle { get; init; } = Array.Empty<CoeLifecycleBucketVm>();
-
     public IReadOnlyList<CoeSubcategoryLifecycleVm> SubcategoriesByLifecycle { get; init; } = Array.Empty<CoeSubcategoryLifecycleVm>();
     // END SECTION
 
@@ -30,10 +28,6 @@ public sealed class CoeAnalyticsVm
 
 // SECTION: CoE stage dataset
 public sealed record CoeStageBucketVm(string StageName, int ProjectCount);
-// END SECTION
-
-// SECTION: CoE lifecycle dataset
-public sealed record CoeLifecycleBucketVm(string LifecycleStatus, int ProjectCount);
 // END SECTION
 
 // SECTION: CoE sub-category dataset

--- a/Pages/Analytics/Partials/_CoeAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CoeAnalytics.cshtml
@@ -13,7 +13,7 @@
     var midTerm = Model.Roadmap.MidTerm ?? Array.Empty<string>();
     var longTerm = Model.Roadmap.LongTerm ?? Array.Empty<string>();
     var noCoeProjectsMessage = "No CoE projects to analyse yet. Create a CoE project to see analytics here.";
-    var noSubcategoryMessage = "No CoE sub-categories with projects yet. Add CoE projects to see this breakdown.";
+    var noSubcategoryMessage = "CoE sub-category breakdown will appear here once projects have sub-categories configured.";
     // END SECTION
 }
 
@@ -41,32 +41,6 @@
                                     role="img"
                                     aria-label="Ongoing CoE projects by current stage"
                                     data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByStage, jsonOptions))'>
-                            </canvas>
-                        </div>
-                    }
-                </div>
-            </article>
-
-            <!-- Card 2: CoE projects by lifecycle status -->
-            <article class="analytics-card">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">CoE projects by lifecycle status</h2>
-                    <p class="analytics-card__meta">
-                        How many CoE projects are ongoing, completed, or cancelled as per lifecycle.
-                    </p>
-                </header>
-                <div class="analytics-card__body">
-                    @if (!Model.HasCoeProjects)
-                    {
-                        <p class="analytics-card__empty-text">@noCoeProjectsMessage</p>
-                    }
-                    else
-                    {
-                        <div class="analytics-card__chart">
-                            <canvas id="coe-by-lifecycle-chart"
-                                    role="img"
-                                    aria-label="CoE projects by lifecycle status"
-                                    data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByLifecycle, jsonOptions))'>
                             </canvas>
                         </div>
                     }

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -289,7 +289,6 @@ function initOngoingAnalytics() {
 // SECTION: CoE analytics initialiser
 function initCoeAnalytics() {
   const stageCanvas = document.getElementById('coe-by-stage-chart');
-  const lifecycleCanvas = document.getElementById('coe-by-lifecycle-chart');
   const subcategoryCanvas = document.getElementById('coe-subcategories-by-lifecycle-chart');
 
   renderSeriesChart(stageCanvas, (series) => {
@@ -305,69 +304,6 @@ function initCoeAnalytics() {
             ticks: {
               precision: 0,
               stepSize: 1
-            }
-          }
-        }
-      }
-    });
-  });
-
-  renderSeriesChart(lifecycleCanvas, (series) => {
-    const buckets = lifecycleStatuses.map((status) => {
-      const match = series.find((point) => {
-        const key = point.lifecycleStatus ?? point.status ?? point.label;
-        return key === status;
-      });
-      const count = ensureNumber(match?.projectCount ?? match?.value ?? match?.count);
-      return {
-        status,
-        count,
-        color: lifecycleColorMap[status] ?? palette[0]
-      };
-    });
-
-    const activeBuckets = buckets.filter((bucket) => bucket.count > 0);
-    const dataset = activeBuckets.length ? activeBuckets : buckets.slice(0, 1);
-    const datasetIndexLookup = new Map();
-    dataset.forEach((bucket, index) => datasetIndexLookup.set(bucket.status, index));
-
-    const legendEntries = buckets.map((bucket) => ({
-      status: bucket.status,
-      count: bucket.count,
-      color: bucket.count > 0 ? bucket.color : '#cbd5f5',
-      isActive: bucket.count > 0,
-      datasetIndex: datasetIndexLookup.get(bucket.status) ?? 0
-    }));
-
-    createDoughnutChart(lifecycleCanvas, {
-      labels: dataset.map((bucket) => bucket.status),
-      values: dataset.map((bucket) => bucket.count),
-      colors: dataset.map((bucket) => bucket.color),
-      options: {
-        plugins: {
-          legend: {
-            position: 'bottom',
-            labels: {
-              usePointStyle: true,
-              generateLabels() {
-                return legendEntries.map((entry) => ({
-                  text: `${entry.status} · ${entry.count}`,
-                  fillStyle: entry.color,
-                  strokeStyle: entry.color,
-                  hidden: false,
-                  lineWidth: entry.isActive ? 1 : 0,
-                  datasetIndex: entry.datasetIndex
-                }));
-              }
-            },
-            onClick(event, legendItem, legend) {
-              const entry = legendEntries[legendItem.index];
-              if (!entry?.isActive) {
-                return;
-              }
-
-              const defaultClick = getDefaultLegendClick();
-              defaultClick.call(this, event, legendItem, legend);
             }
           }
         }


### PR DESCRIPTION
## Summary
- remove the CoE lifecycle doughnut card from the analytics partial and update the empty-state message for the sub-category chart
- drop the lifecycle data set from the Coe analytics view model and aggregation, count projects directly, and rebuild the CoE sub-category breakdown from live project data without grouping into “Other”
- delete the lifecycle chart wiring on the client, keep the stacked bar chart tied to the live dataset, and update the CoE analytics unit tests accordingly

## Testing
- `dotnet test` *(fails: dotnet command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b26c4fc6083299d1082e2899fd071)