### PR TITLE
Fix proliferation search FTS query translation error

### DIFF
--- a/Services/Search/GlobalProjectReportsSearchService.cs
+++ b/Services/Search/GlobalProjectReportsSearchService.cs
@@ -325,8 +325,7 @@ namespace ProjectManagement.Services.Search
                 .Where(record =>
                     EF.Functions.ToTsVector("english",
                         record.UnitName + " " +
-                        (record.Remarks ?? string.Empty) + " " +
-                        record.Source.ToString())
+                        (record.Remarks ?? string.Empty))
                         .Matches(EF.Functions.WebSearchToTsQuery("english", trimmedQuery)))
                 .OrderByDescending(record => record.LastUpdatedOnUtc)
                 .Take(limit)
@@ -342,8 +341,7 @@ namespace ProjectManagement.Services.Search
                     Snippet = ApplicationDbContext.TsHeadline(
                         "english",
                         record.UnitName + " " +
-                        (record.Remarks ?? string.Empty) + " " +
-                        record.Source.ToString(),
+                        (record.Remarks ?? string.Empty),
                         EF.Functions.WebSearchToTsQuery("english", trimmedQuery),
                         headlineOptions)
                 })


### PR DESCRIPTION
## Summary
- remove enum ToString usage from proliferation full-text search vector and snippet to avoid translation failures
- keep remarks and unit name in search inputs while preserving existing result rendering

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231334f9088329a5f9701073ca86aa)