### PR TITLE
Fix nullable projections in proliferation report queries

### DIFF
--- a/Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs
+++ b/Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs
@@ -522,19 +522,19 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
                                k.ProjectId,
                                k.Source,
                                k.Year,
-                               YearlyTotal = y?.YearlyTotal ?? 0,
-                               GranularTotal = g?.GranularTotal ?? 0
+                               YearlyTotal = y != null && y.YearlyTotal.HasValue ? y.YearlyTotal.Value : 0,
+                               GranularTotal = g != null && g.GranularTotal.HasValue ? g.GranularTotal.Value : 0
                            };
 
             var withPrefs = from c in combined
                             where c.ProjectId != null && c.Source != null && c.Year != null
-                            join pref in prefs on new { ProjectId = c.ProjectId.Value, Source = c.Source.Value, Year = c.Year.Value } equals new { pref.ProjectId, pref.Source, pref.Year } into pj
+                            join pref in prefs on new { ProjectId = c.ProjectId.GetValueOrDefault(), Source = c.Source.GetValueOrDefault(), Year = c.Year.GetValueOrDefault() } equals new { pref.ProjectId, pref.Source, pref.Year } into pj
                             from pref in pj.DefaultIfEmpty()
                             select new
                             {
-                                ProjectId = c.ProjectId.Value,
-                                Source = c.Source.Value,
-                                Year = c.Year.Value,
+                                ProjectId = c.ProjectId.GetValueOrDefault(),
+                                Source = c.Source.GetValueOrDefault(),
+                                Year = c.Year.GetValueOrDefault(),
                                 c.YearlyTotal,
                                 c.GranularTotal,
                                 Mode = pref != null ? pref.Mode : YearPreferenceMode.UseYearlyAndGranular


### PR DESCRIPTION
### Motivation
- Fix compiler error `CS8072` caused by using the null-propagating operator inside expression tree lambdas for EF queries.
- Address nullable warnings `CS8629` introduced by the previous change that accessed `.Value` on nullable types.
- Ensure LINQ-to-Entities projections and joins remain translatable by EF and avoid nullable-related runtime/translation issues.

### Description
- Replace `y?.YearlyTotal ?? 0` / `g?.GranularTotal ?? 0` style null propagation with explicit checks like `y != null && y.YearlyTotal.HasValue ? y.YearlyTotal.Value : 0` in the projection.
- Replace direct `.Value` usage with `GetValueOrDefault()` for join keys and projected fields to eliminate nullable warnings and produce non-nullable join keys.
- Update the anonymous projection in `Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs` to return non-nullable `ProjectId`, `Source`, and `Year` values.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695968f5bbc4832990bf810e02baface)