### PR TITLE
Display overview categories as plain text

### DIFF
--- a/Pages/Projects/_ProjectOverviewCard.cshtml
+++ b/Pages/Projects/_ProjectOverviewCard.cshtml
@@ -116,28 +116,19 @@
                 </div>
             </div>
             <div class="col-12 col-lg-7 col-xl-8">
+                @* SECTION: Project categories *@
                 <dl class="row mb-0">
                     <dt class="col-sm-4">Category</dt>
                     <dd class="col-sm-8">
-                        @if (Model.CategoryPath.Any())
-                        {
-                            <span class="badge text-bg-light">@string.Join(" › ", Model.CategoryPath.Select(c => c.Name))</span>
-                        }
-                        else
-                        {
-                            <span>—</span>
-                        }
+                        @(Model.CategoryPath.Any()
+                            ? string.Join(" › ", Model.CategoryPath.Select(c => c.Name))
+                            : "—")
                     </dd>
                     <dt class="col-sm-4">Technical Category</dt>
                     <dd class="col-sm-8">
-                        @if (Model.TechnicalCategoryPath.Any())
-                        {
-                            <span class="badge text-bg-primary-subtle text-primary-emphasis">@string.Join(" › ", Model.TechnicalCategoryPath.Select(c => c.Name))</span>
-                        }
-                        else
-                        {
-                            <span>—</span>
-                        }
+                        @(Model.TechnicalCategoryPath.Any()
+                            ? string.Join(" › ", Model.TechnicalCategoryPath.Select(c => c.Name))
+                            : "—")
                     </dd>
 
                     <dt class="col-sm-4">Sponsoring Unit</dt>


### PR DESCRIPTION
## Summary
- render category and technical category values in the project overview card as plain text instead of badge chips
- keep existing layout while noting the categories section for readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d745db288329aca213e743218368)