### PR TITLE
Replace inline styles with reusable utilities

### DIFF
--- a/Areas/Admin/Pages/Documents/Recycle.cshtml
+++ b/Areas/Admin/Pages/Documents/Recycle.cshtml
@@ -96,7 +96,7 @@
             <table class="table align-middle">
                 <thead>
                     <tr>
-                        <th scope="col" class="text-center" style="width: 3rem;">Select</th>
+                        <th scope="col" class="text-center pm-util-col-3rem">Select</th>
                         <th scope="col">Project</th>
                         <th scope="col">Stage</th>
                         <th scope="col">Nomenclature</th>

--- a/Areas/DocumentRepository/Pages/Admin/DeleteRequests/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Admin/DeleteRequests/Index.cshtml
@@ -39,7 +39,7 @@
                         <th>Requested by</th>
                         <th>Reason</th>
                         <th>Requested at (UTC)</th>
-                        <th style="width: 180px;"></th>
+                        <th class="pm-util-col-180"></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/Areas/DocumentRepository/Pages/Admin/DocumentCategories/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Admin/DocumentCategories/Index.cshtml
@@ -39,8 +39,8 @@
                         <thead>
                             <tr>
                                 <th scope="col">Name</th>
-                                <th scope="col" style="width: 110px;">Sort order</th>
-                                <th scope="col" style="width: 120px;">Status</th>
+                                <th scope="col" class="pm-util-col-110">Sort order</th>
+                                <th scope="col" class="pm-util-col-120">Status</th>
                                 <th scope="col" class="text-end">Actions</th>
                             </tr>
                         </thead>

--- a/Areas/DocumentRepository/Pages/Admin/OCRFailures/OcrFailures.cshtml
+++ b/Areas/DocumentRepository/Pages/Admin/OCRFailures/OcrFailures.cshtml
@@ -28,7 +28,7 @@
                     @(Model.FailedDocuments.Count == 0 ? "disabled" : null)>
                 Re-queue all
             </button>
-            <span id="requeueAllStatus" class="text-muted ms-2" style="display:none;">Re-queuing…</span>
+            <span id="requeueAllStatus" class="text-muted ms-2 d-none">Re-queuing…</span>
         </form>
     </div>
     <div class="card-body p-0">

--- a/Areas/DocumentRepository/Pages/Admin/OfficeCategories/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Admin/OfficeCategories/Index.cshtml
@@ -39,8 +39,8 @@
                         <thead>
                             <tr>
                                 <th scope="col">Name</th>
-                                <th scope="col" style="width: 110px;">Sort order</th>
-                                <th scope="col" style="width: 120px;">Status</th>
+                                <th scope="col" class="pm-util-col-110">Sort order</th>
+                                <th scope="col" class="pm-util-col-120">Status</th>
                                 <th scope="col" class="text-end">Actions</th>
                             </tr>
                         </thead>

--- a/Areas/DocumentRepository/Pages/Admin/Trash/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Admin/Trash/Index.cshtml
@@ -56,7 +56,7 @@
                         <th>Deleted by</th>
                         <th>Reason</th>
                         <th class="text-end">Size</th>
-                        <th class="text-end" style="width: 180px;">Actions</th>
+                        <th class="text-end pm-util-col-180">Actions</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/Areas/ProjectOfficeReports/Pages/FFC/Countries/_CountryTable.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Countries/_CountryTable.cshtml
@@ -37,8 +37,8 @@
         foreach (var country in Model.Countries)
         {
             <tr>
-                <td class="text-break" style="min-width:160px;">
-                    <span class="d-inline-block text-truncate w-100" style="max-width:260px;" data-bs-toggle="tooltip" data-bs-placement="top" title="@country.Name">@country.Name</span>
+                <td class="text-break pm-util-minw-160">
+                    <span class="d-inline-block text-truncate w-100 pm-util-maxw-260" data-bs-toggle="tooltip" data-bs-placement="top" title="@country.Name">@country.Name</span>
                 </td>
                 <td>@country.IsoCode</td>
                 <td class="text-center">

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordTable.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/_RecordTable.cshtml
@@ -75,8 +75,8 @@
                         <small class="text-muted">Total: @summary.Total</small>
                     }
                 </td>
-                <td class="text-break" style="max-width:220px;">
-                    <span class="d-inline-block text-truncate w-100" style="max-width:220px;" data-bs-toggle="tooltip" data-bs-placement="top" title="@record.OverallRemarks">@record.OverallRemarks</span>
+                <td class="text-break pm-util-maxw-220">
+                    <span class="d-inline-block text-truncate w-100 pm-util-maxw-220" data-bs-toggle="tooltip" data-bs-placement="top" title="@record.OverallRemarks">@record.OverallRemarks</span>
                 </td>
                 <td class="text-end">
                     <authorize roles="Admin,HoD">

--- a/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
@@ -12,7 +12,7 @@ else
         <table class="table table-sm align-middle ffc-dtable mb-0">
             <thead>
                 <tr>
-                    <th scope="col" style="width:4rem;">S. No.</th>
+                    <th scope="col" class="pm-util-col-70">S. No.</th>
                     <th scope="col">Project</th>
                     <th scope="col" class="text-end">Cost (₹ Cr)</th>
                     <th scope="col" class="text-end">Quantity</th>

--- a/Areas/ProjectOfficeReports/Pages/Ipr/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Ipr/Index.cshtml
@@ -69,8 +69,7 @@
     @if (!string.IsNullOrWhiteSpace(toastMessage) || !string.IsNullOrWhiteSpace(toastError))
     {
         <div id="iprToastContainer"
-             class="toast-container position-fixed top-0 end-0 p-3"
-             style="z-index: 1100;"
+             class="toast-container position-fixed top-0 end-0 p-3 pm-util-z-1100"
              aria-live="polite"
              aria-atomic="true">
             @if (!string.IsNullOrWhiteSpace(toastMessage))
@@ -106,42 +105,55 @@
                     <div class="pm-kpi pm-kpi--total h-100">
                         <div class="pm-kpi__label">Total</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.Total</div>
-                        <div class="pm-kpi__spark mt-2" aria-hidden="true"><span style="width:@Math.Clamp(Model.Kpis.TotalPercent, 0, 100)%"></span></div>
+                        <!-- SECTION: KPI spark bar widths -->
+                        <div class="pm-kpi__spark mt-2" aria-hidden="true">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.TotalPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg">
                     <div class="pm-kpi pm-kpi--filing h-100">
                         <div class="pm-kpi__label">Filing under process</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.FilingUnderProcess</div>
-                        <div class="pm-kpi__spark mt-2"><span style="width:@Math.Clamp(Model.Kpis.FilingUnderProcessPercent, 0, 100)%"></span></div>
+                        <div class="pm-kpi__spark mt-2">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.FilingUnderProcessPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg">
                     <div class="pm-kpi pm-kpi--filed h-100">
                         <div class="pm-kpi__label">Filed</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.Filed</div>
-                        <div class="pm-kpi__spark mt-2"><span style="width:@Math.Clamp(Model.Kpis.FiledPercent, 0, 100)%"></span></div>
+                        <div class="pm-kpi__spark mt-2">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.FiledPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg">
                     <div class="pm-kpi pm-kpi--granted h-100">
                         <div class="pm-kpi__label">Granted</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.Granted</div>
-                        <div class="pm-kpi__spark mt-2"><span style="width:@Math.Clamp(Model.Kpis.GrantedPercent, 0, 100)%"></span></div>
+                        <div class="pm-kpi__spark mt-2">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.GrantedPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg">
                     <div class="pm-kpi pm-kpi--rejected h-100">
                         <div class="pm-kpi__label">Rejected</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.Rejected</div>
-                        <div class="pm-kpi__spark mt-2"><span style="width:@Math.Clamp(Model.Kpis.RejectedPercent, 0, 100)%"></span></div>
+                        <div class="pm-kpi__spark mt-2">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.RejectedPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12 col-sm-6 col-lg">
                     <div class="pm-kpi pm-kpi--withdrawn h-100">
                         <div class="pm-kpi__label">Withdrawn</div>
                         <div class="pm-kpi__value mt-1">@Model.Kpis.Withdrawn</div>
-                        <div class="pm-kpi__spark mt-2"><span style="width:@Math.Clamp(Model.Kpis.WithdrawnPercent, 0, 100)%"></span></div>
+                        <div class="pm-kpi__spark mt-2">
+                            <span class="pm-kpi__spark-bar" data-kpi-width="@Math.Clamp(Model.Kpis.WithdrawnPercent, 0, 100)"></span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -219,7 +231,7 @@
                                    data-totals='@Html.Raw(totalsJson)'>
                                 <thead>
                                 <tr>
-                                    <th style="width:70px">Year</th>
+                                    <th class="pm-util-col-70">Year</th>
                                     <th>Filed</th>
                                     <th>Granted</th>
                                     <th>Rejected</th>
@@ -383,10 +395,10 @@
                     @for (var index = 0; index < 3; index++)
                     {
                         <div class="border rounded-3 p-4 mb-3">
-                            <div class="placeholder col-4 mb-2" style="min-height: 1.4rem;"></div>
-                            <div class="placeholder col-6 mb-2" style="min-height: 1rem;"></div>
-                            <div class="placeholder col-8 mb-2" style="min-height: 0.8rem;"></div>
-                            <div class="placeholder col-5" style="min-height: 0.8rem;"></div>
+                            <div class="placeholder col-4 mb-2 pm-util-minh-14"></div>
+                            <div class="placeholder col-6 mb-2 pm-util-minh-10"></div>
+                            <div class="placeholder col-8 mb-2 pm-util-minh-08"></div>
+                            <div class="placeholder col-5 pm-util-minh-08"></div>
                         </div>
                     }
                 </div>

--- a/Areas/ProjectOfficeReports/Pages/Ipr/Manage.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Ipr/Manage.cshtml
@@ -57,12 +57,12 @@
                     <table class="table table-sm align-middle mb-0">
                         <thead>
                             <tr>
-                                <th style="width: 140px;">Filing no.</th>
+                                <th class="pm-util-col-140">Filing no.</th>
                                 <th>Title</th>
-                                <th style="width: 140px;">Type</th>
-                                <th style="width: 160px;">Status</th>
-                                <th style="width: 160px;">Project</th>
-                                <th style="width: 140px;"></th>
+                                <th class="pm-util-col-140">Type</th>
+                                <th class="pm-util-col-160">Status</th>
+                                <th class="pm-util-col-160">Project</th>
+                                <th class="pm-util-col-140"></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/Areas/ProjectOfficeReports/Pages/Proliferation/Summary.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Proliferation/Summary.cshtml
@@ -121,7 +121,7 @@
 
             <div id="proliferation-techcat-chart"
                  data-categories='@JsonSerializer.Serialize(Model.TechnicalCategoryBreakdown, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })'>
-                <div class="ratio" style="--bs-aspect-ratio: 60%;">
+                <div class="ratio pm-util-aspect-60">
                     <canvas id="proliferation-techcat-chart-canvas"></canvas>
                 </div>
             </div>

--- a/Areas/ProjectOfficeReports/Pages/Tot/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Tot/Index.cshtml
@@ -428,7 +428,7 @@
                     <input type="hidden" name="MetCompletedOnly" value="@Model.MetCompletedOnly" />
                     <input type="hidden" name="SelectedProjectId" value="@Model.SelectedProjectId" />
 
-                    <div class="input-group input-group-sm" style="max-width: 320px;">
+                    <div class="input-group input-group-sm pm-util-maxw-320">
                         <span class="input-group-text bg-white border-end-0">
                             <i class="bi bi-search" aria-hidden="true"></i>
                         </span>
@@ -517,7 +517,7 @@
         <div class="tot-detail-panel" aria-label="Selected project details">
             @if (selected is null)
             {
-                <div class="text-muted" style="margin-top: .25rem;">
+                <div class="text-muted pm-util-mt-025">
                     Select a project from the list to view its milestones, latest request and actions.
                 </div>
             }

--- a/Areas/ProjectOfficeReports/Pages/Training/Approvals.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Training/Approvals.cshtml
@@ -45,7 +45,7 @@ else
                     <td class="text-end">@request.TotalTrainees.ToString("N0", CultureInfo.CurrentCulture)</td>
                     <td>@request.RequestedByDisplayName</td>
                     <td>@request.RequestedAtUtc.ToLocalTime().ToString("dd MMM yyyy 'at' HH:mm", CultureInfo.CurrentCulture)</td>
-                    <td class="text-break" style="max-width: 320px;">@request.Reason</td>
+                    <td class="text-break pm-util-maxw-320">@request.Reason</td>
                     <td class="text-end">
                         <form method="post" asp-page-handler="Approve" class="d-inline">
                             <input type="hidden" name="requestId" value="@request.Id" />

--- a/Areas/ProjectOfficeReports/Pages/Training/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Training/Index.cshtml
@@ -222,7 +222,7 @@ else
                     </button>
                 </div>
                 <div class="ratio ratio-21x9"
-                     style="max-height: 360px;"
+                     class="pm-util-maxh-360"
                      data-training-year='@System.Text.Json.JsonSerializer.Serialize(Model.TrainingYearChart, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'>
                     <canvas id="training-year-trend-canvas"></canvas>
                 </div>
@@ -476,7 +476,7 @@ else
                                     <td>
                                         <span class="badge bg-light text-dark fw-normal">@training.Strength</span>
                                     </td>
-                                    <td style="min-width: 180px;">
+                                    <td class="pm-util-minw-180">
                                         @if (training.ProjectNames.Count == 0)
                                         {
                                             <span class="text-muted">None linked</span>
@@ -495,7 +495,7 @@ else
                                             }
                                         }
                                     </td>
-                                    <td class="small text-truncate" style="max-width: 200px;">
+                                    <td class="small text-truncate pm-util-maxw-200">
                                         @if (string.IsNullOrWhiteSpace(training.Notes))
                                         {
                                             <span class="text-muted">None</span>

--- a/Areas/ProjectOfficeReports/Pages/Training/Records.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Training/Records.cshtml
@@ -120,7 +120,7 @@ else
                                 <td>
                                     <span class="badge bg-light text-dark fw-normal">@training.Strength</span>
                                 </td>
-                                <td style="min-width: 180px;">
+                                <td class="pm-util-minw-180">
                                     @if (training.ProjectNames.Count == 0)
                                     {
                                         <span class="text-muted">None linked</span>
@@ -139,7 +139,7 @@ else
                                         }
                                     }
                                 </td>
-                                <td class="small text-truncate" style="max-width: 200px;">
+                                <td class="small text-truncate pm-util-maxw-200">
                                     @if (string.IsNullOrWhiteSpace(training.Notes))
                                     {
                                         <span class="text-muted">None</span>

--- a/Areas/ProjectOfficeReports/Pages/Training/_RosterGrid.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Training/_RosterGrid.cshtml
@@ -32,12 +32,12 @@
         <table class="table table-sm align-middle">
             <thead>
                 <tr>
-                    <th style="width: 160px;">Army number</th>
-                    <th style="width: 140px;">Rank</th>
+                    <th class="pm-util-col-160">Army number</th>
+                    <th class="pm-util-col-140">Rank</th>
                     <th>Name</th>
                     <th>Unit</th>
-                    <th style="width: 140px;">Category</th>
-                    <th style="width: 80px;"></th>
+                    <th class="pm-util-col-140">Category</th>
+                    <th class="pm-util-col-80"></th>
                 </tr>
             </thead>
             <tbody id="rosterBody"></tbody>

--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -203,7 +203,7 @@
                     </div>
                     <div id="visits-monthly-chart"
                          data-monthly='@System.Text.Json.JsonSerializer.Serialize(monthlyPoints, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
-                         class="position-relative" style="min-height: 260px;">
+                         class="position-relative pm-util-minh-260">
                         <canvas id="visits-monthly-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-monthly-title"></canvas>
                     </div>
                 </div>
@@ -232,7 +232,7 @@
                     </div>
                     <div id="visits-type-chart"
                          data-types='@System.Text.Json.JsonSerializer.Serialize(allVisitTypes, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
-                         class="flex-grow-1" style="min-height: 240px;">
+                         class="flex-grow-1 pm-util-minh-240">
                         <canvas id="visits-type-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-type-title"></canvas>
                     </div>
                 </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -108,7 +108,7 @@
             <div class="d-flex flex-column flex-md-row align-items-center justify-content-between gap-2 small">
                 <div class="text-muted">© @DateTime.UtcNow.Year — ProjectManagement</div>
                 <div class="d-flex align-items-center gap-2 fw-semibold">
-                    <img src="~/img/logos/sdd.png" alt="Simulator Development Division logo" style="height:22px; width:auto;" />
+                    <img src="~/img/logos/sdd.png" alt="Simulator Development Division logo" class="pm-util-logo-compact" />
                     <span>A product by Simulator Development Division</span>
                 </div>
                 <div>

--- a/wwwroot/css/site-ipr.css
+++ b/wwwroot/css/site-ipr.css
@@ -42,7 +42,13 @@
 .pm-kpi__label { font-size:.75rem; letter-spacing:.04em; color:var(--bs-secondary-color); opacity:.85; text-transform:uppercase; }
 .pm-kpi__value { font-weight:700; font-size:1.35rem; line-height:1; }
 .pm-kpi__spark { height:6px; background:#e9ecef; border-radius:999px; overflow:hidden; }
-.pm-kpi__spark>span{ display:block; height:100%; background:var(--bs-primary); }
+.pm-kpi__spark-bar {
+    display: block;
+    height: 100%;
+    background: var(--bs-primary);
+    width: var(--pm-kpi-spark-width, 0%);
+    transition: width 0.25s ease;
+}
 
 /* contextual variants (very subtle pastels) */
 .pm-kpi--total      { border-color: var(--bs-border-color); }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -7122,3 +7122,106 @@ body.has-project-photo-preview-dialog {
 }
 
 /* END SECTION */
+
+/* =============================================================
+   SECTION: Utility helpers for layout and sizing
+   ============================================================= */
+
+.pm-util-z-1100 {
+    z-index: 1100;
+}
+
+.pm-util-col-3rem {
+    width: 3rem;
+}
+
+.pm-util-col-70 {
+    width: 70px;
+}
+
+.pm-util-col-80 {
+    width: 80px;
+}
+
+.pm-util-col-110 {
+    width: 110px;
+}
+
+.pm-util-col-120 {
+    width: 120px;
+}
+
+.pm-util-col-140 {
+    width: 140px;
+}
+
+.pm-util-col-160 {
+    width: 160px;
+}
+
+.pm-util-col-180 {
+    width: 180px;
+}
+
+.pm-util-minw-160 {
+    min-width: 160px;
+}
+
+.pm-util-minw-180 {
+    min-width: 180px;
+}
+
+.pm-util-maxw-200 {
+    max-width: 200px;
+}
+
+.pm-util-maxw-220 {
+    max-width: 220px;
+}
+
+.pm-util-maxw-260 {
+    max-width: 260px;
+}
+
+.pm-util-maxw-320 {
+    max-width: 320px;
+}
+
+.pm-util-minh-14 {
+    min-height: 1.4rem;
+}
+
+.pm-util-minh-10 {
+    min-height: 1rem;
+}
+
+.pm-util-minh-08 {
+    min-height: .8rem;
+}
+
+.pm-util-minh-240 {
+    min-height: 240px;
+}
+
+.pm-util-minh-260 {
+    min-height: 260px;
+}
+
+.pm-util-maxh-360 {
+    max-height: 360px;
+}
+
+.pm-util-mt-025 {
+    margin-top: .25rem;
+}
+
+.pm-util-aspect-60 {
+    --bs-aspect-ratio: 60%;
+}
+
+.pm-util-logo-compact {
+    height: 22px;
+    width: auto;
+}
+
+/* END SECTION */

--- a/wwwroot/js/por-ipr-index.charts.js
+++ b/wwwroot/js/por-ipr-index.charts.js
@@ -13,6 +13,17 @@
 
   const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+  // SECTION: KPI spark widths
+  function hydrateSparkBars() {
+    document.querySelectorAll('.pm-kpi__spark-bar[data-kpi-width]').forEach(bar => {
+      const widthValue = Number(bar.dataset.kpiWidth);
+      const clampedWidth = Number.isFinite(widthValue) ? Math.min(Math.max(widthValue, 0), 100) : 0;
+      bar.style.setProperty('--pm-kpi-spark-width', `${clampedWidth}%`);
+    });
+  }
+
+  hydrateSparkBars();
+
   function downloadChartPng(canvasId, filenameBase) {
     const canvas = document.getElementById(canvasId);
     if (!canvas || typeof canvas.toDataURL !== 'function') {


### PR DESCRIPTION
## Summary
- add shared utility classes to centralize sizing rules and comply with CSP guardrails
- hydrate IPR KPI spark bars via data attributes and JavaScript instead of inline widths
- apply the utilities across Project Office, admin, and shared layouts to remove remaining inline styles

## Testing
- npm run lint:views

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692560d899d083299720ef17115d92ba)