### PR TITLE
Rename 'Legacy' lifecycle tab to 'Old projects' and add Old project badge

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -282,6 +282,11 @@
                                                 <text> @project.CompletedYear</text>
                                             }
                                         </span>
+                                        @* Section: Old project badge *@
+                                        @if (project.IsLegacy)
+                                        {
+                                            <span class="badge text-bg-light">Old project</span>
+                                        }
                                         @if (project.IsArchived)
                                         {
                                             <span class="badge text-bg-secondary">Archived</span>

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -592,7 +592,7 @@ namespace ProjectManagement.Pages.Projects
                 CreateLifecycleTab(ProjectLifecycleFilter.Active, "Active", counts),
                 CreateLifecycleTab(ProjectLifecycleFilter.Completed, "Completed", counts),
                 CreateLifecycleTab(ProjectLifecycleFilter.Cancelled, "Cancelled", counts),
-                CreateLifecycleTab(ProjectLifecycleFilter.Legacy, "Legacy", counts),
+                CreateLifecycleTab(ProjectLifecycleFilter.Legacy, "Old projects", counts),
             };
         }
 


### PR DESCRIPTION
### Motivation

- Make the existing `Legacy` lifecycle tab label clearer to users by renaming it to `Old projects` while preserving current behavior.
- Improve visibility of legacy/old projects when browsing other tabs by showing an inline badge on project cards.
- Keep all database semantics and filter logic unchanged (no schema or enum renames).

### Description

- Changed the lifecycle tab label in `Pages/Projects/Index.cshtml.cs` inside `BuildLifecycleTabs(...)` from `"Legacy"` to `"Old projects"` (UI text only).
- Added an inline badge to project cards in `Pages/Projects/Index.cshtml` that renders `<span class="badge text-bg-light">Old project</span>` when `project.IsLegacy` is true.
- Did not modify the `ProjectLifecycleFilter.Legacy` enum, `Project.IsLegacy` field, or any query/filter logic, so counts and behavior remain identical.
- No database migrations or schema changes were introduced.

### Testing

- A Playwright-based UI screenshot attempt navigated to `/Projects` but failed with `net::ERR_EMPTY_RESPONSE` because the web app was not running, so the UI check could not complete.
- No unit or integration tests were run in this rollout beyond the Playwright attempt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a2e9d2cc08329a4d6db1dce42ffba)