### PR TITLE
Add bulk actual dates editor to timeline actions

### DIFF
--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -741,6 +741,7 @@
 
                                         if (canReviewTimeline || canEditTimelinePlan)
                                         {
+                                            <!-- SECTION: Timeline actions menu -->
                                             <div class="pm-card-menu dropdown">
                                                 <button class="btn pm-card-menu-toggle"
                                                         type="button"
@@ -764,6 +765,15 @@
                                                     }
                                                     @if (canEditTimelinePlan)
                                                     {
+                                                        <li>
+                                                            <button class="dropdown-item"
+                                                                    type="button"
+                                                                    data-bs-toggle="offcanvas"
+                                                                    data-bs-target="#offcanvasActualDates"
+                                                                    aria-controls="offcanvasActualDates">
+                                                                Edit actual dates
+                                                            </button>
+                                                        </li>
                                                         <li>
                                                             <button class="dropdown-item"
                                                                     type="button"
@@ -894,6 +904,17 @@
         </div>
         <div class="offcanvas-body">
             <partial name="Projects/Procurement/_EditFormBody" model="Model.ProcurementEdit" />
+        </div>
+    </div>
+
+    <!-- SECTION: Actual dates bulk edit offcanvas -->
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasActualDates" aria-labelledby="offcanvasActualDatesLabel">
+        <div class="offcanvas-header">
+            <h5 id="offcanvasActualDatesLabel" class="mb-0">Edit actual dates</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <partial name="Projects/Timeline/_EditActualDates" model="Model.TimelineActuals" />
         </div>
     </div>
 

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -69,6 +69,7 @@ namespace ProjectManagement.Pages.Projects
         public ProcurementEditVm ProcurementEdit { get; private set; } = default!;
         public AssignRolesVm AssignRoles { get; private set; } = default!;
         public TimelineVm Timeline { get; private set; } = default!;
+        public TimelineActualsEditorVm TimelineActuals { get; private set; } = TimelineActualsEditorVm.Empty;
         public PlanEditorVm PlanEdit { get; private set; } = default!;
         public BackfillViewModel Backfill { get; private set; } = BackfillViewModel.Empty;
         public ProjectRemarksPanelViewModel RemarksPanel { get; private set; } = ProjectRemarksPanelViewModel.Empty;
@@ -334,6 +335,7 @@ namespace ProjectManagement.Pages.Projects
                 id,
                 connectionHash);
             Timeline = await _timelineRead.GetAsync(id, ct);
+            TimelineActuals = BuildTimelineActualsEditor(Timeline, todayLocalDate);
             PlanEdit = await _planRead.GetAsync(id, CurrentUserId, ct);
             HasBackfill = Timeline.HasBackfill;
             Backfill = BuildBackfillViewModel(id);
@@ -1964,6 +1966,35 @@ namespace ProjectManagement.Pages.Projects
                 ProjectId = projectId,
                 Today = today,
                 Stages = stages
+            };
+        }
+
+        private static TimelineActualsEditorVm BuildTimelineActualsEditor(TimelineVm timeline, DateOnly today)
+        {
+            if (timeline is null)
+            {
+                return TimelineActualsEditorVm.Empty;
+            }
+
+            var rows = timeline.Items
+                .OrderBy(item => item.SortOrder)
+                .Select(item => new TimelineActualsEditorRowVm
+                {
+                    StageCode = item.Code,
+                    StageName = item.Name,
+                    Status = item.Status,
+                    ActualStart = item.ActualStart,
+                    CompletedOn = item.CompletedOn,
+                    IsAutoCompleted = item.IsAutoCompleted,
+                    RequiresBackfill = item.RequiresBackfill
+                })
+                .ToArray();
+
+            return new TimelineActualsEditorVm
+            {
+                ProjectId = timeline.ProjectId,
+                Today = today,
+                Rows = rows
             };
         }
 

--- a/Pages/Projects/Timeline/_EditActualDates.cshtml
+++ b/Pages/Projects/Timeline/_EditActualDates.cshtml
@@ -1,0 +1,79 @@
+@model ProjectManagement.ViewModels.TimelineActualsEditorVm
+@using ProjectManagement.Models.Stages
+@using ProjectManagement.ViewModels
+@{
+    var rows = Model?.Rows ?? Array.Empty<TimelineActualsEditorRowVm>();
+    var todayIso = Model?.Today.ToString("yyyy-MM-dd") ?? string.Empty;
+}
+
+<!-- SECTION: Actual dates bulk editor -->
+<div class="d-flex flex-column h-100 gap-3" data-actuals-editor>
+    <p class="small text-muted mb-0">
+        Update actual start and completion dates for your stages. Use this view to keep the timeline in sync with on-the-ground progress.
+    </p>
+
+    <div class="flex-grow-1 overflow-auto">
+        <div class="row gy-3">
+            @for (var i = 0; i < rows.Count; i++)
+            {
+                var row = rows[i];
+                var startId = $"actual-start-{row.StageCode}";
+                var completedId = $"actual-completed-{row.StageCode}";
+                var startValue = row.ActualStart?.ToString("yyyy-MM-dd");
+                var completedValue = row.CompletedOn?.ToString("yyyy-MM-dd");
+                <section class="col-12 border rounded p-3" data-actuals-row data-stage-code="@row.StageCode">
+                    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
+                        <div class="d-flex flex-column">
+                            <div class="fw-semibold">@row.StageName</div>
+                            <div class="text-muted small">@row.StageCode</div>
+                        </div>
+                        <div class="d-flex flex-wrap gap-2">
+                            <span class="badge text-bg-secondary">@row.Status</span>
+                            @if (row.RequiresBackfill)
+                            {
+                                <span class="badge bg-warning-subtle text-warning border border-warning-subtle">Needs backfill</span>
+                            }
+                            @if (row.IsAutoCompleted)
+                            {
+                                <span class="badge bg-info-subtle text-info border border-info-subtle">Auto-completed</span>
+                            }
+                        </div>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label" for="@startId">Actual start date</label>
+                            <input type="date"
+                                   class="form-control"
+                                   id="@startId"
+                                   name="ActualRows[@i].ActualStart"
+                                   value="@startValue"
+                                   max="@todayIso"
+                                   aria-describedby="@startId-help" />
+                            <div class="form-text" id="@startId-help">Enter the date work started on this stage.</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="@completedId">Completed on</label>
+                            <input type="date"
+                                   class="form-control"
+                                   id="@completedId"
+                                   name="ActualRows[@i].CompletedOn"
+                                   value="@completedValue"
+                                   max="@todayIso"
+                                   aria-describedby="@completedId-help" />
+                            <div class="form-text" id="@completedId-help">Set the date the stage was completed.</div>
+                        </div>
+                    </div>
+
+                    <input type="hidden" name="ActualRows[@i].StageCode" value="@row.StageCode" />
+                    <input type="hidden" name="ActualRows[@i].StageName" value="@row.StageName" />
+                </section>
+            }
+        </div>
+    </div>
+
+    <div class="border-top pt-3 d-flex justify-content-end gap-2">
+        <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="offcanvas">Close</button>
+        <button class="btn btn-primary" type="button" data-actuals-save disabled>Save changes</button>
+    </div>
+</div>

--- a/ViewModels/TimelineActualsEditorVm.cs
+++ b/ViewModels/TimelineActualsEditorVm.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models.Stages;
+
+namespace ProjectManagement.ViewModels;
+
+public sealed class TimelineActualsEditorVm
+{
+    public static readonly TimelineActualsEditorVm Empty = new()
+    {
+        Rows = Array.Empty<TimelineActualsEditorRowVm>()
+    };
+
+    public int ProjectId { get; init; }
+
+    public DateOnly Today { get; init; }
+
+    public IReadOnlyList<TimelineActualsEditorRowVm> Rows { get; init; } = Array.Empty<TimelineActualsEditorRowVm>();
+}
+
+public sealed class TimelineActualsEditorRowVm
+{
+    public string StageCode { get; init; } = string.Empty;
+
+    public string StageName { get; init; } = string.Empty;
+
+    public StageStatus Status { get; init; } = StageStatus.NotStarted;
+
+    public DateOnly? ActualStart { get; init; }
+
+    public DateOnly? CompletedOn { get; init; }
+
+    public bool IsAutoCompleted { get; init; }
+
+    public bool RequiresBackfill { get; init; }
+}


### PR DESCRIPTION
## Summary
- add a timeline actions dropdown entry for opening an actual dates editor when editing is allowed
- introduce an offcanvas with a bulk actual dates form and supporting view model

## Testing
- dotnet build *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347201b8f48329a48a6fa654a4fbd5)