### PR TITLE
Allow HoD to complete stages without dates

### DIFF
--- a/ProjectManagement.Tests/Stages/StageValidationServiceTests.cs
+++ b/ProjectManagement.Tests/Stages/StageValidationServiceTests.cs
@@ -38,6 +38,29 @@ public class StageValidationServiceTests
     }
 
     [Fact]
+    public async Task ValidateAsync_CompletingWithoutDateAsHod_AllowsCompletion()
+    {
+        var today = new DateOnly(2025, 5, 10);
+        var clock = FakeClock.ForIstDate(today);
+        await using var db = CreateContext();
+        await SeedAsync(
+            db,
+            new StageSeed(StageCodes.FS, StageStatus.InProgress, new DateOnly(2025, 5, 1), null));
+
+        var service = new StageValidationService(db, clock);
+
+        var result = await service.ValidateAsync(
+            1,
+            StageCodes.FS,
+            StageStatus.Completed.ToString(),
+            targetDate: null,
+            isHoD: true);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public async Task ValidateAsync_CompletingWithUnmetPredecessors_ReturnsMissingList()
     {
         var today = new DateOnly(2025, 6, 1);

--- a/Services/Stages/StageValidationService.cs
+++ b/Services/Stages/StageValidationService.cs
@@ -110,7 +110,7 @@ public sealed class StageValidationService : IStageValidationService
             errors.Add(transitionError ?? "The requested transition is invalid.");
         }
 
-        if (desiredStatus == StageStatus.Completed && !targetDate.HasValue)
+        if (desiredStatus == StageStatus.Completed && !targetDate.HasValue && !isHoD)
         {
             errors.Add("Completion date is required.");
         }


### PR DESCRIPTION
## Summary
- permit HoD stage validation to allow marking a stage as Completed without providing a date
- add regression test ensuring HoD completion without a date passes validation

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693523de3f288329a609d941739e8db9)