### PR TITLE
Register Document OCR service interface

### DIFF
--- a/Areas/DocumentRepository/Pages/Admin/OCRFailures/OcrFailures.cshtml.cs
+++ b/Areas/DocumentRepository/Pages/Admin/OCRFailures/OcrFailures.cshtml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -12,12 +13,12 @@ namespace ProjectManagement.Areas.DocumentRepository.Pages.Admin
     public class OcrFailuresModel : PageModel
     {
         private readonly ApplicationDbContext _db;
-        private readonly DocumentOcrService _ocrService;
+        private readonly IDocumentOcrService _ocrService;
 
-        public OcrFailuresModel(ApplicationDbContext db, DocumentOcrService ocrService)
+        public OcrFailuresModel(ApplicationDbContext db, IDocumentOcrService ocrService)
         {
-            _db = db;
-            _ocrService = ocrService;
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _ocrService = ocrService ?? throw new ArgumentNullException(nameof(ocrService));
         }
 
         public IList<Document> FailedDocuments { get; private set; } = new List<Document>();

--- a/Program.cs
+++ b/Program.cs
@@ -267,7 +267,7 @@ builder.Services
     .ValidateOnStart();
 builder.Services.AddSingleton<IDocStorage, LocalDocStorageService>();
 builder.Services.AddSingleton<IUrlBuilder, UrlBuilder>();
-builder.Services.AddScoped<DocumentOcrService>();
+builder.Services.AddScoped<IDocumentOcrService, DocumentOcrService>();
 builder.Services.AddSingleton<IOcrmypdfInvoker, ProcessOcrmypdfInvoker>();
 builder.Services.AddSingleton<IPdfTextExtractor, PdfPigTextExtractor>();
 builder.Services.AddScoped<OcrmypdfSharedRunner>();

--- a/Services/DocRepo/DocumentOcrService.cs
+++ b/Services/DocRepo/DocumentOcrService.cs
@@ -9,18 +9,25 @@ using ProjectManagement.Services.Ocr;
 
 namespace ProjectManagement.Services.DocRepo
 {
+    // SECTION: Contract
+    public interface IDocumentOcrService
+    {
+        Task<bool> ReprocessAsync(Guid documentId, CancellationToken ct = default);
+        Task<int> ReprocessAllFailedAsync(CancellationToken ct = default);
+    }
+
     /// <summary>
     /// Admin-facing helper to re-run OCR for failed documents.
     /// </summary>
-    public sealed class DocumentOcrService
+    public sealed class DocumentOcrService : IDocumentOcrService
     {
         private readonly ApplicationDbContext _db;
         private readonly IDocumentOcrRunner _runner;
 
         public DocumentOcrService(ApplicationDbContext db, IDocumentOcrRunner runner)
         {
-            _db = db;
-            _runner = runner;
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         }
 
         /// <summary>

--- a/Services/Ocr/OcrTextBackfillService.cs
+++ b/Services/Ocr/OcrTextBackfillService.cs
@@ -18,13 +18,13 @@ namespace ProjectManagement.Services.Ocr;
 public sealed class OcrTextBackfillService
 {
     private readonly ApplicationDbContext _db;
-    private readonly DocumentOcrService _docRepoService;
+    private readonly IDocumentOcrService _docRepoService;
     private readonly IProjectDocumentOcrRunner _projectRunner;
     private readonly ILogger<OcrTextBackfillService> _logger;
 
     public OcrTextBackfillService(
         ApplicationDbContext db,
-        DocumentOcrService docRepoService,
+        IDocumentOcrService docRepoService,
         IProjectDocumentOcrRunner projectRunner,
         ILogger<OcrTextBackfillService> logger)
     {


### PR DESCRIPTION
## Summary
- add a dedicated interface for document OCR orchestration and register it with DI
- update OCR failures page and backfill service to depend on the interface with null guarding

## Testing
- dotnet test (fails: dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b146e7648329a21d5a438bd67ad3)