### PR TITLE
Fix build errors in services

### DIFF
--- a/Services/Analytics/ProjectAnalyticsService.cs
+++ b/Services/Analytics/ProjectAnalyticsService.cs
@@ -468,7 +468,7 @@ public sealed class ProjectAnalyticsService : IProjectAnalyticsService
         return points;
     }
 
-    private static List<StageTimeBucketRowVm> EnsureAllStageBuckets(List<StageTimeBucketRowVm> rows)
+    private List<StageTimeBucketRowVm> EnsureAllStageBuckets(List<StageTimeBucketRowVm> rows)
     {
         var comparer = StringComparer.OrdinalIgnoreCase;
 

--- a/Services/Remarks/RemarkService.cs
+++ b/Services/Remarks/RemarkService.cs
@@ -165,7 +165,14 @@ public sealed class RemarkService : IRemarkService
 
         if (!string.IsNullOrWhiteSpace(request.StageRef))
         {
-            var stageRef = NormalizeStageRef(request.StageRef);
+            var workflowVersion = await _db.Projects
+                .AsNoTracking()
+                .Where(project => project.Id == request.ProjectId)
+                .Select(project => project.WorkflowVersion)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var stageDefinitions = _workflowStageMetadataProvider.GetStages(workflowVersion);
+            var stageRef = NormalizeStageRef(request.StageRef, stageDefinitions);
             query = query.Where(r => r.StageRef == stageRef);
         }
 

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1079,15 +1079,20 @@ public sealed class ProgressReviewService : IProgressReviewService
             .GroupBy(stage => stage.ProjectId)
             .ToDictionary(
                 g => g.Key,
-                g => PresentStageHelper.ComputePresentStageAndAge(
-                    g.Select(stage => new ProjectStageStatusSnapshot(
-                        stage.StageCode,
-                        stage.Status,
-                        stage.SortOrder,
-                        stage.ActualStart,
-                        stage.CompletedOn)).ToList(),
-                    _workflowStageMetadataProvider,
-                    workflowVersions));
+                g =>
+                {
+                    workflowVersions.TryGetValue(g.Key, out var workflowVersion);
+
+                    return PresentStageHelper.ComputePresentStageAndAge(
+                        g.Select(stage => new ProjectStageStatusSnapshot(
+                            stage.StageCode,
+                            stage.Status,
+                            stage.SortOrder,
+                            stage.ActualStart,
+                            stage.CompletedOn)).ToList(),
+                        _workflowStageMetadataProvider,
+                        workflowVersion);
+                });
     }
 
     private async Task<IReadOnlyDictionary<int, string?>> BuildProjectCategoryLookupAsync(


### PR DESCRIPTION
## Summary
- validate stage references using workflow metadata before filtering remarks
- correct present stage computation to use per-project workflow version lookups
- make analytics stage bucket padding use the instance workflow metadata provider

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693407794d6c832983233932ef5de3a2)