### PR TITLE
Allow To-Do titles to wrap

### DIFF
--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -120,7 +120,7 @@
                         <li class="list-group-item d-flex align-items-center justify-content-between py-1 todo-row @(t.Status == TodoStatus.Done ? "done" : "")"
                             data-priority="@t.Priority"
                             data-status="@status">
-                            <div class="d-flex align-items-center gap-2">
+                            <div class="d-flex align-items-start gap-2 todo-row__content">
                                 <form method="post"
                                       asp-page="/Dashboard/Index"
                                       asp-page-handler="Toggle"

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -256,6 +256,11 @@
     }
 }
 
+/* Row content alignment */
+.todo-row__content {
+    align-items: flex-start;
+}
+
 /* Priority dot */
 .todo-dot {
     display: inline-block;
@@ -279,9 +284,13 @@
 
 .todo-title {
     font-weight: 500;
-    white-space: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
 }
 
 .todo-widget .todo-badge {


### PR DESCRIPTION
## Summary
- allow To-Do widget row content to align to the top and give the title area a flexible width
- clamp To-Do titles to two lines while permitting wrapping to show more of each task

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e7acd5c9083299296ea08719c0361)