### PR TITLE
Revamp FFC detailed table grouping

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
@@ -8,8 +8,8 @@
         <div>
             <h1 class="h4 mb-1">FFC – Detailed table</h1>
             <p class="pm-page-subtitle">
-                Installed / Delivered (not installed) / Planned totals show project units captured against each FFC record.
-                Use the Linked? column to distinguish rows tied to a core project from stand-alone entries.
+                Installed / Delivered / Planned totals show project units captured against each FFC record. Linked project
+                details feed the cost and progress summaries shown per row.
             </p>
         </div>
         <div class="d-flex flex-wrap gap-2 align-items-center">
@@ -23,14 +23,13 @@
         <table id="ffc-dtable" class="table table-sm align-middle">
             <thead>
                 <tr>
-                    <th scope="col">Country</th>
-                    <th scope="col">ISO3</th>
+                    <th scope="col" style="width:4rem;">S. No.</th>
                     <th scope="col">Project</th>
-                    <th scope="col">Linked?</th>
+                    <th scope="col" class="text-end">Cost (₹ Cr)</th>
                     <th scope="col" class="text-end">Quantity</th>
-                    <th scope="col">Bucket</th>
-                    <th scope="col">Latest stage</th>
-                    <th scope="col">External remark</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Progress / present status</th>
+                    <th scope="col">Overall remarks</th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed.js
@@ -1,55 +1,125 @@
 (function () {
+  // SECTION: DOM references
   const table = document.getElementById('ffc-dtable');
   if (!table) {
     return;
   }
 
-  const tbody = table.querySelector('tbody');
-
-  function esc(value) {
-    return String(value ?? '').replace(/[&<>"']/g, (match) => ({
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    })[match]);
+  const tbody = table.tBodies[0];
+  if (!tbody) {
+    return;
   }
 
-  async function load() {
-    const response = await fetch('/ProjectOfficeReports/FFC/MapTableDetailed?handler=Data', { credentials: 'same-origin' });
+  // SECTION: Formatting helpers
+  const escapeMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+
+  const costFormatter = new Intl.NumberFormat('en-IN', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
+  });
+
+  const quantityFormatter = new Intl.NumberFormat('en-IN', {
+    maximumFractionDigits: 0
+  });
+
+  function esc(value) {
+    return String(value ?? '').replace(/[&<>"']/g, (match) => escapeMap[match]);
+  }
+
+  function formatCost(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return '—';
+    }
+
+    return costFormatter.format(value);
+  }
+
+  function formatQuantity(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return '';
+    }
+
+    return quantityFormatter.format(value);
+  }
+
+  // SECTION: Data access
+  async function loadGroups() {
+    const response = await fetch('?handler=Data', { credentials: 'same-origin' });
     if (!response.ok) {
       throw new Error('Failed to load detailed data');
     }
 
-    /** @type {{countryIso3:string,countryName:string,projectName:string,isLinked:boolean,quantity:number,bucket:string,latestStage:string,externalRemark:string}[]} */
-    const rows = await response.json();
-    return rows;
+    /** @type {{countryName:string,countryIso3:string,year:number,overallRemarks:string|null,projects:{serialNumber:number,projectName:string,costInCr:number|null,quantity:number,bucket:string,progressRemark:string|null}[]}[]} */
+    const groups = await response.json();
+    return groups;
   }
 
-  function render(rows) {
-    if (!Array.isArray(rows) || rows.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="8" class="text-muted">No projects found.</td></tr>';
+  // SECTION: Rendering
+  function render(groups) {
+    if (!Array.isArray(groups) || groups.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" class="text-muted text-center">No project units found.</td></tr>';
       return;
     }
 
-        tbody.innerHTML = rows.map((row) => `
-      <tr>
-        <td>${esc(row.countryName)}</td>
-        <td><code>${esc((row.countryIso3 || '').toUpperCase())}</code></td>
-        <td>${esc(row.projectName)}</td>
-        <td>${row.isLinked ? 'Yes' : 'No'}</td>
-        <td class="text-end">${row.quantity ?? 0}</td>
-        <td>${esc(row.bucket)}</td>
-        <td>${esc(row.latestStage)}</td>
-        <td>${esc(row.externalRemark)}</td>
-      </tr>
-    `).join('');
+    const rows = [];
+
+    groups.forEach((group) => {
+      const projectRows = Array.isArray(group.projects) ? group.projects : [];
+      if (projectRows.length === 0) {
+        return;
+      }
+
+      rows.push(
+        `<tr class="table-light">
+          <td colspan="7">
+            <strong>${esc(group.countryName)} – ${esc(group.year)}</strong>
+            <span class="ms-2 text-muted">${esc(group.countryIso3)}</span>
+          </td>
+        </tr>`
+      );
+
+      const overallRemarks = esc(group.overallRemarks || '');
+      const rowspan = projectRows.length;
+
+      projectRows.forEach((project, index) => {
+        const serialNumber = typeof project.serialNumber === 'number' ? project.serialNumber : index + 1;
+        const cost = formatCost(project.costInCr);
+        const qty = formatQuantity(project.quantity);
+        const status = esc(project.bucket || '');
+        const progress = esc(project.progressRemark || '');
+        const name = esc(project.projectName || '');
+
+        rows.push(
+          `<tr>
+            <td class="text-muted">${serialNumber}</td>
+            <td>${name}</td>
+            <td class="text-end">${cost}</td>
+            <td class="text-end">${qty}</td>
+            <td>${status}</td>
+            <td>${progress}</td>
+            ${index === 0 ? `<td rowspan="${rowspan}" class="align-top">${overallRemarks}</td>` : ''}
+          </tr>`
+        );
+      });
+    });
+
+    if (rows.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" class="text-muted text-center">No project units found.</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = rows.join('');
   }
 
-  load()
+  loadGroups()
     .then(render)
     .catch(() => {
-      tbody.innerHTML = '<tr><td colspan="8" class="text-danger">Failed to load detailed table.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="7" class="text-danger text-center">Failed to load detailed table.</td></tr>';
     });
 })();


### PR DESCRIPTION
## Summary
- reshape the FFC detailed table backend to emit grouped DTOs with per-project cost/progress info and updated Excel export columns
- refresh the Razor markup and client renderer to show grouped country/year blocks with rowspan overall remarks and the new column set

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d77a3c4408329abde3cd3ab1e57bb)