### PR TITLE
Allow ActualsUpdated stage change log action

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1890,7 +1890,7 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Note).HasMaxLength(1024);
                 e.HasIndex(x => new { x.ProjectId, x.StageCode, x.At });
 
-                const string allowedStageLogActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')";
+                const string allowedStageLogActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill','ActualsUpdated')";
 
                 if (Database.IsSqlServer())
                 {

--- a/Migrations/20261115103000_AddStageActualsUpdatedAction.cs
+++ b/Migrations/20261115103000_AddStageActualsUpdatedAction.cs
@@ -1,0 +1,72 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261115103000_AddStageActualsUpdatedAction")]
+    public partial class AddStageActualsUpdatedAction : Migration
+    {
+        // SECTION: Apply stage change log action update
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            const string allowedActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill','ActualsUpdated')";
+
+            if (ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE \"StageChangeLogs\" DROP CONSTRAINT IF EXISTS \"CK_StageChangeLogs_Action\";
+ALTER TABLE \"StageChangeLogs\" ADD CONSTRAINT \"CK_StageChangeLogs_Action\" CHECK (\"Action\" IN {allowedActions});");
+            }
+            else if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE [StageChangeLogs] DROP CONSTRAINT IF EXISTS CK_StageChangeLogs_Action;
+ALTER TABLE [StageChangeLogs] WITH CHECK ADD CONSTRAINT CK_StageChangeLogs_Action CHECK ([Action] IN {allowedActions});");
+            }
+            else if (ActiveProvider == "Microsoft.EntityFrameworkCore.Sqlite")
+            {
+                // SECTION: SQLite skip - altering check constraints is unsupported
+            }
+            else
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE \"StageChangeLogs\" DROP CONSTRAINT IF EXISTS \"CK_StageChangeLogs_Action\";
+ALTER TABLE \"StageChangeLogs\" ADD CONSTRAINT \"CK_StageChangeLogs_Action\" CHECK (\"Action\" IN {allowedActions});");
+            }
+        }
+
+        // SECTION: Revert stage change log action update
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            const string allowedActions = "('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')";
+
+            if (ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE \"StageChangeLogs\" DROP CONSTRAINT IF EXISTS \"CK_StageChangeLogs_Action\";
+ALTER TABLE \"StageChangeLogs\" ADD CONSTRAINT \"CK_StageChangeLogs_Action\" CHECK (\"Action\" IN {allowedActions});");
+            }
+            else if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE [StageChangeLogs] DROP CONSTRAINT IF EXISTS CK_StageChangeLogs_Action;
+ALTER TABLE [StageChangeLogs] WITH CHECK ADD CONSTRAINT CK_StageChangeLogs_Action CHECK ([Action] IN {allowedActions});");
+            }
+            else if (ActiveProvider == "Microsoft.EntityFrameworkCore.Sqlite")
+            {
+                // SECTION: SQLite skip - altering check constraints is unsupported
+            }
+            else
+            {
+                migrationBuilder.Sql($@"
+ALTER TABLE \"StageChangeLogs\" DROP CONSTRAINT IF EXISTS \"CK_StageChangeLogs_Action\";
+ALTER TABLE \"StageChangeLogs\" ADD CONSTRAINT \"CK_StageChangeLogs_Action\" CHECK (\"Action\" IN {allowedActions});");
+            }
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -5234,7 +5234,7 @@ namespace ProjectManagement.Migrations
 
                     b.ToTable("StageChangeLogs", t =>
                         {
-                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill')");
+                            t.HasCheckConstraint("CK_StageChangeLogs_Action", "\"Action\" IN ('Requested','Approved','Rejected','DirectApply','Applied','Superseded','AutoBackfill','Backfill','ActualsUpdated')");
                         });
                 });
 

--- a/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
+++ b/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Plans;
+using ProjectManagement.Models.Stages;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Stages;
+using ProjectManagement.ViewModels;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+// SECTION: Stage actuals update tests
+public sealed class StageActualsUpdateServiceTests
+{
+    [Fact]
+    public async Task UpdateAsync_SavesActualsAndLogsWithoutConstraintError()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Projects.Add(new Project
+        {
+            Name = "Actuals Test Project",
+            CreatedByUserId = "user-1",
+            WorkflowVersion = PlanConstants.DefaultStageTemplateVersion
+        });
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = StageStatus.InProgress,
+            ActualStart = new DateOnly(2024, 1, 5),
+            CompletedOn = new DateOnly(2024, 1, 20),
+            RequiresBackfill = false
+        });
+
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        var service = new StageActualsUpdateService(db, clock, new FakeAudit(), NullLogger<StageActualsUpdateService>.Instance);
+
+        var result = await service.UpdateAsync(
+            new ActualsEditInput
+            {
+                ProjectId = 1,
+                Rows = new List<ActualsEditRowInput>
+                {
+                    new()
+                    {
+                        StageCode = StageCodes.IPA,
+                        ActualStart = new DateOnly(2024, 1, 10),
+                        CompletedOn = new DateOnly(2024, 1, 25)
+                    }
+                }
+            },
+            userId: "user-1",
+            userName: "Tester");
+
+        Assert.Equal(1, result.UpdatedCount);
+
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Equal(new DateOnly(2024, 1, 10), stage.ActualStart);
+        Assert.Equal(new DateOnly(2024, 1, 25), stage.CompletedOn);
+
+        var log = await db.StageChangeLogs.SingleAsync();
+        Assert.Equal("ActualsUpdated", log.Action);
+        Assert.Equal(new DateOnly(2024, 1, 10), log.ToActualStart);
+        Assert.Equal(new DateOnly(2024, 1, 25), log.ToCompletedOn);
+    }
+
+    // SECTION: Test helpers
+    private sealed class FixedClock : IClock
+    {
+        public FixedClock(DateTimeOffset now) => UtcNow = now;
+
+        public DateTimeOffset UtcNow { get; set; }
+    }
+
+    private sealed class FakeAudit : IAuditService
+    {
+        public Task LogAsync(
+            string action,
+            string? message = null,
+            string level = "Info",
+            string? userId = null,
+            string? userName = null,
+            IDictionary<string, string?>? data = null,
+            Microsoft.AspNetCore.Http.HttpContext? http = null)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add the ActualsUpdated action to stage change log constraints to align with bulk actual updates
- add a migration to rebuild the StageChangeLogs action check constraint with the new value
- add a SQLite-backed test covering StageActualsUpdateService logging without constraint failures

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935184408a083298e148c752c4bc4a4)