### PR TITLE
Ensure footer sticks to bottom on short pages

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="~/css/print.css" asp-append-version="true" media="print" />
     <link rel="icon" href="~/favicon.ico" />
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
     @{
         var currentPage = ViewContext.RouteData.Values["page"]?.ToString();
         var currentArea = ViewContext.RouteData.Values["area"]?.ToString();

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -60,6 +60,11 @@ body {
     background-color: var(--pm-surface);
 }
 
+/* --- Layout shell --- */
+main[role="main"] {
+    flex: 1 0 auto;
+}
+
 /* --- Page header & spacing --- */
 .pm-page-header {
     display: flex;


### PR DESCRIPTION
## Summary
- make the shared layout body a flex column that fills the viewport for proper footer placement
- let the main content area flex to occupy remaining height and push the footer down

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252637879c8329a17f4ed73c054ea0)