### PR TITLE
Allow Project Office role to access lookup projects

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1718,8 +1718,20 @@ proliferationEffectiveApi.MapGet("", async (
     return Results.Ok(new { projectId, source, year, total });
 });
 
+// -------------------------------------------------------------
+// LOOKUP API
+// -------------------------------------------------------------
+var lookupApiRoles = string.Join(',', new[]
+{
+    RoleNames.Admin,
+    RoleNames.HoD,
+    RoleNames.ProjectOfficer,
+    RoleNames.ProjectOffice,
+    RoleNames.ProjectOfficeAlternate
+});
+
 var lookupApi = app.MapGroup("/api/lookups")
-    .RequireAuthorization(new AuthorizeAttribute { Roles = "Admin,HoD,Project Officer" });
+    .RequireAuthorization(new AuthorizeAttribute { Roles = lookupApiRoles });
 
 lookupApi.MapGet("/sponsoring-units", async (
     ApplicationDbContext db,


### PR DESCRIPTION
## Summary
- expand lookup API authorization to include Project Office role variants
- centralize lookup role list to prevent future mismatches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69254cb8c4a883299a6067284a95dfc1)