### PR TITLE
Clarify FFC dashboard controls and improve card labels

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Index.cshtml
@@ -16,17 +16,20 @@
             <div>
                 <h1 class="h4 mb-1">FFC Proposals</h1>
                 <p class="pm-page-subtitle">Review project delivery and installation progress by country and year.</p>
+                @* SECTION: Record filters trigger *@
                 <div class="d-flex flex-wrap gap-2 mt-3">
                     <button type="button"
-                            class="btn btn-outline-secondary"
+                            class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
                             data-bs-toggle="modal"
                             data-bs-target="#ffcFiltersModal">
-                        Filter records
+                        <span class="bi bi-funnel" aria-hidden="true"></span>
+                        <span>Filter</span>
                     </button>
                 </div>
             </div>
-            <div class="btn-toolbar flex-wrap justify-content-end gap-2" role="toolbar" aria-label="FFC navigation">
-                <div class="btn-group" role="group" aria-label="FFC views">
+            @* SECTION: FFC navigation toolbar *@
+            <div class="btn-toolbar flex-wrap justify-content-end gap-3" role="toolbar" aria-label="FFC navigation">
+                <div class="btn-group btn-group-sm" role="group" aria-label="FFC views">
                     <a asp-area="ProjectOfficeReports"
                        asp-page="/FFC/Map"
                        class="btn btn-outline-secondary">Map view</a>
@@ -39,13 +42,13 @@
                 </div>
                 @if (Model.CanManageRecords)
                 {
-                    <div class="btn-group" role="group" aria-label="Management actions">
+                    <div class="d-flex flex-wrap gap-2" role="group" aria-label="Management actions">
                         <a asp-area="ProjectOfficeReports"
                            asp-page="/FFC/Records/Manage"
-                           class="btn btn-outline-secondary">Manage records</a>
+                           class="btn btn-outline-secondary btn-sm">Manage records</a>
                         <a asp-area="ProjectOfficeReports"
                            asp-page="/FFC/Countries/Manage"
-                           class="btn btn-outline-secondary">Manage countries</a>
+                           class="btn btn-outline-secondary btn-sm">Manage countries</a>
                     </div>
                 }
             </div>

--- a/Areas/ProjectOfficeReports/Pages/FFC/_FfcRecordCard.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_FfcRecordCard.cshtml
@@ -67,24 +67,28 @@
                 <h2 class="ffc-record-card__country">@countryName</h2>
             </div>
         </div>
+        @* SECTION: Record summary counters *@
         <div class="ffc-record-card__summary" aria-label="Record summary">
             <div class="ffc-record-card__summary-item ffc-record-card__summary-item--projects">
                 <span class="ffc-record-card__summary-value ffc-record-card__summary-value--projects">@projectCount</span>
                 <span class="ffc-record-card__summary-label"
                       data-bs-toggle="tooltip"
                       data-bs-placement="top"
-                      title="Number of FFC projects for this country and year">Projects</span>
+                      title="Number of projects for this country and year">Projects</span>
             </div>
             <div class="ffc-record-card__summary-item ffc-record-card__summary-item--units">
                 <span class="ffc-record-card__summary-value ffc-record-card__summary-value--units">@projectUnits</span>
                 <span class="ffc-record-card__summary-label"
                       data-bs-toggle="tooltip"
                       data-bs-placement="top"
-                      title="Number of individual project units recorded for this record">Project units</span>
+                      title="Total project units captured for this country and year">Project units</span>
             </div>
             <div class="ffc-record-card__summary-item ffc-record-card__summary-item--attachments">
                 <span class="ffc-record-card__summary-value ffc-record-card__summary-value--attachments">@attachmentCount</span>
-                <span class="ffc-record-card__summary-label">Attachments</span>
+                <span class="ffc-record-card__summary-label"
+                      data-bs-toggle="tooltip"
+                      data-bs-placement="top"
+                      title="Number of attachments linked to this record">Attachments</span>
             </div>
         </div>
     </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -543,10 +543,12 @@ body {
     --ffc-summary-border: rgba(147, 51, 234, .5);
 }
 
+/* SECTION: FFC record card summary labels */
 .ffc-record-card__summary-label {
-    font-size: .75rem;
-    text-transform: uppercase;
-    letter-spacing: .08em;
+    font-size: .85rem;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: normal;
     color: var(--pm-muted);
 }
 


### PR DESCRIPTION
## Summary
- clarify the filter trigger and reorganise the toolbar so analytical and admin actions have distinct visual weight
- add consistent wording and helpful tooltips to the FFC record card counters and adjust their typography for sentence case

## Testing
- `dotnet test` *(fails: `dotnet` CLI is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd5a376088329b95502bb755643e0)