### PR TITLE
Improve dashboard card styling coherence

### DIFF
--- a/wwwroot/css/dashboard/search-health-widget.css
+++ b/wwwroot/css/dashboard/search-health-widget.css
@@ -1,6 +1,7 @@
 /* SECTION: Card layout */
 .search-health-card {
-    border-radius: 0.9rem;
+    border-radius: 18px;
+    border: 1px solid var(--pm-border-muted);
 }
 
 .search-health-card__body {

--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -1,10 +1,32 @@
-﻿/* SECTION: Dashboard layout spacing */
+/* SECTION: Dashboard surface & card shell */
 
 /* Shared vertical rhythm tokens for all four circled gaps */
 .dashboard {
     --dashboard-gap-small: clamp(1.9rem, 2.1vw, 2.3rem); /* 1 & 2 */
     --dashboard-gap-large: clamp(2.4rem, 2.8vw, 3rem); /* 3 & 4 */
 }
+
+/* Base shell for dashboard cards to match Analytics polish */
+.dashboard-card-shell,
+.ppulse,
+.ops-signals__tile,
+.ffc-simulator-map-widget,
+.todo-widget,
+.search-health-card,
+.dashboard-my-projects__projects {
+    background: var(--pm-surface-elevated);
+    border: 1px solid var(--pm-border-muted);
+    border-radius: 18px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+}
+
+/* Light, cool dashboard canvas behind the cards */
+.analytics-main {
+    background: var(--pm-surface-steel);
+}
+/* END SECTION */
+
+/* SECTION: Dashboard layout spacing */
 
 /* Circle 1: header → Project pulse; also kill Bootstrap's vertical gutter */
 .row.dashboard {
@@ -134,6 +156,27 @@
 }
 /* END SECTION */
 
+/* SECTION: Dashboard right column softening */
+.dashboard-sidebar .card-body,
+.dashboard-sidebar .pm-card-body {
+    padding: 1rem 1.25rem;
+}
+
+.dashboard-sidebar .btn-primary {
+    border-radius: 999px;
+    padding-inline: 1.05rem;
+}
+
+.todo-widget .todo-badge {
+    background: var(--pm-chip-bg);
+    color: var(--pm-chip-text, var(--pm-text));
+    border-radius: 999px;
+    padding: 0.1rem 0.55rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+/* END SECTION */
+
 /* SECTION: Dashboard - My projects */
 .dashboard-my-projects {
     display: flex;
@@ -145,10 +188,11 @@
 }
 
 .dashboard-my-projects__projects {
-    border: 1px solid var(--pm-border);
-    border-radius: 1rem;
-    background-color: var(--pm-card);
+    border: 1px solid var(--pm-border-muted);
+    border-radius: 18px;
+    background-color: var(--pm-surface-elevated);
     padding: 1rem 1.25rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
 .dashboard-my-projects__section + .dashboard-my-projects__section {

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -1,16 +1,16 @@
 /* Shared styles for the compact to-do widget used on the dashboard and tasks page */
 .todo-widget {
-    --mission-panel-surface: rgba(255, 255, 255, .95);
-    --mission-panel-border: rgba(13, 110, 253, .22);
-    --mission-panel-shadow: 0 24px 48px -32px rgba(13, 110, 253, .6);
-    --mission-panel-header-bg: linear-gradient(135deg, rgba(13, 110, 253, .12), rgba(25, 135, 84, .08));
+    --mission-panel-surface: var(--pm-surface-elevated);
+    --mission-panel-border: var(--pm-border-muted);
+    --mission-panel-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+    --mission-panel-header-bg: linear-gradient(135deg, rgba(13, 110, 253, .08), rgba(25, 135, 84, .05));
     --mission-panel-ring-fill: var(--pm-primary-strong);
     --mission-panel-ring-track: rgba(13, 110, 253, .18);
     --mission-scroll-thumb: rgba(13, 110, 253, .4);
     --todo-row-hover-bg: rgba(13, 110, 253, .08);
     --todo-row-hover-border: rgba(13, 110, 253, .18);
     background-color: var(--mission-panel-surface, var(--pm-card));
-    background-image: linear-gradient(135deg, rgba(13, 110, 253, .08), rgba(111, 66, 193, .05));
+    background-image: none;
     border: 1px solid var(--mission-panel-border);
     box-shadow: var(--mission-panel-shadow);
 }

--- a/wwwroot/css/widgets/ffc-simulator-map.css
+++ b/wwwroot/css/widgets/ffc-simulator-map.css
@@ -1,13 +1,14 @@
 /* SECTION: FFC simulator map widget layout */
 .ffc-simulator-map-widget {
-    border: 0;
-    border-radius: 1rem;
-    background: linear-gradient(135deg, var(--pm-card)fff 0%, var(--pm-project-hero-accent-2) 55%, var(--pm-surface-lilac) 100%);
+    border: 1px solid var(--pm-border-muted);
+    border-radius: 18px;
+    background: var(--pm-surface-elevated);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
     margin-top: 0;
 }
 
     .ffc-simulator-map-widget .pm-card-body {
-        padding: 1.75rem;
+        padding: 1.5rem 1.5rem 1.75rem;
     }
 
 .ffc-simulator-map-widget__header {
@@ -28,6 +29,7 @@
     letter-spacing: 0.08em;
     font-size: 0.75rem;
     color: var(--pm-text-muted);
+    font-weight: 600;
 }
 
 .ffc-simulator-map-widget__stats {
@@ -54,15 +56,17 @@
     font-size: 1.4rem;
     color: var(--pm-accent-indigo-deep);
     line-height: 1.2;
+    letter-spacing: 0.01em;
 }
 
 .ffc-simulator-map {
     position: relative;
     margin-top: 1.5rem;
-    background: var(--pm-surface-contrast);
-    border-radius: 1rem;
+    background: transparent;
+    border-radius: 14px;
     overflow: hidden;
-    border: 1px solid rgba(15, 23, 42, 0.05);
+    border: 1px solid var(--pm-border-muted);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
     min-height: 320px;
 }
 

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -35,14 +35,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--ops-gap-xs);
-  background: var(--pm-card);
-  border: 1px solid var(--pm-border, var(--pm-border));
-  border-radius: 12px;
-  padding: 12px 14px;
+  background: var(--pm-surface-elevated);
+  border: 1px solid var(--pm-border-muted, var(--pm-border));
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
   color: inherit;
   text-decoration: none;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  min-height: 120px;
 }
 
 .ops-signals__tile:hover {
@@ -76,12 +77,13 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
+  justify-content: space-between;
 }
 
 .ops-signals__num {
   font-weight: 700;
-  font-size: 1.4rem;
-  letter-spacing: 0.02em;
+  font-size: 1.45rem;
+  letter-spacing: 0.01em;
 }
 
 .ops-signals__unit {
@@ -95,7 +97,7 @@
 }
 
 .ops-signals__spark {
-  height: 40px;
+  height: 36px;
 }
 
 .ops-signals__delta {

--- a/wwwroot/css/widgets/project-pulse.css
+++ b/wwwroot/css/widgets/project-pulse.css
@@ -4,10 +4,10 @@
   --pp-gap-sm: 12px;
   --pp-gap-md: 16px;
   --pp-gap-lg: 24px;
-  --pp-border: var(--pm-border, var(--pm-border));
-  background: var(--pm-card);
-  border-radius: 14px;
-  box-shadow: var(--pm-shadow, 0 8px 30px rgba(15, 23, 42, 0.08));
+  --pp-border: var(--pm-border-muted, var(--pm-border));
+  background: var(--pm-surface-elevated);
+  border-radius: 18px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
   padding: clamp(var(--pp-gap-md), 3vw, var(--pp-gap-lg));
   border: 1px solid var(--pp-border);
 }
@@ -133,10 +133,10 @@
 
 /* SECTION: Card */
 .ppulse__card {
-  background: var(--pm-card);
-  border-radius: 12px;
-  border: 1px solid var(--pp-border);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  background: transparent;
+  border-radius: 14px;
+  border: 1px solid color-mix(in oklab, var(--pp-border) 55%, white);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
 }
 
 .ppulse__link {
@@ -164,6 +164,7 @@
 .ppulse__card-head h3 {
   margin: 0;
   font-size: 1rem;
+  font-weight: 600;
   display: flex;
   align-items: baseline;
   gap: 0.35rem;
@@ -171,21 +172,23 @@
 
 .ppulse__card-head small {
   color: var(--pm-text-secondary, var(--pm-accent-slate-mid));
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .ppulse__chart {
-  margin: var(--pp-gap-xs) 0;
-  height: 140px;
-  padding: 8px 8px 6px;
-  border-radius: 10px;
-  background: color-mix(in oklab, var(--pm-border, var(--pm-border)) 35%, white);
-  border: 1px solid var(--pp-border);
+  margin: var(--pp-gap-sm) 0;
+  height: 148px;
+  padding: 10px 12px 8px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px solid color-mix(in oklab, var(--pp-border) 45%, white);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .ppulse__chart canvas {
   width: 100% !important;
   height: 100% !important;
+  background: transparent;
 }
 
 .ppulse__foot {


### PR DESCRIPTION
## Summary
- unify dashboard card shells and page canvas to match analytics styling
- refine project pulse, metric tiles, and FFC map surfaces for clearer contrast
- soften right column widget accents and badges for calmer presentation

## Testing
- not run (CSS-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aafdffd6c8329a1e8160c840fc489)