### PR TITLE
Fix skipped and blocked stage labels on timeline

### DIFF
--- a/Pages/Shared/_ProjectTimeline.cshtml
+++ b/Pages/Shared/_ProjectTimeline.cshtml
@@ -10,10 +10,13 @@
 @functions {
     string D(DateOnly? d) => d.HasValue ? d.Value.ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
 
+    // SECTION: Stage pill rendering helpers
     string StatusPillClass(StageStatus s) => s switch
     {
         StageStatus.Completed  => "pm-pill pm-pill-success",
         StageStatus.InProgress => "pm-pill pm-pill-primary",
+        StageStatus.Blocked    => "pm-pill pm-pill-warning",
+        StageStatus.Skipped    => "pm-pill pm-pill-muted",
         _                      => "pm-pill pm-pill-muted"
     };
 
@@ -21,7 +24,10 @@
     {
         StageStatus.Completed  => "Completed",
         StageStatus.InProgress => "In progress",
-        _                      => "Not started"
+        StageStatus.Blocked    => "Blocked",
+        StageStatus.Skipped    => "Skipped",
+        StageStatus.NotStarted => "Not started",
+        _                      => "Unknown"
     };
 
     (string text, string description, string cssClass) VarianceToken(string name, int value)

--- a/wwwroot/js/projects/stages.js
+++ b/wwwroot/js/projects/stages.js
@@ -104,6 +104,10 @@
         return 'pm-pill pm-pill-success';
       case 'inprogress':
         return 'pm-pill pm-pill-primary';
+      case 'blocked':
+        return 'pm-pill pm-pill-warning';
+      case 'skipped':
+        return 'pm-pill pm-pill-muted';
       default:
         return 'pm-pill pm-pill-muted';
     }


### PR DESCRIPTION
## Summary
- add explicit labels for skipped and blocked stages in the project timeline view
- align client-side badge styling with the new stage statuses to avoid misleading "Not started" pills

## Testing
- dotnet test (fails: dotnet not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693069893fd483298dee42b2f2b08d8b)