### PR TITLE
Allow plan approval when backfill pending

### DIFF
--- a/Pages/Projects/Timeline/Review.cshtml.cs
+++ b/Pages/Projects/Timeline/Review.cshtml.cs
@@ -88,15 +88,6 @@ public class ReviewModel : PageModel
 
             if (string.Equals(Input.Decision, "Approve", StringComparison.OrdinalIgnoreCase))
             {
-                var hasBackfill = await _timeline.HasBackfillAsync(id, ct);
-                if (hasBackfill)
-                {
-                    TempData["Error"] = "Resolve required procurement backfill before approval.";
-                    TempData["OpenOffcanvas"] = "plan-review";
-                    _logger.LogInformation("Plan approval blocked for project {ProjectId} due to pending backfill.", id);
-                    return RedirectToPage("/Projects/Overview", new { id });
-                }
-
                 var approved = await _approval.ApproveLatestDraftAsync(id, userId, ct);
                 if (approved)
                 {

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -49,9 +49,9 @@ else
     {
         <div class="alert alert-info">No draft has been submitted for approval.</div>
     }
-    else if (requiresBackfill)
+    if (requiresBackfill)
     {
-        <div class="alert alert-warning">Resolve required procurement backfill before approval.</div>
+        <div class="alert alert-warning">Some earlier stages were auto-completed and still need dates or costs (procurement backfill pending). This does not block approval of the timeline, but should be addressed separately in the procurement details.</div>
     }
 
     var hasChanges = Model.Any(row => row.NewStart != row.OldStart || row.NewDue != row.OldDue);
@@ -124,7 +124,7 @@ else
         <input type="hidden" name="Input.ProjectId" value="@ViewBag.ProjectId" />
         <div class="d-flex gap-2 justify-content-end">
             <button name="Input.Decision" value="Reject" class="btn btn-outline-secondary" @(isPending ? null : "disabled") data-plan-review-reject="true">Reject</button>
-            <button name="Input.Decision" value="Approve" class="btn btn-primary" @((!isPending || requiresBackfill) ? "disabled" : null)>Approve plan</button>
+            <button name="Input.Decision" value="Approve" class="btn btn-primary" @(!isPending ? "disabled" : null)>Approve plan</button>
         </div>
         <div class="mt-1" data-plan-review-note hidden>
             <label class="form-label" for="plan-review-reject-note">Reason (optional)</label>


### PR DESCRIPTION
## Summary
- update plan review UI warning to inform about procurement backfill without blocking approval
- remove backfill gate from plan approval handler so pending plans can be approved regardless of backfill status

## Testing
- `dotnet test` *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693049a3d0f88329ade6cb0f84298ff8)