### PR TITLE
Add supplier name to supply order facts and harden tests

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1659,6 +1659,7 @@ namespace ProjectManagement.Data
                 ConfigureRowVersion(e);
                 e.Property(x => x.ProjectId).IsRequired();
                 e.Property(x => x.CreatedByUserId).HasMaxLength(64).IsRequired();
+                e.Property(x => x.SupplierName).HasMaxLength(200).IsRequired();
                 e.HasIndex(x => x.ProjectId);
                 e.Property(x => x.SupplyOrderDate).HasColumnType("date");
                 e.HasOne<Project>()

--- a/Models/ProjectFacts.cs
+++ b/Models/ProjectFacts.cs
@@ -58,6 +58,11 @@ namespace ProjectManagement.Models
 
     public class ProjectSupplyOrderFact : ProjectFactBase
     {
+        // SECTION: Supply order details
+        [Required]
+        [MaxLength(200)]
+        public string SupplierName { get; set; } = string.Empty;
+
         public DateOnly SupplyOrderDate { get; set; }
     }
 }

--- a/ProjectManagement.Tests/EditPlanPncOptionalityTests.cs
+++ b/ProjectManagement.Tests/EditPlanPncOptionalityTests.cs
@@ -248,7 +248,10 @@ public class EditPlanPncOptionalityTests
 
         Assert.False(page.ModelState.IsValid);
         Assert.IsType<RedirectToPageResult>(result);
-        Assert.Contains(page.ModelState[string.Empty].Errors, error => error.ErrorMessage.Contains("PNC", StringComparison.OrdinalIgnoreCase));
+        var hasPncValidationError = page.ModelState.TryGetValue(string.Empty, out var modelStateEntry)
+            && modelStateEntry.Errors.Any(error => error.ErrorMessage.Contains("PNC", StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(hasPncValidationError);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add supplier name to supply order facts model and configuration
- adjust supply order fact EF configuration to enforce supplier metadata
- harden plan edit duration validation test to avoid null dereference warnings

## Testing
- dotnet test (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933eb9395ec83298d68fb8f7b1b58bf)