### PR TITLE
Make analytics left nav sticky on desktop

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -47,8 +47,18 @@
   }
 }
 
+/* SECTION: Analytics left rail */
 .analytics-left-rail {
   align-self: stretch;
+}
+
+@media (min-width: 992px) {
+  .analytics-left-rail {
+    position: sticky;
+    top: 5.25rem;
+    align-self: flex-start;
+    height: fit-content;
+  }
 }
 
 .analytics-left-nav {


### PR DESCRIPTION
## Summary
- make the analytics left rail sticky on desktop breakpoints so the navigation stays visible while charts scroll
- keep existing mobile and tablet behavior unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3365a1fc8329a8e60fd8b9b97144)