### PR TITLE
Include planned-only countries in FFC widget and add detail link

### DIFF
--- a/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
+++ b/Areas/Dashboard/Components/FfcSimulatorMap/_Widget.cshtml
@@ -8,6 +8,7 @@
     var geoUrl = Url.Content("~/ffc/maps/world_india_view.geojson");
     var focusBounds = "37,-20|-35,55";
     var fullMapUrl = Url.Page("/FFC/Map", values: new { area = "ProjectOfficeReports" });
+    var detailTableUrl = Url.Page("/FFC/MapTableDetailed", values: new { area = "ProjectOfficeReports" });
 
     // Show all countries, sorted by total then by name.
     var countriesToShow = Model.Countries
@@ -92,6 +93,13 @@
                         </button>
                     }
                 </div>
+            </div>
+
+            <div class="mt-2">
+                <a href="@detailTableUrl"
+                   class="btn btn-link btn-sm px-0">
+                    View detailed table →
+                </a>
             </div>
         }
         else

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -299,7 +299,7 @@ namespace ProjectManagement.Pages.Dashboard
                 var ffcRows = await FfcCountryRollupDataSource.LoadAsync(_db, cancellationToken);
                 // SECTION: FFC simulator map footprint and totals
                 var ffcFootprintCountries = ffcRows
-                    .Where(row => row.Installed + row.Delivered > 0)
+                    .Where(row => row.Total > 0)
                     .Select(row => new FfcSimulatorCountryVm
                     {
                         CountryId = row.CountryId,


### PR DESCRIPTION
## Summary
- include planned-only countries in the dashboard FFC simulator map widget by basing inclusion on total units
- add a link beneath the widget country strip to navigate to the detailed FFC table view

## Testing
- dotnet test (fails: dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dac54b48832991b9bebf5e9946e6)