### PR TITLE
Arrange CoE analytics charts side by side

### DIFF
--- a/Pages/Analytics/Partials/_CoeAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CoeAnalytics.cshtml
@@ -18,9 +18,10 @@
 <section class="analytics-panel analytics-panel--coe" aria-label="CoE projects analytics">
     <!-- SECTION: CoE analytics layout -->
     <div class="analytics-layout">
-        <!-- SECTION: CoE stage chart -->
-        <div class="analytics-layout__row">
-            <article class="analytics-card analytics-card--wide">
+        <!-- SECTION: CoE stage and lifecycle charts row -->
+        <div class="analytics-layout__row analytics-layout__row--coe-grid">
+            <!-- SECTION: CoE stage chart -->
+            <article class="analytics-card">
                 <header class="analytics-card__header">
                     <h2 class="analytics-card__title">Ongoing CoE projects by current stage</h2>
                     <p class="analytics-card__meta">
@@ -44,12 +45,10 @@
                     }
                 </div>
             </article>
-        </div>
-        <!-- END SECTION -->
+            <!-- END SECTION -->
 
-        <!-- SECTION: CoE sub-category lifecycle chart -->
-        <div class="analytics-layout__row">
-            <article class="analytics-card analytics-card--wide analytics-card--coe-subcategories">
+            <!-- SECTION: CoE sub-category lifecycle chart -->
+            <article class="analytics-card analytics-card--coe-subcategories">
                 <header class="analytics-card__header">
                     <h2 class="analytics-card__title">CoE sub-categories by lifecycle</h2>
                     <p class="analytics-card__meta">
@@ -74,6 +73,7 @@
                     }
                 </div>
             </article>
+            <!-- END SECTION -->
         </div>
         <!-- END SECTION -->
 

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -154,6 +154,19 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
 }
+
+.analytics-panel--coe .analytics-layout__row--coe-grid {
+  gap: 1.5rem;
+}
+/* END SECTION */
+
+/* SECTION: CoE analytics responsive overrides */
+@media (min-width: 992px) {
+  .analytics-panel--coe .analytics-layout__row--coe-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+  }
+}
 /* END SECTION */
 
 /* SECTION: Analytics grid utilities */


### PR DESCRIPTION
## Summary
- place the CoE stage and lifecycle charts into a single grid row so they appear beside one another on large screens while still stacking on small devices
- add responsive CoE-specific grid styling so the cards retain spacing and alignment across breakpoints

## Testing
- `dotnet test` *(fails: `dotnet` is not available in the container image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be067e1708329ae60d883874316c5)