### PR TITLE
Prefer L1 cost for project overview

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -377,9 +377,20 @@ namespace ProjectManagement.Pages.Projects
                 .Select(f => f.ApproxProductionCost)
                 .FirstOrDefaultAsync(ct);
 
+            decimal? rdOrL1CostLakhs = null;
+
+            if (Procurement.L1Cost.HasValue)
+            {
+                rdOrL1CostLakhs = Procurement.L1Cost.Value / 1_00_000m;
+            }
+            else
+            {
+                rdOrL1CostLakhs = project.CostLakhs;
+            }
+
             CostSummary = new ProjectCostSummaryViewModel
             {
-                RdCostLakhs = project.CostLakhs,
+                RdCostLakhs = rdOrL1CostLakhs,
                 ApproxProductionCost = approxProductionCost
             };
 


### PR DESCRIPTION
## Summary
- prefer procurement L1 cost for the overview R&D/L1 display when available
- convert L1 full INR values to lakhs before rendering the summary

## Testing
- `dotnet test -q` *(fails: dotnet command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ece99adc8329a257ca20de090fe1)