### PR TITLE
Make FFC map full width and add toolbar

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
@@ -9,7 +9,8 @@
     <link rel="stylesheet" href="~/css/project-office-reports/ffc-map.css" asp-append-version="true" />
 }
 
-<div class="container-xxl py-0">
+<div class="container-fluid px-3 px-lg-4 py-0">
+    <!-- Section: Page header -->
     <div class="pm-page-header">
         <div>
             <h1 class="h4 mb-1">FFC – Simulators footprint</h1>
@@ -19,6 +20,31 @@
         </div>
     </div>
 
+    <!-- Section: Map toolbar -->
+    <div class="ffc-map-toolbar d-flex flex-wrap align-items-center gap-3 mb-3">
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+            <button type="button"
+                    class="btn btn-outline-primary"
+                    data-action="ffc-map-toggle-fullwidth"
+                    aria-pressed="false">
+                Use full-width map
+            </button>
+            <div class="text-muted small">
+                Expand the map to the entire viewport to fit more countries and details.
+            </div>
+        </div>
+
+        <div class="d-flex align-items-center gap-2 flex-wrap">
+            <span class="text-muted small fw-semibold">Quick focus</span>
+            <div class="btn-group" role="group" aria-label="Quick map focus">
+                <button type="button" class="btn btn-outline-secondary" data-zoom="world">World</button>
+                <button type="button" class="btn btn-outline-secondary" data-zoom="africa">Africa</button>
+                <button type="button" class="btn btn-outline-secondary" data-zoom="southasia">South Asia</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Section: Map -->
     <section class="ffc-map-layout"
              id="ffc-map-shell"
              data-map-fullwidth="on">

--- a/wwwroot/css/project-office-reports/ffc-map.css
+++ b/wwwroot/css/project-office-reports/ffc-map.css
@@ -1,19 +1,23 @@
 
-/* 2-col layout: map + sidebar */
+/* ----- Layout shell ----- */
 .ffc-map-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 260px;
+  grid-template-columns: minmax(0, 1fr);
   gap: 1.25rem;
   position: relative;
+}
+
+.ffc-map-layout.has-sidebar {
+  grid-template-columns: minmax(0, 1fr) 260px;
 }
 
 .ffc-map-canvas {
   position: relative;
 }
 
+/* ----- Map canvas ----- */
 .ffc-map {
-  height: 70vh;
-  min-height: 520px;
+  height: clamp(520px, 76vh, 840px);
   border-radius: 1rem;
   box-shadow: 0 1px 4px rgba(2, 6, 23, 0.08);
   overflow: hidden;
@@ -26,6 +30,15 @@
 
 .ffc-map-sidebar .card .card-body {
   padding: 0.75rem 0.75rem;
+}
+
+/* ----- Toolbar ----- */
+.ffc-map-toolbar {
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
 

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
@@ -396,7 +396,8 @@
             savedPreference = null;
           }
 
-          if (savedPreference === 'on') {
+          var datasetPreference = shell.dataset.mapFullwidth === 'on';
+          if (savedPreference === 'on' || (!savedPreference && datasetPreference)) {
             applyFullWidthState(true, true);
           }
         }


### PR DESCRIPTION
## Summary
- switch the FFC map page to a fluid layout with a toolbar offering full-width toggles and quick-focus shortcuts
- restyle the map shell for a single-column layout and taller canvas suitable for full-viewport viewing
- honor the page’s full-width preference by default in the map initializer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925abddbe248329a7c2ad2dabea34bf)