### PR TITLE
Fix FFC country lookup and category label initialization

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
@@ -219,7 +219,7 @@ public class MapTableDetailedModel : PageModel
 
         var matchedId = await _db.FfcCountries
             .AsNoTracking()
-            .Where(country => country.Iso3 == iso)
+            .Where(country => country.IsoCode == iso)
             .Select(country => country.Id)
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/Services/Dashboard/ProjectPulseService.cs
+++ b/Services/Dashboard/ProjectPulseService.cs
@@ -188,13 +188,13 @@ public sealed class ProjectPulseService : IProjectPulseService
         var ongoingSeries = groupedByParent
             .Select(g =>
             {
-                string label;
+                var label = "Unknown";
 
                 if (g.ParentCategoryId.HasValue)
                 {
-                    if (!categoryNames.TryGetValue(g.ParentCategoryId.Value, out label))
+                    if (categoryNames.TryGetValue(g.ParentCategoryId.Value, out var resolvedLabel))
                     {
-                        label = "Unknown";
+                        label = resolvedLabel;
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
- update FFC country resolution to use the existing IsoCode field when matching ISO3 codes
- initialize category labels before lookup to remove nullable warnings

## Testing
- dotnet build (fails: .NET SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e68780b08329843dedc814cc8a01)