### PR TITLE
Refine dark theme palette and skeleton styling

### DIFF
--- a/wwwroot/css/pages/proliferation-dashboard.css
+++ b/wwwroot/css/pages/proliferation-dashboard.css
@@ -232,7 +232,7 @@
 .skeleton {
   position: relative;
   overflow: hidden;
-  background-color: var(--pm-border-subtle);
+  background-color: var(--pm-skeleton);
   border-radius: 0.75rem;
   height: 100%;
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -34,6 +34,7 @@
     --pm-surface-mint: #f0f7f3;
     --pm-surface-violet: #f7f1ff;
     --pm-card: #ffffff;
+    --pm-skeleton: #e5e7eb;
 
     /* -- SECTION: Text -- */
     --pm-text: #0b1220;
@@ -216,7 +217,7 @@
     --pm-surface-soft: #020617;
     --pm-surface-subtle: #0b1220;
     --pm-surface-elevated: #0f172a;
-    --pm-surface-contrast: #0f172a;
+    --pm-surface-contrast: #020617;
     --pm-surface-muted: #111827;
     --pm-surface-veil: #111827;
     --pm-surface-plain: #0f172a;
@@ -232,6 +233,7 @@
     --pm-surface-mint: #0f172a;
     --pm-surface-violet: #1e1b4b;
     --pm-card: #020617;
+    --pm-skeleton: #111827;
 
     /* -- SECTION: Text -- */
     --pm-text: #e5e7eb;
@@ -250,7 +252,7 @@
     --pm-text-project-muted: #a5b4fc;
 
     /* -- SECTION: Borders & dividers -- */
-    --pm-border: #374151;
+    --pm-border: #1f2937;
     --pm-border-subtle: #1f2937;
     --pm-border-strong: #4b5563;
     --pm-border-muted: #1f2937;


### PR DESCRIPTION
## Summary
- align dark theme surface tokens to improve card contrast
- introduce a reusable skeleton token for both themes
- apply the skeleton token to dashboard placeholder blocks for dark-mode consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a92c8b8708329a83b3e0d2b7eaf90)