### PR TITLE
Add Project model import to skipped stage tests

### DIFF
--- a/ProjectManagement.Tests/PlanApprovalValidationSkippedStagesTests.cs
+++ b/ProjectManagement.Tests/PlanApprovalValidationSkippedStagesTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using ProjectManagement.Data;
+using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Stages;


### PR DESCRIPTION
## Summary
- add missing Project model namespace to skipped stage validation tests so Project type resolves during compilation

## Testing
- Not run (dotnet CLI not available in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693058da2cd48329af8e750a7bff9d15)