### PR TITLE
Allow partial timelines during plan validation

### DIFF
--- a/Services/Plans/PlanApprovalService.cs
+++ b/Services/Plans/PlanApprovalService.cs
@@ -361,7 +361,8 @@ public class PlanApprovalService
 
             if (stage.PlannedStart is not DateOnly start || stage.PlannedDue is not DateOnly due)
             {
-                errors.Add($"Stage {template.Name} must have both a planned start and due date.");
+                // SECTION: Partial timeline support
+                // Allow submission even when planned dates are missing; validation only applies when both are provided.
                 continue;
             }
 
@@ -395,7 +396,6 @@ public class PlanApprovalService
 
                 if (!stagePlans.TryGetValue(dependencyCode, out var prerequisite) || prerequisite.PlannedDue is not DateOnly prerequisiteDue)
                 {
-                    errors.Add($"Stage {template.Name} requires {dependencyName} to have a planned due date before submission.");
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- allow timeline plans to be submitted even when some stages lack planned dates
- keep validation only when both start and due dates are present for a stage

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340b1e41808329bd33014b1e5727d4)