### PR TITLE
Add JSON-friendly date fields to proliferation report DTO

### DIFF
--- a/Areas/ProjectOfficeReports/Api/ProliferationReportsDtos.cs
+++ b/Areas/ProjectOfficeReports/Api/ProliferationReportsDtos.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using ProjectManagement.Areas.ProjectOfficeReports.Domain;
 
 namespace ProjectManagement.Areas.ProjectOfficeReports.Api
@@ -36,29 +37,53 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Api
     // SECTION: Row DTO
     public sealed class ProliferationReportRowDto
     {
+        // SECTION: Project fields
         public int? ProjectId { get; init; }
         public string? ProjectName { get; init; }
         public string? ProjectCode { get; init; }
 
+        // SECTION: Source fields
         public ProliferationSource? Source { get; init; }
         public string? SourceLabel { get; init; }
 
+        // SECTION: Unit fields
         public string? UnitName { get; init; }
+
+        // SECTION: Date fields
+        [JsonIgnore]
         public DateTime? ProliferationDateUtc { get; init; }
+
+        [JsonPropertyName("proliferationDate")]
+        public string? ProliferationDate => ProliferationDateUtc?.ToString("yyyy-MM-dd");
+
         public int? Year { get; init; }
 
+        // SECTION: Quantities
         public int? Quantity { get; init; }
         public int? TotalQuantity { get; init; }
 
+        // SECTION: Aggregates
         public int? UniqueUnits { get; init; }
+
+        [JsonIgnore]
         public DateTime? FirstProliferationDateUtc { get; init; }
+
+        [JsonIgnore]
         public DateTime? LastProliferationDateUtc { get; init; }
 
+        [JsonPropertyName("firstDate")]
+        public string? FirstProliferationDate => FirstProliferationDateUtc?.ToString("yyyy-MM-dd");
+
+        [JsonPropertyName("lastDate")]
+        public string? LastProliferationDate => LastProliferationDateUtc?.ToString("yyyy-MM-dd");
+
+        // SECTION: Yearly reconciliation
         public int? YearlyApprovedTotal { get; init; }
         public int? GranularApprovedTotal { get; init; }
         public string? PreferenceMode { get; init; }
         public int? EffectiveTotal { get; init; }
 
+        // SECTION: Status fields
         public string? Remarks { get; init; }
         public string? ApprovalStatus { get; init; }
     }


### PR DESCRIPTION
### Motivation
- Ensure proliferation report date columns serialize with expected JSON keys and formats for the front-end.
- Avoid exposing raw `DateTime` fields directly in JSON and provide stable `YYYY-MM-DD` strings instead.
- Improve DTO readability and maintainability by grouping fields with section comments.

### Description
- Added `using System.Text.Json.Serialization` and applied `[JsonIgnore]` to `ProliferationDateUtc`, `FirstProliferationDateUtc`, and `LastProliferationDateUtc` in `ProliferationReportRowDto`.
- Added JSON string properties `ProliferationDate`, `FirstProliferationDate`, and `LastProliferationDate` decorated with `JsonPropertyName` and formatted as `yyyy-MM-dd`.
- Introduced section comments to organize project, source, unit, date, quantity, aggregate, yearly reconciliation, and status fields within the DTO.

### Testing
- No automated tests were executed for this change (not requested).
- The change is small and limited to DTO shape and serialization metadata only, so it should be safe to validate with existing serialization tests if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596f1896d08329a067fda9af5d26bf)