### PR TITLE
Allow HoD to approve submitted plan

### DIFF
--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -114,12 +114,6 @@ public class PlanApprovalService
             return false;
         }
 
-        var submitterId = plan.OwnerUserId ?? plan.SubmittedByUserId;
-        if (!string.IsNullOrEmpty(submitterId) && string.Equals(submitterId, hodUserId, StringComparison.Ordinal))
-        {
-            throw new ForbiddenException("The submitter cannot approve their own plan.");
-        }
-
         var project = await _db.Projects
             .FirstOrDefaultAsync(p => p.Id == projectId, cancellationToken)
             ?? throw new InvalidOperationException("Project not found.");


### PR DESCRIPTION
## Summary
- remove restriction preventing submitters from approving their own plans when acting as HoD

## Testing
- dotnet test (fails: command not found)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934090f3f048329acaac95a2b538f3c)