### PR TITLE
Clarify data root usage and harden backup scripts

### DIFF
--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -1,7 +1,13 @@
-{ 
+{
+  "Storage": {
+    "DataRoot": "C:/ProjectManagementData"
+  },
+  "ProjectPhotos": {
+    "StorageRoot": "C:/ProjectManagementData/uploads"
+  },
   "ProjectDocuments": {
     "Ocr": {
-      "WorkRoot": "App_Data/project-ocr",
+      "WorkRoot": "C:/ProjectManagementData/project-ocr",
       "InputSubpath": "input",
       "OutputSubpath": "output",
       "LogsSubpath": "logs",
@@ -14,6 +20,7 @@
     }
   },
   "DocRepo": {
+    "RootPath": "C:/ProjectManagementData/DocRepo",
     "OcrWorkRoot": "ocr-work",
     "OcrInput": "input",
     "OcrOutput": "output",

--- a/docs/production-readiness-backup.md
+++ b/docs/production-readiness-backup.md
@@ -42,7 +42,17 @@ Source code and build outputs should remain in Git/CI artifacts, yet archiving t
 
 ### 4.1 Central data root
 * Configure a single `Storage:DataRoot` (e.g., `D:/ProjectManagementData` on Windows, `/srv/projectmanagement-data` on Linux).
+* Treat `PM_DATA_ROOT` as the authoritative environment variable for the server and backup scripts; point it at the same locatio
+n as `Storage:DataRoot`.
 * All module-specific uploads must live within subfolders of this root to keep file backups simple.
+* Set the runtime roots so they stay under this directory:
+  * `PM_UPLOAD_ROOT` → `${PM_DATA_ROOT}/uploads` (or equivalent path) so `UploadRootProvider` resolves to the same tree used by b
+ackup scripts.
+  * `DocRepo:RootPath` → `${PM_DATA_ROOT}/DocRepo`.
+  * `ProjectDocuments:Ocr:WorkRoot` and any OCR work roots → `${PM_DATA_ROOT}/project-ocr`, `${PM_DATA_ROOT}/DocRepo/ocr-work`,
+ etc.
+* Include the example layout in `appsettings.Production.json` (see repo) so new environments inherit the convention automatically
+.
 
 ### 4.2 Relative database paths
 * Persist only relative paths per module (e.g., `projects-photos/2025/04/abc123.webp`).
@@ -62,8 +72,10 @@ DataRoot/
 * Logs under `logs/` can be rotated independently but should follow the same backup cadence if storage allows.
 
 ### 4.4 Backup automation
-* Nightly logical database dump using `pg_dump` (custom format) stored under `DataRoot/backups/db`.
-* Nightly file synchronization of `DataRoot` to a secondary volume or NAS using `robocopy` (Windows) or `rsync` (Linux).
+* Nightly logical database dump using `pg_dump` (custom format) stored under `DataRoot/backups/db`. Configure the Linux scripts w
+ith `PM_BACKUP_DIR` and Windows scripts via parameters so dumps land beside the file snapshots.
+* Nightly file synchronization of `DataRoot` to a secondary volume or NAS using `robocopy` (Windows) or `rsync` (Linux). Provide
+ `PM_FILE_BACKUP_ROOT` (Linux) or the PowerShell `BackupRoot` parameter, and keep it separate from the live data root.
 * Weekly offline/offsite copy (external disk, secondary site) for ransomware resilience.
 
 ### 4.5 Restore discipline
@@ -87,13 +99,13 @@ DataRoot/
 ## 6. Operational procedures
 
 ### 6.1 Regular backups
-* **Database:** Schedule `ops/backup-db.ps1` or `ops/backup-db.sh` nightly via Task Scheduler or cron. Store dumps on a separate volume with 30-day retention.
-* **Files:** Mirror `Storage:DataRoot` using the provided file backup scripts. Keep at least the last 7 nightly copies plus 4 weekly copies.
+* **Database:** Schedule `ops/backup-db.ps1` or `ops/backup-db.sh` nightly via Task Scheduler or cron. Store dumps on a separate volume with 30-day retention. Document the required environment variables (`PGBIN`, `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PM_BACKUP_DIR`) alongside the job definition so rotations remain portable.
+* **Files:** Mirror `Storage:DataRoot` using the provided file backup scripts. Keep at least the last 7 nightly copies plus 4 weekly copies. For Linux, set `PM_DATA_ROOT` (source) and `PM_FILE_BACKUP_ROOT` (destination); for Windows supply `DataRoot`/`BackupRoot` parameters or matching environment variables.
 * **Configs & certificates:** Include `appsettings.Production.json`, SSL certs, and service definitions in the same backup job or a dedicated secure repository.
 
 ### 6.2 Restore runbook (abridged)
 1. Provision OS, .NET Runtime, and PostgreSQL (matching major versions).
-2. Create/restore `Storage:DataRoot` from the latest file backup.
+2. Create/restore `Storage:DataRoot` from the latest file backup. On Linux this means exporting `PM_FILE_BACKUP_SOURCE` to the desired timestamped mirror before running `ops/restore-files.sh`; on Windows pass the equivalent `BackupSource` parameter to the PowerShell script.
 3. Deploy the published application build.
 4. Recreate the PostgreSQL database and run `ops/restore-db.*` with the chosen dump.
 5. Drop the restored `appsettings.Production.json` (or environment variables) on the server, pointing to the restored database and data root.

--- a/ops/backup-db.ps1
+++ b/ops/backup-db.ps1
@@ -31,6 +31,10 @@ New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
 #region Execution
 $pgDumpPath = Join-Path $PgBin "pg_dump.exe"
 
+if (-not (Test-Path $pgDumpPath)) {
+    throw "pg_dump not found at $pgDumpPath"
+}
+
 & $pgDumpPath `
     --format=custom `
     --host=$Host `

--- a/ops/backup-files.ps1
+++ b/ops/backup-files.ps1
@@ -22,9 +22,27 @@ New-Item -ItemType Directory -Force -Path $destination | Out-Null
 
 #region Execution
 $logPath = Join-Path $BackupRoot "backup.log"
-robocopy $DataRoot $destination /MIR /R:2 /W:5 /NP /NDL /NFL /LOG+:"$logPath"
+$logArgument = '/LOG+:"' + $logPath + '"'
+$robocopyArgs = @(
+    $DataRoot,
+    $destination,
+    '/MIR',
+    '/R:2',
+    '/W:5',
+    '/NP',
+    '/NDL',
+    '/NFL',
+    $logArgument
+)
+
+robocopy @robocopyArgs
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -gt 3) {
+    throw "robocopy reported a failure (exit code $exitCode). Review $logPath for details."
+}
 #endregion
 
 #region Output
-Write-Host "File backup completed:" $destination
+Write-Host "File backup completed:" $destination "(robocopy exit code $exitCode)"
 #endregion

--- a/ops/restore-db.ps1
+++ b/ops/restore-db.ps1
@@ -30,12 +30,22 @@ if (-not (Test-Path $PgBin)) {
 $dropDb = Join-Path $PgBin "dropdb.exe"
 $createDb = Join-Path $PgBin "createdb.exe"
 
+foreach ($tool in @($dropDb, $createDb)) {
+    if (-not (Test-Path $tool)) {
+        throw "Required PostgreSQL utility not found: $tool"
+    }
+}
+
 & $dropDb --if-exists --host=$Host --port=$Port --username=$User $DbName
 & $createDb --host=$Host --port=$Port --username=$User $DbName
 #endregion
 
 #region Restore
 $pgRestore = Join-Path $PgBin "pg_restore.exe"
+
+if (-not (Test-Path $pgRestore)) {
+    throw "pg_restore not found at $pgRestore"
+}
 
 & $pgRestore `
     --host=$Host `

--- a/ops/restore-files.ps1
+++ b/ops/restore-files.ps1
@@ -19,9 +19,25 @@ New-Item -ItemType Directory -Force -Path $DataRoot | Out-Null
 #endregion
 
 #region Execution
-robocopy $BackupSource $DataRoot /MIR /R:2 /W:5 /NP /NDL /NFL
+$robocopyArgs = @(
+    $BackupSource,
+    $DataRoot,
+    '/MIR',
+    '/R:2',
+    '/W:5',
+    '/NP',
+    '/NDL',
+    '/NFL'
+)
+
+robocopy @robocopyArgs
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -gt 3) {
+    throw "robocopy reported a failure (exit code $exitCode). Inspect the console output for details."
+}
 #endregion
 
 #region Output
-Write-Host "File restore completed from" $BackupSource
+Write-Host "File restore completed from" $BackupSource "(robocopy exit code $exitCode)"
 #endregion


### PR DESCRIPTION
## Summary
- align the production configuration and documentation so every persistent folder lives under a single Storage:DataRoot/PM_DATA_ROOT
- document the backup and restore environment variables so ops can configure the scripts without digging through code
- add basic safety checks and exit-code handling to the PowerShell backup/restore scripts to avoid silent failures

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d46ea9f248329bd57e9e0d5d79adb)