### PR TITLE
Fix ts_headline search helpers to use DbContext mapping

### DIFF
--- a/Services/Search/GlobalActivitiesSearchService.cs
+++ b/Services/Search/GlobalActivitiesSearchService.cs
@@ -59,7 +59,7 @@ public sealed class GlobalActivitiesSearchService : IGlobalActivitiesSearchServi
                 activity.Location,
                 activity.CreatedAtUtc,
                 activity.ScheduledStartUtc,
-                Snippet = EF.Functions.TsHeadline(
+                Snippet = ApplicationDbContext.TsHeadline(
                     "english",
                     (activity.Title ?? string.Empty) + " " +
                     (activity.Description ?? string.Empty) + " " +

--- a/Services/Search/GlobalFfcSearchService.cs
+++ b/Services/Search/GlobalFfcSearchService.cs
@@ -70,7 +70,7 @@ namespace ProjectManagement.Services.Search
                     record.GslRemarks,
                     record.DeliveryRemarks,
                     record.InstallationRemarks,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (record.Country != null ? record.Country.Name : string.Empty) + " " +
                         (record.OverallRemarks ?? string.Empty) + " " +

--- a/Services/Search/GlobalProjectReportsSearchService.cs
+++ b/Services/Search/GlobalProjectReportsSearchService.cs
@@ -76,7 +76,7 @@ namespace ProjectManagement.Services.Search
                     visit.CreatedAtUtc,
                     visit.LastModifiedAtUtc,
                     TypeName = visit.VisitType != null ? visit.VisitType.Name : null,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (visit.VisitorName ?? string.Empty) + " " +
                         (visit.Remarks ?? string.Empty) + " " +
@@ -132,7 +132,7 @@ namespace ProjectManagement.Services.Search
                     e.CreatedAtUtc,
                     e.LastModifiedAtUtc,
                     PlatformName = e.SocialMediaPlatform != null ? e.SocialMediaPlatform.Name : null,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (e.Title ?? string.Empty) + " " +
                         (e.Description ?? string.Empty) + " " +
@@ -190,7 +190,7 @@ namespace ProjectManagement.Services.Search
                     training.CreatedAtUtc,
                     training.LastModifiedAtUtc,
                     TrainingTypeName = training.TrainingType != null ? training.TrainingType.Name : null,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (training.Notes ?? string.Empty) + " " +
                         (training.TrainingType != null ? training.TrainingType.Name : string.Empty),
@@ -263,7 +263,7 @@ namespace ProjectManagement.Services.Search
                     training.EndDate,
                     training.CreatedAtUtc,
                     training.LastModifiedAtUtc,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         training.Notes ?? string.Empty,
                         searchQuery,
@@ -327,7 +327,7 @@ namespace ProjectManagement.Services.Search
                     record.SurveyDate,
                     record.CreatedAtUtc,
                     record.LastModifiedAtUtc,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (record.Country ?? string.Empty) + " " +
                         (record.Topic ?? string.Empty) + " " +

--- a/Services/Search/GlobalProjectSearchService.cs
+++ b/Services/Search/GlobalProjectSearchService.cs
@@ -67,7 +67,7 @@ namespace ProjectManagement.Services.Search
                     p.DeletedAt,
                     SponsoringUnit = p.SponsoringUnit != null ? p.SponsoringUnit.Name : null,
                     LineDirectorate = p.SponsoringLineDirectorate != null ? p.SponsoringLineDirectorate.Name : null,
-                    Snippet = EF.Functions.TsHeadline(
+                    Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         (p.Name ?? string.Empty) + " " +
                         (p.Description ?? string.Empty) + " " +


### PR DESCRIPTION
## Summary
- update search services to call the ApplicationDbContext ts_headline mapping instead of EF.Functions

## Testing
- `dotnet test` *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f6140e4c83298d6d02c0d1a03b71)