### PR TITLE
Expand analytics shell to full width

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -29,15 +29,9 @@
 
 /* SECTION: Analytics shell widths */
 .analytics-layout--shell {
-  width: min(1360px, 100%);
+  width: 100%;
   max-width: none;
   margin-inline: auto;
-}
-
-@media (min-width: 1600px) {
-  .analytics-layout--shell {
-    width: min(1480px, calc(100% - 3rem));
-  }
 }
 /* END SECTION */
 


### PR DESCRIPTION
## Summary
- allow the analytics shell container to span the full viewport width by removing the hard-coded max width
- clean up the redundant wide-screen media query clamp so the CoE partial can use the entire page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be2ab70ac8329ac8d02860060a134)