### PR TITLE
Improve FFC widget totals

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/FfcSimulatorMapVm.cs
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/FfcSimulatorMapVm.cs
@@ -11,7 +11,11 @@ public sealed class FfcSimulatorMapVm
 
     public int TotalDelivered { get; init; }
 
-    public int TotalProjects { get; init; }
+    public int TotalPlanned { get; init; }
+
+    public int TotalCompleted => TotalInstalled + TotalDelivered;
+
+    public int TotalUnits => TotalCompleted + TotalPlanned;
 
     public bool HasData => Countries.Count > 0;
 }

--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -31,9 +31,13 @@
                     <span class="label">Delivered units</span>
                     <strong>@Model.TotalDelivered</strong>
                 </div>
-                <div class="ffc-simulator-map-widget__stat">
-                    <span class="label">Total units</span>
-                    <strong>@Model.TotalProjects</strong>
+                <div class="ffc-simulator-map-widget__stat ffc-simulator-map-widget__stat--emphasis">
+                    <span class="label">Completed units</span>
+                    <strong>@Model.TotalCompleted</strong>
+                    @if (Model.TotalPlanned > 0)
+                    {
+                        <span class="ffc-simulator-map-widget__stat-note">@Model.TotalPlanned planned units</span>
+                    }
                 </div>
             </div>
             <a href="@fullMapUrl" class="btn btn-outline-primary btn-sm">View full map</a>
@@ -74,7 +78,14 @@
                             role="listitem"
                         >
                             <span class="ffc-country-chip__name">@country.Name</span>
-                            <span class="ffc-country-chip__total">(<strong>@country.Total</strong>)</span>
+                            <span class="ffc-country-chip__total">
+                                (<strong>@country.Completed</strong> completed
+                                @if (country.Planned > 0)
+                                {
+                                    <span class="ffc-country-chip__planned">+@country.Planned planned</span>
+                                }
+                                )
+                            </span>
                         </button>
                     }
                     @if (remainingCount > 0)

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -229,7 +229,7 @@ namespace ProjectManagement.Pages.Dashboard
                 Countries = ffcCountries,
                 TotalInstalled = ffcCountries.Sum(country => country.Installed),
                 TotalDelivered = ffcCountries.Sum(country => country.Delivered),
-                TotalProjects = ffcCountries.Sum(country => country.Total)
+                TotalPlanned = ffcCountries.Sum(country => country.Planned)
             };
         }
 

--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -38,6 +38,17 @@
   color: #475569;
 }
 
+.ffc-simulator-map-widget__stat-note {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: 0.1rem;
+}
+
+.ffc-simulator-map-widget__stat--emphasis strong {
+  color: #5b21b6;
+}
+
 .ffc-simulator-map-widget__stat strong {
   display: block;
   font-size: 1.4rem;
@@ -278,6 +289,12 @@
 
 .ffc-country-chip__total strong {
   font-weight: 800;
+}
+
+.ffc-country-chip__planned {
+  color: #6b7280;
+  font-weight: 600;
+  margin-left: 0.15rem;
 }
 
 .ffc-country-chip--more {

--- a/wwwroot/js/widgets/ffc-simulator-map.js
+++ b/wwwroot/js/widgets/ffc-simulator-map.js
@@ -54,11 +54,13 @@
     var installed = valueOrZero(country, 'installed');
     var delivered = valueOrZero(country, 'delivered');
     var planned = valueOrZero(country, 'planned');
-    var total = installed + delivered;
+    var completed = installed + delivered;
+    var total = completed + planned;
     return {
       installed: installed,
       delivered: delivered,
       planned: planned,
+      completed: completed,
       total: total,
       displayCount: delivered > 0 ? delivered : installed
     };
@@ -201,16 +203,26 @@
             '<div class="ffc-simulator-map__tooltip-title">' + name + '</div>',
             '<dl class="ffc-simulator-map__tooltip-metrics">',
             '  <div class="ffc-simulator-map__tooltip-row">',
+            '    <dt>Completed units</dt><dd>' + stats.completed + '</dd>',
+            '  </div>',
+            '  <div class="ffc-simulator-map__tooltip-row">',
             '    <dt>Installed units</dt><dd>' + stats.installed + '</dd>',
             '  </div>',
             '  <div class="ffc-simulator-map__tooltip-row">',
             '    <dt>Delivered units</dt><dd>' + stats.delivered + '</dd>',
-            '  </div>',
-            '  <div class="ffc-simulator-map__tooltip-row">',
-            '    <dt>Total units</dt><dd>' + stats.total + '</dd>',
-            '  </div>',
-            '</dl>'
+            '  </div>'
           ];
+          if (stats.planned > 0) {
+            rows.push(
+              '  <div class="ffc-simulator-map__tooltip-row">',
+              '    <dt>Planned units</dt><dd>' + stats.planned + '</dd>',
+              '  </div>',
+              '  <div class="ffc-simulator-map__tooltip-row">',
+              '    <dt>All units</dt><dd>' + stats.total + '</dd>',
+              '  </div>'
+            );
+          }
+          rows.push('</dl>');
           tooltip.innerHTML = rows.join('');
         }
 


### PR DESCRIPTION
## Summary
- clarify the FFC dashboard widget so the headline numbers reflect completed units and expose the pending planned quantity
- update the country chip strip and tooltip to surface completed vs planned counts consistently
- add the CSS/JS support required for the refreshed labels and emphasis

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb054e3f4832991863065e218f5a0)