### PR TITLE
Ensure CoE analytics show zero-count stages

### DIFF
--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -259,11 +259,6 @@ namespace ProjectManagement.Pages.Analytics
                         .ToList()))
                 .ToListAsync(cancellationToken);
 
-            if (stageSnapshots.Count == 0)
-            {
-                return Array.Empty<CoeStageBucketVm>();
-            }
-
             var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             foreach (var project in stageSnapshots)
             {
@@ -277,19 +272,17 @@ namespace ProjectManagement.Pages.Analytics
                 counts[stage.StageCode] = existing + 1;
             }
 
-            if (counts.Count == 0)
-            {
-                return Array.Empty<CoeStageBucketVm>();
-            }
-
             var orderedCodes = StageCodes.All
-                .Where(code => counts.ContainsKey(code))
                 .Concat(counts.Keys.Where(code => !StageCodes.All.Contains(code, StringComparer.OrdinalIgnoreCase)))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             return orderedCodes
-                .Select(code => new CoeStageBucketVm(StageCodes.DisplayNameOf(code), counts[code]))
+                .Select(code =>
+                {
+                    counts.TryGetValue(code, out var count);
+                    return new CoeStageBucketVm(StageCodes.DisplayNameOf(code), count);
+                })
                 .ToList();
             // END SECTION
         }

--- a/ProjectManagement.Tests/CoeAnalyticsTests.cs
+++ b/ProjectManagement.Tests/CoeAnalyticsTests.cs
@@ -92,9 +92,14 @@ public sealed class CoeAnalyticsTests : IDisposable
 
         Assert.Equal(3, result.TotalCoeProjects);
 
-        var stageBucket = Assert.Single(result.ByStage);
-        Assert.Equal(StageCodes.DisplayNameOf(StageCodes.IPA), stageBucket.StageName);
+        Assert.Equal(StageCodes.All.Length, result.ByStage.Count);
+        var stageBucket = Assert.Single(result.ByStage
+            .Where(bucket => bucket.StageName == StageCodes.DisplayNameOf(StageCodes.IPA)));
         Assert.Equal(1, stageBucket.ProjectCount);
+        Assert.All(result.ByStage.Where(bucket => bucket.StageName != StageCodes.DisplayNameOf(StageCodes.IPA)), bucket =>
+        {
+            Assert.Equal(0, bucket.ProjectCount);
+        });
 
         var aiBucket = Assert.Single(result.SubcategoriesByLifecycle.Where(s => s.Name == "AI Innovation"));
         Assert.Equal(1, aiBucket.Ongoing);


### PR DESCRIPTION
## Summary
- build CoE stage buckets from the authoritative stage list so stages with zero ongoing projects remain visible on the chart
- update the CoE analytics unit test to reflect the expanded stage series output

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd0ab7db883298731d71b7f83bcd4)