### PR TITLE
Add workflow checklist provider and seed templates by version

### DIFF
--- a/Models/Stages/WorkflowChecklistConfiguration.cs
+++ b/Models/Stages/WorkflowChecklistConfiguration.cs
@@ -1,91 +1,97 @@
+using System;
 using System.Collections.Generic;
+using ProjectManagement.Models.Plans;
 
-namespace ProjectManagement.Features.Process;
+namespace ProjectManagement.Models.Stages;
 
-public static class StageChecklistCatalog
+/// <summary>
+/// Holds version-aware checklist definitions sourced from workflow configuration.
+/// </summary>
+public static class WorkflowChecklistConfiguration
 {
-    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> Checklists =
-        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+    // SECTION: Backing store
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> SharedChecklist
+        = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
         {
-            ["FS"] = new[]
+            [StageCodes.FS] = new[]
             {
                 "Confirm business need and scope with key stakeholders",
                 "Document available budgetary approvals and constraints",
                 "Compile feasibility report with risk and impact analysis"
             },
-            ["IPA"] = new[]
+            [StageCodes.IPA] = new[]
             {
                 "Prepare in-principle approval note with executive summary",
                 "Collect endorsements from finance, legal and technical teams",
                 "Upload supporting documents to the procurement workspace"
             },
-            ["SOW"] = new[]
+            [StageCodes.SOW] = new[]
             {
                 "Draft detailed statement of work with deliverables and timelines",
                 "Align scope with compliance, security and sustainability guidelines",
                 "Validate acceptance criteria with the requesting department"
             },
-            ["AON"] = new[]
+            [StageCodes.AON] = new[]
             {
                 "Create acceptance of necessity proposal for approval board",
                 "Attach comparative market study and cost justification",
                 "Capture board decisions and action items in the tracker"
             },
-            ["BID"] = new[]
+            [StageCodes.BID] = new[]
             {
                 "Publish tender package to approved vendor list",
                 "Schedule bidder conference and capture clarifications",
                 "Monitor bid submission status and acknowledge receipts"
             },
-            ["TEC"] = new[]
+            [StageCodes.TEC] = new[]
             {
                 "Constitute evaluation committee and assign reviewers",
                 "Distribute technical scorecards and evaluation criteria",
                 "Consolidate evaluation results and prepare recommendation"
             },
-            ["BM"] = new[]
+            [StageCodes.BM] = new[]
             {
                 "Identify benchmark sources relevant to the procurement category",
                 "Validate price points against historical procurement data",
                 "Summarise benchmarking insights for negotiation strategy"
             },
-            ["COB"] = new[]
+            [StageCodes.COB] = new[]
             {
                 "Schedule commercial opening with finance and legal observers",
                 "Verify bid security, compliance documents and pricing sheets",
                 "Document minutes and communicate outcomes to stakeholders"
             },
-            ["PNC"] = new[]
+            [StageCodes.PNC] = new[]
             {
                 "Form negotiation team and define negotiation objectives",
                 "Align negotiation levers with risk and value analysis",
                 "Record negotiation proceedings and final agreed terms"
             },
-            ["EAS"] = new[]
+            [StageCodes.EAS] = new[]
             {
                 "Prepare expenditure sanction dossier with financial impacts",
                 "Ensure approvals align with delegated financial authority matrix",
                 "Archive sanction documents for audit readiness"
             },
-            ["SO"] = new[]
+            [StageCodes.SO] = new[]
             {
                 "Draft supply order with clear deliverables and payment terms",
                 "Validate supplier master data and compliance requirements",
                 "Circulate signed order to vendor and internal teams"
             },
-            ["DEVP"] = new[]
+            [StageCodes.DEVP] = new[]
             {
                 "Confirm project kickoff readiness with vendor and stakeholders",
                 "Track development milestones against agreed plan",
                 "Raise and resolve issues through change control process"
             },
-            ["ATP"] = new[]
+            [StageCodes.ATP] = new[]
             {
                 "Define acceptance scenarios and test environment setup",
                 "Coordinate test execution with business and technical leads",
                 "Sign-off acceptance certificates and log residual observations"
             },
-            ["PAYMENT"] = new[]
+            [StageCodes.PAYMENT] = new[]
             {
                 "Receive vendor invoice and verify against contractual terms",
                 "Complete three-way match with order and delivery documents",
@@ -93,13 +99,44 @@ public static class StageChecklistCatalog
             }
         };
 
-    public static IReadOnlyList<string> GetChecklist(string stageCode)
-    {
-        if (Checklists.TryGetValue(stageCode, out var items))
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>> VersionedChecklists
+        = new Dictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>>(StringComparer.OrdinalIgnoreCase)
         {
-            return items;
+            [ProcurementWorkflow.VersionV1] = BuildVersionLookup(ProcurementWorkflow.VersionV1),
+            [ProcurementWorkflow.VersionV2] = BuildVersionLookup(ProcurementWorkflow.VersionV2)
+        };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> DefaultLookup
+        = BuildVersionLookup(PlanConstants.DefaultStageTemplateVersion);
+
+    // SECTION: API
+    public static IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>> All
+        => VersionedChecklists;
+
+    public static IReadOnlyDictionary<string, IReadOnlyList<string>> GetForVersion(string? workflowVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(workflowVersion)
+            && VersionedChecklists.TryGetValue(workflowVersion, out var lookup))
+        {
+            return lookup;
         }
 
-        return Array.Empty<string>();
+        return DefaultLookup;
+    }
+
+    // SECTION: Helpers
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> BuildVersionLookup(string workflowVersion)
+    {
+        var stageCodes = ProcurementWorkflow.StageCodesFor(workflowVersion);
+        var lookup = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var stageCode in stageCodes)
+        {
+            lookup[stageCode] = SharedChecklist.TryGetValue(stageCode, out var items)
+                ? items
+                : Array.Empty<string>();
+        }
+
+        return lookup;
     }
 }

--- a/Models/Stages/WorkflowChecklistProvider.cs
+++ b/Models/Stages/WorkflowChecklistProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models.Plans;
+
+namespace ProjectManagement.Models.Stages;
+
+public interface IWorkflowChecklistProvider
+{
+    IReadOnlyList<string> GetChecklist(string? workflowVersion, string? stageCode);
+}
+
+/// <summary>
+/// Supplies checklist entries based on workflow version configuration.
+/// </summary>
+public sealed class WorkflowChecklistProvider : IWorkflowChecklistProvider
+{
+    // SECTION: Backing store
+    private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<string>>> _versionedChecklists;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _defaultLookup;
+
+    // SECTION: Constructor
+    public WorkflowChecklistProvider()
+    {
+        _versionedChecklists = WorkflowChecklistConfiguration.All;
+        _defaultLookup = WorkflowChecklistConfiguration.GetForVersion(PlanConstants.DefaultStageTemplateVersion);
+    }
+
+    // SECTION: API
+    public IReadOnlyList<string> GetChecklist(string? workflowVersion, string? stageCode)
+    {
+        if (string.IsNullOrWhiteSpace(stageCode))
+        {
+            return Array.Empty<string>();
+        }
+
+        if (!string.IsNullOrWhiteSpace(workflowVersion)
+            && _versionedChecklists.TryGetValue(workflowVersion, out var lookup)
+            && lookup.TryGetValue(stageCode, out var items))
+        {
+            return items;
+        }
+
+        return _defaultLookup.TryGetValue(stageCode, out var fallbackItems)
+            ? fallbackItems
+            : Array.Empty<string>();
+    }
+}


### PR DESCRIPTION
## Summary
- add a workflow-aware checklist configuration/provider keyed by version and stage
- seed new checklist templates from the provider when first created via the checklist API
- replace the legacy StageChecklistCatalog with version-scoped lookups and register the provider in DI

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934047a25d08329b71d871075e62e14)