### PR TITLE
Improve ongoing projects search and filter UX

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -28,7 +28,10 @@
 
 <h1 class="mb-3">Ongoing projects – progress & timelines</h1>
 
-<form method="get" class="row g-3 align-items-end mb-4" novalidate>
+<form id="ongoingProjectsFilterForm"
+      method="get"
+      class="row g-3 align-items-end mb-4"
+      novalidate>
     <div class="col-12 col-md-3">
         <label asp-for="ProjectCategoryId" class="form-label">Project category</label>
         <select asp-for="ProjectCategoryId"
@@ -46,13 +49,18 @@
         <input asp-for="Search" class="form-control form-control-sm" />
     </div>
     <div class="col-12 col-md-3 d-flex gap-2 justify-content-md-end">
-        <button type="submit" class="btn btn-sm btn-primary">Filter</button>
+        <button type="submit" class="btn btn-sm btn-primary">
+            <i class="bi bi-funnel" aria-hidden="true"></i>
+            <span>Filter</span>
+        </button>
         <a asp-page="./Index"
            asp-page-handler="Export"
            asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
            asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
            asp-route-Search="@Model.Search"
-           class="btn btn-sm btn-outline-secondary">Export</a>
+           class="btn btn-sm btn-outline-secondary">
+            Export
+        </a>
     </div>
 </form>
 
@@ -328,4 +336,10 @@ else
             </div>
         }
     </div>
+}
+
+@section Scripts {
+    <script src="~/js/projects/ongoing.js"
+            asp-append-version="true"
+            defer></script>
 }

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -56,10 +56,13 @@ namespace ProjectManagement.Services.Projects
                 q = q.Where(p => p.LeadPoUserId == officerId);
             }
 
+            // -------------------- Search filtering (case-insensitive) --------------------
             if (!string.IsNullOrWhiteSpace(search))
             {
                 var term = search.Trim();
-                q = q.Where(p => p.Name.Contains(term));
+                var like = $"%{term}%";
+
+                q = q.Where(p => EF.Functions.ILike(p.Name, like));
             }
 
             var projects = await q

--- a/wwwroot/js/projects/ongoing.js
+++ b/wwwroot/js/projects/ongoing.js
@@ -1,0 +1,30 @@
+// -------------------- Ongoing projects filter auto-submit --------------------
+(function () {
+  const form = document.getElementById('ongoingProjectsFilterForm');
+  if (!form) {
+    return;
+  }
+
+  const categorySelect = form.querySelector('[name="ProjectCategoryId"]');
+  const officerSelect = form.querySelector('[name="ProjectOfficerId"]');
+  const searchInput = form.querySelector('[name="Search"]');
+
+  function submitFilters() {
+    // Use requestSubmit so HTML5 validation and normal form behaviour are preserved
+    if (typeof form.requestSubmit === 'function') {
+      form.requestSubmit();
+    } else {
+      form.submit();
+    }
+  }
+
+  categorySelect?.addEventListener('change', submitFilters);
+  officerSelect?.addEventListener('change', submitFilters);
+
+  // Pressing Enter in the search box already submits the form, but this keeps behaviour explicit
+  searchInput?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      submitFilters();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- make ongoing project name search case-insensitive using PostgreSQL ILIKE
- enhance the Ongoing Projects filter form with an icon and layout adjustments
- add a page-specific script to auto-submit filters when dropdowns change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929cfe6f9ec83299ab20c44357ed15e)