### PR TITLE
Update tests for new attachment dependencies

### DIFF
--- a/ProjectManagement.Tests/Application/Ffc/FfcAttachmentStorageTests.cs
+++ b/ProjectManagement.Tests/Application/Ffc/FfcAttachmentStorageTests.cs
@@ -141,10 +141,14 @@ public sealed class FfcAttachmentStorageTests : IDisposable
         var resolvedRoot = GetResolvedStorageRoot(effectiveOptions);
         effectiveOptions.StorageRoot = resolvedRoot;
 
+        var uploadRootProvider = new TestUploadRootProvider(_uploadsRoot);
+        var pathResolver = new UploadPathResolver(uploadRootProvider);
+
         return new FfcAttachmentStorage(
             _db,
             _validator,
-            new TestUploadRootProvider(_uploadsRoot),
+            uploadRootProvider,
+            pathResolver,
             userContext,
             Options.Create(effectiveOptions));
     }

--- a/ProjectManagement.Tests/IprIndexPageTests.cs
+++ b/ProjectManagement.Tests/IprIndexPageTests.cs
@@ -303,7 +303,7 @@ public sealed class IprIndexPageTests
         var options = Options.Create(new IprAttachmentOptions
         {
             MaxFileSizeBytes = 1024 * 1024,
-            AllowedContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            AllowedContentTypes = new List<string> { "application/pdf" }
         });
 
         var uploadRootProvider = new TestUploadRootProvider(root);

--- a/ProjectManagement.Tests/IprWriteServiceTests.cs
+++ b/ProjectManagement.Tests/IprWriteServiceTests.cs
@@ -170,7 +170,7 @@ public sealed class IprWriteServiceTests
         var options = new IprAttachmentOptions
         {
             MaxFileSizeBytes = 1024,
-            AllowedContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            AllowedContentTypes = new List<string>
             {
                 "application/pdf"
             }
@@ -224,7 +224,7 @@ public sealed class IprWriteServiceTests
         var options = new IprAttachmentOptions
         {
             MaxFileSizeBytes = 1024,
-            AllowedContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            AllowedContentTypes = new List<string>
             {
                 "application/pdf"
             }
@@ -268,7 +268,7 @@ public sealed class IprWriteServiceTests
         var options = new IprAttachmentOptions
         {
             MaxFileSizeBytes = 5,
-            AllowedContentTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            AllowedContentTypes = new List<string>
             {
                 "application/pdf"
             }

--- a/ProjectManagement.Tests/ProjectOfficeReports/FfcAttachmentsUploadPageTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReports/FfcAttachmentsUploadPageTests.cs
@@ -22,6 +22,7 @@ using ProjectManagement.Configuration;
 using ProjectManagement.Data;
 using ProjectManagement.Services;
 using ProjectManagement.Services.DocRepo;
+using ProjectManagement.Services.Storage;
 using Xunit;
 
 namespace ProjectManagement.Tests.ProjectOfficeReports;
@@ -56,7 +57,14 @@ public sealed class FfcAttachmentsUploadPageTests
         var storage = new ThrowingAttachmentStorage();
         var options = Options.Create(new FfcAttachmentOptions { MaxFileSizeBytes = 10_000_000 });
         var ingestion = new StubDocRepoIngestionService();
-        return new UploadModel(db, storage, options, new StubAuditService(), NullLogger<UploadModel>.Instance, ingestion);
+        return new UploadModel(
+            db,
+            storage,
+            options,
+            new StubAuditService(),
+            NullLogger<UploadModel>.Instance,
+            ingestion,
+            new StubUploadPathResolver());
     }
 
     private static ApplicationDbContext CreateDbContext()
@@ -133,5 +141,12 @@ public sealed class FfcAttachmentsUploadPageTests
         public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
         {
         }
+    }
+
+    private sealed class StubUploadPathResolver : IUploadPathResolver
+    {
+        public string ToAbsolute(string storageKey) => storageKey;
+
+        public string ToRelative(string absolutePath) => absolutePath;
     }
 }


### PR DESCRIPTION
## Summary
- update the FFC attachment storage and upload page tests to provide the newly required upload path resolver dependency
- adjust the IPR tests so the attachment options use the IList-based `AllowedContentTypes`

## Testing
- `dotnet test ProjectManagement.sln` *(fails: `dotnet` is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2314ad5483299464fa774ec9b6a7)