### PR TITLE
Ongoing projects: group header counts by top-level category and improve header UI

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -28,7 +28,10 @@
 }
 
 <!-- SECTION: Page header -->
-<h1 class="mb-3">Ongoing projects – progress & timelines @Model.HeaderCountsText</h1>
+<div class="ongoing-projects__header mb-3">
+    <h1 class="mb-0">Ongoing projects – progress &amp; timelines</h1>
+    <span class="ongoing-projects__counts">@Model.HeaderCountsText</span>
+</div>
 
 <form id="ongoingProjectsFilterForm"
       method="get"

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -5921,6 +5921,20 @@ body.has-project-photo-preview-dialog {
     max-width: 28rem;
 }
 
+/* SECTION: Ongoing projects header counts */
+.ongoing-projects__header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.75rem;
+}
+
+.ongoing-projects__counts {
+    font-size: 0.95rem;
+    font-weight: 400;
+    color: #6c757d;
+    margin: 0;
+}
 
 /* ongoing projects cards */
 .ongoing-card {
@@ -7685,4 +7699,3 @@ body {
     color: #475569 !important;
     line-height: 1.6;
 }
-


### PR DESCRIPTION
### Motivation

- Ensure header counts reflect the current filtered list and roll up subcategories into their top-level category (so e.g. “CoE Mid Term” and “CoE Short Term” count under `CoE`).
- Avoid rendering the counts as part of the main H1 so the title remains visually clean and the counts wrap neatly as a subtitle.
- Keep category ordering stable and only show categories with a positive count.

### Description

- Use the same filtered `Items` list to compute counts and added a category cache populated in `LoadCategoriesAsync` to resolve parent relationships. 
- Aggregate counts by top-level category via a new helper `ResolveTopLevelCategory` and compute `FilteredTotal` and `FilteredCategoryCounts` in `BuildHeaderCounts`.
- Move the counts out of the H1 into a secondary element by replacing `@Model.HeaderCountsText` in `Pages/Projects/Ongoing/Index.cshtml` with a separate `<span class="ongoing-projects__counts">` and keep the H1 unchanged.
- Add styling in `wwwroot/css/site.css` to render the counts as a muted, smaller subtitle next to the H1.

### Testing

- No automated tests were executed as part of this change (none requested or run).
- Local smoke attempts to request the running app failed because the server was not available during rollout (connection to `http://localhost:7130` failed).
- Changes were limited to presentation and header-count calculation code paths: `Pages/Projects/Ongoing/Index.cshtml`, `Pages/Projects/Ongoing/Index.cshtml.cs`, and `wwwroot/css/site.css`.
- Manual verification checklist to run after deployment: confirm totals and top-level category breakdowns update correctly under different filter/search combinations and that zero-results shows `Total - 0` only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959cd41f8408329b910b549e4173c24)