### PR TITLE
Support partial ToT date entry

### DIFF
--- a/Pages/Projects/Tot/Edit.cshtml
+++ b/Pages/Projects/Tot/Edit.cshtml
@@ -105,10 +105,10 @@
                 </div>
                 <div class="card-body pm-card-body">
                     <ul class="list-unstyled mb-0 small">
-                        <li class="mb-2"><strong>Not required</strong>: Leave both dates empty.</li>
-                        <li class="mb-2"><strong>Not started</strong>: Leave both dates empty until ToT begins.</li>
-                        <li class="mb-2"><strong>In progress</strong>: Provide the start date; completion must stay empty.</li>
-                        <li><strong>Completed</strong>: Provide both start and completion dates; completion cannot be earlier than the start.</li>
+                        <li class="mb-2"><strong>Not required</strong>: Leave all ToT dates and milestones empty.</li>
+                        <li class="mb-2"><strong>Not started</strong>: Leave the start and completion dates empty.</li>
+                        <li class="mb-2"><strong>In progress</strong>: Provide when ToT started (year, month and year, or exact date). Completion must stay empty.</li>
+                        <li><strong>Completed</strong>: Provide when ToT was completed (year, month and year, or exact date). Start date is optional; completion cannot be earlier than the start if provided.</li>
                         <li class="mt-2">Update MET and first production model milestones when available.</li>
                     </ul>
                 </div>

--- a/Pages/Shared/Tot/_TotFormFields.cshtml
+++ b/Pages/Shared/Tot/_TotFormFields.cshtml
@@ -29,22 +29,46 @@
 
 <div class="row g-3">
     <div class="col-md-6">
-        <label asp-for="StartedOn" class="form-label">Start date</label>
-        <input asp-for="StartedOn" class="form-control" type="date" />
+        <label class="form-label" for="@Html.IdFor(m => m.StartYear)">Start date</label>
+        <div class="row g-2">
+            <div class="col-4">
+                <input asp-for="StartYear" class="form-control" type="number" min="1900" max="2100" placeholder="yyyy" inputmode="numeric" />
+                <span asp-validation-for="StartYear" class="text-danger"></span>
+            </div>
+            <div class="col-4">
+                <input asp-for="StartMonth" class="form-control" type="number" min="1" max="12" placeholder="mm" inputmode="numeric" />
+                <span asp-validation-for="StartMonth" class="text-danger"></span>
+            </div>
+            <div class="col-4">
+                <input asp-for="StartDay" class="form-control" type="number" min="1" max="31" placeholder="dd" inputmode="numeric" />
+                <span asp-validation-for="StartDay" class="text-danger"></span>
+            </div>
+        </div>
         @if (showMilestoneHelp)
         {
-            <div class="form-text">Required when ToT is in progress or completed.</div>
+            <div class="form-text">Required (at least the year) when ToT is in progress. Optional when ToT is completed.</div>
         }
-        <span asp-validation-for="StartedOn" class="text-danger"></span>
     </div>
     <div class="col-md-6">
-        <label asp-for="CompletedOn" class="form-label">Completion date</label>
-        <input asp-for="CompletedOn" class="form-control" type="date" />
+        <label class="form-label" for="@Html.IdFor(m => m.CompletionYear)">Completion date</label>
+        <div class="row g-2">
+            <div class="col-4">
+                <input asp-for="CompletionYear" class="form-control" type="number" min="1900" max="2100" placeholder="yyyy" inputmode="numeric" />
+                <span asp-validation-for="CompletionYear" class="text-danger"></span>
+            </div>
+            <div class="col-4">
+                <input asp-for="CompletionMonth" class="form-control" type="number" min="1" max="12" placeholder="mm" inputmode="numeric" />
+                <span asp-validation-for="CompletionMonth" class="text-danger"></span>
+            </div>
+            <div class="col-4">
+                <input asp-for="CompletionDay" class="form-control" type="number" min="1" max="31" placeholder="dd" inputmode="numeric" />
+                <span asp-validation-for="CompletionDay" class="text-danger"></span>
+            </div>
+        </div>
         @if (showMilestoneHelp)
         {
-            <div class="form-text">Required when ToT is completed.</div>
+            <div class="form-text">Required (at least the year) when ToT is completed.</div>
         }
-        <span asp-validation-for="CompletedOn" class="text-danger"></span>
     </div>
 </div>
 

--- a/Services/Projects/ProjectTotService.cs
+++ b/Services/Projects/ProjectTotService.cs
@@ -311,7 +311,7 @@ public sealed class ProjectTotService
             {
                 if (normalizedRequest.StartedOn is null)
                 {
-                    return ProjectTotUpdateResult.ValidationFailed("Start date is required when ToT is in progress.");
+                    return ProjectTotUpdateResult.ValidationFailed("Start date (year or month and year) is required when ToT is in progress.");
                 }
 
                 if (normalizedRequest.StartedOn.Value > todayLocal)
@@ -329,30 +329,28 @@ public sealed class ProjectTotService
             }
             case ProjectTotStatus.Completed:
             {
-                if (normalizedRequest.StartedOn is null)
-                {
-                    return ProjectTotUpdateResult.ValidationFailed("Start date is required when ToT is completed.");
-                }
-
                 if (normalizedRequest.CompletedOn is null)
                 {
-                    return ProjectTotUpdateResult.ValidationFailed("Completion date is required when ToT is completed.");
-                }
-
-                if (normalizedRequest.CompletedOn.Value < normalizedRequest.StartedOn.Value)
-                {
-                    return ProjectTotUpdateResult.ValidationFailed(
-                        "Completion date cannot be earlier than the start date.");
-                }
-
-                if (normalizedRequest.StartedOn.Value > todayLocal)
-                {
-                    return ProjectTotUpdateResult.ValidationFailed("Start date cannot be in the future.");
+                    return ProjectTotUpdateResult.ValidationFailed("Completion date (year or month and year) is required when ToT is completed.");
                 }
 
                 if (normalizedRequest.CompletedOn.Value > todayLocal)
                 {
                     return ProjectTotUpdateResult.ValidationFailed("Completion date cannot be in the future.");
+                }
+
+                if (normalizedRequest.StartedOn.HasValue)
+                {
+                    if (normalizedRequest.CompletedOn.Value < normalizedRequest.StartedOn.Value)
+                    {
+                        return ProjectTotUpdateResult.ValidationFailed(
+                            "Completion date cannot be earlier than the start date.");
+                    }
+
+                    if (normalizedRequest.StartedOn.Value > todayLocal)
+                    {
+                        return ProjectTotUpdateResult.ValidationFailed("Start date cannot be in the future.");
+                    }
                 }
 
                 break;

--- a/Utilities/PartialDates/PartialDateHelper.cs
+++ b/Utilities/PartialDates/PartialDateHelper.cs
@@ -1,0 +1,182 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Utilities.PartialDates;
+
+// SECTION: Partial date representations and conversions
+public enum PartialDatePrecision
+{
+    None = 0,
+    Year = 1,
+    Month = 2,
+    Day = 3
+}
+
+public sealed class PartialDateInput
+{
+    [Range(1900, 2100)]
+    public int? Year { get; set; }
+
+    [Range(1, 12)]
+    public int? Month { get; set; }
+
+    [Range(1, 31)]
+    public int? Day { get; set; }
+
+    public PartialDatePrecision GetPrecision()
+    {
+        if (Year.HasValue && !Month.HasValue && !Day.HasValue)
+        {
+            return PartialDatePrecision.Year;
+        }
+
+        if (Year.HasValue && Month.HasValue && !Day.HasValue)
+        {
+            return PartialDatePrecision.Month;
+        }
+
+        if (Year.HasValue && Month.HasValue && Day.HasValue)
+        {
+            return PartialDatePrecision.Day;
+        }
+
+        return PartialDatePrecision.None;
+    }
+}
+
+public static class PartialDateHelper
+{
+    // SECTION: Start date conversion
+    public static bool TryToStartDate(PartialDateInput input, out DateOnly value, out string? error)
+    {
+        error = null;
+        value = default;
+
+        if (input.Year.HasValue && (input.Year < 1900 || input.Year > 2100))
+        {
+            error = "Enter a year between 1900 and 2100.";
+            return false;
+        }
+
+        if (input.Month.HasValue && (input.Month < 1 || input.Month > 12))
+        {
+            error = "Enter a month between 1 and 12.";
+            return false;
+        }
+
+        if (input.Day.HasValue && (input.Day < 1 || input.Day > 31))
+        {
+            error = "Enter a day between 1 and 31.";
+            return false;
+        }
+
+        if (input.Month.HasValue && !input.Year.HasValue)
+        {
+            error = "Year is required when specifying a month.";
+            return false;
+        }
+
+        if (input.Day.HasValue && (!input.Year.HasValue || !input.Month.HasValue))
+        {
+            error = "Provide year and month when specifying a day.";
+            return false;
+        }
+
+        switch (input.GetPrecision())
+        {
+            case PartialDatePrecision.Year:
+                value = new DateOnly(input.Year!.Value, 1, 1);
+                return true;
+            case PartialDatePrecision.Month:
+                value = new DateOnly(input.Year!.Value, input.Month!.Value, 1);
+                return true;
+            case PartialDatePrecision.Day:
+                var daysInMonth = DateTime.DaysInMonth(input.Year!.Value, input.Month!.Value);
+                if (input.Day > daysInMonth)
+                {
+                    error = $"Day must be between 1 and {daysInMonth} for the selected month.";
+                    return false;
+                }
+
+                value = new DateOnly(input.Year!.Value, input.Month!.Value, input.Day!.Value);
+                return true;
+            case PartialDatePrecision.None:
+                error = "At least the year is required.";
+                return false;
+            default:
+                error = "Invalid date input.";
+                return false;
+        }
+    }
+
+    // SECTION: Completion date conversion
+    public static bool TryToCompletionDate(PartialDateInput input, out DateOnly value, out string? error)
+    {
+        error = null;
+        value = default;
+
+        if (input.Year.HasValue && (input.Year < 1900 || input.Year > 2100))
+        {
+            error = "Enter a year between 1900 and 2100.";
+            return false;
+        }
+
+        if (input.Month.HasValue && (input.Month < 1 || input.Month > 12))
+        {
+            error = "Enter a month between 1 and 12.";
+            return false;
+        }
+
+        if (input.Day.HasValue && (input.Day < 1 || input.Day > 31))
+        {
+            error = "Enter a day between 1 and 31.";
+            return false;
+        }
+
+        if (input.Month.HasValue && !input.Year.HasValue)
+        {
+            error = "Year is required when specifying a month.";
+            return false;
+        }
+
+        if (input.Day.HasValue && (!input.Year.HasValue || !input.Month.HasValue))
+        {
+            error = "Provide year and month when specifying a day.";
+            return false;
+        }
+
+        switch (input.GetPrecision())
+        {
+            case PartialDatePrecision.Year:
+            {
+                var year = input.Year!.Value;
+                value = new DateOnly(year, 12, 31);
+                return true;
+            }
+            case PartialDatePrecision.Month:
+            {
+                var year = input.Year!.Value;
+                var month = input.Month!.Value;
+                var lastDay = DateTime.DaysInMonth(year, month);
+                value = new DateOnly(year, month, lastDay);
+                return true;
+            }
+            case PartialDatePrecision.Day:
+                var lastDayOfMonth = DateTime.DaysInMonth(input.Year!.Value, input.Month!.Value);
+                if (input.Day > lastDayOfMonth)
+                {
+                    error = $"Day must be between 1 and {lastDayOfMonth} for the selected month.";
+                    return false;
+                }
+
+                value = new DateOnly(input.Year!.Value, input.Month!.Value, input.Day!.Value);
+                return true;
+            case PartialDatePrecision.None:
+                error = "Completion year is required when ToT is completed.";
+                return false;
+            default:
+                error = "Invalid date input.";
+                return false;
+        }
+    }
+}

--- a/ViewModels/ITotStatusMilestoneFields.cs
+++ b/ViewModels/ITotStatusMilestoneFields.cs
@@ -5,12 +5,27 @@ namespace ProjectManagement.ViewModels;
 
 public interface ITotStatusMilestoneFields
 {
+    // SECTION: Status and derived date values
     ProjectTotStatus Status { get; set; }
 
     DateOnly? StartedOn { get; set; }
 
     DateOnly? CompletedOn { get; set; }
 
+    // SECTION: Partial date entry fields
+    int? StartYear { get; set; }
+
+    int? StartMonth { get; set; }
+
+    int? StartDay { get; set; }
+
+    int? CompletionYear { get; set; }
+
+    int? CompletionMonth { get; set; }
+
+    int? CompletionDay { get; set; }
+
+    // SECTION: Milestone fields
     string? MetDetails { get; set; }
 
     DateOnly? MetCompletedOn { get; set; }


### PR DESCRIPTION
## Summary
- add reusable partial date helper to translate year/month/day inputs into start or completion dates
- update ToT edit and tracker forms to capture partial dates and refreshed guidance text
- relax completed status validation and expand service tests for the new rules

## Testing
- not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e97e719a4832997cf9416e73179ea)