### PR TITLE
Fix dashboard project summary properties and Razor section parsing

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -137,9 +137,9 @@
                                 {
                                     <section class="myprojects-section">
                                         <header class="myprojects-section__header">
-                                            <span class="myprojects-section__title">@section.CategoryName</span>
+                                            <span class="myprojects-section__title">@(section.CategoryName)</span>
                                             <span class="myprojects-section__count">
-                                                @section.ProjectCount project@(section.ProjectCount == 1 ? string.Empty : "s")
+                                                @(section.ProjectCount) project@(section.ProjectCount == 1 ? string.Empty : "s")
                                             </span>
                                         </header>
 

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -444,6 +444,8 @@ namespace ProjectManagement.Pages.Dashboard
                         : "Uncategorised",
                     CoverPhotoId = p.CoverPhotoId,
                     CoverPhotoVersion = p.CoverPhotoVersion,
+                    LeadPoUserId = p.LeadPoUserId,
+                    HodUserId = p.HodUserId,
                     CurrentStageCode = p.ProjectStages
                         .Where(stage => stage.Status == StageStatus.InProgress)
                         .OrderBy(stage => stage.SortOrder)
@@ -628,6 +630,8 @@ namespace ProjectManagement.Pages.Dashboard
             public string CategoryName { get; init; } = string.Empty;
             public int? CoverPhotoId { get; init; }
             public int CoverPhotoVersion { get; init; }
+            public string? LeadPoUserId { get; init; }
+            public string? HodUserId { get; init; }
             public string CurrentStageCode { get; init; } = string.Empty;
         }
 


### PR DESCRIPTION
## Summary
- include lead project officer and HoD ids when building project assignment summaries
- adjust Razor markup to avoid misinterpreting section expressions as directives

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be0ec564483298fabd759cc4c8dfb)