### PR TITLE
Remove duplicate CoE analytics shell layout

### DIFF
--- a/Pages/Analytics/Partials/_CoeAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CoeAnalytics.cshtml
@@ -17,7 +17,7 @@
 
 <section class="analytics-panel analytics-panel--coe" aria-label="CoE projects analytics">
     <!-- SECTION: CoE analytics layout -->
-    <div class="analytics-layout analytics-layout--shell">
+    <div class="analytics-layout">
         <!-- SECTION: CoE stage chart -->
         <div class="analytics-layout__row">
             <article class="analytics-card analytics-card--wide">


### PR DESCRIPTION
## Summary
- remove the nested shell layout class inside the CoE analytics partial so it aligns with the other tabs

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb8b53b2c83299593429cbd70123a)