### PR TITLE
Add export PDF option to progress review report

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -141,6 +141,10 @@
             </div>
             <div class="progress-review__toolbar-actions">
                 <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#progress-review-range">Date range</button>
+                <button class="btn btn-outline-primary btn-sm" type="button" data-action="export-pdf">
+                    <i class="bi bi-file-earmark-pdf me-1"></i>
+                    <span class="d-none d-md-inline">Export PDF</span>
+                </button>
                 <button class="btn btn-primary btn-sm" type="button" data-action="print">
                     <i class="bi bi-printer me-1"></i>
                     <span class="d-none d-md-inline">Print</span>

--- a/wwwroot/js/pages/project-office-reports/progress-review.js
+++ b/wwwroot/js/pages/project-office-reports/progress-review.js
@@ -52,14 +52,16 @@
   // =========================================================
   // SECTION: Quick action bindings
   // =========================================================
-  const bindPrintButton = () => {
-    const button = document.querySelector('[data-action="export-pdf"], [data-action="print"]');
-    if (!button) {
+  const bindPrintButtons = () => {
+    const buttons = document.querySelectorAll('[data-action="export-pdf"], [data-action="print"]');
+    if (!buttons.length) {
       return;
     }
 
-    button.addEventListener('click', () => {
-      window.print();
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        window.print();
+      });
     });
   };
 
@@ -70,6 +72,6 @@
     }
 
     ensureDefaultDates(form);
-    bindPrintButton();
+    bindPrintButtons();
   });
 })();


### PR DESCRIPTION
## Summary
- add an Export PDF button to the Progress Review toolbar for quick access
- allow both print and export controls to trigger the print-to-PDF flow consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924683869ac83299914f71fd671b3e6)