### PR TITLE
Restrict editing actual dates to in-progress or completed stages

### DIFF
--- a/Pages/Projects/Timeline/_EditActualsForm.cshtml
+++ b/Pages/Projects/Timeline/_EditActualsForm.cshtml
@@ -30,7 +30,8 @@
                 var completedId = $"actual-completed-{row.StageCode}";
                 var startValue = row.ActualStart?.ToString("yyyy-MM-dd");
                 var completedValue = row.CompletedOn?.ToString("yyyy-MM-dd");
-                var disableAttr = row.HasPendingDecision ? "disabled" : null;
+                var canEdit = row.IsEditable && !row.HasPendingDecision;
+                var disableAttr = canEdit ? null : "disabled";
                 <section class="col-12 border rounded p-3" data-actuals-row data-stage-code="@row.StageCode" data-stage-status="@row.Status">
                     <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
                         <div class="d-flex flex-column">
@@ -82,6 +83,11 @@
                             <div class="form-text" id="@completedId-help">Set the actual completion date.</div>
                         </div>
                     </div>
+
+                    @if (!row.IsEditable)
+                    {
+                        <div class="text-muted small">Actual dates can be edited only when a stage is InProgress or Completed.</div>
+                    }
 
                     <div class="text-danger small d-none" data-row-error role="alert"></div>
 

--- a/Services/Projects/ProjectTimelineReadService.cs
+++ b/Services/Projects/ProjectTimelineReadService.cs
@@ -70,12 +70,15 @@ public sealed class ProjectTimelineReadService
             {
                 stageLookup.TryGetValue(stage.Code, out var projectStage);
                 var hasPending = pendingLookup.ContainsKey(stage.Code);
+                var status = projectStage?.Status ?? StageStatus.NotStarted;
+                var isEditable = status is StageStatus.InProgress or StageStatus.Completed;
 
                 return new ActualsEditorRowVm
                 {
                     StageCode = stage.Code,
                     StageName = stage.Name,
-                    Status = projectStage?.Status ?? StageStatus.NotStarted,
+                    Status = status,
+                    IsEditable = isEditable,
                     ActualStart = projectStage?.ActualStart,
                     CompletedOn = projectStage?.CompletedOn,
                     IsAutoCompleted = projectStage?.IsAutoCompleted ?? false,

--- a/Services/Stages/StageActualsUpdateService.cs
+++ b/Services/Stages/StageActualsUpdateService.cs
@@ -106,6 +106,16 @@ public sealed class StageActualsUpdateService
             var resolvedStart = start ?? stage.ActualStart;
             var resolvedCompleted = completed ?? stage.CompletedOn;
 
+            if (stage.Status is not StageStatus.InProgress and not StageStatus.Completed)
+            {
+                if (start.HasValue || completed.HasValue)
+                {
+                    validationErrors.Add($"{row.StageCode}: Actual dates can only be edited when the stage is InProgress or Completed.");
+                }
+
+                continue;
+            }
+
             if (resolvedStart is not null && resolvedStart > today)
             {
                 validationErrors.Add($"{row.StageCode}: Start date cannot be in the future.");

--- a/ViewModels/ActualsEditorVm.cs
+++ b/ViewModels/ActualsEditorVm.cs
@@ -27,6 +27,8 @@ public sealed class ActualsEditorRowVm
 
     public StageStatus Status { get; init; } = StageStatus.NotStarted;
 
+    public bool IsEditable { get; init; }
+
     public DateOnly? ActualStart { get; init; }
 
     public DateOnly? CompletedOn { get; init; }


### PR DESCRIPTION
## Summary
- add editability flag to actuals editor rows and show helper text/disabled inputs for stages that are not in progress or completed
- only allow server-side updates for stages in progress or completed, returning validation feedback otherwise
- expose editability data in actuals editor construction for consistent UI/validation

## Testing
- ⚠️ `dotnet test` *(fails because the dotnet CLI is not available in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934fabb3ecc8329a9b6fd186ff53411)