### PR TITLE
Handle nullable category filters in ongoing projects

### DIFF
--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -47,7 +47,7 @@ namespace ProjectManagement.Services.Projects
             if (projectCategoryId is { } catId && catId > 0)
             {
                 var categoryScopeIds = await GetCategoryScopeIdsAsync(catId, cancellationToken);
-                q = q.Where(p => categoryScopeIds.Contains(p.CategoryId));
+                q = q.Where(p => p.CategoryId.HasValue && categoryScopeIds.Contains(p.CategoryId.Value));
             }
 
             if (!string.IsNullOrWhiteSpace(leadPoUserId))
@@ -299,7 +299,8 @@ namespace ProjectManagement.Services.Projects
                 .ToListAsync(cancellationToken);
 
             var childrenByParent = categories
-                .GroupBy(c => c.ParentId)
+                .Where(c => c.ParentId.HasValue)
+                .GroupBy(c => c.ParentId!.Value)
                 .ToDictionary(g => g.Key, g => g.Select(x => x.Id).ToList());
 
             var collectedIds = new List<int> { rootCategoryId };


### PR DESCRIPTION
## Summary
- guard category filtering to only evaluate when projects have a category id
- build category child lookups using non-null parent ids to satisfy dictionary constraints

## Testing
- dotnet build *(fails: dotnet command unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246e2fa7208329894a0d22b1a4bf6f)