### PR TITLE
Sort detailed FFC map table by latest year

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
@@ -96,7 +96,9 @@ public class MapTableDetailedModel : PageModel
         worksheet.Cell(1, columnIndex++).Value = "Overall remarks";
 
         var rowIndex = 2;
-        foreach (var group in groups.OrderBy(g => g.CountryName).ThenBy(g => g.Year))
+        foreach (var group in groups
+            .OrderByDescending(g => g.Year)
+            .ThenBy(g => g.CountryName, StringComparer.OrdinalIgnoreCase))
         {
             if (group.Projects is null || group.Projects.Count == 0)
             {
@@ -243,8 +245,8 @@ public class MapTableDetailedModel : PageModel
                 project.CountryIso3,
                 project.OverallRemarks
             })
-            .OrderBy(group => group.Key.CountryName ?? string.Empty, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(group => group.Key.Year)
+            .OrderByDescending(group => group.Key.Year)
+            .ThenBy(group => group.Key.CountryName ?? string.Empty, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var result = new List<FfcRecordDetailGroupDto>(groups.Count);


### PR DESCRIPTION
## Summary
- sort the grouped FFC detail data by year (descending) and then by country name so the newest records appear first
- mirror the same ordering in the Excel export to keep the download consistent with the on-screen table

## Testing
- `dotnet test` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d800f41e08329b2786710df5b6223)