### PR TITLE
Add theme toggle and dark mode styles

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -140,6 +140,7 @@
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/lib/microsoft/signalr/signalr.min.js" asp-append-version="true"></script>
+    <script src="~/js/theme-toggle.js" asp-append-version="true"></script>
     <script type="module" src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/comments.js" asp-append-version="true" defer></script>
     <script src="~/js/notifications.js" asp-append-version="true" defer></script>

--- a/Pages/Shared/_LoginPartial.cshtml
+++ b/Pages/Shared/_LoginPartial.cshtml
@@ -22,8 +22,17 @@
             }
             <li><hr class="dropdown-divider" /></li>
             <li>
-                <form class="px-3 py-1" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="~/" method="post">
-                    <button type="submit" class="btn btn-sm btn-outline-secondary w-100">Sign out</button>
+                <button type="button"
+                        id="pm-theme-toggle"
+                        class="dropdown-item d-flex align-items-center justify-content-between">
+                    <span>Theme</span>
+                    <span class="small text-muted" id="pm-theme-toggle-label">Light</span>
+                </button>
+            </li>
+            <li><hr class="dropdown-divider" /></li>
+            <li>
+                <form asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="~/" method="post">
+                    <button type="submit" class="dropdown-item">Sign out</button>
                 </form>
             </li>
         </ul>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,5 +1,13 @@
-/* ---------- Base tokens ---------- */
+/* ---------- Theme tokens ---------- */
+/* -- SECTION: Theme fallback -- */
 :root {
+    --pm-theme-name: light;
+}
+
+/* -------- Light theme tokens -------- */
+:root[data-theme="light"] {
+    --pm-theme-name: light;
+
     /* -- SECTION: Brand & core palette -- */
     --pm-primary: #2d6cdf;
     --pm-primary-hover: #2558c6;
@@ -186,6 +194,210 @@
     --remarks-role-mco-bg: var(--bs-primary-bg-subtle, #cfe2ff);
     --remarks-role-mco-border: var(--bs-primary-border-subtle, #9ec5fe);
     --remarks-role-mco-text: var(--bs-primary-text-emphasis, #052c65);
+
+    /* -- SECTION: Bootstrap mappings -- */
+    --bs-body-bg: var(--pm-surface);
+    --bs-body-color: var(--pm-text);
+    --bs-border-color: var(--pm-border);
+    --bs-card-bg: var(--pm-card);
+}
+
+/* -------- Dark theme tokens -------- */
+:root[data-theme="dark"] {
+    --pm-theme-name: dark;
+
+    /* -- SECTION: Brand & core palette -- */
+    --pm-primary: #60a5fa;
+    --pm-primary-hover: #3b82f6;
+    --pm-primary-strong: #2563eb;
+
+    /* -- SECTION: Neutrals & surfaces -- */
+    --pm-surface: #020617;
+    --pm-surface-soft: #020617;
+    --pm-surface-subtle: #0b1220;
+    --pm-surface-elevated: #0f172a;
+    --pm-surface-contrast: #0f172a;
+    --pm-surface-muted: #111827;
+    --pm-surface-veil: #111827;
+    --pm-surface-plain: #0f172a;
+    --pm-surface-foam: #0b1220;
+    --pm-surface-lilac: #312e81;
+    --pm-surface-ice: #1e293b;
+    --pm-surface-steel: #111827;
+    --pm-surface-haze: #1f2937;
+    --pm-surface-mist: #1e293b;
+    --pm-surface-silver: #111827;
+    --pm-surface-ghost: #0b1220;
+    --pm-surface-porcelain: #1f2937;
+    --pm-surface-mint: #0f172a;
+    --pm-surface-violet: #1e1b4b;
+    --pm-card: #020617;
+
+    /* -- SECTION: Text -- */
+    --pm-text: #e5e7eb;
+    --pm-text-secondary: #9ca3af;
+    --pm-text-muted: #6b7280;
+    --pm-muted: #6b7280;
+    --pm-text-contrast: #f9fafb;
+    --pm-text-inverted: #0b1220;
+    --pm-text-tertiary: #9ca3af;
+    --pm-text-muted-strong: #d1d5db;
+    --pm-text-dim: #9ca3af;
+    --pm-text-true: #ffffff;
+    --pm-text-gray-soft: #9ca3af;
+    --pm-text-slate: #cbd5e1;
+    --pm-text-project: #e0e7ff;
+    --pm-text-project-muted: #a5b4fc;
+
+    /* -- SECTION: Borders & dividers -- */
+    --pm-border: #374151;
+    --pm-border-subtle: #1f2937;
+    --pm-border-strong: #4b5563;
+    --pm-border-muted: #1f2937;
+    --pm-border-faint: #0f172a;
+    --pm-border-alt: #334155;
+    --pm-border-soft: #1f2937;
+    --pm-border-outline: #334155;
+
+    /* -- SECTION: Status colors -- */
+    --pm-success: #22c55e;
+    --pm-success-strong: #15803d;
+    --pm-success-soft-bg: rgba(34, 197, 94, .16);
+    --pm-success-soft-text: #bbf7d0;
+    --pm-success-soft-border: #166534;
+    --pm-success-contrast: #22c55e;
+
+    --pm-warning: #f59e0b;
+    --pm-warning-strong: #d97706;
+    --pm-warning-soft-bg: rgba(245, 158, 11, .16);
+    --pm-warning-soft-text: #fcd34d;
+    --pm-warning-soft-border: #f59e0b;
+    --pm-warning-muted: #fbbf24;
+    --pm-warning-contrast: #fcd34d;
+
+    --pm-danger: #ef4444;
+    --pm-danger-strong: #dc2626;
+    --pm-danger-soft-bg: rgba(239, 68, 68, .18);
+    --pm-danger-soft-text: #fecdd3;
+    --pm-danger-soft-border: #b91c1c;
+    --pm-danger-emphasis: #ef4444;
+    --pm-danger-invert: #fef2f2;
+    --pm-danger-accent: #dc2626;
+
+    --pm-info: #38bdf8;
+    --pm-info-strong: #0284c7;
+    --pm-info-soft-bg: rgba(56, 189, 248, .18);
+    --pm-info-soft-text: #bae6fd;
+    --pm-info-soft-border: #0ea5e9;
+    --pm-info-contrast: #22d3ee;
+
+    /* -- SECTION: Accents & category colors -- */
+    --pm-accent-blue: #60a5fa;
+    --pm-accent-blue-strong: #3b82f6;
+    --pm-accent-blue-bolder: #2563eb;
+    --pm-accent-blue-soft-1: #1d4ed8;
+    --pm-accent-blue-soft-2: #1e3a8a;
+    --pm-accent-blue-soft-3: #172554;
+    --pm-accent-blue-tint: #0b1220;
+    --pm-accent-blue-muted: #93c5fd;
+    --pm-accent-blue-glow: #bfdbfe;
+    --pm-accent-indigo: #818cf8;
+    --pm-accent-indigo-bright: #a5b4fc;
+    --pm-accent-indigo-deep: #312e81;
+    --pm-accent-indigo-night: #1e1b4b;
+    --pm-accent-purple: #c084fc;
+    --pm-accent-pink-soft: #f9a8d4;
+    --pm-accent-pink: #fb7185;
+    --pm-accent-teal: #2dd4bf;
+    --pm-accent-teal-soft: rgba(45, 212, 191, .15);
+    --pm-accent-teal-strong: #0f766e;
+    --pm-accent-amber: #fbbf24;
+    --pm-accent-amber-soft: rgba(251, 191, 36, .2);
+    --pm-accent-slate: #cbd5e1;
+    --pm-accent-slate-strong: #e5e7eb;
+    --pm-accent-slate-mid: #9ca3af;
+    --pm-accent-ffc: #c4b5fd;
+    --pm-accent-highlight-soft: rgba(255, 255, 204, .2);
+    --pm-accent-info-muted: #bae6fd;
+    --pm-accent-info-soft: #0ea5e9;
+    --pm-accent-success-strong: #22c55e;
+    --pm-accent-danger-strong: #ef4444;
+    --pm-accent-navy: #0ea5e9;
+    --pm-accent-navy-strong: #0284c7;
+    --pm-accent-navy-shadow: #0b1220;
+    --pm-accent-gold-dark: #fbbf24;
+    --pm-accent-mint: #34d399;
+    --pm-accent-lavender: #a78bfa;
+
+    /* -- SECTION: Project palette -- */
+    --pm-project-hero-gradient-start: #1e1b4b;
+    --pm-project-hero-gradient-mid: #0f172a;
+    --pm-project-hero-accent-1: #312e81;
+    --pm-project-hero-accent-2: #4338ca;
+    --pm-project-ink: #e0e7ff;
+    --pm-project-ink-strong: #cbd5ff;
+    --pm-project-ink-deep: #a5b4fc;
+    --pm-project-ink-muted: #94a3b8;
+    --pm-project-ink-alt: #818cf8;
+    --pm-project-surface: #0f172a;
+    --pm-project-muted: #c7d2fe;
+    --pm-project-text: #cbd5e1;
+    --pm-project-text-soft: #a5b4fc;
+    --pm-project-text-contrast: #e0e7ff;
+    --pm-project-text-deep: #e2e8f0;
+    --pm-project-text-fade: #94a3b8;
+    --pm-project-royal: #a78bfa;
+    --pm-project-link: #93c5fd;
+    --pm-project-border: #334155;
+    --pm-project-border-soft: #1f2937;
+
+    /* -- SECTION: Charts & widgets -- */
+    --pm-chart-grid: #1f2937;
+    --pm-chart-axis: #d1d5db;
+    --pm-chart-accent-1: #93c5fd;
+    --pm-chart-accent-2: #fdba74;
+    --pm-chart-accent-3: #4ade80;
+    --pm-chart-accent-4: #c4b5fd;
+    --pm-chart-accent-5: #fb7185;
+    --pm-chart-accent-6: #2dd4bf;
+
+    /* -- SECTION: Effects & typography -- */
+    --pm-shadow: 0 8px 20px rgba(0, 0, 0, .45);
+    --pm-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    /* GitHub-aligned system font stack and typographic scale */
+    --pm-font-size-xxs: 0.6875rem;   /* 11px */
+    --pm-font-size-xs: 0.75rem;      /* 12px */
+    --pm-font-size-sm: 0.8125rem;    /* 13px */
+    --pm-font-size-compact: 0.85rem; /* compact text */
+    --pm-font-size-base: 0.875rem;   /* 14px */
+    --pm-font-size-tight: 0.9rem;    /* dense body */
+    --pm-font-size-comfortable: 0.95rem; /* spacious body */
+    --pm-font-size-md: 1rem;         /* 16px */
+    --pm-font-size-lg: 1.125rem;     /* 18px */
+    --pm-font-size-xl: 1.25rem;      /* 20px */
+    --pm-font-size-2xl: 1.5rem;      /* 24px */
+    --pm-font-size-3xl: 1.75rem;     /* 28px */
+    --pm-font-size-4xl: 2rem;        /* 32px */
+    --pm-line-height-base: 1.5;
+    --bs-font-sans-serif: var(--pm-font-stack);
+    --bs-body-font-family: var(--pm-font-stack);
+    --bs-body-font-size: var(--pm-font-size-base);
+    --bs-body-line-height: var(--pm-line-height-base);
+    --remarks-role-comdt-bg: rgba(220, 53, 69, .25);
+    --remarks-role-comdt-border: rgba(220, 53, 69, .55);
+    --remarks-role-comdt-text: #fff;
+    --remarks-role-hod-bg: rgba(25, 135, 84, .25);
+    --remarks-role-hod-border: rgba(25, 135, 84, .5);
+    --remarks-role-hod-text: #fff;
+    --remarks-role-mco-bg: rgba(13, 110, 253, .25);
+    --remarks-role-mco-border: rgba(13, 110, 253, .55);
+    --remarks-role-mco-text: #fff;
+
+    /* -- SECTION: Bootstrap mappings -- */
+    --bs-body-bg: var(--pm-surface);
+    --bs-body-color: var(--pm-text);
+    --bs-border-color: var(--pm-border);
+    --bs-card-bg: var(--pm-card);
 }
 
 [data-bs-theme="dark"] {

--- a/wwwroot/js/theme-toggle.js
+++ b/wwwroot/js/theme-toggle.js
@@ -1,0 +1,66 @@
+// SECTION: Theme toggle and persistence
+(function () {
+    const STORAGE_KEY = 'pm-theme';
+    const root = document.documentElement;
+
+    function applyTheme(theme) {
+        const safeTheme = theme === 'dark' ? 'dark' : 'light';
+        root.setAttribute('data-theme', safeTheme);
+
+        // SECTION: Persist preference
+        try {
+            localStorage.setItem(STORAGE_KEY, safeTheme);
+        } catch (e) {
+            // Ignore storage errors (private mode, etc.)
+        }
+
+        // SECTION: Update dropdown label
+        const label = document.getElementById('pm-theme-toggle-label');
+        if (label) {
+            label.textContent = safeTheme === 'dark' ? 'Dark' : 'Light';
+        }
+
+        // SECTION: Broadcast theme change for listeners (charts, maps, etc.)
+        window.dispatchEvent(
+            new CustomEvent('pm-theme-changed', { detail: { theme: safeTheme } })
+        );
+    }
+
+    function getStoredTheme() {
+        try {
+            return localStorage.getItem(STORAGE_KEY);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function getSystemPreference() {
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            return 'dark';
+        }
+        return 'light';
+    }
+
+    function initTheme() {
+        // SECTION: Initialise theme
+        const stored = getStoredTheme();
+        const initial = stored || getSystemPreference();
+        applyTheme(initial);
+
+        // SECTION: Wire dropdown toggle
+        const toggle = document.getElementById('pm-theme-toggle');
+        if (!toggle) return;
+
+        toggle.addEventListener('click', function () {
+            const current = root.getAttribute('data-theme') || 'light';
+            const next = current === 'light' ? 'dark' : 'light';
+            applyTheme(next);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTheme);
+    } else {
+        initTheme();
+    }
+})();


### PR DESCRIPTION
## Summary
- add HTML theme attribute and dropdown toggle for switching light/dark modes with persisted preference
- define theme-scoped token sets for light and dark palettes across site CSS
- load external theme toggle script to update data-theme and notify listeners

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a8a93f6f083299216f27b887ac77a)