### PR TITLE
Switch inline file access to query mode parameter

### DIFF
--- a/ProjectManagement.Tests/Activities/ActivityAttachmentManagerTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityAttachmentManagerTests.cs
@@ -183,7 +183,7 @@ public class ActivityAttachmentManagerTests : IDisposable
 
         public string CreateInlineUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
         {
-            return string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/inline/{storageKey}";
+            return string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/signed/{storageKey}?mode=inline";
         }
     }
 

--- a/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
@@ -569,7 +569,7 @@ internal sealed class FakeFileUrlBuilder : IProtectedFileUrlBuilder
         => string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/{storageKey}";
 
     public string CreateInlineUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
-        => string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/inline/{storageKey}";
+        => string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/{storageKey}?mode=inline";
 }
 
 internal sealed class TestUploadRootProvider : IUploadRootProvider, IDisposable

--- a/ProjectManagement.Tests/ProtectedFileUrlBuilderTests.cs
+++ b/ProjectManagement.Tests/ProtectedFileUrlBuilderTests.cs
@@ -25,7 +25,7 @@ public sealed class ProtectedFileUrlBuilderTests
         var inlineUrl = builder.CreateInlineUrl("activities/1/example.pdf", "example.pdf", "application/pdf");
 
         // SECTION: Assert
-        Assert.Equal("/pm/files/inline/token-123", inlineUrl);
+        Assert.Equal("/pm/files/token-123?mode=inline", inlineUrl);
     }
 
     [Fact]

--- a/Services/Storage/IProtectedFileUrlBuilder.cs
+++ b/Services/Storage/IProtectedFileUrlBuilder.cs
@@ -35,16 +35,16 @@ public sealed class ProtectedFileUrlBuilder : IProtectedFileUrlBuilder
 
     public string CreateDownloadUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
     {
-        return CreateUrl("files", storageKey, fileName, contentType, lifetime);
+        return CreateUrl("files", storageKey, fileName, contentType, lifetime, inline: false);
     }
 
     public string CreateInlineUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
     {
-        return CreateUrl("files/inline", storageKey, fileName, contentType, lifetime);
+        return CreateUrl("files", storageKey, fileName, contentType, lifetime, inline: true);
     }
 
     // SECTION: URL creation helpers
-    private string CreateUrl(string basePath, string storageKey, string? fileName, string? contentType, TimeSpan? lifetime)
+    private string CreateUrl(string basePath, string storageKey, string? fileName, string? contentType, TimeSpan? lifetime, bool inline)
     {
         if (string.IsNullOrWhiteSpace(storageKey))
         {
@@ -69,6 +69,12 @@ public sealed class ProtectedFileUrlBuilder : IProtectedFileUrlBuilder
         var pathBase = _httpContextAccessor.HttpContext?.Request.PathBase ?? PathString.Empty;
         var normalizedBase = pathBase.HasValue ? pathBase.Value!.TrimEnd('/') : string.Empty;
 
-        return $"{normalizedBase}/{trimmedBasePath}/{encoded}";
+        var url = $"{normalizedBase}/{trimmedBasePath}/{encoded}";
+        if (inline)
+        {
+            url += "?mode=inline";
+        }
+
+        return url;
     }
 }


### PR DESCRIPTION
## Summary
- update protected file URL builder to generate inline links with a query parameter instead of a separate path
- consolidate file retrieval into a single FilesController action that respects the inline mode flag
- adjust activity stubs and unit tests to align with the new inline URL pattern

## Testing
- `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f20aafdb083299726537abc114ca7)