### PR TITLE
Fix project office search data sources

### DIFF
--- a/Services/Search/GlobalProjectReportsSearchService.cs
+++ b/Services/Search/GlobalProjectReportsSearchService.cs
@@ -256,7 +256,15 @@ namespace ProjectManagement.Services.Search
                         (tot.Project != null ? tot.Project.Name : string.Empty) + " " +
                         (tot.MetDetails ?? string.Empty))
                         .Matches(searchQuery))
-                .OrderByDescending(tot => tot.LastApprovedOnUtc ?? tot.CompletedOn ?? tot.StartedOn ?? tot.Project!.CreatedAt)
+                .OrderByDescending(tot =>
+                    tot.LastApprovedOnUtc
+                    ?? (tot.CompletedOn.HasValue
+                        ? tot.CompletedOn.Value.ToDateTime(TimeOnly.MinValue)
+                        : (DateTime?)null)
+                    ?? (tot.StartedOn.HasValue
+                        ? tot.StartedOn.Value.ToDateTime(TimeOnly.MinValue)
+                        : (DateTime?)null)
+                    ?? (DateTime?)tot.Project!.CreatedAt)
                 .Take(limit)
                 .Select(tot => new
                 {


### PR DESCRIPTION
## Summary
- adjust project office training search results to use existing manage URL
- update TOT and proliferation search queries to target existing entities and headline generation
- fix TOT search ordering to coalesce DateOnly and DateTime fields without compilation errors

## Testing
- dotnet build *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ffac901083299fe5842c54e20cd4)