### PR TITLE
Handle IO failures during document upload

### DIFF
--- a/Pages/Projects/Documents/UploadRequest.cshtml.cs
+++ b/Pages/Projects/Documents/UploadRequest.cshtml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -187,6 +188,11 @@ public class UploadRequestModel : PageModel
         {
             _logger.LogWarning(ex, "Validation failed while staging upload request for project {ProjectId}", Input.ProjectId);
             ModelState.AddModelError("Input.File", ex.Message);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "File read failed while staging upload request for project {ProjectId}", Input.ProjectId);
+            ModelState.AddModelError("Input.File", "We couldn't read the uploaded file. Please try again with a fresh upload.");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- add explicit IOException handling when staging document upload requests
- surface a clear validation message when the uploaded file cannot be read
- log file-read errors separately from general upload failures

## Testing
- not run (environment missing dotnet SDK)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ddf567808329bf6ede901fab5739)