### PR TITLE
Show live filtered project counts in Ongoing projects header

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -27,7 +27,8 @@
     }
 }
 
-<h1 class="mb-3">Ongoing projects – progress & timelines</h1>
+<!-- SECTION: Page header -->
+<h1 class="mb-3">Ongoing projects – progress & timelines @Model.HeaderCountsText</h1>
 
 <form id="ongoingProjectsFilterForm"
       method="get"


### PR DESCRIPTION
### Motivation

- Add a live counts summary to the `Ongoing projects – progress & timelines` header showing the total and a top-level project category breakdown for the currently filtered list.
- Ensure counts are derived from the same filtered dataset used to render the project list so the header always reflects active filters (category, project officer, search).
- Keep ordering stable and consistent with the category dropdown ordering and only show categories with count > 0.

### Description

- Added `FilteredTotal`, `FilteredCategoryCounts`, and `HeaderCountsText` properties to `Pages/Projects/Ongoing/Index.cshtml.cs` and a `CategoryCountDto` DTO to hold category counts.
- Implemented `BuildHeaderCounts()` which computes totals by grouping `Items` and orders categories using `ProjectCategoryOptions` to produce a stable `HeaderCountsText` string.
- Populated header counts after retrieving `Items` from `OngoingProjectsReadService` by calling `BuildHeaderCounts()` in `OnGetAsync`.
- Updated `Pages/Projects/Ongoing/Index.cshtml` to render the formatted summary in the page title: `Ongoing projects – progress & timelines @Model.HeaderCountsText`.

### Testing

- No automated tests were executed as part of this change.
- The change is server-side only and does not alter database schema or client-side scripts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959cbb20c908329ba0c37ff769253f5)