### PR TITLE
Add attachment option limits

### DIFF
--- a/Application/Ipr/IprAttachmentStorage.cs
+++ b/Application/Ipr/IprAttachmentStorage.cs
@@ -177,7 +177,8 @@ public sealed class IprAttachmentStorage
         return string.IsNullOrWhiteSpace(safe) ? "attachment" : safe;
     }
 
-    private static string BuildStorageKey(int iprId, string fileName)
+    // SECTION: Storage helpers
+    private string BuildStorageKey(int iprId, string fileName)
     {
         var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
         var uniqueName = new StringBuilder(timestamp.Length + 1 + 32 + 1 + fileName.Length);

--- a/Configuration/IprAttachmentOptions.cs
+++ b/Configuration/IprAttachmentOptions.cs
@@ -1,8 +1,19 @@
+using System.Collections.Generic;
+
 namespace ProjectManagement.Configuration;
 
 public sealed class IprAttachmentOptions
 {
+    // SECTION: Storage settings
     public string StorageFolderName { get; set; } = "ipr-attachments";
 
     public string? StorageRoot { get; set; }
+
+    // SECTION: Content validation
+    public long MaxFileSizeBytes { get; set; } = 20 * 1024 * 1024;
+
+    public IList<string> AllowedContentTypes { get; set; } = new List<string>
+    {
+        "application/pdf"
+    };
 }


### PR DESCRIPTION
## Summary
- add the missing max file size and allowed MIME type properties to `IprAttachmentOptions`
- allow `IprAttachmentStorage` to use its instance storage folder name when building keys, fixing the static usage errors

## Testing
- `dotnet test` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2215bad08329802823a9c16704bc)