### PR TITLE
Fix stage axis labels for EAS and SO

### DIFF
--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -287,6 +287,11 @@ function renderEmptyState(canvas) {
 // END SECTION
 
 // SECTION: Stage axis helpers
+const stageAxisLabelOverrides = {
+  EAS: 'EAS',
+  SO: 'SO'
+};
+
 function getStageAxisLabel(point) {
   if (!point) {
     return '';
@@ -294,6 +299,12 @@ function getStageAxisLabel(point) {
 
   const name = point.name ?? '';
   const code = point.stageCode ?? '';
+
+  const normalizedCode = code.toUpperCase();
+  const overrideLabel = stageAxisLabelOverrides[normalizedCode];
+  if (overrideLabel) {
+    return overrideLabel;
+  }
 
   if (!name) {
     return code;


### PR DESCRIPTION
## Summary
- ensure the stage axis label helper returns the short labels for EAS and SO stages so the chart x-axis always shows the expected abbreviations

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8ac03ac883299bc2a21c0c2a4a08)