### PR TITLE
Add stage delay hotspots card

### DIFF
--- a/Models/Analytics/StageTimeInsightsVm.cs
+++ b/Models/Analytics/StageTimeInsightsVm.cs
@@ -14,6 +14,8 @@ public sealed class StageTimeInsightsVm
 {
     public IReadOnlyList<StageTimeBucketRowVm> Rows { get; init; } = Array.Empty<StageTimeBucketRowVm>();
 
+    public IReadOnlyList<StageHotspotPointVm> StageHotspots { get; init; } = Array.Empty<StageHotspotPointVm>();
+
     public bool HasData => Rows.Count > 0;
 
     public int? SelectedCategoryId { get; init; }
@@ -33,5 +35,15 @@ public sealed class StageTimeBucketRowVm
     public int ProjectCount { get; init; }
     public int CompletedProjectCount { get; init; }
     public int OngoingProjectCount { get; init; }
+}
+
+public sealed class StageHotspotPointVm
+{
+    public string StageKey { get; init; } = string.Empty;
+    public string StageName { get; init; } = string.Empty;
+    public int StageOrder { get; init; }
+    public double MedianDays { get; init; }
+    public double AverageDays { get; init; }
+    public int ProjectCount { get; init; }
 }
 // END SECTION

--- a/Pages/Analytics/Partials/_ProjectManagementInsights.cshtml
+++ b/Pages/Analytics/Partials/_ProjectManagementInsights.cshtml
@@ -22,6 +22,7 @@
     }
     // END SECTION
     var filterId = "project-category-filter";
+    var hotspotFilterId = $"{filterId}-hotspots";
 }
 
 <!-- SECTION: Project management insights -->
@@ -98,6 +99,80 @@
                             Only stages with both actual start and completion dates are counted.
                             Stages from ongoing projects are only included once they complete.
                             Cost buckets use the latest AoN, benchmark, PNC, L1, or IPA entry available per project.
+                        </p>
+                    }
+                </div>
+            </article>
+        </div>
+
+        <div class="analytics-layout__row">
+            <article class="analytics-card analytics-card--wide analytics-card--insights-hotspots">
+                <header class="analytics-card__header">
+                    <div class="d-flex justify-content-between align-items-start gap-3">
+                        <div>
+                            <h2 class="analytics-card__title">Stage delay hotspots</h2>
+                            <p class="analytics-card__meta">
+                                Median days taken to complete each project stage. Ongoing stages are only included after they finish.
+                            </p>
+                        </div>
+
+                        <!-- SECTION: Shared project category filter -->
+                        <form method="get" asp-page="./Index" class="analytics-card__filters">
+                            <input type="hidden" name="tab" value="Insights" />
+                            <div class="analytics-card__filter-chip">
+                                <label class="form-label mb-0" for="@hotspotFilterId">
+                                    Project category
+                                </label>
+                                <select
+                                    id="@hotspotFilterId"
+                                    name="categoryId"
+                                    class="form-select form-select-sm"
+                                    data-auto-submit="change"
+                                >
+                                    <option
+                                        value=""
+                                        selected="@(!selectedCategoryId.HasValue ? "selected" : null)"
+                                    >
+                                        All
+                                    </option>
+                                    @foreach (var category in categories)
+                                    {
+                                        var isSelected = selectedCategoryId.HasValue && selectedCategoryId.Value == category.Id;
+                                        <option
+                                            value="@category.Id"
+                                            selected="@(isSelected ? "selected" : null)"
+                                        >
+                                            @category.Name
+                                        </option>
+                                    }
+                                </select>
+                            </div>
+                        </form>
+                        <!-- END SECTION -->
+                    </div>
+                </header>
+
+                <div class="analytics-card__body">
+                    @if (!(Model.StageHotspots?.Any() ?? false))
+                    {
+                        <p class="analytics-card__empty-text">
+                            No completed stages available yet to analyse stage delays.
+                        </p>
+                    }
+                    else
+                    {
+                        <div class="analytics-card__chart">
+                            <canvas
+                                id="stage-hotspots-chart"
+                                role="img"
+                                aria-label="Stage delay hotspots - median days per stage"
+                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.StageHotspots, jsonOptions))'
+                                data-empty-message="No completed stages available yet to analyse stage delays."
+                            ></canvas>
+                        </div>
+
+                        <p class="analytics-card__footnote">
+                            Only stages with both actual start and completion dates are counted. Ongoing projects contribute once their stages finish. Outliers are included; use median to understand the central tendency.
                         </p>
                     }
                 </div>

--- a/ProjectManagement.Tests/ProjectAnalyticsServiceStageTimeTests.cs
+++ b/ProjectManagement.Tests/ProjectAnalyticsServiceStageTimeTests.cs
@@ -97,6 +97,11 @@ public class ProjectAnalyticsServiceStageTimeTests
         Assert.Equal(1, aboveRow.ProjectCount);
         Assert.Equal(5, belowRow.MedianDays);
         Assert.Equal(1, belowRow.ProjectCount);
+
+        var hotspot = Assert.Single(result.StageHotspots);
+        Assert.Equal(StageCodes.FS, hotspot.StageKey);
+        Assert.Equal(7.5, hotspot.MedianDays);
+        Assert.Equal(2, hotspot.ProjectCount);
     }
 
     [Fact]
@@ -186,5 +191,10 @@ public class ProjectAnalyticsServiceStageTimeTests
         Assert.Equal(0, belowRow.ProjectCount);
 
         Assert.Equal(designCategoryId, result.SelectedCategoryId);
+
+        var designHotspot = Assert.Single(result.StageHotspots);
+        Assert.Equal(StageCodes.FS, designHotspot.StageKey);
+        Assert.Equal(10, designHotspot.MedianDays);
+        Assert.Equal(1, designHotspot.ProjectCount);
     }
 }

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -291,6 +291,12 @@
   padding: 1rem 1.25rem 1.5rem;
 }
 
+/* SECTION: Stage delay hotspots card */
+.analytics-card--insights-hotspots .analytics-card__chart {
+  min-height: 320px;
+}
+/* END SECTION */
+
 .analytics-card__chart canvas {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- add a new "Stage delay hotspots" insights card that reuses the shared project category filter and renders a horizontal bar chart of median stage durations
- extend the stage time insights view model, analytics service, and client script to surface hotspot data alongside the existing cost band view
- style the hotspots card and cover the new aggregation with unit tests

## Testing
- `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8b1f819c8329af06f932f0f39c91)