### PR TITLE
Fix MapBoard page link helper

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapBoard.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapBoard.cshtml.cs
@@ -1,11 +1,21 @@
+// -----------------------------------------------------------------------------
+// Usings
+// -----------------------------------------------------------------------------
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
+// -----------------------------------------------------------------------------
+// Namespace
+// -----------------------------------------------------------------------------
 namespace ProjectManagement.Areas.ProjectOfficeReports.Pages.FFC;
 
 [Authorize]
 public class MapBoardModel : PageModel
 {
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
     public void OnGet()
     {
         FfcBreadcrumbs.Set(


### PR DESCRIPTION
## Summary
- import `Microsoft.AspNetCore.Mvc` so the `Url.Page` helper is available when setting the breadcrumbs on the MapBoard page
- add section comments to keep the file aligned with the project's coding guidelines

## Testing
- `dotnet build` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd34dfd2483298c1044513a4ae13f)