### PR TITLE
Use workflow metadata for stage display names

### DIFF
--- a/Models/Stages/ProcurementWorkflow.cs
+++ b/Models/Stages/ProcurementWorkflow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ProjectManagement.Models.Plans;
 
 namespace ProjectManagement.Models.Stages;
@@ -11,49 +12,52 @@ public static class ProcurementWorkflow
     public const string VersionV2 = PlanConstants.StageTemplateVersionV2;
 
     // SECTION: Stage Sequences
-    public static readonly string[] V1Stages =
+    public static readonly WorkflowStageDefinition[] V1Stages =
     {
-        StageCodes.FS,
-        StageCodes.IPA,
-        StageCodes.SOW,
-        StageCodes.AON,
-        StageCodes.BID,
-        StageCodes.TEC,
-        StageCodes.BM,
-        StageCodes.COB,
-        StageCodes.PNC,
-        StageCodes.EAS,
-        StageCodes.SO,
-        StageCodes.DEVP,
-        StageCodes.ATP,
-        StageCodes.PAYMENT,
-        StageCodes.TOT
+        new(StageCodes.FS, "Feasibility Study"),
+        new(StageCodes.IPA, "In-Principle Approval"),
+        new(StageCodes.SOW, "SOW Vetting"),
+        new(StageCodes.AON, "Acceptance of Necessity"),
+        new(StageCodes.BID, "Bidding/ Tendering"),
+        new(StageCodes.TEC, "Technical Evaluation"),
+        new(StageCodes.BM, "Benchmarking"),
+        new(StageCodes.COB, "Commercial Bid Opening"),
+        new(StageCodes.PNC, "PNC"),
+        new(StageCodes.EAS, "EAS Approval"),
+        new(StageCodes.SO, "Supply Order"),
+        new(StageCodes.DEVP, "Development"),
+        new(StageCodes.ATP, "Acceptance Testing/ Trials"),
+        new(StageCodes.PAYMENT, "Payment"),
+        new(StageCodes.TOT, "Transfer of Technology")
     };
 
-    public static readonly string[] V2Stages =
+    public static readonly WorkflowStageDefinition[] V2Stages =
     {
-        StageCodes.FS,
-        StageCodes.SOW,
-        StageCodes.IPA,
-        StageCodes.AON,
-        StageCodes.BID,
-        StageCodes.TEC,
-        StageCodes.BM,
-        StageCodes.COB,
-        StageCodes.PNC,
-        StageCodes.EAS,
-        StageCodes.SO,
-        StageCodes.DEVP,
-        StageCodes.ATP,
-        StageCodes.PAYMENT,
-        StageCodes.TOT
+        new(StageCodes.FS, "Feasibility Study"),
+        new(StageCodes.SOW, "SOW Vetting"),
+        new(StageCodes.IPA, "In-Principle Approval"),
+        new(StageCodes.AON, "Acceptance of Necessity"),
+        new(StageCodes.BID, "Bidding/ Tendering"),
+        new(StageCodes.TEC, "Technical Evaluation"),
+        new(StageCodes.BM, "Benchmarking"),
+        new(StageCodes.COB, "Commercial Bid Opening"),
+        new(StageCodes.PNC, "PNC"),
+        new(StageCodes.EAS, "EAS Approval"),
+        new(StageCodes.SO, "Supply Order"),
+        new(StageCodes.DEVP, "Development"),
+        new(StageCodes.ATP, "Acceptance Testing/ Trials"),
+        new(StageCodes.PAYMENT, "Payment"),
+        new(StageCodes.TOT, "Transfer of Technology")
     };
 
     // SECTION: Helpers
-    public static string[] StageCodesFor(string? workflowVersion) =>
+    public static WorkflowStageDefinition[] StageDefinitionsFor(string? workflowVersion) =>
         string.Equals(workflowVersion, VersionV1, StringComparison.OrdinalIgnoreCase)
             ? V1Stages
             : V2Stages;
+
+    public static string[] StageCodesFor(string? workflowVersion)
+        => StageDefinitionsFor(workflowVersion).Select(stage => stage.Code).ToArray();
 
     public static int OrderOf(string? workflowVersion, string? stageCode)
     {
@@ -69,12 +73,12 @@ public static class ProcurementWorkflow
 
     public static Dictionary<string, int> BuildOrderLookup(string? workflowVersion)
     {
-        var codes = StageCodesFor(workflowVersion);
+        var definitions = StageDefinitionsFor(workflowVersion);
         var lookup = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-        for (var i = 0; i < codes.Length; i++)
+        for (var i = 0; i < definitions.Length; i++)
         {
-            lookup[codes[i]] = i;
+            lookup[definitions[i].Code] = i;
         }
 
         return lookup;

--- a/Models/Stages/StageCodes.cs
+++ b/Models/Stages/StageCodes.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace ProjectManagement.Models.Stages;
 
@@ -22,7 +21,7 @@ public static class StageCodes
     public const string TOT = "TOT";
 
     public static readonly string[] All =
-    {
+    {    
         FS,
         IPA,
         SOW,
@@ -39,27 +38,12 @@ public static class StageCodes
         PAYMENT,
         TOT
     };
-    private static readonly Dictionary<string, string> DisplayNames = new(StringComparer.OrdinalIgnoreCase)
-    {
-        [FS] = "Feasibility Study",
-        [IPA] = "In-Principle Approval",
-        [SOW] = "SOW Vetting",
-        [AON] = "Acceptance of Necessity",
-        [BID] = "Bidding/ Tendering",
-        [TEC] = "Technical Evaluation",
-        [BM] = "Benchmarking",
-        [COB] = "Commercial Bid Opening",
-        [PNC] = "PNC",
-        [EAS] = "EAS Approval",
-        [SO] = "Supply Order",
-        [DEVP] = "Development",
-        [ATP] = "Acceptance Testing/ Trials",
-        [PAYMENT] = "Payment",
-        [TOT] = "Transfer of Technology"
-    };
+    private static readonly IWorkflowStageMetadataProvider WorkflowStageMetadataProvider = new WorkflowStageMetadataProvider();
 
-    public static string DisplayNameOf(string code) =>
-        code is null ? "—" : (DisplayNames.TryGetValue(code, out var name) ? name : code);
+    public static string DisplayNameOf(string code) => DisplayNameOf(null, code);
+
+    public static string DisplayNameOf(string? workflowVersion, string code) =>
+        WorkflowStageMetadataProvider.GetDisplayName(workflowVersion, code);
 
     public static bool IsTot(string? code) => string.Equals(code, TOT, StringComparison.OrdinalIgnoreCase);
 

--- a/Models/Stages/WorkflowStageDefinition.cs
+++ b/Models/Stages/WorkflowStageDefinition.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace ProjectManagement.Models.Stages;
+
+/// <summary>
+/// Captures workflow-specific metadata for a stage.
+/// </summary>
+public sealed class WorkflowStageDefinition
+{
+    // SECTION: Constructor
+    public WorkflowStageDefinition(string code, string name)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new ArgumentException("Stage code cannot be empty.", nameof(code));
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Stage name cannot be empty.", nameof(name));
+        }
+
+        Code = code;
+        Name = name;
+    }
+
+    // SECTION: Properties
+    public string Code { get; }
+
+    public string Name { get; }
+}

--- a/Models/Stages/WorkflowStageMetadataProvider.cs
+++ b/Models/Stages/WorkflowStageMetadataProvider.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models.Plans;
+
+namespace ProjectManagement.Models.Stages;
+
+public interface IWorkflowStageMetadataProvider
+{
+    IReadOnlyList<WorkflowStageDefinition> GetStages(string? workflowVersion);
+
+    IReadOnlyDictionary<string, string> GetDisplayNameLookup(string? workflowVersion);
+
+    string GetDisplayName(string? workflowVersion, string? stageCode);
+}
+
+/// <summary>
+/// Provides workflow-specific stage metadata for display and lookup.
+/// </summary>
+public sealed class WorkflowStageMetadataProvider : IWorkflowStageMetadataProvider
+{
+    // SECTION: Backing stores
+    private readonly Dictionary<string, WorkflowStageDefinition[]> _definitions;
+    private readonly WorkflowStageDefinition[] _defaultDefinitions;
+
+    // SECTION: Constructor
+    public WorkflowStageMetadataProvider()
+    {
+        _definitions = new Dictionary<string, WorkflowStageDefinition[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ProcurementWorkflow.VersionV1] = ProcurementWorkflow.StageDefinitionsFor(ProcurementWorkflow.VersionV1),
+            [ProcurementWorkflow.VersionV2] = ProcurementWorkflow.StageDefinitionsFor(ProcurementWorkflow.VersionV2)
+        };
+
+        _defaultDefinitions = ProcurementWorkflow.StageDefinitionsFor(PlanConstants.DefaultStageTemplateVersion);
+    }
+
+    // SECTION: API
+    public IReadOnlyList<WorkflowStageDefinition> GetStages(string? workflowVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(workflowVersion)
+            && _definitions.TryGetValue(workflowVersion, out var definitions))
+        {
+            return definitions;
+        }
+
+        return _defaultDefinitions;
+    }
+
+    public IReadOnlyDictionary<string, string> GetDisplayNameLookup(string? workflowVersion)
+    {
+        return GetStages(workflowVersion)
+            .ToDictionary(stage => stage.Code, stage => stage.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public string GetDisplayName(string? workflowVersion, string? stageCode)
+    {
+        if (string.IsNullOrWhiteSpace(stageCode))
+        {
+            return "—";
+        }
+
+        var lookup = GetDisplayNameLookup(workflowVersion);
+        return lookup.TryGetValue(stageCode, out var name) ? name : stageCode;
+    }
+}

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -903,10 +903,11 @@
             <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body">
-            @{
+            @{ 
                 ViewBag.ProjectId = Model.Project!.Id;
                 ViewBag.HasBackfill = Model.HasBackfill;
                 ViewBag.PlanState = planState;
+                ViewBag.WorkflowVersion = Model.Project!.WorkflowVersion;
                 var diffs = await Model.PlanCompare.GetDraftVsCurrentAsync(Model.Project!.Id);
                 await Html.RenderPartialAsync("~/Pages/Projects/Timeline/_ReviewPlan.cshtml", diffs ?? Array.Empty<ProjectManagement.Services.Stages.PlanDiffRow>());
             }

--- a/Pages/Projects/Timeline/_ReviewPlan.cshtml
+++ b/Pages/Projects/Timeline/_ReviewPlan.cshtml
@@ -1,4 +1,9 @@
 @model IReadOnlyList<ProjectManagement.Services.Stages.PlanDiffRow>
+@inject ProjectManagement.Models.Stages.IWorkflowStageMetadataProvider WorkflowStageMetadataProvider
+
+@{
+    var workflowVersion = ViewBag.WorkflowVersion as string;
+}
 @using System.Linq
 @using ProjectManagement.Models.Plans
 @using ProjectManagement.Models.Stages
@@ -76,7 +81,7 @@ else
                     var changed = row.OldStart != row.NewStart || row.OldDue != row.NewDue;
                     <tr class="@(changed ? "table-warning" : "table-secondary")">
                         <td>
-                            <span class="fw-semibold">@StageCodes.DisplayNameOf(row.StageCode)</span>
+                            <span class="fw-semibold">@WorkflowStageMetadataProvider.GetDisplayName(workflowVersion, row.StageCode)</span>
                             <div class="text-muted small">@row.StageCode</div>
                         </td>
                         <td class="text-center">

--- a/Program.cs
+++ b/Program.cs
@@ -362,6 +362,7 @@ builder.Services.AddScoped<ProliferationOverviewService>();
 builder.Services.AddScoped<IProliferationSummaryReadService, ProliferationSummaryReadService>();
 builder.Services.AddScoped<ProliferationSubmissionService>();
 builder.Services.AddScoped<ProliferationManageService>();
+builder.Services.AddSingleton<IWorkflowStageMetadataProvider, WorkflowStageMetadataProvider>();
 builder.Services.AddScoped<StageRulesService>();
 builder.Services.AddScoped<StageProgressService>();
 builder.Services.AddScoped<IStageValidationService, StageValidationService>();

--- a/ProjectManagement.Tests/ProjectAnalyticsServiceStageTimeTests.cs
+++ b/ProjectManagement.Tests/ProjectAnalyticsServiceStageTimeTests.cs
@@ -83,7 +83,7 @@ public class ProjectAnalyticsServiceStageTimeTests
         await db.SaveChangesAsync();
 
         var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
-        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db));
+        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db), new WorkflowStageMetadataProvider());
 
         var result = await service.GetStageTimeInsightsAsync();
 
@@ -177,7 +177,7 @@ public class ProjectAnalyticsServiceStageTimeTests
         await db.SaveChangesAsync();
 
         var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
-        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db));
+        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db), new WorkflowStageMetadataProvider());
 
         var result = await service.GetStageTimeInsightsAsync(designCategoryId);
 
@@ -250,7 +250,7 @@ public class ProjectAnalyticsServiceStageTimeTests
         await db.SaveChangesAsync();
 
         var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
-        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db));
+        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db), new WorkflowStageMetadataProvider());
 
         var result = await service.GetStageTimeInsightsAsync();
 
@@ -300,7 +300,7 @@ public class ProjectAnalyticsServiceStageTimeTests
         await db.SaveChangesAsync();
 
         var clock = FakeClock.AtUtc(DateTimeOffset.UtcNow);
-        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db));
+        var service = new ProjectAnalyticsService(db, clock, new ProjectCategoryHierarchyService(db), new WorkflowStageMetadataProvider());
 
         var result = await service.GetStageTimeInsightsAsync();
 

--- a/ProjectManagement.Tests/ProjectAnalyticsServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectAnalyticsServiceTests.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Analytics;
 using ProjectManagement.Services.Projects;
@@ -36,7 +37,7 @@ public class ProjectAnalyticsServiceTests : IDisposable
 
         _clock = new TestClock(new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero));
         _categories = new ProjectCategoryHierarchyService(_db);
-        _service = new ProjectAnalyticsService(_db, _clock, _categories);
+        _service = new ProjectAnalyticsService(_db, _clock, _categories, new WorkflowStageMetadataProvider());
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ProjectIndexPageTests.cs
+++ b/ProjectManagement.Tests/ProjectIndexPageTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Pages.Projects;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Analytics;
@@ -362,7 +363,7 @@ namespace ProjectManagement.Tests
         private static IndexModel CreateModel(ApplicationDbContext context)
         {
             var categories = new ProjectCategoryHierarchyService(context);
-            var analytics = new ProjectAnalyticsService(context, new TestClock(), categories);
+            var analytics = new ProjectAnalyticsService(context, new TestClock(), categories, new WorkflowStageMetadataProvider());
             return new IndexModel(context, analytics, categories);
         }
 

--- a/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
+++ b/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Options;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Remarks;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Projects;
 using ProjectManagement.Services.Stages;
@@ -348,11 +349,12 @@ public sealed class ProjectOverviewLifecycleTests
     private static ProjectsOverviewModel CreateOverviewPage(ApplicationDbContext db, IClock clock)
     {
         var procure = new ProjectProcurementReadService(db);
-        var timeline = new ProjectTimelineReadService(db, clock);
+        var workflowMetadata = new WorkflowStageMetadataProvider();
+        var timeline = new ProjectTimelineReadService(db, clock, workflowMetadata);
         var planRead = new PlanReadService(db);
         var planCompare = new PlanCompareService(db);
         var userManager = CreateUserManager(db);
-        var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
+        var remarksPanel = new ProjectRemarksPanelService(userManager, clock, workflowMetadata);
         var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
         var mediaAggregator = new ProjectMediaAggregator();
         return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator);

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -25,6 +25,7 @@ using ProjectManagement.Configuration;
 using Microsoft.Net.Http.Headers;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
 using PhotosIndexModel = ProjectManagement.Pages.Projects.Photos.IndexModel;
 using PhotoViewModel = ProjectManagement.Pages.Projects.Photos.ViewModel;
 using ProjectsOverviewModel = ProjectManagement.Pages.Projects.OverviewModel;
@@ -405,11 +406,12 @@ public sealed class ProjectPhotoPageTests
     private static ProjectsOverviewModel CreateOverviewPage(ApplicationDbContext db, IClock clock)
     {
         var procure = new ProjectProcurementReadService(db);
-        var timeline = new ProjectTimelineReadService(db, clock);
+        var workflowMetadata = new WorkflowStageMetadataProvider();
+        var timeline = new ProjectTimelineReadService(db, clock, workflowMetadata);
         var planRead = new PlanReadService(db);
         var planCompare = new PlanCompareService(db);
         var userManager = CreateUserManager(db);
-        var remarksPanel = new ProjectRemarksPanelService(userManager, clock);
+        var remarksPanel = new ProjectRemarksPanelService(userManager, clock, workflowMetadata);
         var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
         var mediaAggregator = new ProjectMediaAggregator();
         return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator);

--- a/ProjectManagement.Tests/ProjectRemarksPanelServiceTests.cs
+++ b/ProjectManagement.Tests/ProjectRemarksPanelServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class ProjectRemarksPanelServiceTests
         await using var db = CreateContext();
         using var userManager = CreateUserManager(db);
         var clock = new FixedClock(DateTimeOffset.UtcNow);
-        var service = new ProjectRemarksPanelService(userManager, clock);
+        var service = new ProjectRemarksPanelService(userManager, clock, new WorkflowStageMetadataProvider());
 
         var user = new ApplicationUser { Id = "user-1", UserName = "user@example.com" };
         await userManager.CreateAsync(user);
@@ -57,7 +57,7 @@ public sealed class ProjectRemarksPanelServiceTests
         await using var db = CreateContext();
         using var userManager = CreateUserManager(db);
         var clock = new FixedClock(DateTimeOffset.UtcNow);
-        var service = new ProjectRemarksPanelService(userManager, clock);
+        var service = new ProjectRemarksPanelService(userManager, clock, new WorkflowStageMetadataProvider());
 
         var user = new ApplicationUser { Id = "user-2", UserName = "user2@example.com" };
         await userManager.CreateAsync(user);
@@ -86,7 +86,7 @@ public sealed class ProjectRemarksPanelServiceTests
         await using var db = CreateContext();
         using var userManager = CreateUserManager(db);
         var clock = new FixedClock(DateTimeOffset.UtcNow);
-        var service = new ProjectRemarksPanelService(userManager, clock);
+        var service = new ProjectRemarksPanelService(userManager, clock, new WorkflowStageMetadataProvider());
 
         var user = new ApplicationUser { Id = "user-3", UserName = "user3@example.com" };
         await userManager.CreateAsync(user);

--- a/ProjectManagement.Tests/RemarkServiceTests.cs
+++ b/ProjectManagement.Tests/RemarkServiceTests.cs
@@ -533,7 +533,7 @@ public sealed class RemarkServiceTests
         notifier = new TestRemarkNotificationService();
         metrics = new TestRemarkMetrics();
         var userManager = CreateUserManager(db);
-        return new RemarkService(db, clock, NullLogger<RemarkService>.Instance, notifier, metrics, userManager);
+        return new RemarkService(db, clock, NullLogger<RemarkService>.Instance, notifier, metrics, new WorkflowStageMetadataProvider(), userManager);
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -22,11 +22,16 @@ public sealed class ProjectTimelineReadService
 
     private readonly ApplicationDbContext _db;
     private readonly IClock _clock;
+    private readonly IWorkflowStageMetadataProvider _workflowStageMetadataProvider;
 
-    public ProjectTimelineReadService(ApplicationDbContext db, IClock clock)
+    public ProjectTimelineReadService(
+        ApplicationDbContext db,
+        IClock clock,
+        IWorkflowStageMetadataProvider workflowStageMetadataProvider)
     {
         _db = db;
         _clock = clock;
+        _workflowStageMetadataProvider = workflowStageMetadataProvider;
     }
 
     public Task<bool> HasBackfillAsync(int projectId, CancellationToken ct = default)
@@ -96,7 +101,7 @@ public sealed class ProjectTimelineReadService
                 {
                     RequestId = r.Id,
                     StageCode = r.StageCode,
-                    StageName = StageCodes.DisplayNameOf(r.StageCode),
+                    StageName = _workflowStageMetadataProvider.GetDisplayName(workflowVersion, r.StageCode),
                     CurrentStatus = stageRow?.Status ?? StageStatus.NotStarted,
                     RequestedStatus = r.RequestedStatus,
                     RequestedDate = r.RequestedDate,
@@ -143,7 +148,7 @@ public sealed class ProjectTimelineReadService
             items.Add(new TimelineItemVm
             {
                 Code = code,
-                Name = StageCodes.DisplayNameOf(code),
+                Name = _workflowStageMetadataProvider.GetDisplayName(workflowVersion, code),
                 Status = r?.Status ?? StageStatus.NotStarted,
                 PlannedStart = plannedStart,
                 PlannedEnd = plannedEnd,


### PR DESCRIPTION
## Summary
- add a workflow stage metadata provider derived from procurement workflow definitions
- route stage display lookups in projects, analytics, and remarks through the metadata provider using workflow versions
- refresh dependent services, views, and tests to consume the injected provider and workflow-aware ordering

## Testing
- dotnet test *(fails: `dotnet` command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f1e5ddb08329bedbd5f0d314e98c)