### PR TITLE
Add startup validation for project document configuration

### DIFF
--- a/Configuration/ProjectDocumentOcrOptionsValidator.cs
+++ b/Configuration/ProjectDocumentOcrOptionsValidator.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Options;
+
+namespace ProjectManagement.Configuration;
+
+// SECTION: Validation for project document OCR options
+public sealed class ProjectDocumentOcrOptionsValidator : IValidateOptions<ProjectDocumentOcrOptions>
+{
+    // SECTION: Options validator entry point
+    public ValidateOptionsResult Validate(string? name, ProjectDocumentOcrOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.WorkRoot))
+        {
+            failures.Add("ProjectDocuments:Ocr:WorkRoot must be configured.");
+        }
+
+        ValidateSubpath(options.InputSubpath, nameof(options.InputSubpath), failures);
+        ValidateSubpath(options.OutputSubpath, nameof(options.OutputSubpath), failures);
+        ValidateSubpath(options.LogsSubpath, nameof(options.LogsSubpath), failures);
+
+        if (!string.IsNullOrWhiteSpace(options.OcrExecutablePath))
+        {
+            var expanded = Environment.ExpandEnvironmentVariables(options.OcrExecutablePath);
+            var fullPath = Path.GetFullPath(expanded);
+
+            if (!File.Exists(fullPath))
+            {
+                failures.Add($"ProjectDocuments:Ocr:OcrExecutablePath points to '{fullPath}', which does not exist.");
+            }
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    // SECTION: Subpath guard rails
+    private static void ValidateSubpath(string? value, string propertyName, ICollection<string> failures)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            failures.Add($"ProjectDocuments:Ocr:{propertyName} is required.");
+            return;
+        }
+
+        if (Path.IsPathRooted(trimmed))
+        {
+            failures.Add($"ProjectDocuments:Ocr:{propertyName} must be a relative subpath.");
+        }
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        if (trimmed.Split(separators, StringSplitOptions.RemoveEmptyEntries).Any(segment => segment is "." or ".."))
+        {
+            failures.Add($"ProjectDocuments:Ocr:{propertyName} cannot contain '.' or '..' segments.");
+        }
+    }
+}

--- a/Configuration/ProjectDocumentOptionsValidator.cs
+++ b/Configuration/ProjectDocumentOptionsValidator.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Options;
+
+namespace ProjectManagement.Configuration;
+
+// SECTION: Validation for project document storage options
+public sealed class ProjectDocumentOptionsValidator : IValidateOptions<ProjectDocumentOptions>
+{
+    // SECTION: Options validator entry point
+    public ValidateOptionsResult Validate(string? name, ProjectDocumentOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+
+        ValidateSubpath(options.ProjectsSubpath, nameof(options.ProjectsSubpath), allowEmpty: false, failures);
+        ValidateSubpath(options.StorageSubPath, nameof(options.StorageSubPath), allowEmpty: false, failures);
+        ValidateSubpath(options.TempSubPath, nameof(options.TempSubPath), allowEmpty: false, failures);
+        ValidateSubpath(options.CommentsSubpath, nameof(options.CommentsSubpath), allowEmpty: false, failures);
+        ValidateSubpath(options.VideosSubpath, nameof(options.VideosSubpath), allowEmpty: false, failures);
+        ValidateSubpath(options.PhotosSubpath, nameof(options.PhotosSubpath), allowEmpty: true, failures);
+
+        if (options.MaxSizeMb < 0)
+        {
+            failures.Add("ProjectDocuments:MaxSizeMb cannot be negative.");
+        }
+
+        if (options.AllowedMimeTypes is null || options.AllowedMimeTypes.Count == 0)
+        {
+            failures.Add("ProjectDocuments:AllowedMimeTypes must include at least one content type (for example 'application/pdf').");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    // SECTION: Subpath guard rails
+    private static void ValidateSubpath(string? value, string propertyName, bool allowEmpty, ICollection<string> failures)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            if (!allowEmpty)
+            {
+                failures.Add($"ProjectDocuments:{propertyName} is required and cannot be empty.");
+            }
+
+            return;
+        }
+
+        if (Path.IsPathRooted(trimmed))
+        {
+            failures.Add($"ProjectDocuments:{propertyName} must be a relative subpath, not an absolute path.");
+        }
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        if (trimmed.Split(separators, StringSplitOptions.RemoveEmptyEntries).Any(segment => segment is "." or ".."))
+        {
+            failures.Add($"ProjectDocuments:{propertyName} cannot contain '.' or '..' segments.");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -291,6 +291,7 @@ builder.Services
         options => !string.IsNullOrWhiteSpace(options.WorkRoot),
         "ProjectDocuments:Ocr:WorkRoot must be configured.")
     .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<ProjectDocumentOcrOptions>, ProjectDocumentOcrOptionsValidator>();
 builder.Services.AddSingleton<IProjectDocumentStorageResolver, ProjectDocumentStorageResolver>();
 builder.Services.AddScoped<IProjectDocumentOcrRunner, OcrmypdfProjectOcrRunner>();
 builder.Services.AddScoped<IGlobalProjectDocumentSearchService, GlobalProjectDocumentSearchService>();
@@ -454,7 +455,9 @@ builder.Services.AddOptions<SocialMediaPhotoOptions>()
 builder.Services.AddOptions<TrainingTrackerOptions>()
     .Bind(builder.Configuration.GetSection("ProjectOfficeReports:TrainingTracker"));
 builder.Services.AddOptions<ProjectDocumentOptions>()
-    .Bind(builder.Configuration.GetSection("ProjectDocuments"));
+    .Bind(builder.Configuration.GetSection("ProjectDocuments"))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<ProjectDocumentOptions>, ProjectDocumentOptionsValidator>();
 builder.Services.AddOptions<ProjectVideoOptions>()
     .Bind(builder.Configuration.GetSection("ProjectVideos"));
 builder.Services.AddSingleton<IConfigureOptions<ProjectPhotoOptions>, ProjectPhotoOptionsSetup>();


### PR DESCRIPTION
## Summary
- add option validators for project document OCR and storage settings to guard against invalid paths and missing mime types
- enable startup validation for project document options and register validators in dependency injection

## Testing
- dotnet test *(fails in container: `dotnet` command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e229cee4832998c33221efa49156)