### PR TITLE
Fix optional stage filtering for workflow version

### DIFF
--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -373,7 +373,7 @@ public class EditPlanModel : PageModel
         var optionalStageCodes = await _db.StageTemplates
             .AsNoTracking()
             .Where(template => template.Optional &&
-                               (workflowVersion is null || template.Version == workflowVersion))
+                               (workflowVersion == null || template.Version == workflowVersion))
             .Select(template => template.Code)
             .ToListAsync(ct);
 


### PR DESCRIPTION
## Summary
- replace the pattern matching workflow version check with a null comparison compatible with EF expression trees

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693076df68d0832998cd7de3630a63b6)