### PR TITLE
Fix CoE subcategory aggregation query

### DIFF
--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -296,11 +296,19 @@ namespace ProjectManagement.Pages.Analytics
             CancellationToken cancellationToken)
         {
             // SECTION: CoE sub-category aggregation
-            var groupedBuckets = await coeProjectsQuery
+            var lifecycleSnapshots = await coeProjectsQuery
                 .Select(p => new
                 {
-                    Subcategory = NormalizeCoeSubcategoryName(p.Category != null ? p.Category.Name : null),
+                    CategoryName = p.Category != null ? p.Category.Name : null,
                     p.LifecycleStatus
+                })
+                .ToListAsync(cancellationToken);
+
+            var groupedBuckets = lifecycleSnapshots
+                .Select(item => new
+                {
+                    Subcategory = NormalizeCoeSubcategoryName(item.CategoryName),
+                    item.LifecycleStatus
                 })
                 .GroupBy(item => item.Subcategory)
                 .Select(g => new
@@ -310,7 +318,7 @@ namespace ProjectManagement.Pages.Analytics
                     Completed = g.Count(item => item.LifecycleStatus == ProjectLifecycleStatus.Completed),
                     Cancelled = g.Count(item => item.LifecycleStatus == ProjectLifecycleStatus.Cancelled)
                 })
-                .ToListAsync(cancellationToken);
+                .ToList();
 
             if (groupedBuckets.Count == 0)
             {


### PR DESCRIPTION
## Summary
- move CoE subcategory normalization out of the EF query so it runs after the data is materialized
- keep the rest of the aggregation logic intact so buckets are still sorted, truncated, and combined as before

## Testing
- `dotnet test --filter CoeAnalyticsTests` *(fails: ProjectManagement.Tests currently fails to build because DashboardPageTests requires additional constructor parameters)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2fe5ec0083299d6326928620e3a8)