### PR TITLE
Fix actuals update compilation errors

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -335,7 +335,7 @@ namespace ProjectManagement.Pages.Projects
                 id,
                 connectionHash);
             Timeline = await _timelineRead.GetAsync(id, ct);
-            ActualsEditor = await _timelineRead.GetActualsEditorAsync(id, cancellationToken);
+            ActualsEditor = await _timelineRead.GetActualsEditorAsync(id, ct);
             PlanEdit = await _planRead.GetAsync(id, CurrentUserId, ct);
             HasBackfill = Timeline.HasBackfill;
             Backfill = BuildBackfillViewModel(id);

--- a/Pages/Projects/Timeline/EditActuals.cshtml.cs
+++ b/Pages/Projects/Timeline/EditActuals.cshtml.cs
@@ -49,7 +49,7 @@ public class EditActualsModel : PageModel
         }
 
         var userId = _userContext.UserId;
-        var userName = _userContext.UserName;
+        var userName = _userContext.User.Identity?.Name;
         var principal = _userContext.User;
 
         if (string.IsNullOrWhiteSpace(userId) || principal is null)

--- a/Services/Stages/StageActualsUpdateService.cs
+++ b/Services/Stages/StageActualsUpdateService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -173,10 +174,10 @@ public sealed class StageActualsUpdateService
             return StageActualsUpdateResult.NoChanges();
         }
 
-        var auditData = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        var auditData = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
-            ["ProjectId"] = input.ProjectId,
-            ["UpdatedCount"] = changes.Count
+            ["ProjectId"] = input.ProjectId.ToString(CultureInfo.InvariantCulture),
+            ["UpdatedCount"] = changes.Count.ToString(CultureInfo.InvariantCulture)
         };
 
         for (var i = 0; i < changes.Count; i++)
@@ -184,10 +185,10 @@ public sealed class StageActualsUpdateService
             var change = changes[i];
             var prefix = $"Stage[{i}]";
             auditData[$"{prefix}.Code"] = change.Stage.StageCode;
-            auditData[$"{prefix}.From.Start"] = change.Stage.ActualStart;
-            auditData[$"{prefix}.From.Completed"] = change.Stage.CompletedOn;
-            auditData[$"{prefix}.To.Start"] = change.NewStart;
-            auditData[$"{prefix}.To.Completed"] = change.NewCompleted;
+            auditData[$"{prefix}.From.Start"] = FormatDate(change.Stage.ActualStart);
+            auditData[$"{prefix}.From.Completed"] = FormatDate(change.Stage.CompletedOn);
+            auditData[$"{prefix}.To.Start"] = FormatDate(change.NewStart);
+            auditData[$"{prefix}.To.Completed"] = FormatDate(change.NewCompleted);
         }
 
         foreach (var change in changes)
@@ -244,6 +245,9 @@ public sealed record StageActualsUpdateResult(int UpdatedCount, IReadOnlyList<st
 }
 
 internal sealed record StageActualChange(ProjectStage Stage, DateOnly? NewStart, DateOnly? NewCompleted);
+
+// SECTION: Helpers
+internal static string? FormatDate(DateOnly? date) => date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
 public sealed class StageActualsValidationException : Exception
 {


### PR DESCRIPTION
## Summary
- replace incorrect cancellation token usage in project overview page
- log stage actual updates with string-based audit data formatting
- derive username from claims principal in actuals editor handler

## Testing
- dotnet test *(fails: `dotnet` command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934f67c8bc88329b4d06cd49b8df996)