### PR TITLE
Improve progress review print pagination

### DIFF
--- a/wwwroot/css/progress-review.print.css
+++ b/wwwroot/css/progress-review.print.css
@@ -65,8 +65,15 @@
         height: auto;
     }
 
+    /* SECTION: Pagination behaviour */
     .pr-section {
-        page-break-inside: avoid;
+        page-break-inside: auto;
+        break-inside: auto;
+    }
+
+    .progress-review__section-header {
+        page-break-after: avoid;
+        break-after: avoid;
     }
 
     .pr-category-header {


### PR DESCRIPTION
## Summary
- allow progress review sections to break naturally across pages for cleaner print previews
- keep progress review section headers attached to their content while avoiding excessive whitespace

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692464ae465c83299475789e947e2f58)