### PR TITLE
Show cost summary on project overview

### DIFF
--- a/Pages/Projects/_ProjectOverviewCard.cshtml
+++ b/Pages/Projects/_ProjectOverviewCard.cshtml
@@ -151,6 +151,13 @@
 
                     <dt class="col-sm-4">Project Officer</dt>
                     <dd class="col-sm-8">@FormatUser(project?.LeadPoUser)</dd>
+
+                    @* SECTION: Cost summary *@
+                    <dt class="col-sm-4">R&amp;D / L1 cost</dt>
+                    <dd class="col-sm-8">@FormatCost(Model.CostSummary.RdCostLakhs)</dd>
+
+                    <dt class="col-sm-4">Approx production cost</dt>
+                    <dd class="col-sm-8">@FormatCost(Model.CostSummary.ApproxProductionCost)</dd>
                 </dl>
             </div>
             <div class="col-12">
@@ -186,5 +193,12 @@
         }
 
         return "—";
+    }
+
+    private static string FormatCost(decimal? costLakhs)
+    {
+        return costLakhs.HasValue
+            ? $"{costLakhs.Value:0.##} lakh"
+            : "—";
     }
 }


### PR DESCRIPTION
## Summary
- load R&D/L1 and production cost details for projects when building the overview page
- surface the cost figures alongside existing project facts within the overview card
- add reusable cost summary view model for the overview

## Testing
- `dotnet test` *(fails: command not found in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692558b6a4c88329baefd2b4bddd2ba2)