### PR TITLE
Refine My Projects widget with grouped view and PDC alerts

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -125,147 +125,120 @@
 
                 @* SECTION: My Projects + Stage PDC split widget *@
                 <div class="myproj-stage-widget__body">
-                    <div class="myproj-stage-widget__projects" data-role="myproj-projects-pane">
-                        @* SECTION: My Projects listing *@
-                        @if (Model.HasMyProjects)
-                        {
-                            <div class="dashboard-my-projects__projects">
-                                @foreach (var projectSection in Model.MyProjectSections)
+                    <div class="myprojects-card">
+                        <div class="myprojects-card__left" data-role="myproj-projects-pane">
+                            <div class="myprojects-header">
+                                <span class="myprojects-header__label">Head of Department</span>
+                            </div>
+
+                            @if (Model.HasMyProjects)
+                            {
+                                foreach (var section in Model.MyProjects.Sections)
                                 {
-                                    <div class="dashboard-my-projects__section">
-                                        <h3 class="dashboard-my-projects__section-title text-uppercase text-secondary fw-semibold small mb-2">
-                                            @projectSection.Title
-                                        </h3>
-                                        <div class="dashboard-my-projects__list" role="list">
-                                            @foreach (var project in projectSection.Items)
+                                    <section class="myprojects-section">
+                                        <header class="myprojects-section__header">
+                                            <span class="myprojects-section__title">@section.CategoryName</span>
+                                            <span class="myprojects-section__count">
+                                                @section.ProjectCount project@(section.ProjectCount == 1 ? string.Empty : "s")
+                                            </span>
+                                        </header>
+
+                                        <div class="myprojects-grid" role="list">
+                                            @foreach (var project in section.Projects)
                                             {
                                                 <a asp-page="/Projects/Overview"
                                                    asp-route-id="@project.ProjectId"
-                                                   class="dashboard-project-card"
+                                                   class="myproject-tile"
                                                    role="listitem"
-                                                   data-project-id="@project.ProjectId">
-                                                    <div class="dashboard-project-card__cover" aria-hidden="true">
-                                                        @if (!string.IsNullOrEmpty(project.CoverImageUrl))
+                                                   data-project-id="@project.ProjectId"
+                                                   title="@project.Name">
+                                                    <div class="myproject-tile__cover" aria-hidden="true">
+                                                        @if (!string.IsNullOrEmpty(project.CoverUrl))
                                                         {
-                                                            <img src="@project.CoverImageUrl"
+                                                            <img src="@project.CoverUrl"
                                                                  alt=""
                                                                  loading="lazy" />
                                                         }
                                                         else
                                                         {
-                                                            <span class="dashboard-project-card__cover-placeholder">No cover</span>
+                                                            <span class="myproject-tile__cover-label">No cover</span>
                                                         }
                                                     </div>
-                                                    <div class="dashboard-project-card__content">
-                                                        <div class="dashboard-project-card__title text-truncate" title="@project.Name">
-                                                            @project.Name
-                                                        </div>
-                                                        <div class="dashboard-project-card__meta text-truncate">
-                                                            @(string.IsNullOrWhiteSpace(project.Category) ? "No category" : project.Category)
-                                                        </div>
+
+                                                    <div class="myproject-tile__body">
+                                                        <div class="myproject-tile__name">@project.Name</div>
+                                                        <div class="myproject-tile__category">@project.CategoryName</div>
                                                     </div>
-                                                    <span class="dashboard-project-card__chevron" aria-hidden="true">
+
+                                                    <div class="myproject-tile__chevron" aria-hidden="true">
                                                         <i class="bi bi-arrow-right-short"></i>
-                                                    </span>
+                                                    </div>
                                                 </a>
                                             }
                                         </div>
-                                    </div>
+
+                                        <hr class="myprojects-section__divider" />
+                                    </section>
                                 }
-                            </div>
-                        }
-                        else if (Model.ShowEmptyMyProjectsMessage)
-                        {
-                            <p class="text-secondary small mb-0">
-                                You are not currently assigned to any projects.
-                            </p>
-                        }
-                        @* END SECTION *@
-                    </div>
-
-                    <div class="myproj-stage-widget__divider" aria-hidden="true"></div>
-
-                    <aside class="myproj-stage-widget__pdc" data-role="myproj-pdc-pane" aria-label="Ongoing stage PDC">
-                        <div class="dashboard-my-projects__pdc-header d-flex flex-column gap-1">
-                            <p class="text-uppercase text-secondary fw-semibold small mb-0">Ongoing stage PDC</p>
-                            <p class="text-muted small mb-0">Live PDC status for projects shown on the left.</p>
-                        </div>
-                        @if (Model.HasMyProjects)
-                        {
-                            var pdcProjects = Model.MyProjectSections.SelectMany(section => section.Items).ToList();
-                            if (pdcProjects.Count > 0)
+                            }
+                            else if (Model.ShowEmptyMyProjectsMessage)
                             {
-                                <ul class="dashboard-my-projects__pdc-list list-unstyled mb-0" role="list">
-                                    @foreach (var project in pdcProjects)
-                                    {
-                                        var stage = project.StageSummary;
-                                        <li class="dashboard-my-projects__pdc-item myproj-stage-widget__pdc-row"
-                                            data-project-id="@project.ProjectId"
-                                            role="listitem"
-                                            tabindex="0">
-                                            <div class="d-flex justify-content-between align-items-start gap-2">
-                                                <div class="dashboard-my-projects__pdc-label text-truncate">
-                                                    <div class="fw-semibold text-truncate" title="@project.Name">@project.Name</div>
-                                                    <div class="text-muted small text-truncate">
-                                                        @if (stage is not null)
-                                                        {
-                                                            @:Stage: @stage.StageName (@stage.StageCode)
-                                                        }
-                                                        else
-                                                        {
-                                                            <span class="text-muted">Stage data unavailable</span>
-                                                        }
-                                                    </div>
-                                                </div>
-                                                <div class="text-end">
-                                                    @if (stage?.PlannedDue is { } plannedDue)
-                                                    {
-                                                        var badgeClass = stage.IsOverdue ? "text-bg-danger" : "text-bg-success";
-                                                        <span class=$"badge rounded-pill {badgeClass}">
-                                                            @plannedDue.ToString("dd-MMM-yyyy")
-                                                        </span>
-                                                        <div class="dashboard-my-projects__pdc-meta small">
-                                                            @if (stage.DaysToPdc.HasValue)
-                                                            {
-                                                                if (stage.IsOverdue)
-                                                                {
-                                                                    <span class="text-danger">
-                                                                        Overdue by @stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s")
-                                                                    </span>
-                                                                }
-                                                                else
-                                                                {
-                                                                    <span class="text-success">
-                                                                        @stage.DaysToPdc.Value day@(stage.DaysToPdc == 1 ? "" : "s") to PDC
-                                                                    </span>
-                                                                }
-                                                            }
-                                                        </div>
-                                                    }
-                                                    else if (stage is not null)
-                                                    {
-                                                        <span class="badge rounded-pill text-bg-secondary">PDC not set</span>
-                                                    }
-                                                    else
-                                                    {
-                                                        <span class="badge rounded-pill text-bg-secondary">Unavailable</span>
-                                                    }
-                                                </div>
-                                            </div>
-                                        </li>
-                                    }
-                                </ul>
+                                <p class="text-secondary small mb-0">
+                                    You are not currently assigned to any projects.
+                                </p>
                             }
                             else
                             {
-                                <p class="text-secondary small mb-0">No projects available for PDC tracking.</p>
+                                <p class="text-secondary small mb-0">Add yourself to a project to see it here.</p>
                             }
-                        }
-                        else
-                        {
-                            <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
-                        }
-                    </aside>
+                        </div>
+
+                        <div class="myprojects-card__right" data-role="myproj-pdc-pane" aria-label="Ongoing stage PDC">
+                            <div class="myprojects-right-header">
+                                <span class="myprojects-right-header__title">Stage &amp; PDC alerts</span>
+                                <a asp-page="/Projects/StagePdc" class="btn btn-link btn-sm">View full Stage &amp; PDC →</a>
+                            </div>
+
+                            @if (!Model.MyProjects.StagePdcAlerts.Any())
+                            {
+                                <p class="text-muted small mb-0">No projects with urgent Stage &amp; PDC issues.</p>
+                            }
+                            else
+                            {
+                                var groupedAlerts = Model.MyProjects.StagePdcAlerts
+                                    .GroupBy(alert => alert.AlertType)
+                                    .OrderBy(group => group.Key);
+
+                                foreach (var group in groupedAlerts)
+                                {
+                                    <section class="myprojects-alert-group">
+                                        <header class="myprojects-alert-group__header">
+                                            <span>@IndexModel.GetAlertGroupTitle(group.Key)</span>
+                                        </header>
+
+                                        <ul class="myprojects-alert-list">
+                                            @foreach (var alert in group)
+                                            {
+                                                <li class="myprojects-alert-item" data-project-id="@alert.ProjectId">
+                                                    <a asp-page="/Projects/StagePdc"
+                                                       asp-route-id="@alert.ProjectId"
+                                                       class="myprojects-alert-item__main">
+                                                        <div class="myprojects-alert-item__name">@alert.ProjectName</div>
+                                                        <div class="myprojects-alert-item__meta">
+                                                            Stage @alert.CurrentStageCode · @alert.CategoryName
+                                                        </div>
+                                                    </a>
+                                                    <span class=$"myprojects-alert-item__pdc @IndexModel.GetAlertTypeCss(alert.AlertType)">
+                                                        @IndexModel.GetAlertPdcLabel(alert)
+                                                    </span>
+                                                </li>
+                                            }
+                                        </ul>
+                                    </section>
+                                }
+                            }
+                        </div>
+                    </div>
                 </div>
                 @* END SECTION *@
             </section>

--- a/ViewModels/Dashboard/MyProjectsVm.cs
+++ b/ViewModels/Dashboard/MyProjectsVm.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.ViewModels.Dashboard
+{
+    // SECTION: My Projects portfolio view models
+    public sealed class MyProjectTileVm
+    {
+        public int ProjectId { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string CategoryName { get; init; } = string.Empty;
+        public string? CoverUrl { get; init; }
+    }
+
+    public sealed class MyProjectCategorySectionVm
+    {
+        public string CategoryName { get; init; } = string.Empty;
+        public int ProjectCount { get; init; }
+        public IReadOnlyList<MyProjectTileVm> Projects { get; init; } = Array.Empty<MyProjectTileVm>();
+    }
+
+    public enum StagePdcAlertType
+    {
+        Overdue,
+        DueSoon,
+        NotSet
+    }
+
+    public sealed class StagePdcAlertVm
+    {
+        public int ProjectId { get; init; }
+        public string ProjectName { get; init; } = string.Empty;
+        public string CategoryName { get; init; } = string.Empty;
+        public string CurrentStageCode { get; init; } = string.Empty;
+        public DateTime? PdcDate { get; init; }
+        public StagePdcAlertType AlertType { get; init; }
+    }
+
+    public sealed class MyProjectsVm
+    {
+        public IReadOnlyList<MyProjectCategorySectionVm> Sections { get; init; } = Array.Empty<MyProjectCategorySectionVm>();
+        public IReadOnlyList<StagePdcAlertVm> StagePdcAlerts { get; init; } = Array.Empty<StagePdcAlertVm>();
+    }
+}

--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -554,6 +554,229 @@
 }
 /* END SECTION */
 
+/* SECTION: Dashboard - My projects grouped grid and alerts */
+.myprojects-card {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1.6fr);
+    gap: 1.25rem;
+}
+
+.myprojects-card__left,
+.myprojects-card__right {
+    max-height: 420px;
+    overflow-y: auto;
+    padding-right: .25rem;
+}
+
+.myprojects-header__label {
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--pm-accent-slate-mid);
+    margin-bottom: .5rem;
+}
+
+.myprojects-section {
+    margin-bottom: .75rem;
+}
+
+.myprojects-section__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin: .35rem 0 .4rem;
+}
+
+.myprojects-section__title {
+    font-size: .85rem;
+    font-weight: 600;
+    color: var(--pm-accent-slate-strong);
+}
+
+.myprojects-section__count {
+    font-size: .75rem;
+    color: var(--pm-accent-slate-mid);
+}
+
+.myprojects-section__divider {
+    border: 0;
+    border-top: 1px dashed rgba(148, 163, 184, .4);
+    margin: .4rem 0 .3rem;
+}
+
+.myprojects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    gap: .6rem;
+}
+
+.myproject-tile {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: .55rem;
+    align-items: center;
+    padding: .55rem .75rem;
+    border-radius: .75rem;
+    background: var(--pm-surface);
+    border: 1px solid var(--pm-border-subtle);
+    text-decoration: none;
+    color: inherit;
+}
+
+.myproject-tile.is-active {
+    border-color: rgba(45, 108, 223, .65);
+    box-shadow: 0 24px 36px -26px rgba(45, 108, 223, .45);
+    background-color: rgba(37, 99, 235, .04);
+}
+
+.myproject-tile__cover {
+    width: 42px;
+    height: 42px;
+    border-radius: .6rem;
+    background: var(--pm-surface-contrast);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.myproject-tile__cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: .6rem;
+}
+
+.myproject-tile__cover-label {
+    font-size: .6rem;
+    text-transform: uppercase;
+    color: var(--pm-accent-slate-mid);
+}
+
+.myproject-tile__body {
+    min-width: 0;
+}
+
+.myproject-tile__name {
+    font-size: .85rem;
+    font-weight: 600;
+    color: var(--pm-text);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.myproject-tile__category {
+    font-size: .75rem;
+    color: var(--pm-accent-slate-mid);
+    margin-top: 2px;
+}
+
+.myproject-tile__chevron {
+    color: var(--pm-accent-slate-mid);
+}
+
+.myprojects-right-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: .4rem;
+}
+
+.myprojects-right-header__title {
+    font-size: .85rem;
+    font-weight: 600;
+    color: var(--pm-accent-slate-strong);
+}
+
+.myprojects-alert-group {
+    margin-top: .5rem;
+}
+
+.myprojects-alert-group__header {
+    font-size: .75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--pm-accent-slate-mid);
+    margin-bottom: .25rem;
+}
+
+.myprojects-alert-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.myprojects-alert-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: .5rem;
+    padding: .45rem .1rem;
+    border-radius: .5rem;
+}
+
+.myprojects-alert-item.is-active {
+    background: rgba(37, 99, 235, .06);
+}
+
+.myprojects-alert-item__main {
+    text-decoration: none;
+    color: inherit;
+    flex: 1 1 auto;
+}
+
+.myprojects-alert-item__name {
+    font-size: .82rem;
+    font-weight: 600;
+    color: var(--pm-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.myprojects-alert-item__meta {
+    font-size: .75rem;
+    color: var(--pm-accent-slate-mid);
+}
+
+.myprojects-alert-item__pdc {
+    font-size: .72rem;
+    padding: .15rem .45rem;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.myprojects-alert-item__pdc.is-overdue {
+    background: rgba(248, 113, 113, .1);
+    color: #b91c1c;
+}
+
+.myprojects-alert-item__pdc.is-due-soon {
+    background: rgba(250, 204, 21, .1);
+    color: #92400e;
+}
+
+.myprojects-alert-item__pdc.is-not-set {
+    background: rgba(148, 163, 184, .16);
+    color: #475569;
+}
+
+@media (max-width: 992px) {
+    .myprojects-card {
+        grid-template-columns: 1fr;
+    }
+
+    .myprojects-card__left,
+    .myprojects-card__right {
+        max-height: none;
+    }
+}
+/* END SECTION */
+
 /* SECTION: Dashboard widget helpers */
 .pm-scroll {
     max-height: 340px;

--- a/wwwroot/js/dashboard/myproj-stage-widget.js
+++ b/wwwroot/js/dashboard/myproj-stage-widget.js
@@ -6,8 +6,8 @@
             return;
         }
 
-        const projectCards = widget.querySelectorAll('[data-project-id].dashboard-project-card');
-        const pdcRows = widget.querySelectorAll('.myproj-stage-widget__pdc-row[data-project-id]');
+        const projectCards = widget.querySelectorAll('[data-project-id].myproject-tile');
+        const pdcRows = widget.querySelectorAll('.myprojects-alert-item[data-project-id]');
 
         if (!projectCards.length || !pdcRows.length) {
             return;


### PR DESCRIPTION
## Summary
- add grouped My Projects view models that organize projects by category and expose Stage/PDC alerts
- rebuild the dashboard widget to show grouped project tiles with ellipsized names and a focused Stage & PDC alert list
- update styling and widget behavior for the refreshed layout and highlighting

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bdd4609548329bc7142c325bcec83)