### PR TITLE
Fix CoE analytics panel width

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -135,6 +135,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  align-items: stretch;
 }
 
 .analytics-panel .analytics-layout__row {


### PR DESCRIPTION
## Summary
- ensure the CoE analytics layout inside analytics panels stretches to the full available width so the chart cards no longer leave an empty column on the right

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be702a60483299b0a0dccd06c61e1)