### PR TITLE
Finalize FFC project unit rollout

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -19,20 +19,20 @@
     <div class="pm-card-body">
         <div class="ffc-simulator-map-widget__header">
             <div>
-                <p class="ffc-simulator-map-widget__eyebrow text-uppercase mb-1">Simulators for Friendly Foreign Countries </p>
-                <h2 id="ffc-simulator-map-title" class="h5 mb-1">Installed & delivered footprint</h2>
+                <p class="ffc-simulator-map-widget__eyebrow text-uppercase mb-1">Friendly Foreign Countries</p>
+                <h2 id="ffc-simulator-map-title" class="h5 mb-1">Project unit footprint</h2>
             </div>
             <div class="ffc-simulator-map-widget__stats" aria-label="FFC delivery totals">
                 <div class="ffc-simulator-map-widget__stat">
-                    <span class="label">Installed</span>
+                    <span class="label">Installed units</span>
                     <strong>@Model.TotalInstalled</strong>
                 </div>
                 <div class="ffc-simulator-map-widget__stat">
-                    <span class="label">Delivered</span>
+                    <span class="label">Delivered units</span>
                     <strong>@Model.TotalDelivered</strong>
                 </div>
                 <div class="ffc-simulator-map-widget__stat">
-                    <span class="label">Total</span>
+                    <span class="label">Total units</span>
                     <strong>@Model.TotalProjects</strong>
                 </div>
             </div>
@@ -52,12 +52,12 @@
                 <div
                     class="ffc-simulator-map__canvas"
                     role="img"
-                    aria-label="World map highlighting African FFC simulator deliveries"
+                    aria-label="World map highlighting African FFC project units"
                 ></div>
                 <div class="ffc-simulator-map__status" data-map-status>Loading delivery footprint…</div>
             </div>
             @* SECTION: Below-map country chip strip *@
-            <div class="ffc-simulator-map__country-strip" aria-label="FFC simulator activity by country">
+            <div class="ffc-simulator-map__country-strip" aria-label="FFC project unit activity by country">
                 <div class="ffc-country-strip" role="list">
                     @for (var index = 0; index < topCountries.Count; index++)
                     {
@@ -89,7 +89,7 @@
         }
         else
         {
-            <p class="text-secondary small mb-0 mt-3">FFC simulator delivery data is not available right now.</p>
+            <p class="text-secondary small mb-0 mt-3">FFC delivery data is not available right now.</p>
         }
     </div>
 </section>

--- a/Areas/ProjectOfficeReports/Domain/FfcProject.cs
+++ b/Areas/ProjectOfficeReports/Domain/FfcProject.cs
@@ -1,3 +1,4 @@
+using System;
 using ProjectManagement.Models;
 
 namespace ProjectManagement.Areas.ProjectOfficeReports.Domain;
@@ -9,6 +10,11 @@ public class FfcProject
     public string Name { get; set; } = string.Empty;
     public string? Remarks { get; set; }
     public int? LinkedProjectId { get; set; }
+    public int Quantity { get; set; } = 1;
+    public bool IsDelivered { get; set; }
+    public DateOnly? DeliveredOn { get; set; }
+    public bool IsInstalled { get; set; }
+    public DateOnly? InstalledOn { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
 

--- a/Areas/ProjectOfficeReports/Domain/FfcProjectBucketHelper.cs
+++ b/Areas/ProjectOfficeReports/Domain/FfcProjectBucketHelper.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectManagement.Areas.ProjectOfficeReports.Domain;
+
+// SECTION: Delivery bucket contract
+public enum FfcDeliveryBucket
+{
+    Planned,
+    DeliveredNotInstalled,
+    Installed
+}
+
+// SECTION: Quantity summary projection
+public sealed record FfcProjectQuantitySummary(int Installed, int DeliveredNotInstalled, int Planned)
+{
+    public int Total => Installed + DeliveredNotInstalled + Planned;
+}
+
+// SECTION: Helper entry points
+public static class FfcProjectBucketHelper
+{
+    // SECTION: Object classification overloads
+    public static (FfcDeliveryBucket Bucket, int Quantity) Classify(FfcProject project)
+    {
+        if (project is null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+
+        return Classify(project.IsInstalled, project.IsDelivered, project.Quantity);
+    }
+
+    public static (FfcDeliveryBucket Bucket, int Quantity) Classify(bool isInstalled, bool isDelivered, int quantity)
+    {
+        var safeQuantity = quantity <= 0 ? 1 : quantity;
+
+        if (isInstalled)
+        {
+            return (FfcDeliveryBucket.Installed, safeQuantity);
+        }
+
+        if (isDelivered)
+        {
+            return (FfcDeliveryBucket.DeliveredNotInstalled, safeQuantity);
+        }
+
+        return (FfcDeliveryBucket.Planned, safeQuantity);
+    }
+
+    // SECTION: Aggregation helpers
+    public static FfcProjectQuantitySummary Summarize(IEnumerable<FfcProject> projects)
+    {
+        if (projects is null)
+        {
+            return new FfcProjectQuantitySummary(0, 0, 0);
+        }
+
+        var totals = projects
+            .Select(Classify)
+            .GroupBy(tuple => tuple.Bucket)
+            .ToDictionary(group => group.Key, group => group.Sum(item => item.Quantity));
+
+        totals.TryGetValue(FfcDeliveryBucket.Installed, out var installed);
+        totals.TryGetValue(FfcDeliveryBucket.DeliveredNotInstalled, out var delivered);
+        totals.TryGetValue(FfcDeliveryBucket.Planned, out var planned);
+
+        return new FfcProjectQuantitySummary(installed, delivered, planned);
+    }
+
+    // SECTION: Label helper
+    public static string GetBucketLabel(FfcDeliveryBucket bucket) => bucket switch
+    {
+        FfcDeliveryBucket.Installed => "Installed",
+        FfcDeliveryBucket.DeliveredNotInstalled => "Delivered (not installed)",
+        _ => "Planned"
+    };
+}

--- a/Areas/ProjectOfficeReports/Pages/FFC/Countries/Manage.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Countries/Manage.cshtml
@@ -12,7 +12,7 @@
             <nav aria-label="Breadcrumb">
                 <ol class="breadcrumb mb-0 small">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC simulators</a></li>
+                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC deliveries</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Manage countries</li>
                 </ol>
             </nav>

--- a/Areas/ProjectOfficeReports/Pages/FFC/FfcRecordListPageModel.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/FfcRecordListPageModel.cs
@@ -234,8 +234,8 @@ public abstract class FfcRecordListPageModel : PageModel
     {
         queryable = ApplyMilestoneFilter(queryable, IpaStatus, record => record.IpaYes);
         queryable = ApplyMilestoneFilter(queryable, GslStatus, record => record.GslYes);
-        queryable = ApplyMilestoneFilter(queryable, DeliveryStatus, record => record.DeliveryYes);
-        queryable = ApplyMilestoneFilter(queryable, InstallationStatus, record => record.InstallationYes);
+        queryable = ApplyMilestoneFilter(queryable, DeliveryStatus, record => record.Projects.Any(project => project.IsDelivered));
+        queryable = ApplyMilestoneFilter(queryable, InstallationStatus, record => record.Projects.Any(project => project.IsInstalled));
         return queryable;
     }
 

--- a/Areas/ProjectOfficeReports/Pages/FFC/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Index.cshtml
@@ -6,7 +6,7 @@
 @using ProjectManagement.Models
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.FFC.IndexModel
 @{
-    ViewData["Title"] = "FFC simulators";
+    ViewData["Title"] = "FFC deliveries";
 
 }
 
@@ -14,8 +14,8 @@
     <section class="ffc-index">
         <div class="pm-page-header">
             <div>
-                <h1 class="h4 mb-1">FFC simulators</h1>
-                <p class="pm-page-subtitle">Review the status of FFC simulator deliveries by country and year.</p>
+                <h1 class="h4 mb-1">FFC deliveries</h1>
+                <p class="pm-page-subtitle">Review project-level delivery and installation progress by country and year.</p>
             </div>
             <div class="d-flex flex-wrap align-items-center gap-2">
                 @if (Model.CanManageRecords)
@@ -58,7 +58,7 @@
         }
         else
         {
-            <section class="ffc-record-grid" aria-label="FFC simulator records">
+            <section class="ffc-record-grid" aria-label="FFC delivery records">
                 @foreach (var record in Model.Records)
                 {
                     <div class="ffc-record-grid__item">
@@ -73,6 +73,7 @@
                         @await Html.PartialAsync("_FfcRecordCard", new ProjectManagement.Areas.ProjectOfficeReports.ViewModels.FfcRecordCardViewModel
                         {
                             Record = record,
+                            ProjectSummary = ProjectManagement.Areas.ProjectOfficeReports.Domain.FfcProjectBucketHelper.Summarize(record.Projects),
                             CanManageRecords = Model.CanManageRecords,
                             PageNumber = Model.PageNumber,
                             Query = Model.Query,

--- a/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
@@ -14,8 +14,8 @@
         <div>
             <h1 class="h4 mb-1">FFC – World map</h1>
             <p class="pm-page-subtitle">
-                Countries shaded by the number of <strong>completed, linked projects</strong>.
-                'Installed', 'Delivered (not installed)' and 'Planned' totals are shown per country.
+                Countries shaded by total <strong>project units</strong> (Installed / Delivered / Planned).
+                Drill into each country to see how many units are installed, delivered, or still planned.
             </p>
         </div>
         <div class="d-flex align-items-center gap-2">
@@ -59,7 +59,7 @@
             <div id="ffc-map"
                  class="ffc-map"
                  role="img"
-                 aria-label="World map showing FFC completed linked project counts"
+                 aria-label="World map showing FFC project unit counts"
                  data-data-url="@Url.Page("./Map", pageHandler: "Data")"
                  data-geo-url="@Url.Content("~/ffc/maps/world_india_view.geojson")"
                  data-ffc-index-url-base="@Url.Page("./Index")"></div>
@@ -78,7 +78,7 @@
         <aside class="ffc-map-sidebar" id="ffc-map-sidebar" aria-label="Map controls">
             <div class="card shadow-sm">
                 <div class="card-body">
-                    <h2 class="h6 mb-3">Total completed linked projects</h2>
+                    <h2 class="h6 mb-3">Total project units</h2>
                     <div id="legendRamp" class="legend-ramp ffc-legend-ramp" aria-hidden="true"></div>
                     <ul id="legendLabels" class="legend-labels ffc-legend-labels list-unstyled small mb-0"></ul>
                 </div>

--- a/Areas/ProjectOfficeReports/Pages/FFC/MapBoard.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapBoard.cshtml
@@ -13,7 +13,7 @@
         <div>
             <h1 class="h4 mb-1">FFC – Country board</h1>
             <p class="pm-page-subtitle">
-                Completed, linked projects per country (Installed / Delivered / Planned). Optimised for screenshots.
+                Project units per country (Installed / Delivered / Planned). Optimised for screenshots.
             </p>
         </div>
         <div class="d-flex flex-wrap gap-2 align-items-center">

--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTable.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTable.cshtml
@@ -8,7 +8,7 @@
     <section class="pm-page-header">
         <div>
             <h1 class="h4 mb-1">FFC – Country table</h1>
-            <p class="pm-page-subtitle">Sortable table of Installed / Delivered / Planned (completed, linked projects).</p>
+            <p class="pm-page-subtitle">Sortable table of installed / delivered / planned project units per country.</p>
         </div>
         <div class="d-flex flex-wrap gap-2">
             <a asp-area="ProjectOfficeReports" asp-page="/FFC/Map" class="btn btn-outline-secondary">Back to map</a>
@@ -22,10 +22,10 @@
             <thead>
                 <tr>
                     <th scope="col" data-k="name">Country</th>
-                    <th scope="col" data-k="installed">Installed</th>
+                    <th scope="col" data-k="installed">Installed units</th>
                     <th scope="col" data-k="delivered">Delivered (not installed)</th>
-                    <th scope="col" data-k="planned">Planned</th>
-                    <th scope="col" data-k="total">Total</th>
+                    <th scope="col" data-k="planned">Planned units</th>
+                    <th scope="col" data-k="total">Total units</th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
@@ -8,8 +8,8 @@
         <div>
             <h1 class="h4 mb-1">FFC – Detailed table</h1>
             <p class="pm-page-subtitle">
-                Installed / Delivered (not installed) / Planned are from completed, linked projects.
-                <strong>Proposed Projects</strong> are FFC entries not yet linked to a project.
+                Installed / Delivered (not installed) / Planned totals show project units captured against each FFC record.
+                Use the Linked? column to distinguish rows tied to a core project from stand-alone entries.
             </p>
         </div>
         <div class="d-flex flex-wrap gap-2 align-items-center">
@@ -27,6 +27,7 @@
                     <th scope="col">ISO3</th>
                     <th scope="col">Project</th>
                     <th scope="col">Linked?</th>
+                    <th scope="col" class="text-end">Quantity</th>
                     <th scope="col">Bucket</th>
                     <th scope="col">Latest stage</th>
                     <th scope="col">External remark</th>

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/Attachments/Upload.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/Attachments/Upload.cshtml
@@ -16,7 +16,7 @@
             <nav aria-label="Breadcrumb">
                 <ol class="breadcrumb mb-2 small">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC simulators</a></li>
+                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC deliveries</a></li>
                     <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Records/Manage">Manage records</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Attachments</li>
                 </ol>

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/Manage.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/Manage.cshtml
@@ -12,11 +12,11 @@
             <nav aria-label="Breadcrumb">
                 <ol class="breadcrumb mb-0 small">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC simulators</a></li>
+                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC deliveries</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Manage records</li>
                 </ol>
             </nav>
-            <p class="text-muted mb-0 mt-2">Create, edit, or remove simulator delivery records and keep information up to date.</p>
+            <p class="text-muted mb-0 mt-2">Create, edit, or remove project delivery records and keep information up to date.</p>
         </div>
 
         <div class="d-flex flex-wrap gap-2">

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml
@@ -12,12 +12,12 @@
             <nav aria-label="Breadcrumb">
                 <ol class="breadcrumb mb-2 small">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC simulators</a></li>
+                    <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Index">FFC deliveries</a></li>
                     <li class="breadcrumb-item"><a asp-area="ProjectOfficeReports" asp-page="/FFC/Records/Manage">Manage records</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Projects</li>
                 </ol>
             </nav>
-            <p class="text-muted mb-0">Link simulator deliveries to projects and record any supporting remarks.</p>
+            <p class="text-muted mb-0">Track project-level quantities and milestones for this country-year record.</p>
         </div>
     </div>
 
@@ -30,7 +30,7 @@
                     <div class="pm-card-heading">
                         <div>
                             <h2 class="pm-card-title h5 mb-1">Linked projects</h2>
-                            <p class="pm-card-subtitle text-muted mb-0">Review existing links and keep simulator details in sync.</p>
+                            <p class="pm-card-subtitle text-muted mb-0">Review existing links and keep project unit details in sync.</p>
                         </div>
                     </div>
                 </div>
@@ -40,7 +40,10 @@
                             <thead>
                                 <tr>
                                     <th>Name</th>
+                                    <th class="text-end">Quantity</th>
                                     <th>Linked</th>
+                                    <th>Delivered</th>
+                                    <th>Installed</th>
                                     <th>Remarks</th>
                                     <th class="text-end">Actions</th>
                                 </tr>
@@ -49,7 +52,7 @@
                             @if (!Model.Items.Any())
                             {
                                 <tr>
-                                    <td colspan="4" class="text-center text-muted py-4">No projects linked yet. Add one using the form to the right.</td>
+                                    <td colspan="7" class="text-center text-muted py-4">No projects linked yet. Add one using the form to the right.</td>
                                 </tr>
                             }
                             else
@@ -58,7 +61,26 @@
                                 {
                                     <tr>
                                         <td>@p.Name</td>
+                                        <td class="text-end">@p.Quantity</td>
                                         <td>@(p.LinkedProject?.Name ?? "— none —")</td>
+                                        <td>
+                                            <span class="badge rounded-pill @(p.IsDelivered || p.IsInstalled ? "text-bg-success" : "text-bg-secondary")">
+                                                @(p.IsDelivered || p.IsInstalled ? "Yes" : "No")
+                                            </span>
+                                            @if ((p.IsDelivered || p.IsInstalled) && (p.DeliveredOn ?? p.InstalledOn).HasValue)
+                                            {
+                                                <small class="text-muted d-block">@((p.DeliveredOn ?? p.InstalledOn)!.Value.ToString("dd MMM yyyy"))</small>
+                                            }
+                                        </td>
+                                        <td>
+                                            <span class="badge rounded-pill @(p.IsInstalled ? "text-bg-success" : "text-bg-secondary")">
+                                                @(p.IsInstalled ? "Yes" : "No")
+                                            </span>
+                                            @if (p.IsInstalled && p.InstalledOn.HasValue)
+                                            {
+                                                <small class="text-muted d-block">@p.InstalledOn.Value.ToString("dd MMM yyyy")</small>
+                                            }
+                                        </td>
                                         <td>@p.Remarks</td>
                                         <td class="text-end">
                                             <authorize roles="Admin,HoD">
@@ -94,7 +116,7 @@
                         <div class="pm-card-heading">
                             <div>
                                 <h2 class="pm-card-title h5 mb-0">@(Model.Input.Id.HasValue ? "Edit project" : "Add project")</h2>
-                                <p class="pm-card-subtitle text-muted mb-0">Capture project details and link simulator deliveries.</p>
+                                <p class="pm-card-subtitle text-muted mb-0">Capture per-project quantity, delivery, and installation data.</p>
                             </div>
                         </div>
                     </div>
@@ -111,10 +133,35 @@
                                 <span asp-validation-for="Input.Name" class="text-danger"></span>
                             </div>
                             <div>
+                                <label asp-for="Input.Quantity" class="form-label">Quantity</label>
+                                <input asp-for="Input.Quantity" type="number" min="1" class="form-control" />
+                                <span asp-validation-for="Input.Quantity" class="text-danger"></span>
+                            </div>
+                            <div>
                                 <label asp-for="Input.LinkedProjectId" class="form-label">Link to Project (optional)</label>
                                 <select asp-for="Input.LinkedProjectId" class="form-select" asp-items="Model.LinkedProjects">
                                     <option value="">-- none --</option>
                                 </select>
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <div class="form-check">
+                                        <input class="form-check-input" asp-for="Input.IsDelivered" />
+                                        <label class="form-check-label" asp-for="Input.IsDelivered">Delivered</label>
+                                    </div>
+                                    <label asp-for="Input.DeliveredOn" class="form-label">Delivered on (optional)</label>
+                                    <input asp-for="Input.DeliveredOn" type="date" class="form-control" />
+                                    <span asp-validation-for="Input.DeliveredOn" class="text-danger"></span>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-check">
+                                        <input class="form-check-input" asp-for="Input.IsInstalled" />
+                                        <label class="form-check-label" asp-for="Input.IsInstalled">Installed</label>
+                                    </div>
+                                    <label asp-for="Input.InstalledOn" class="form-label">Installed on (optional)</label>
+                                    <input asp-for="Input.InstalledOn" type="date" class="form-control" />
+                                    <span asp-validation-for="Input.InstalledOn" class="text-danger"></span>
+                                </div>
                             </div>
                             <div>
                                 <label asp-for="Input.Remarks" class="form-label">Remarks</label>

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordForm.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordForm.cshtml
@@ -51,42 +51,6 @@
 </div>
 
 <hr />
-<h6 class="mb-2">Delivery</h6>
-<div class="form-check">
-    <input class="form-check-input" asp-for="Input.DeliveryYes" />
-    <label class="form-check-label" asp-for="Input.DeliveryYes">Yes</label>
-</div>
-<div class="row g-3">
-    <div class="col-md-6">
-        <label asp-for="Input.DeliveryDate" class="form-label">Date (optional)</label>
-        <input asp-for="Input.DeliveryDate" type="date" class="form-control" />
-        <span asp-validation-for="Input.DeliveryDate" class="text-danger"></span>
-    </div>
-    <div class="col-md-6">
-        <label asp-for="Input.DeliveryRemarks" class="form-label">Remarks</label>
-        <input asp-for="Input.DeliveryRemarks" class="form-control" />
-    </div>
-</div>
-
-<hr />
-<h6 class="mb-2">Installation</h6>
-<div class="form-check">
-    <input class="form-check-input" asp-for="Input.InstallationYes" />
-    <label class="form-check-label" asp-for="Input.InstallationYes">Yes</label>
-</div>
-<div class="row g-3">
-    <div class="col-md-6">
-        <label asp-for="Input.InstallationDate" class="form-label">Date (optional)</label>
-        <input asp-for="Input.InstallationDate" type="date" class="form-control" />
-        <span asp-validation-for="Input.InstallationDate" class="text-danger"></span>
-    </div>
-    <div class="col-md-6">
-        <label asp-for="Input.InstallationRemarks" class="form-label">Remarks</label>
-        <input asp-for="Input.InstallationRemarks" class="form-control" />
-    </div>
-</div>
-
-<hr />
 <div>
     <label asp-for="Input.OverallRemarks" class="form-label">Overall Remarks</label>
     <textarea asp-for="Input.OverallRemarks" rows="3" class="form-control"></textarea>

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordTable.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordTable.cshtml
@@ -28,8 +28,7 @@
             </th>
             <th>IPA</th>
             <th>GSL</th>
-            <th>Delivery</th>
-            <th>Installation</th>
+            <th>Project units<br /><small class="text-muted">Installed / Delivered / Planned</small></th>
             <th>Remarks</th>
             <th class="text-end">Actions</th>
         </tr>
@@ -38,13 +37,14 @@
     @if (!Model.Records.Any())
     {
         <tr>
-            <td colspan="8" class="text-center text-muted">No records found.</td>
+            <td colspan="7" class="text-center text-muted">No records found.</td>
         </tr>
     }
     else
     {
         foreach (var record in Model.Records)
         {
+            var summary = Model.GetProjectSummary(record);
             <tr>
                 <td>@record.Year</td>
                 <td>@record.Country?.Name</td>
@@ -65,19 +65,14 @@
                     }
                 </td>
                 <td class="text-center">
-                    @{ var deliveryDate = FormatMilestoneDate(record.DeliveryDate); }
-                    <span class="badge @GetMilestoneBadgeClass(record.DeliveryYes)">@GetMilestoneBadgeText(record.DeliveryYes)</span>
-                    @if (!string.IsNullOrWhiteSpace(deliveryDate))
+                    @if (summary.Total == 0)
                     {
-                        <small class="text-muted d-block">@deliveryDate</small>
+                        <span class="text-muted">—</span>
                     }
-                </td>
-                <td class="text-center">
-                    @{ var installationDate = FormatMilestoneDate(record.InstallationDate); }
-                    <span class="badge @GetMilestoneBadgeClass(record.InstallationYes)">@GetMilestoneBadgeText(record.InstallationYes)</span>
-                    @if (!string.IsNullOrWhiteSpace(installationDate))
+                    else
                     {
-                        <small class="text-muted d-block">@installationDate</small>
+                        <div class="fw-semibold">@summary.Installed / @summary.DeliveredNotInstalled / @summary.Planned</div>
+                        <small class="text-muted">Total: @summary.Total</small>
                     }
                 </td>
                 <td class="text-break" style="max-width:220px;">

--- a/Areas/ProjectOfficeReports/Pages/FFC/_FfcRecordCard.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_FfcRecordCard.cshtml
@@ -10,15 +10,17 @@
     var milestoneStatuses = new[]
     {
         new { Title = "IPA", IsComplete = record.IpaYes, Date = record.IpaDate, Remarks = record.IpaRemarks },
-        new { Title = "GSL", IsComplete = record.GslYes, Date = record.GslDate, Remarks = record.GslRemarks },
-        new { Title = "Delivery", IsComplete = record.DeliveryYes, Date = record.DeliveryDate, Remarks = record.DeliveryRemarks },
-        new { Title = "Installation", IsComplete = record.InstallationYes, Date = record.InstallationDate, Remarks = record.InstallationRemarks }
+        new { Title = "GSL", IsComplete = record.GslYes, Date = record.GslDate, Remarks = record.GslRemarks }
     };
 
     var projects = record.Projects
         .OrderBy(p => p.Name)
         .ToList();
     var projectCount = projects.Count;
+    var projectUnits = Model.ProjectSummary.Total;
+    var deliveredUnits = Model.ProjectSummary.DeliveredNotInstalled + Model.ProjectSummary.Installed;
+    var installedUnits = Model.ProjectSummary.Installed;
+    var plannedUnits = Model.ProjectSummary.Planned;
     var countryName = record.Country?.Name ?? "Unassigned";
 
     var attachments = record.Attachments
@@ -70,6 +72,10 @@
                 <span class="ffc-record-card__summary-value ffc-record-card__summary-value--projects">@projectCount</span>
                 <span class="ffc-record-card__summary-label">Project@(projectCount == 1 ? string.Empty : "s")</span>
             </div>
+            <div class="ffc-record-card__summary-item ffc-record-card__summary-item--units">
+                <span class="ffc-record-card__summary-value ffc-record-card__summary-value--projects">@projectUnits</span>
+                <span class="ffc-record-card__summary-label">Project unit@(projectUnits == 1 ? string.Empty : "s")</span>
+            </div>
             <div class="ffc-record-card__summary-item ffc-record-card__summary-item--attachments">
                 <span class="ffc-record-card__summary-value ffc-record-card__summary-value--attachments">@attachmentCount</span>
                 <span class="ffc-record-card__summary-label">Attachment@(attachmentCount == 1 ? string.Empty : "s")</span>
@@ -100,6 +106,50 @@
                         }
                     </article>
                 }
+            </div>
+        </section>
+
+        <section class="ffc-record-card__section" aria-label="Delivery and installation summary">
+            <h3 class="ffc-record-card__section-title">Delivery &amp; installation</h3>
+            <div class="ffc-record-card__statuses">
+                @{
+                    var deliveryBadge = projectUnits > 0
+                        ? deliveredUnits >= projectUnits ? "text-bg-success" : deliveredUnits > 0 ? "text-bg-warning" : "text-bg-secondary"
+                        : "text-bg-secondary";
+                    var installBadge = projectUnits > 0
+                        ? installedUnits >= projectUnits ? "text-bg-success" : installedUnits > 0 ? "text-bg-warning" : "text-bg-secondary"
+                        : "text-bg-secondary";
+                }
+                <article class="ffc-record-card__status">
+                    <header class="ffc-record-card__status-header">
+                        <span class="ffc-record-card__status-title">Delivery</span>
+                        <span class="badge rounded-pill @deliveryBadge">@((deliveredUnits >= projectUnits && projectUnits > 0) ? "Complete" : deliveredUnits > 0 ? "Partial" : "Pending")</span>
+                    </header>
+                    @if (projectUnits > 0)
+                    {
+                        <div class="ffc-record-card__status-date">@deliveredUnits of @projectUnits unit@(projectUnits == 1 ? string.Empty : "s") delivered</div>
+                        <p class="ffc-record-card__status-remarks mb-0">Planned: @plannedUnits unit@(plannedUnits == 1 ? string.Empty : "s")</p>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">No project units captured yet.</p>
+                    }
+                </article>
+                <article class="ffc-record-card__status">
+                    <header class="ffc-record-card__status-header">
+                        <span class="ffc-record-card__status-title">Installation</span>
+                        <span class="badge rounded-pill @installBadge">@((installedUnits >= projectUnits && projectUnits > 0) ? "Complete" : installedUnits > 0 ? "Partial" : "Pending")</span>
+                    </header>
+                    @if (projectUnits > 0)
+                    {
+                        <div class="ffc-record-card__status-date">@installedUnits of @projectUnits unit@(projectUnits == 1 ? string.Empty : "s") installed</div>
+                        <p class="ffc-record-card__status-remarks mb-0">Awaiting install: @(projectUnits - installedUnits)</p>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">No project units captured yet.</p>
+                    }
+                </article>
             </div>
         </section>
 
@@ -163,6 +213,7 @@
                                 {
                                     <div class="text-muted small">@stageSummary</div>
                                 }
+                                <div class="text-muted small">Units: @Math.Max(1, project.Quantity)</div>
                                 <div class="text-muted small">
                                     @if (!string.IsNullOrWhiteSpace(externalRemark))
                                     {
@@ -184,6 +235,7 @@
                     {
                         <div class="mb-2">
                             <div class="fw-semibold">@project.Name</div>
+                            <div class="text-muted small">Units: @Math.Max(1, project.Quantity)</div>
                             @if (!string.IsNullOrWhiteSpace(project.Remarks))
                             {
                                 <div class="text-muted small">@project.Remarks</div>

--- a/Areas/ProjectOfficeReports/ViewModels/FfcRecordCardViewModel.cs
+++ b/Areas/ProjectOfficeReports/ViewModels/FfcRecordCardViewModel.cs
@@ -7,6 +7,7 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.ViewModels;
 public sealed class FfcRecordCardViewModel
 {
     public required FfcRecord Record { get; init; }
+    public required FfcProjectQuantitySummary ProjectSummary { get; init; }
     public required bool CanManageRecords { get; init; }
     public int PageNumber { get; init; }
     public string CurrentSort { get; init; } = "year";

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -759,6 +759,9 @@ namespace ProjectManagement.Data
                 entity.ToTable("FfcProjects");
                 entity.Property(x => x.Name).HasMaxLength(256).IsRequired();
                 entity.Property(x => x.Remarks).HasColumnType("text");
+                entity.Property(x => x.Quantity).HasDefaultValue(1);
+                entity.Property(x => x.IsDelivered).HasDefaultValue(false);
+                entity.Property(x => x.IsInstalled).HasDefaultValue(false);
                 entity.Property(x => x.CreatedAt).HasDefaultValueSql("now() at time zone 'utc'");
                 entity.Property(x => x.UpdatedAt).HasDefaultValueSql("now() at time zone 'utc'");
 
@@ -782,6 +785,17 @@ namespace ProjectManagement.Data
                     .WithMany()
                     .HasForeignKey(x => x.LinkedProjectId)
                     .OnDelete(DeleteBehavior.SetNull);
+
+                entity.ToTable(tb =>
+                {
+                    tb.HasCheckConstraint("CK_FfcProjects_Quantity_Positive", "\"Quantity\" > 0");
+                    tb.HasCheckConstraint(
+                        "CK_FfcProjects_DeliveredOn_RequiresFlag",
+                        "\"DeliveredOn\" IS NULL OR \"IsDelivered\" = TRUE");
+                    tb.HasCheckConstraint(
+                        "CK_FfcProjects_InstalledOn_RequiresFlag",
+                        "\"InstalledOn\" IS NULL OR \"IsInstalled\" = TRUE");
+                });
             });
 
             builder.Entity<FfcAttachment>(entity =>

--- a/Migrations/20251118172046_AddPerProjectQuantityAndMilestonesToFfcProjects.Designer.cs
+++ b/Migrations/20251118172046_AddPerProjectQuantityAndMilestonesToFfcProjects.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251118172046_AddPerProjectQuantityAndMilestonesToFfcProjects")]
+    partial class AddPerProjectQuantityAndMilestonesToFfcProjects
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251118172046_AddPerProjectQuantityAndMilestonesToFfcProjects.cs
+++ b/Migrations/20251118172046_AddPerProjectQuantityAndMilestonesToFfcProjects.cs
@@ -1,0 +1,141 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerProjectQuantityAndMilestonesToFfcProjects : Migration
+    {
+        /// <inheritdoc />
+        // SECTION: Up migration
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "DeliveredOn",
+                table: "FfcProjects",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDelivered",
+                table: "FfcProjects",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsInstalled",
+                table: "FfcProjects",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "InstalledOn",
+                table: "FfcProjects",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Quantity",
+                table: "FfcProjects",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_FfcProjects_Quantity_Positive",
+                table: "FfcProjects",
+                sql: "\"Quantity\" > 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_FfcProjects_DeliveredOn_RequiresFlag",
+                table: "FfcProjects",
+                sql: "\"DeliveredOn\" IS NULL OR \"IsDelivered\" = TRUE");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_FfcProjects_InstalledOn_RequiresFlag",
+                table: "FfcProjects",
+                sql: "\"InstalledOn\" IS NULL OR \"IsInstalled\" = TRUE");
+
+            migrationBuilder.Sql(
+                @"
+                UPDATE ""FfcProjects"" AS project
+                SET ""IsDelivered"" = record.""DeliveryYes"",
+                    ""DeliveredOn"" = record.""DeliveryDate"",
+                    ""IsInstalled"" = record.""InstallationYes"",
+                    ""InstalledOn"" = record.""InstallationDate""
+                FROM ""FfcRecords"" AS record
+                WHERE project.""FfcRecordId"" = record.""Id"";
+                ");
+
+            migrationBuilder.Sql(
+                @"
+                INSERT INTO ""FfcProjects"" (
+                        ""FfcRecordId"",
+                        ""Name"",
+                        ""Remarks"",
+                        ""Quantity"",
+                        ""IsDelivered"",
+                        ""DeliveredOn"",
+                        ""IsInstalled"",
+                        ""InstalledOn""
+                    )
+                    SELECT record.""Id"",
+                           'Legacy project entry',
+                           'Auto generated during FFC schema upgrade',
+                           1,
+                           record.""DeliveryYes"",
+                           record.""DeliveryDate"",
+                           record.""InstallationYes"",
+                           record.""InstallationDate""
+                    FROM ""FfcRecords"" AS record
+                    WHERE (record.""DeliveryYes"" = TRUE OR record.""InstallationYes"" = TRUE)
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM ""FfcProjects"" AS project
+                          WHERE project.""FfcRecordId"" = record.""Id""
+                      );
+                ");
+        }
+
+        /// <inheritdoc />
+        // SECTION: Down migration
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_FfcProjects_Quantity_Positive",
+                table: "FfcProjects");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_FfcProjects_DeliveredOn_RequiresFlag",
+                table: "FfcProjects");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_FfcProjects_InstalledOn_RequiresFlag",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "DeliveredOn",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "IsDelivered",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "IsInstalled",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "InstalledOn",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "Quantity",
+                table: "FfcProjects");
+        }
+    }
+}

--- a/ProjectManagement.Tests/ProjectOfficeReports/FfcCountryRollupDataSourceTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReports/FfcCountryRollupDataSourceTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Areas.ProjectOfficeReports.Domain;
+using ProjectManagement.Areas.ProjectOfficeReports.Pages.FFC;
+using ProjectManagement.Data;
+using Xunit;
+
+namespace ProjectManagement.Tests.ProjectOfficeReports;
+
+public sealed class FfcCountryRollupDataSourceTests
+{
+    // SECTION: Aggregation test harness
+    [Fact]
+    public async Task LoadAsync_WithMixedProjects_ReturnsCountryTotals()
+    {
+        await using var db = CreateDbContext();
+        var (alpha, beta, gamma) = await SeedCountriesAsync(db);
+        var (alphaRecord, betaRecord, gammaRecord) = await SeedRecordsAsync(db, alpha, beta, gamma);
+
+        db.FfcProjects.AddRange(
+            new FfcProject
+            {
+                FfcRecordId = alphaRecord.Id,
+                Name = "Alpha Install",
+                Quantity = 3,
+                IsDelivered = true,
+                IsInstalled = true
+            },
+            new FfcProject
+            {
+                FfcRecordId = alphaRecord.Id,
+                Name = "Alpha Delivery",
+                Quantity = 2,
+                IsDelivered = true
+            },
+            new FfcProject
+            {
+                FfcRecordId = betaRecord.Id,
+                Name = "Beta Planned",
+                Quantity = 5
+            },
+            new FfcProject
+            {
+                FfcRecordId = gammaRecord.Id,
+                Name = "Gamma Ignore",
+                Quantity = 10,
+                IsDelivered = true,
+                IsInstalled = true
+            });
+        await db.SaveChangesAsync();
+
+        var result = await FfcCountryRollupDataSource.LoadAsync(db, CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+
+        var alphaRow = Assert.Single(result.Where(row => row.CountryId == alpha.Id));
+        Assert.Equal(3, alphaRow.Installed);
+        Assert.Equal(2, alphaRow.Delivered);
+        Assert.Equal(0, alphaRow.Planned);
+        Assert.Equal(5, alphaRow.Total);
+
+        var betaRow = Assert.Single(result.Where(row => row.CountryId == beta.Id));
+        Assert.Equal(0, betaRow.Installed);
+        Assert.Equal(0, betaRow.Delivered);
+        Assert.Equal(5, betaRow.Planned);
+        Assert.Equal(5, betaRow.Total);
+    }
+
+    private static async Task<(FfcCountry Alpha, FfcCountry Beta, FfcCountry Gamma)> SeedCountriesAsync(ApplicationDbContext db)
+    {
+        var alpha = new FfcCountry { Name = "Alpha", IsoCode = "ALP", IsActive = true };
+        var beta = new FfcCountry { Name = "Beta", IsoCode = "BET", IsActive = true };
+        var gamma = new FfcCountry { Name = "Gamma", IsoCode = "GAM", IsActive = false };
+        db.FfcCountries.AddRange(alpha, beta, gamma);
+        await db.SaveChangesAsync();
+        return (alpha, beta, gamma);
+    }
+
+    private static async Task<(FfcRecord Alpha, FfcRecord Beta, FfcRecord Gamma)> SeedRecordsAsync(
+        ApplicationDbContext db,
+        FfcCountry alpha,
+        FfcCountry beta,
+        FfcCountry gamma)
+    {
+        var alphaRecord = new FfcRecord { CountryId = alpha.Id, Year = (short)DateTime.UtcNow.Year };
+        var betaRecord = new FfcRecord { CountryId = beta.Id, Year = (short)DateTime.UtcNow.Year };
+        var gammaRecord = new FfcRecord { CountryId = gamma.Id, Year = (short)DateTime.UtcNow.Year };
+        db.FfcRecords.AddRange(alphaRecord, betaRecord, gammaRecord);
+        await db.SaveChangesAsync();
+        return (alphaRecord, betaRecord, gammaRecord);
+    }
+
+    private static ApplicationDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+}

--- a/ProjectManagement.Tests/ProjectOfficeReports/FfcProjectBucketHelperTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReports/FfcProjectBucketHelperTests.cs
@@ -1,0 +1,60 @@
+using ProjectManagement.Areas.ProjectOfficeReports.Domain;
+using Xunit;
+
+namespace ProjectManagement.Tests.ProjectOfficeReports;
+
+public sealed class FfcProjectBucketHelperTests
+{
+    // SECTION: Classification helpers
+    [Fact]
+    public void Classify_WithInstalledProject_ReturnsInstalledBucket()
+    {
+        var project = new FfcProject { Quantity = 3, IsInstalled = true, IsDelivered = true };
+
+        var (bucket, quantity) = FfcProjectBucketHelper.Classify(project);
+
+        Assert.Equal(FfcDeliveryBucket.Installed, bucket);
+        Assert.Equal(3, quantity);
+    }
+
+    [Fact]
+    public void Classify_WithDeliveredOnlyProject_ReturnsDeliveredBucket()
+    {
+        var project = new FfcProject { Quantity = 2, IsDelivered = true };
+
+        var (bucket, quantity) = FfcProjectBucketHelper.Classify(project);
+
+        Assert.Equal(FfcDeliveryBucket.DeliveredNotInstalled, bucket);
+        Assert.Equal(2, quantity);
+    }
+
+    [Fact]
+    public void Classify_WithZeroQuantity_FallsBackToOne()
+    {
+        var project = new FfcProject { Quantity = 0 };
+
+        var (bucket, quantity) = FfcProjectBucketHelper.Classify(project);
+
+        Assert.Equal(FfcDeliveryBucket.Planned, bucket);
+        Assert.Equal(1, quantity);
+    }
+
+    // SECTION: Summary helpers
+    [Fact]
+    public void Summarize_WithMixedProjects_ReturnsQuantities()
+    {
+        var projects = new[]
+        {
+            new FfcProject { Quantity = 2, IsDelivered = true, IsInstalled = true },
+            new FfcProject { Quantity = 5, IsDelivered = true },
+            new FfcProject { Quantity = 4 }
+        };
+
+        var summary = FfcProjectBucketHelper.Summarize(projects);
+
+        Assert.Equal(2, summary.Installed);
+        Assert.Equal(5, summary.DeliveredNotInstalled);
+        Assert.Equal(4, summary.Planned);
+        Assert.Equal(11, summary.Total);
+    }
+}

--- a/ProjectManagement.Tests/ProjectOfficeReports/FfcRecordsManagePageTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReports/FfcRecordsManagePageTests.cs
@@ -38,8 +38,6 @@ public sealed class FfcRecordsManagePageTests
     [Theory]
     [InlineData(nameof(FfcRecordsManagePageTests.SetIpaMismatch), nameof(ManageModel.Input.IpaDate))]
     [InlineData(nameof(FfcRecordsManagePageTests.SetGslMismatch), nameof(ManageModel.Input.GslDate))]
-    [InlineData(nameof(FfcRecordsManagePageTests.SetDeliveryMismatch), nameof(ManageModel.Input.DeliveryDate))]
-    [InlineData(nameof(FfcRecordsManagePageTests.SetInstallationMismatch), nameof(ManageModel.Input.InstallationDate))]
     public async Task OnPostCreateAsync_WithFlagDateMismatch_AddsModelError(string setupMethod, string expectedKey)
     {
         await using var db = CreateDbContext();
@@ -80,11 +78,7 @@ public sealed class FfcRecordsManagePageTests
             IpaYes = true,
             IpaDate = new DateOnly(2025, 1, 10),
             GslYes = true,
-            GslDate = new DateOnly(2025, 2, 15),
-            DeliveryYes = true,
-            DeliveryDate = new DateOnly(2025, 3, 20),
-            InstallationYes = true,
-            InstallationDate = new DateOnly(2025, 4, 25)
+            GslDate = new DateOnly(2025, 2, 15)
         };
 
         var result = await page.OnPostCreateAsync();
@@ -233,18 +227,6 @@ public sealed class FfcRecordsManagePageTests
     {
         input.GslYes = false;
         input.GslDate = new DateOnly(2024, 2, 1);
-    }
-
-    private static void SetDeliveryMismatch(ManageModel.InputModel input)
-    {
-        input.DeliveryYes = false;
-        input.DeliveryDate = new DateOnly(2024, 3, 1);
-    }
-
-    private static void SetInstallationMismatch(ManageModel.InputModel input)
-    {
-        input.InstallationYes = false;
-        input.InstallationDate = new DateOnly(2024, 4, 1);
     }
 
     private static ManageModel CreatePage(ApplicationDbContext db)

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-board.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-board.js
@@ -47,12 +47,12 @@
                         <div class="ffc-card__country">${esc(name)}</div>
                         <div class="text-muted small">ISO-3 <span class="ffc-card__iso">${esc(iso)}</span></div>
                     </div>
-                    <div class="ffc-chip">Total ${(row.total || 0)}</div>
+                    <div class="ffc-chip">Total units ${(row.total || 0)}</div>
                 </div>
                 <div class="ffc-rows">
-                    <div class="ffc-row"><span>Installed</span><strong>${row.installed || 0}</strong></div>
+                    <div class="ffc-row"><span>Installed units</span><strong>${row.installed || 0}</strong></div>
                     <div class="ffc-row"><span>Delivered (not installed)</span><strong>${row.delivered || 0}</strong></div>
-                    <div class="ffc-row"><span>Planned</span><strong>${row.planned || 0}</strong></div>
+                    <div class="ffc-row"><span>Planned units</span><strong>${row.planned || 0}</strong></div>
                 </div>
             </div>`;
     }

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed.js
@@ -22,23 +22,24 @@
       throw new Error('Failed to load detailed data');
     }
 
-    /** @type {{countryIso3:string,countryName:string,projectName:string,isLinked:boolean,bucket:string,latestStage:string,externalRemark:string}[]} */
+    /** @type {{countryIso3:string,countryName:string,projectName:string,isLinked:boolean,quantity:number,bucket:string,latestStage:string,externalRemark:string}[]} */
     const rows = await response.json();
     return rows;
   }
 
   function render(rows) {
     if (!Array.isArray(rows) || rows.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="7" class="text-muted">No projects found.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="8" class="text-muted">No projects found.</td></tr>';
       return;
     }
 
-    tbody.innerHTML = rows.map((row) => `
+        tbody.innerHTML = rows.map((row) => `
       <tr>
         <td>${esc(row.countryName)}</td>
         <td><code>${esc((row.countryIso3 || '').toUpperCase())}</code></td>
         <td>${esc(row.projectName)}</td>
         <td>${row.isLinked ? 'Yes' : 'No'}</td>
+        <td class="text-end">${row.quantity ?? 0}</td>
         <td>${esc(row.bucket)}</td>
         <td>${esc(row.latestStage)}</td>
         <td>${esc(row.externalRemark)}</td>
@@ -49,6 +50,6 @@
   load()
     .then(render)
     .catch(() => {
-      tbody.innerHTML = '<tr><td colspan="7" class="text-danger">Failed to load detailed table.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="8" class="text-danger">Failed to load detailed table.</td></tr>';
     });
 })();

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
@@ -106,10 +106,10 @@
 
     var rowsHtml = '' +
       '<div class="ffc-tip__rows">' +
-      '<div class="ffc-tip__row"><span>Installed</span><strong>' + formatNumber(installed) + '</strong></div>' +
+      '<div class="ffc-tip__row"><span>Installed units</span><strong>' + formatNumber(installed) + '</strong></div>' +
       '<div class="ffc-tip__row"><span>Delivered (not installed)</span><strong>' + formatNumber(delivered) + '</strong></div>' +
-      '<div class="ffc-tip__row"><span>Planned</span><strong>' + formatNumber(planned) + '</strong></div>' +
-      '<div class="ffc-tip__row ffc-tip__row--muted"><span>Total</span><strong>' + formatNumber(total) + '</strong></div>' +
+      '<div class="ffc-tip__row"><span>Planned units</span><strong>' + formatNumber(planned) + '</strong></div>' +
+      '<div class="ffc-tip__row ffc-tip__row--muted"><span>Total units</span><strong>' + formatNumber(total) + '</strong></div>' +
       '</div>';
 
     var drillHref = total > 0 ? buildDrillUrl(cfg, datum) : '';

--- a/wwwroot/js/widgets/ffc-simulator-map.js
+++ b/wwwroot/js/widgets/ffc-simulator-map.js
@@ -201,13 +201,13 @@
             '<div class="ffc-simulator-map__tooltip-title">' + name + '</div>',
             '<dl class="ffc-simulator-map__tooltip-metrics">',
             '  <div class="ffc-simulator-map__tooltip-row">',
-            '    <dt>Installed</dt><dd>' + stats.installed + '</dd>',
+            '    <dt>Installed units</dt><dd>' + stats.installed + '</dd>',
             '  </div>',
             '  <div class="ffc-simulator-map__tooltip-row">',
-            '    <dt>Delivered</dt><dd>' + stats.delivered + '</dd>',
+            '    <dt>Delivered units</dt><dd>' + stats.delivered + '</dd>',
             '  </div>',
             '  <div class="ffc-simulator-map__tooltip-row">',
-            '    <dt>Total</dt><dd>' + stats.total + '</dd>',
+            '    <dt>Total units</dt><dd>' + stats.total + '</dd>',
             '  </div>',
             '</dl>'
           ];


### PR DESCRIPTION
## Summary
- add the new FfcProject bucket helper and refactor the rollup data source to aggregate per-project unit counts
- regenerate the AddPerProjectQuantityAndMilestonesToFfcProjects migration so the schema adds quantity/milestone columns and backfills legacy data
- extend the FFC record/project test coverage to match the new per-project semantics and add focused unit tests for the helper and rollup source

## Testing
- `dotnet test` *(fails: in-memory tests cannot map the NpgsqlTsVector column and integration tests require a PostgreSQL instance in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca5c9d0e08329b185aedf9a50300a)