### PR TITLE
Fix stage insights query translation

### DIFF
--- a/Services/Analytics/ProjectAnalyticsService.cs
+++ b/Services/Analytics/ProjectAnalyticsService.cs
@@ -311,7 +311,7 @@ public sealed class ProjectAnalyticsService : IProjectAnalyticsService
                 && (s.Project.LifecycleStatus == ProjectLifecycleStatus.Active
                     || s.Project.LifecycleStatus == ProjectLifecycleStatus.Completed))
             .Where(s => s.ActualStart.HasValue && s.CompletedOn.HasValue)
-            .Where(s => !StageCodes.IsTot(s.StageCode));
+            .Where(s => !string.Equals(s.StageCode, StageCodes.TOT));
 
         if (categoryId.HasValue)
         {


### PR DESCRIPTION
## Summary
- replace the `StageCodes.IsTot` predicate in the analytics stage query with a SQL-translatable comparison to prevent runtime LINQ translation errors when loading insights

## Testing
- `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ProjectAnalyticsServiceStageTimeTests` *(fails: `dotnet` is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c91d769d083298743705af1e8d3a6)