### PR TITLE
Add production readiness and backup plan

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,93 @@
+# Disaster Recovery Runbook
+
+This runbook provides the operational checklist for restoring ProjectManagement after hardware loss, OS corruption, or accidental data deletion. It assumes backups were created using the scripts in the `ops/` folder and stored on secondary media.
+
+---
+
+## 1. Pre-requisites
+
+### 1.1 Software versions
+* OS: Windows Server 2022 or Ubuntu 22.04 LTS (match production choice).
+* .NET Runtime: version defined in `global.json`/`Directory.Build.props` for ProjectManagement.
+* PostgreSQL: **same major version** as production (currently 16.x).
+
+### 1.2 Accounts & secrets
+* PostgreSQL superuser (or owner) credentials.
+* Backup role password (for `pg_dump`).
+* SSL certificates (if HTTPS termination happens on the app host).
+* Application secrets for `appsettings.Production.json` (connection string, SSO, SMTP, etc.).
+
+### 1.3 Backup assets
+* Latest database dump from `ops/backup-db.*`.
+* Latest file archive/mirror from `ops/backup-files.*`.
+* Last known-good `appsettings.Production.json` and deployment scripts.
+
+---
+
+## 2. Restore scenarios
+
+### 2.1 Full server loss (bare-metal)
+1. **Rebuild infrastructure**
+   * Install OS updates.
+   * Install .NET Hosting Bundle.
+   * Install PostgreSQL (matching major version), create admin user.
+2. **Restore `Storage:DataRoot`**
+   * Create the designated root (e.g., `/srv/projectmanagement-data`).
+   * Copy the latest file backup into place (mirror or extract archive).
+3. **Deploy application**
+   * Pull release artifact from CI or build server.
+   * Publish to IIS/site folder or `/var/www/projectmanagement` as applicable.
+4. **Restore PostgreSQL**
+   * Run `ops/restore-db.ps1` or `.sh` pointing at the `.dump` file. Provide admin credentials when prompted or via environment variables.
+5. **Apply configuration**
+   * Place `appsettings.Production.json` (or environment-specific config) with accurate connection string and `Storage:DataRoot` path.
+6. **Start services**
+   * Start PostgreSQL (if not already) and the ProjectManagement app service.
+7. **Smoke tests**
+   * Login, open dashboards, browse multiple modules, download attachments.
+   * Attempt a small upload and confirm the file appears under the restored `DataRoot`.
+
+### 2.2 Database-only rollback
+1. Stop the application service to avoid writes.
+2. Run the DB restore script against the target dump.
+3. Start the application and validate data.
+
+### 2.3 File-only rollback
+1. Stop the application service.
+2. Restore only the affected subfolders from the file backup (e.g., `projects-photos`).
+3. Start the service and verify links/files.
+
+---
+
+## 3. Scripts reference
+
+| Script | Purpose | Key parameters |
+| --- | --- | --- |
+| `ops/backup-db.ps1` / `.sh` | Nightly PostgreSQL logical backup using `pg_dump` (custom format). | Host, port, DB name, backup directory, DB role. |
+| `ops/restore-db.ps1` / `.sh` | Restores database dump using `pg_restore`. | Host, port, DB name, dump file path, admin role. |
+| `ops/backup-files.ps1` / `.sh` | Mirrors `Storage:DataRoot` to backup location using `robocopy` or `rsync`. | Source data root, destination root, retention policy. |
+| `ops/restore-files.ps1` / `.sh` | Copies backed-up files back into `Storage:DataRoot`. | Backup location, target data root. |
+
+Always run scripts from an elevated prompt or with permissions sufficient to read/write the relevant folders.
+
+---
+
+## 4. Testing cadence
+* **Quarterly DR drill:** Execute full restore to an isolated server and measure recovery time objective (RTO).
+* **Monthly validation:** Restore the latest backup to a staging database and run automated smoke tests.
+* **Continuous monitoring:** After each scheduled backup, verify the presence of a new dump/rsync folder and check script exit codes/logs.
+
+---
+
+## 5. Troubleshooting tips
+* If `pg_restore` reports schema mismatches, confirm the PostgreSQL major version matches the one used for the dump.
+* When file paths fail after restore, inspect the database for absolute paths and normalize them with SQL scripts (strip prior prefixes).
+* Ensure the application identity has read/write access to `Storage:DataRoot`; permission issues manifest as upload failures or missing thumbnails.
+* Keep at least two historical dumps and file copies offline to mitigate silent corruption or ransomware.
+
+---
+
+## 6. Change management
+* Update this runbook whenever configuration keys, deployment topology, or backup destinations change.
+* Version control the `ops/` scripts alongside the application so changes are reviewed and tested.
+

--- a/docs/production-readiness-backup.md
+++ b/docs/production-readiness-backup.md
@@ -1,0 +1,128 @@
+# Production Readiness & Backup/Restore Plan
+
+**Application:** ProjectManagement (ASP.NET Core + PostgreSQL)
+
+---
+
+## 1. Purpose
+This document equips both engineering and operations teams with a production-ready strategy for protecting every persistent asset that powers ProjectManagement. It clarifies what must be captured in backups, how the current design influences disaster recovery, which development tasks close remaining gaps, and which day-to-day procedures operations teams can run to back up and restore the system confidently on-premises.
+
+---
+
+## 2. Scope
+A complete backup of ProjectManagement must include all application data that is **not** rebuilt automatically from source control:
+
+1. **PostgreSQL** – the schema, reference data, transactional records, and migrations history.
+2. **Uploaded files** – every module that allows uploads (projects, visits, FFC, document repository, etc.).
+3. **Configuration and deployment assets** – `appsettings.*.json`, deployment scripts, SSL certificates, service files, and backup scripts themselves.
+
+Source code and build outputs should remain in Git/CI artifacts, yet archiving the shipped build alongside backups helps accelerate bare-metal restores.
+
+---
+
+## 3. Backup-sensitive architecture overview
+
+### 3.1 Database
+* Entity Framework Core migrations initialize/upgrade the PostgreSQL schema but do **not** perform backups.
+* Operations must rely on PostgreSQL-native tooling (`pg_dump`, `pg_restore`, WAL archiving) for protection.
+
+### 3.2 File storage
+* Upload services (photos, videos, documents, attachments) obtain their storage root through `UploadRootProvider`, which honors the `PM_UPLOAD_ROOT` environment variable, `ProjectPhotos:StorageRoot`, or the `/var/pm/uploads` fallback.
+* Subfolders (`projects`, `videos`, etc.) are created lazily under that root, but multiple modules still specify their own subpaths.
+* Individual file paths are persisted in the database and must remain relative so that a restore to a different volume or server succeeds without rewriting records.
+
+### 3.3 Observed risks
+* Absolute file paths in the database would tie records to a single drive letter.
+* Upload subtrees may still live under the web root on development machines; binaries should remain read-only while uploads land in a writable data directory.
+* There was no shared runbook or automation for backups/restores; operators had to craft ad-hoc commands.
+
+---
+
+## 4. Target state design
+
+### 4.1 Central data root
+* Configure a single `Storage:DataRoot` (e.g., `D:/ProjectManagementData` on Windows, `/srv/projectmanagement-data` on Linux).
+* All module-specific uploads must live within subfolders of this root to keep file backups simple.
+
+### 4.2 Relative database paths
+* Persist only relative paths per module (e.g., `projects-photos/2025/04/abc123.webp`).
+* At runtime, combine the module’s root (`Path.Combine(Storage.DataRoot, RelativeModuleRoot)`) and the stored relative path.
+* Provide migrations/scripts that strip hard-coded prefixes from existing data if absolute paths already exist.
+
+### 4.3 Standard directory tree
+```
+DataRoot/
+├─ projects-photos/
+├─ document-repository/
+├─ ffc-attachments/
+├─ visit-photos/
+└─ logs/
+```
+* No module should write outside this tree.
+* Logs under `logs/` can be rotated independently but should follow the same backup cadence if storage allows.
+
+### 4.4 Backup automation
+* Nightly logical database dump using `pg_dump` (custom format) stored under `DataRoot/backups/db`.
+* Nightly file synchronization of `DataRoot` to a secondary volume or NAS using `robocopy` (Windows) or `rsync` (Linux).
+* Weekly offline/offsite copy (external disk, secondary site) for ransomware resilience.
+
+### 4.5 Restore discipline
+* Scripts under `/ops` wrap `pg_dump`, `pg_restore`, `robocopy`, and `rsync` with consistent parameters.
+* Disaster Recovery (DR) runbook describes the step-by-step rebuild path, post-restore validation, and recommended fire drills.
+
+---
+
+## 5. Engineering action items
+
+1. **Introduce `StorageOptions`** with a `DataRoot` property, bind from configuration, and inject anywhere uploads occur.
+2. **Refactor module options** (project photos, documents, videos, FFC, visits, etc.) so they describe *relative* subfolders under `DataRoot`.
+3. **Normalize persisted paths** to relative strings. Backfill existing rows through migrations or SQL scripts.
+4. **Enforce directory boundaries** (unit/integration tests ensuring upload paths resolve under `StorageOptions.DataRoot`).
+5. **Publish automation** (PowerShell/Bash scripts) within `ops/` and keep them updated as connection strings or folder names evolve.
+6. **Author & maintain DR documentation** (this file plus `docs/disaster-recovery.md`).
+7. **Perform a full-scale restore rehearsal** at least once before production cutover and quarterly thereafter.
+
+---
+
+## 6. Operational procedures
+
+### 6.1 Regular backups
+* **Database:** Schedule `ops/backup-db.ps1` or `ops/backup-db.sh` nightly via Task Scheduler or cron. Store dumps on a separate volume with 30-day retention.
+* **Files:** Mirror `Storage:DataRoot` using the provided file backup scripts. Keep at least the last 7 nightly copies plus 4 weekly copies.
+* **Configs & certificates:** Include `appsettings.Production.json`, SSL certs, and service definitions in the same backup job or a dedicated secure repository.
+
+### 6.2 Restore runbook (abridged)
+1. Provision OS, .NET Runtime, and PostgreSQL (matching major versions).
+2. Create/restore `Storage:DataRoot` from the latest file backup.
+3. Deploy the published application build.
+4. Recreate the PostgreSQL database and run `ops/restore-db.*` with the chosen dump.
+5. Drop the restored `appsettings.Production.json` (or environment variables) on the server, pointing to the restored database and data root.
+6. Start the application service (IIS site, systemd service, Windows Service, etc.).
+7. Perform smoke tests: login, open projects, download attachments, verify uploads.
+
+### 6.3 Disaster recovery drills
+* Twice per year (minimum), execute the full restore to a staging server. Capture gaps, update scripts/docs, and verify time-to-recover against SLA.
+
+---
+
+## 7. Security and compliance
+* Use dedicated PostgreSQL roles for backup/restore scripts; never embed credentials in scripts—read from environment variables or secure vaults.
+* Encrypt backups at rest (disk encryption, encrypted shares) and in transit (SFTP, SMB over VPN).
+* Limit permissions on `Storage:DataRoot` to the application identity and backup account.
+* Validate upload content (MIME filtering, antivirus) and honor ASP.NET Core’s request size limits in production.
+
+---
+
+## 8. Future enhancements (not in scope yet)
+* Automate point-in-time recovery with WAL archiving or streaming replication.
+* Integrate monitoring for backup job success/failure (Prometheus exporters, Windows Event Log alerts).
+* Provide an administrative UI for viewing backup status once infrastructure-level automation proves stable.
+
+---
+
+## 9. References
+* `docs/disaster-recovery.md` – hands-on restore instructions.
+* `ops/backup-*.ps1/.sh` – automation entry points for scheduling.
+* `Services/Storage/UploadRootProvider.cs` – runtime logic for resolving the upload root.
+* `docs/configuration-reference.md` – configuration keys, including `ProjectPhotos:StorageRoot`.
+

--- a/ops/backup-db.ps1
+++ b/ops/backup-db.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Creates a logical PostgreSQL backup using pg_dump (custom format).
+.DESCRIPTION
+    Mirrors the documented procedure in docs/production-readiness-backup.md. Provide credentials via environment variables
+    (PGPASSWORD) or pgpass files instead of embedding secrets.
+#>
+
+#region Parameters
+param(
+    [string]$PgBin = "C:\Program Files\PostgreSQL\16\bin",
+    [string]$Host = "localhost",
+    [int]$Port = 5432,
+    [string]$DbName = "ProjectManagement",
+    [string]$User = "pm_backup",
+    [string]$BackupDir = "D:\\ProjectManagementData\\backups\\db"
+)
+#endregion
+
+#region Preparation
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$backupFile = Join-Path $BackupDir "$($DbName)-$timestamp.dump"
+
+if (-not (Test-Path $PgBin)) {
+    throw "PostgreSQL bin directory not found: $PgBin"
+}
+
+New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
+#endregion
+
+#region Execution
+$pgDumpPath = Join-Path $PgBin "pg_dump.exe"
+
+& $pgDumpPath `
+    --format=custom `
+    --host=$Host `
+    --port=$Port `
+    --username=$User `
+    --file=$backupFile `
+    $DbName
+#endregion
+
+#region Output
+Write-Host "Database backup completed:" $backupFile
+#endregion

--- a/ops/backup-db.sh
+++ b/ops/backup-db.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==== Parameters ==============================================================
+PGBIN="${PGBIN:-/usr/bin}"
+HOST="${PGHOST:-localhost}"
+PORT="${PGPORT:-5432}"
+DBNAME="${PGDATABASE:-ProjectManagement}"
+USER="${PGUSER:-pm_backup}"
+BACKUP_DIR="${PM_BACKUP_DIR:-/srv/projectmanagement-data/backups/db}"
+# ============================================================================
+
+# ==== Preparation ============================================================
+mkdir -p "$BACKUP_DIR"
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+BACKUP_FILE="$BACKUP_DIR/${DBNAME}-${TIMESTAMP}.dump"
+# ============================================================================
+
+# ==== Execution ==============================================================
+"$PGBIN/pg_dump" \
+  --format=custom \
+  --host="$HOST" \
+  --port="$PORT" \
+  --username="$USER" \
+  --file="$BACKUP_FILE" \
+  "$DBNAME"
+# ============================================================================
+
+# ==== Output =================================================================
+echo "Database backup created: $BACKUP_FILE"
+# ============================================================================

--- a/ops/backup-files.ps1
+++ b/ops/backup-files.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    Mirrors the configured DataRoot to a backup destination using robocopy.
+#>
+
+#region Parameters
+param(
+    [string]$DataRoot = "D:\\ProjectManagementData",
+    [string]$BackupRoot = "E:\\PM-Backups\\files"
+)
+#endregion
+
+#region Preparation
+if (-not (Test-Path $DataRoot)) {
+    throw "DataRoot not found: $DataRoot"
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$destination = Join-Path $BackupRoot "Data-$timestamp"
+New-Item -ItemType Directory -Force -Path $destination | Out-Null
+#endregion
+
+#region Execution
+$logPath = Join-Path $BackupRoot "backup.log"
+robocopy $DataRoot $destination /MIR /R:2 /W:5 /NP /NDL /NFL /LOG+:"$logPath"
+#endregion
+
+#region Output
+Write-Host "File backup completed:" $destination
+#endregion

--- a/ops/backup-files.sh
+++ b/ops/backup-files.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==== Parameters ==============================================================
+DATA_ROOT="${PM_DATA_ROOT:-/srv/projectmanagement-data}"
+BACKUP_ROOT="${PM_FILE_BACKUP_ROOT:-/mnt/pm-backups/files}"
+# ============================================================================
+
+# ==== Validation ==============================================================
+if [[ ! -d "$DATA_ROOT" ]]; then
+  echo "Data root not found: $DATA_ROOT" >&2
+  exit 1
+fi
+mkdir -p "$BACKUP_ROOT"
+# ============================================================================
+
+# ==== Execution ===============================================================
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+DEST="$BACKUP_ROOT/Data-$TIMESTAMP"
+rsync -a --delete "$DATA_ROOT/" "$DEST/"
+# ============================================================================
+
+echo "File backup complete: $DEST"

--- a/ops/restore-db.ps1
+++ b/ops/restore-db.ps1
@@ -1,0 +1,52 @@
+<#
+.SYNOPSIS
+    Restores a PostgreSQL database from a pg_dump custom-format file.
+.DESCRIPTION
+    Drops and recreates the database before running pg_restore with --clean and --if-exists to ensure schema alignment.
+#>
+
+#region Parameters
+param(
+    [string]$PgBin = "C:\Program Files\PostgreSQL\16\bin",
+    [string]$Host = "localhost",
+    [int]$Port = 5432,
+    [string]$DbName = "ProjectManagement",
+    [string]$User = "postgres",
+    [Parameter(Mandatory = $true)][string]$DumpFile
+)
+#endregion
+
+#region Validation
+if (-not (Test-Path $DumpFile)) {
+    throw "Dump file not found: $DumpFile"
+}
+
+if (-not (Test-Path $PgBin)) {
+    throw "PostgreSQL bin directory not found: $PgBin"
+}
+#endregion
+
+#region Drop and recreate database
+$dropDb = Join-Path $PgBin "dropdb.exe"
+$createDb = Join-Path $PgBin "createdb.exe"
+
+& $dropDb --if-exists --host=$Host --port=$Port --username=$User $DbName
+& $createDb --host=$Host --port=$Port --username=$User $DbName
+#endregion
+
+#region Restore
+$pgRestore = Join-Path $PgBin "pg_restore.exe"
+
+& $pgRestore `
+    --host=$Host `
+    --port=$Port `
+    --username=$User `
+    --dbname=$DbName `
+    --clean `
+    --if-exists `
+    $DumpFile
+#endregion
+
+#region Output
+Write-Host "Database restore completed from $DumpFile"
+#endregion

--- a/ops/restore-db.sh
+++ b/ops/restore-db.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==== Parameters ==============================================================
+PGBIN="${PGBIN:-/usr/bin}"
+HOST="${PGHOST:-localhost}"
+PORT="${PGPORT:-5432}"
+DBNAME="${PGDATABASE:-ProjectManagement}"
+USER="${PGRESTORE_USER:-postgres}"
+DUMP_FILE="${PM_DUMP_FILE:-}"
+# ============================================================================
+
+# ==== Validation ==============================================================
+if [[ -z "$DUMP_FILE" ]]; then
+  echo "PM_DUMP_FILE must point to a pg_dump custom-format file" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DUMP_FILE" ]]; then
+  echo "Dump file not found: $DUMP_FILE" >&2
+  exit 1
+fi
+# ============================================================================
+
+# ==== Drop and recreate database =============================================
+"$PGBIN/dropdb" --if-exists --host="$HOST" --port="$PORT" --username="$USER" "$DBNAME"
+"$PGBIN/createdb" --host="$HOST" --port="$PORT" --username="$USER" "$DBNAME"
+# ============================================================================
+
+# ==== Restore ================================================================
+"$PGBIN/pg_restore" \
+  --host="$HOST" \
+  --port="$PORT" \
+  --username="$USER" \
+  --dbname="$DBNAME" \
+  --clean \
+  --if-exists \
+  "$DUMP_FILE"
+# ============================================================================
+
+echo "Database restored from $DUMP_FILE"

--- a/ops/restore-files.ps1
+++ b/ops/restore-files.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Restores files from a backup location back into DataRoot.
+#>
+
+#region Parameters
+param(
+    [Parameter(Mandatory = $true)][string]$BackupSource,
+    [string]$DataRoot = "D:\\ProjectManagementData"
+)
+#endregion
+
+#region Validation
+if (-not (Test-Path $BackupSource)) {
+    throw "Backup source not found: $BackupSource"
+}
+
+New-Item -ItemType Directory -Force -Path $DataRoot | Out-Null
+#endregion
+
+#region Execution
+robocopy $BackupSource $DataRoot /MIR /R:2 /W:5 /NP /NDL /NFL
+#endregion
+
+#region Output
+Write-Host "File restore completed from" $BackupSource
+#endregion

--- a/ops/restore-files.sh
+++ b/ops/restore-files.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==== Parameters ==============================================================
+BACKUP_SOURCE="${PM_FILE_BACKUP_SOURCE:-}"
+DATA_ROOT="${PM_DATA_ROOT:-/srv/projectmanagement-data}"
+# ============================================================================
+
+# ==== Validation ==============================================================
+if [[ -z "$BACKUP_SOURCE" ]]; then
+  echo "PM_FILE_BACKUP_SOURCE must point to a directory containing a DataRoot backup" >&2
+  exit 1
+fi
+
+if [[ ! -d "$BACKUP_SOURCE" ]]; then
+  echo "Backup source not found: $BACKUP_SOURCE" >&2
+  exit 1
+fi
+mkdir -p "$DATA_ROOT"
+# ============================================================================
+
+# ==== Execution ===============================================================
+rsync -a --delete "$BACKUP_SOURCE/" "$DATA_ROOT/"
+# ============================================================================
+
+echo "Files restored from $BACKUP_SOURCE into $DATA_ROOT"


### PR DESCRIPTION
## Summary
- add a comprehensive production readiness and backup/restore design note
- document the disaster recovery runbook operators can follow step by step
- provide cross-platform database and file backup/restore scripts under ops/

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2441312c83299419d842de478e37)