### PR TITLE
Fix start date validation variable shadowing

### DIFF
--- a/Pages/Projects/Tot/Edit.cshtml.cs
+++ b/Pages/Projects/Tot/Edit.cshtml.cs
@@ -411,9 +411,9 @@ public class EditModel : PageModel
 
                 if (startPartial.GetPrecision() != PartialDatePrecision.None)
                 {
-                    if (!PartialDateHelper.TryToStartDate(startPartial, out var completedStart, out var startError))
+                    if (!PartialDateHelper.TryToStartDate(startPartial, out var completedStart, out var completedStartError))
                     {
-                        ModelState.AddModelError(nameof(input.StartYear), startError ?? "Invalid start date.");
+                        ModelState.AddModelError(nameof(input.StartYear), completedStartError ?? "Invalid start date.");
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- rename the duplicate start date error variable in ToT edit validation to avoid shadowing
- ensure start date validation compiles when completion status is handled

## Testing
- dotnet build -v minimal *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e9cd1f54c83298fad14167ba30884)