### PR TITLE
Enhance FFC map popups and filtering

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml
@@ -14,9 +14,28 @@
     <div class="pm-page-header">
         <div>
             <h1 class="h4 mb-1">FFC – Simulators footprint</h1>
-            <p class="pm-page-subtitle">
-                Countries shaded by total project/ simulators units (installed, delivered, planned). Drill into a country to see details.
+            <p class="pm-page-subtitle text-muted small mb-2">
+                Countries are shaded by total simulator units (installed, delivered and planned). Click a country to see its breakdown and open the detailed table.
             </p>
+            <div class="d-flex flex-wrap gap-3 mb-2 small text-muted">
+                <span><strong>@Model.TotalCountriesWithUnits</strong> countries with activity</span>
+                <span><strong>@Model.TotalUnits</strong> total units</span>
+                <span><strong>@Model.TotalInstalled</strong> installed</span>
+                <span><strong>@Model.TotalDelivered</strong> delivered (not installed)</span>
+                <span><strong>@Model.TotalPlanned</strong> planned</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex align-items-center gap-3 mb-2">
+        <span class="text-muted small">Show:</span>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="ffcFilterCompleted" checked>
+            <label class="form-check-label small" for="ffcFilterCompleted">Completed (installed + delivered)</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="ffcFilterPlanned" checked>
+            <label class="form-check-label small" for="ffcFilterPlanned">Planned</label>
         </div>
     </div>
 
@@ -55,7 +74,7 @@
                  aria-label="World map showing FFC project unit counts"
                  data-data-url="@Url.Page("./Map", pageHandler: "Data")"
                  data-geo-url="@Url.Content("~/ffc/maps/world_india_view.geojson")"
-                 data-ffc-detail-url="@Url.Page("./MapTableDetailed")"></div>
+                 data-ffc-detail-url="@Url.Page("/FFC/MapTableDetailed", new { area = "ProjectOfficeReports" })"></div>
 
             <div class="ffc-focus-floating card shadow-sm" id="ffc-focus-floating">
                 <div class="card-body">

--- a/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Map.cshtml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -12,17 +13,37 @@ public class MapModel : PageModel
 {
     private readonly ApplicationDbContext _db;
 
+    // SECTION: Summary counters
+    public int TotalCountriesWithUnits { get; private set; }
+
+    public int TotalUnits { get; private set; }
+
+    public int TotalInstalled { get; private set; }
+
+    public int TotalDelivered { get; private set; }
+
+    public int TotalPlanned { get; private set; }
+
     public MapModel(ApplicationDbContext db)
     {
         _db = db;
     }
 
-    public void OnGet()
+    // SECTION: Request handlers
+    public async Task OnGetAsync(CancellationToken cancellationToken)
     {
         FfcBreadcrumbs.Set(
             ViewData,
             ("FFC Proposals", Url.Page("/FFC/Index", new { area = "ProjectOfficeReports" })),
             ("World map", null));
+
+        var rows = await FfcCountryRollupDataSource.LoadAsync(_db, cancellationToken);
+
+        TotalCountriesWithUnits = rows.Count(row => (row?.Total ?? 0) > 0);
+        TotalInstalled = rows.Sum(row => row?.Installed ?? 0);
+        TotalDelivered = rows.Sum(row => row?.Delivered ?? 0);
+        TotalPlanned = rows.Sum(row => row?.Planned ?? 0);
+        TotalUnits = TotalInstalled + TotalDelivered + TotalPlanned;
     }
 
     public async Task<IActionResult> OnGetDataAsync(CancellationToken cancellationToken)

--- a/wwwroot/css/project-office-reports/ffc-map.css
+++ b/wwwroot/css/project-office-reports/ffc-map.css
@@ -115,6 +115,81 @@
   color: #64748b;
 }
 
+/* ----- Popup cards ----- */
+.ffc-map-popup {
+  min-width: 220px;
+}
+
+.ffc-map-popup__title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.ffc-map-popup__subtitle {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 0.5rem;
+}
+
+.ffc-map-popup__metrics {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.ffc-map-popup__metrics div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ffc-map-popup__metrics dt {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.ffc-map-popup__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.ffc-map-popup__cta {
+  padding: 0;
+}
+
+.ffc-map-popup__cta:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* ----- Legend samples ----- */
+.ffc-legend-note {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+  color: #475569;
+}
+
+.ffc-legend-note__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.ffc-legend-note__sample {
+  width: 26px;
+  height: 12px;
+  border: 2px solid #4b5bb5;
+  border-radius: 6px;
+}
+
+.ffc-legend-note__sample--dashed {
+  border-style: dashed;
+}
+
 @media (max-width: 1200px) {
   .ffc-map-layout {
     grid-template-columns: minmax(0, 1fr);

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map.js
@@ -3,6 +3,7 @@
 
   var FULLWIDTH_STORAGE_KEY = 'ffc.map.fullwidth';
   var escapeHandlerAttached = false;
+  var detailCtaHandlerAttached = false;
 
   var DEFAULT_ICON_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAApCAYAAADAk4LOAAAFgUlEQVR4Aa1XA5BjWRTN2oW17d3YaZtr2962HUzbDNpjszW24mRt28p47v7zq/bXZtrp/lWnXr337j3nPCe85NcypgSFdugCpW5YoDAMRaIMqRi6aKq5E3YqDQO3qAwjVWrD8Ncq/RBpykd8oZUb/kaJutow8r1aP9II0WmLKLIsJyv1w/kqw9Ch2MYdB++12Onxee/QMwvf4/Dk/Lfp/i4nxTXtOoQ4pW5Aj7wpici1A9erdAN2OH64x8OSP9j3Ft3b7aWkTg/Fm91siTra0f9on5sQr9INejH6CUUUpavjFNq1B+Oadhxmnfa8RfEmN8VNAsQhPqF55xHkMzz3jSmChWU6f7/XZKNH+9+hBLOHYozuKQPxyMPUKkrX/K0uWnfFaJGS1QPRtZsOPtr3NsW0uyh6NNCOkU3Yz+bXbT3I8G3xE5EXLXtCXbbqwCO9zPQYPRTZ5vIDXD7U+w7rFDEoUUf7ibHIR4y6bLVPXrz8JVZEql13trxwue/uDivd3fkWRbS6/IA2bID4uk0UpF1N8qLlbBlXs4Ee7HLTfV1j54APvODnSfOWBqtKVvjgLKzF5YdEk5ewRkGlK0i33Eofffc7HT56jD7/6U+qH3Cx7SBLNntH5YIPvODnyfIXZYRVDPqgHtLs5ABHD3YzLuespb7t79FY34DjMwrVrcTuwlT55YMPvOBnRrJ4VXTdNnYug5ucHLBjEpt30701A3Ts+HEa73u6dT3FNWwflY86eMHPk+Yu+i6pzUpRrW7SNDg5JHR4KapmM5Wv2E8Tfcb1HoqqHMHU+uWDD7zg54mz5/2BSnizi9T1Dg4QQXLToGNCkb6tb1NU+QAlGr1++eADrzhn/u8Q2YZhQVlZ5+CAOtqfbhmaUCS1ezNFVm2imDbPmPng5wmz+gwh+oHDce0eUtQ6OGDIyR0uUhUsoO3vfDmmgOezH0mZN59x7MBi++WDL1g/eEiU3avlidO671bkLfwbw5XV2P8Pzo0ydy4t2/0eu33xYSOMOD8hTf4CrBtGMSoXfPLchX+J0ruSePw3LZeK0juPJbYzrhkH0io7B3k164hiGvawhOKMLkrQLyVpZg8rHFW7E2uHOL888IBPlNZ1FPzstSJM694fWr6RwpvcJK60+0HCILTBzZLFNdtAzJaohze60T8qBzyh5ZuOg5e7uwQppofEmf2++DYvmySqGBuKaicF1blQjhuHdvCIMvp8whTTfZzI7RldpwtSzL+F1+wkdZ2TBOW2gIF88PBTzD/gpeREAMEbxnJcaJHNHrpzji0gQCS6hdkEeYt9DF/2qPcEC8RM28Hwmr3sdNyht00byAut2k3gufWNtgtOEOFGUwcXWNDbdNbpgBGxEvKkOQsxivJx33iow0Vw5S6SVTrpVq11ysA2Rp7gTfPfktc6zhtXBBC+adRLshf6sG2RfHPZ5EAc4sVZ83yCN00Fk/4kggu40ZTvIEm5g24qtU4KjBrx/BTTH8ifVASAG7gKrnWxJDcU7x8X6Ecczhm3o6YicvsLXWfh3Ch1W0k8x0nXF+0fFxgt4phz8QvypiwCCFKMqXCnqXExjq10beH+UUA7+nG6mdG/Pu0f3LgFcGrl2s0kNNjpmoJ9o4B29CMO8dMT4Q5ox8uitF6fqsrJOr8qnwNbRzv6hSnG5wP+64C7h9lp30hKNtKdWjtdkbuPA19nJ7Tz3zR/ibgARbhb4AlhavcBebmTHcFl2fvYEnW0ox9xMxKBS8btJ+KiEbq9zA4RthQXDhPa0T9TEe69gWupwc6uBUphquXgf+/FrIjweHQS4/pduMe5ERUMHUd9xv8ZR98CxkS4F2n3EUrUZ10EYNw7BWm9x1GiPssi3GgiGRDKWRYZfXlON+dfNbM+GgIwYdwAAAAASUVORK5CYII=';
   var DEFAULT_ICON_RETINA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAABSCAMAAAAhFXfZAAAC91BMVEVMaXEzeak2f7I4g7g3g7cua5gzeKg8hJo3grY4g7c3grU0gLI2frE0daAubJc2gbQwd6QzeKk2gLMtd5sxdKIua5g1frA2f7IydaM0e6w2fq41fK01eqo3grgubJgta5cxdKI1f7AydaQydaMxc6EubJgvbJkwcZ4ubZkwcJwubZgubJcydqUydKIxapgubJctbJcubZcubJcvbJYubJcvbZkubJctbJctbZcubJg2f7AubJcrbZcubJcubJcua5g3grY0fq8ubJcubJdEkdEwhsw6i88vhswuhcsuhMtBjMgthMsrg8srgss6is8qgcs8i9A9iMYtg8spgcoogMo7hcMngMonf8olfso4gr8kfck5iM8jfMk4iM8he8k1fro7itAgesk2hs8eecgzfLcofssdeMg0hc4cd8g2hcsxeLQbdsgZdcgxeLImfcszhM0vda4xgckzhM4xg84wf8Yxgs4udKsvfcQucqhUndROmdM1fK0wcZ8vb5w0eqpQm9MzeKhXoNVcpdYydKNWn9VZotVKltJFjsIwcJ1Rms9OlslLmtH///8+kc9epdYzd6dbo9VHkMM2f7FHmNBClM8ydqVcpNY9hro3gLM9hLczealQmcw3fa46f7A8gLMxc6I3eagyc6FIldJMl9JSnNRSntNNl9JPnNJFi75UnM9ZodVKksg8kM45jc09e6ZHltFBk883gbRBh7pDk9EwcaBzn784g7dKkcY2i81Om9M7j85Llc81is09g7Q4grY/j9A0eqxKmdFFltBEjcXf6fFImdBCiLxJl9FGlNFBi78yiMxVndEvbpo6js74+vx+psPP3+o/ks5HkcpGmNCjwdZCkNDM3ehYoNJEls+lxNkxh8xHks0+jdC1zd5Lg6r+/v/H2ufz9/o3jM3t8/edvdM/k89Th61OiLBSjbZklbaTt9BfptdjmL1AicBHj8hGk9FAgK1dkLNTjLRekrdClc/k7fM0icy0y9tgp9c4jc2NtM9Dlc8zicxeXZn3AAAAQ3RSTlMAHDdTb4yPA+LtnEQmC4L2EmHqB7XA0d0sr478x4/Yd5i1zOfyPkf1sLVq4Nh3FvjxopQ2/STNuFzUwFIwxKaejILpIBEV9wAABhVJREFUeF6s1NdyFEcYBeBeoQIhRAkLlRDGrhIgY3BJL8CVeKzuyXFzzjkn5ZxzzuScg3PO8cKzu70JkO0LfxdTU//pM9vTu7Xgf6KqOVTb9X7toRrVEfBf1HTVjZccrT/2by1VV928Yty9ZbVuucdz90frG8DBjl9pVApbOstvmMuvVgaNXSfAAd6pGxpy6yxf5ph43pS/4f3uoaGm2rdu72S9xzOvMymkZFq/ptDrk90mhW7e4zl7HLzhxGWPR20xmSxJ/VqldG5m9XhaVOA1DadsNh3Pu5L2N6QtPO/32JpqQBVVk20oy/Pi2s23WEvyfHbe1thadVQttvm7Llf65gGmXK67XtupyoM7HQhmXdLS8oGWJNeOJ3C5fG5XCEJnkez3/oFdsvgJ4l2ANZwhrJKk/7OSXa+3Vw2WJMlKnGkobouYk6T0TyX30klOUnTD9HJ5qpckL3EW/w4XF3Xd0FGywXUrstrclVsqz5Pd/sXFYyDnPdrLcQODmGOK47IZb4CmibmMn+MYRzFZ5jg33ZL/EJrWcszHmANy3ARBK/IXtciJy8VsitPSdE3uuHxzougojcUdr8/32atnz/ev3f/K5wtpxUTpcaI45zusVDpYtZi+jg0oU9b3x74h7+n9ABvYEZeKaVq0sh0AtLKsFtqNBdeT0MrSzwwlq9+x6xAO4tgOtSzbCjrNQQiNvQUbUEubvzBUeGw26yDCsRHCoLkTHDa7IdOLIThs/gHvChszh2CimE8peRs47cxANI0lYNB5y1DljpOF0IhzBDPOZnDOqYYbeGKECbPzWnXludPphw5c2YBq5zlwXphIbO4VDCZ0gnPfUO1TwZoYwAs2ExPCedAu9DAjfQUjzITQb3jNj0KG2Sgt6BHaQUdYzWz+XmBktOHwanXjaSTcwwziBcuMOtwBmqPrTOxFQR/DRKKPqyur0aiW6cULYsx6tBm0jXpR/AUWR6HRq9WVW6MRhIq5jLyjbaCTDCijyYJNpCajdyobP/eTw0iexBAKkJ3gA5KcQb2zBXsIBckn+xVv8jkZSaEFHE+jFEleAEfayRU0MouNoBmB/L50Ai/HSLIHxcrpCvnhSQAuakKp2C/YbCylJjXRVy/z3+Kv/RrNcCo+WUzlVEhzKffnTQnxeN9fWF88fiNCUdSTsaufaChKWInHeysygfpIqagoakW+vV20J8uyl6TyNKEZWV4oRSPyCkWpgOLSbkCObT8o2r6tlG58HQquf6O0v50tB7JM7F4EORd2dx/K0w/KHsVkLPaoYrwgP/y7krr3SSMA4zj+OBgmjYkxcdIJQyQRKgg2viX9Hddi9UBb29LrKR7CVVEEEXWojUkXNyfTNDE14W9gbHJNuhjDettN3ZvbOvdOqCD3Jp/9l+/wJE+9PkYGjx/fqkys3S2rMozM/o2106rfMUINo6hVqz+eu/hd1c4xTg0TAfy5kV+4UG6+IthHTU9woWmxuKNbTfuCSfovBCxq7EtHqvYL4Sm6F8GVxsSXHMQ07TOi1DKtZxjWaaIyi4CXWjxPccUw8WVbMYY5wxC1mzEyXMJWkllpRloi+Kkoq69sxBTlElF6aAxYUbjXNlhlDZilDnM4U5SlN5biRsRHnbx3mbeWjEh4mEyiuJDl5XcWVmX5GvNkFgLWZM5qwsop4/AWfLhU1cR7k1VVvcYCWRkOI6Xy5gmnphCYIkvzuNYzHzosq2oNk2RtSs8khfUOfHIDgR6ysYBaMpl4uEgk2U/oJTs9AaTSwma7dT69geAE2ZpEjUsn2ieJNHeKfrI3EcAGJ2ZaNgVuC8EBctCLc57P5u5led6IOBkIYkuQMrmmjChs4VkfOerHqSBkPzZlhe06RslZ3zMjk2sscqKwY0RcjKK+LWbzd7KiHhkncs/siFJ+V5eXxD34B8nVuJEpGJNmxN2gH3vSvp7J70tF+D1Ej8qUJD1TkErAND2GZwTFg/LubvmgiBG3SOvdlsqFQrkEzJCL1rstlnVFROixZoDDSuXQFHESwVGlcuQcMb/b42NgjLowh5MTDFE3vNB5qStRIErdCQEh6pLPR92anSUb/wAIhldAaDMpGgAAAABJRU5ErkJggg==';
@@ -62,56 +63,33 @@
     return value.toString().toUpperCase();
   }
 
-  function buildDetailUrl(cfg, datum) {
-    if (!cfg || !cfg.ffcDetailUrlBase || !datum || datum.countryId == null) {
-      return '';
-    }
-
-    if (typeof URLSearchParams === 'undefined') {
-      var legacy = 'countryId=' + encodeURIComponent(String(datum.countryId));
-      if (datum.latestYear) {
-        legacy += '&year=' + encodeURIComponent(String(datum.latestYear));
-      }
-
-      return cfg.ffcDetailUrlBase + '?' + legacy;
-    }
-
-    var params = new URLSearchParams();
-    params.set('countryId', String(datum.countryId));
-    if (datum.latestYear) {
-      params.set('year', String(datum.latestYear));
-    }
-
-    return cfg.ffcDetailUrlBase + '?' + params.toString();
-  }
-
-  function buildPopupHtml(countryName, datum, cfg) {
-    var name = countryName || 'Unknown';
-    var iso = datum && datum.iso3 ? String(datum.iso3).toUpperCase() : '';
-    var installed = datum ? Number(datum.installed || 0) : 0;
-    var delivered = datum ? Number(datum.delivered || 0) : 0;
-    var planned = datum ? Number(datum.planned || 0) : 0;
+  function buildCountryPopupHtml(country) {
+    var installed = country && country.installed ? Number(country.installed) : 0;
+    var delivered = country && country.delivered ? Number(country.delivered) : 0;
+    var planned = country && country.planned ? Number(country.planned) : 0;
     var total = installed + delivered + planned;
+    var iso = country && country.iso3 ? String(country.iso3).toUpperCase() : '';
+    var name = country && country.name ? country.name : 'Unknown';
 
-    var rowsHtml = '' +
-      '<div class="ffc-tip__rows">' +
-      '<div class="ffc-tip__row"><span>Installed units</span><strong>' + formatNumber(installed) + '</strong></div>' +
-      '<div class="ffc-tip__row"><span>Delivered (not installed)</span><strong>' + formatNumber(delivered) + '</strong></div>' +
-      '<div class="ffc-tip__row"><span>Planned units</span><strong>' + formatNumber(planned) + '</strong></div>' +
-      '<div class="ffc-tip__row ffc-tip__row--muted"><span>Total units</span><strong>' + formatNumber(total) + '</strong></div>' +
-      '</div>';
-
-    var detailHref = total > 0 ? buildDetailUrl(cfg, datum) : '';
-    var linkHtml = detailHref
-      ? '<a class="btn btn-sm btn-outline-primary mt-2" href="' + detailHref + '">View projects in detailed table</a>'
-      : '';
+    if (total === 0) {
+      return '' +
+        '<div class="ffc-map-popup">' +
+        '<div class="ffc-map-popup__title">' + name + '</div>' +
+        '<div class="ffc-map-popup__subtitle">No FFC projects / simulator units recorded.</div>' +
+        '</div>';
+    }
 
     return '' +
-      '<div class="ffc-tip">' +
-      '<div class="ffc-tip__title">' + name + '</div>' +
-      (iso ? '<div class="ffc-tip__meta">ISO ' + iso + '</div>' : '') +
-      rowsHtml +
-      linkHtml +
+      '<div class="ffc-map-popup">' +
+      '<div class="ffc-map-popup__title">' + name + '</div>' +
+      (iso ? '<div class="ffc-map-popup__subtitle">ISO ' + iso + '</div>' : '') +
+      '<dl class="ffc-map-popup__metrics">' +
+      '<div><dt>Total units</dt><dd><strong>' + formatNumber(total) + '</strong></dd></div>' +
+      '<div><dt>Installed units</dt><dd>' + formatNumber(installed) + '</dd></div>' +
+      '<div><dt>Delivered (not installed)</dt><dd>' + formatNumber(delivered) + '</dd></div>' +
+      '<div><dt>Planned units</dt><dd>' + formatNumber(planned) + '</dd></div>' +
+      '</dl>' +
+      '<button type="button" class="btn btn-link btn-sm ffc-map-popup__cta" data-country-id="' + (country && country.countryId != null ? country.countryId : '') + '" data-country-iso3="' + (iso || '') + '">View projects in detailed table</button>' +
       '</div>';
   }
 
@@ -263,15 +241,11 @@
         var world = results[0];
         var countryMap = results[1];
 
-        var maxTotal = 0;
-        countryMap.forEach(function (value) {
-          if (value && Number(value.total || 0) > maxTotal) {
-            maxTotal = Number(value.total || 0);
-          }
-        });
-
-        var scale = buildColorScale(maxTotal);
+        var scale = buildColorScale(1);
+        var showCompleted = true;
+        var showPlanned = true;
         var map = L.map(cfg.mapId, { zoomControl: true, attributionControl: false }).setView([20, 20], 2);
+        var countries = [];
 
         var legendControlElement = document.createElement('div');
         legendControlElement.className = 'ffc-legend-floating card shadow-sm';
@@ -289,9 +263,22 @@
         var legendLabels = document.createElement('ul');
         legendLabels.className = 'legend-labels ffc-legend-labels list-unstyled small mb-0';
 
+        var legendNotes = document.createElement('div');
+        legendNotes.className = 'ffc-legend-note';
+        legendNotes.innerHTML = '' +
+          '<div class="ffc-legend-note__item">' +
+          '<span class="ffc-legend-note__sample"></span>' +
+          '<span>Solid border – has completed units</span>' +
+          '</div>' +
+          '<div class="ffc-legend-note__item">' +
+          '<span class="ffc-legend-note__sample ffc-legend-note__sample--dashed"></span>' +
+          '<span>Dashed border – planned only</span>' +
+          '</div>';
+
         legendControlBody.appendChild(legendTitle);
         legendControlBody.appendChild(legendRamp);
         legendControlBody.appendChild(legendLabels);
+        legendControlBody.appendChild(legendNotes);
         legendControlElement.appendChild(legendControlBody);
 
         var LegendControl = L.Control.extend({
@@ -309,18 +296,69 @@
           fillOpacity: 1
         }).addTo(map);
 
-        function styleFeature(feature) {
-          var props = feature && feature.properties ? feature.properties : {};
-          var iso = getIsoCodeFromProperties(props);
-          var datum = countryMap.get(iso);
-          var total = datum ? Number(datum.total || 0) : 0;
+        function styleFeature() {
+          return {
+            weight: 1,
+            color: '#cbd5e1',
+            fillColor: '#e2e8f0',
+            fillOpacity: 0.2,
+            dashArray: '2 2'
+          };
+        }
+
+        function computeTotals(record) {
+          var installed = record && record.installed ? Number(record.installed) : 0;
+          var delivered = record && record.delivered ? Number(record.delivered) : 0;
+          var planned = record && record.planned ? Number(record.planned) : 0;
 
           return {
-            weight: 0.6,
-            color: '#94a3b8',
-            fillColor: scale.colorFor(total),
-            fillOpacity: total > 0 ? 0.9 : 0.35
+            installed: installed,
+            delivered: delivered,
+            completed: installed + delivered,
+            planned: planned
           };
+        }
+
+        function valueForScale(record) {
+          var totals = computeTotals(record);
+          var completedValue = showCompleted ? totals.completed : 0;
+          var plannedValue = showPlanned ? totals.planned : 0;
+
+          return completedValue + plannedValue;
+        }
+
+        function applyCountryStyle(entry) {
+          var totals = computeTotals(entry.data);
+          var scaleValue = valueForScale(entry.data);
+          var hasCompleted = totals.completed > 0;
+          var hasPlanned = totals.planned > 0;
+          var strokeColor = hasCompleted || hasPlanned ? '#4b5bb5' : '#cbd5e1';
+          var dashArray = hasCompleted ? null : (hasPlanned ? '4 3' : '2 2');
+
+          entry.layer.setStyle({
+            weight: 1,
+            color: strokeColor,
+            dashArray: dashArray,
+            fillColor: scale.colorFor(scaleValue),
+            fillOpacity: scaleValue > 0 ? 0.75 : 0.1
+          });
+        }
+
+        function refreshCountryStyles() {
+          var maxValue = 0;
+          countries.forEach(function (entry) {
+            var computed = valueForScale(entry.data);
+            if (computed > maxValue) {
+              maxValue = computed;
+            }
+          });
+
+          scale = buildColorScale(maxValue);
+          renderLegend(scale);
+
+          countries.forEach(function (entry) {
+            applyCountryStyle(entry);
+          });
         }
 
         function onEachFeature(feature, layer) {
@@ -328,8 +366,23 @@
           var iso = getIsoCodeFromProperties(props);
           var record = countryMap.get(iso);
           var fallbackName = props.name || props.ADMIN || '';
-          var popupName = record && record.name ? record.name : (fallbackName || 'Unknown');
-          var popupHtml = buildPopupHtml(popupName, record, cfg);
+          var popupData = record || { countryId: null, name: fallbackName || 'Unknown', iso3: iso, installed: 0, delivered: 0, planned: 0 };
+          var popupName = popupData && popupData.name ? popupData.name : (fallbackName || 'Unknown');
+          var popupHtml = buildCountryPopupHtml({
+            name: popupName,
+            iso3: popupData.iso3 || iso,
+            countryId: popupData.countryId,
+            installed: popupData.installed,
+            delivered: popupData.delivered,
+            planned: popupData.planned
+          });
+
+          countries.push({
+            iso3: iso,
+            name: popupName,
+            data: popupData,
+            layer: layer
+          });
 
           layer.bindPopup(popupHtml, { maxWidth: 260, closeButton: true });
           layer.on({
@@ -337,7 +390,12 @@
               event.target.setStyle({ weight: 1.2, color: '#475569' });
             },
             mouseout: function (event) {
-              event.target.setStyle({ weight: 0.6, color: '#94a3b8' });
+              var countryMatch = countries.find(function (entry) { return entry.layer === event.target; });
+              if (countryMatch) {
+                applyCountryStyle(countryMatch);
+              } else {
+                event.target.setStyle({ weight: 1, color: '#cbd5e1', dashArray: '2 2' });
+              }
             }
           });
         }
@@ -357,7 +415,40 @@
 
         focusMap(map, 'africa', worldBounds);
         attachZoomControls(map, geoLayer, worldBounds);
-        renderLegend(scale);
+        refreshCountryStyles();
+
+        // SECTION: Filters and CTA wiring
+        var completedCheckbox = document.getElementById('ffcFilterCompleted');
+        var plannedCheckbox = document.getElementById('ffcFilterPlanned');
+
+        if (completedCheckbox) {
+          completedCheckbox.addEventListener('change', function () {
+            showCompleted = !!completedCheckbox.checked;
+            refreshCountryStyles();
+          });
+        }
+
+        if (plannedCheckbox) {
+          plannedCheckbox.addEventListener('change', function () {
+            showPlanned = !!plannedCheckbox.checked;
+            refreshCountryStyles();
+          });
+        }
+
+        if (!detailCtaHandlerAttached && cfg.ffcDetailUrlBase) {
+          document.addEventListener('click', function (event) {
+            var button = event.target.closest ? event.target.closest('.ffc-map-popup__cta') : null;
+            if (!button) {
+              return;
+            }
+
+            var isoValue = button.getAttribute('data-country-iso3');
+            var targetUrl = isoValue ? cfg.ffcDetailUrlBase + '?countryIso3=' + encodeURIComponent(isoValue) : cfg.ffcDetailUrlBase;
+            window.location.href = targetUrl;
+          });
+
+          detailCtaHandlerAttached = true;
+        }
 
         var shell = document.getElementById('ffc-map-shell');
         var toggle = document.querySelector('[data-action="ffc-map-toggle-fullwidth"]');
@@ -373,6 +464,7 @@
 
           if (toggle) {
             toggle.setAttribute('aria-pressed', isOn ? 'true' : 'false');
+            toggle.textContent = isOn ? 'Exit full-width view' : 'Use full-width map';
           }
 
           if (!skipPersist) {


### PR DESCRIPTION
## Summary
- add summary counters and completed/planned filters to the FFC map along with refreshed intro copy
- update popups to handle zero-data countries gracefully and navigate to the detailed table with a country filter
- refine map styling with border cues for planned-only countries, legend notes, and improved full-width toggle labeling

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e1d694dc83299aa5609f95a8263c)