### PR TITLE
Refresh dashboard palette and page background

### DIFF
--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -4,7 +4,11 @@
 body,
 .layout-main,
 .dashboard {
-    background-color: var(--pm-shell-bg);
+    background-color: var(--pm-page-bg);
+}
+
+.dashboard {
+    padding-top: 1.75rem;
 }
 
 .dashboard-main-content,
@@ -29,7 +33,7 @@ body,
     background: var(--pm-surface-card);
     border: 1px solid var(--pm-border-soft);
     border-radius: 20px;
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
 }
 
 /* Light, cool dashboard canvas behind the cards */
@@ -50,7 +54,7 @@ body,
     background-color: var(--pm-surface-card);
     border: 1px solid var(--pm-border-soft);
     border-radius: 20px;
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
 }
 /* END SECTION */
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -10,7 +10,8 @@
     --pm-primary-strong: #1d4ed8;
 
     /* -- SECTION: Neutrals & surfaces -- */
-    --pm-shell-bg: #f7f3eb;
+    --pm-page-bg: #f9f4ee;
+    --pm-shell-bg: var(--pm-page-bg);
     --pm-surface: #f5f7fb;
     --pm-surface-soft: #f9fafb;
     --pm-surface-subtle: #f3f4f6;
@@ -225,7 +226,7 @@
     --remarks-role-mco-text: var(--bs-primary-text-emphasis, #052c65);
 
     /* -- SECTION: Bootstrap mappings -- */
-    --bs-body-bg: var(--pm-surface);
+    --bs-body-bg: var(--pm-page-bg);
     --bs-body-color: var(--pm-text);
     --bs-border-color: var(--pm-border);
     --bs-card-bg: var(--pm-card);
@@ -236,7 +237,7 @@ body {
     font-size: var(--bs-body-font-size);
     line-height: var(--bs-body-line-height);
     color: var(--pm-text);
-    background-color: var(--pm-surface);
+    background-color: var(--pm-page-bg);
 }
 
 /* --- Layout shell --- */

--- a/wwwroot/js/widgets/project-pulse.js
+++ b/wwwroot/js/widgets/project-pulse.js
@@ -60,6 +60,34 @@
   var textColor = getCssVar('--pm-text-main', getCssVar('--pm-text', '#0b1220'));
   var textSecondary = getCssVar('--pm-text-muted', getCssVar('--pm-text-secondary', '#4b5563'));
 
+  // SECTION: Palette helpers
+  function resolveBarPalette(xLabel, yLabel) {
+    var normalizedY = (yLabel || '').toLowerCase();
+    var normalizedX = (xLabel || '').toLowerCase();
+
+    if (normalizedY.indexOf('completed') !== -1) {
+      return {
+        fill: 'rgba(74, 222, 128, 0.9)',
+        border: 'rgba(34, 197, 94, 1)',
+        borderWidth: 1
+      };
+    }
+
+    if (normalizedX.indexOf('technical category') !== -1) {
+      return {
+        fill: 'rgba(148, 163, 184, 0.95)',
+        border: 'rgba(100, 116, 139, 1)',
+        borderWidth: 1
+      };
+    }
+
+    return {
+      fill: 'rgba(34, 197, 94, 0.75)',
+      border: chartPalette.green,
+      borderWidth: 1.5
+    };
+  }
+  
   function safeParse(el, attr) {
     try {
       return JSON.parse(el.getAttribute(attr) || '[]');
@@ -122,22 +150,19 @@
       var value = s && (typeof s.count !== 'undefined' ? s.count : (typeof s.Count !== 'undefined' ? s.Count : 0));
       return Number(value) || 0;
     });
+
+    var donutColors = series.map(function (_slice, index) {
+      return index === 0 ? 'rgba(251, 146, 60, 0.95)' : 'rgba(229, 231, 235, 1)';
+    });
+
     return new ChartCtor(ctx, {
       type: 'doughnut',
       data: {
         labels: labels,
         datasets: [{
           data: data,
-          backgroundColor: [
-            'rgba(245, 158, 11, 0.85)',
-            'rgba(148, 163, 184, 0.9)',
-            'rgba(168, 85, 247, 0.85)'
-          ],
-          hoverBackgroundColor: [
-            'rgba(245, 158, 11, 0.85)',
-            'rgba(148, 163, 184, 0.9)',
-            'rgba(168, 85, 247, 0.85)'
-          ],
+          backgroundColor: donutColors,
+          hoverBackgroundColor: donutColors,
           borderWidth: 0,
           cutout: '60%'
         }]
@@ -214,6 +239,7 @@
       var value = s && (typeof s.count !== 'undefined' ? s.count : (typeof s.Count !== 'undefined' ? s.Count : 0));
       return Number(value) || 0;
     });
+    var palette = resolveBarPalette(xLabel, yLabel);
     return new ChartCtor(ctx, {
       type: 'bar',
       data: {
@@ -222,9 +248,9 @@
           data: data,
           borderRadius: 6,
           maxBarThickness: 22,
-          backgroundColor: 'rgba(34, 197, 94, 0.75)',
-          borderColor: chartPalette.green,
-          borderWidth: 1.5
+          backgroundColor: palette.fill,
+          borderColor: palette.border,
+          borderWidth: palette.borderWidth
         }]
       },
       options: {


### PR DESCRIPTION
## Summary
- add a shared warm page background token and apply it to the layout shell
- soften dashboard spacing and card shadows for a lighter presentation
- update Project pulse chart palettes to use green, amber, and slate mappings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfd2eab0c832983d6d1ea28fd83f2)