### PR TITLE
Restore My Projects widget grid split

### DIFF
--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -557,8 +557,10 @@
 /* SECTION: Dashboard - My projects grouped grid and alerts */
 .myprojects-card {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1.6fr);
-    gap: 1.25rem;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: flex-start;
+    width: 100%;
 }
 
 .myprojects-card__left,
@@ -566,6 +568,7 @@
     max-height: 420px;
     overflow-y: auto;
     padding-right: .25rem;
+    min-width: 0;
 }
 
 .myprojects-header__label {


### PR DESCRIPTION
## Summary
- enforce a grid-based layout on the My Projects + Stage & PDC widget to mirror the intended 9:3 split
- allow both panes to shrink without overflow while keeping consistent spacing and alignment

## Testing
- Not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be9729d048329b88fb1db183744ca)