### PR TITLE
Projects: KPIs reflect filtered dataset, add type/build counts and improve 'Old projects' tab

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -13,6 +13,16 @@
 
     var activeLifecycle = Model.LifecycleTabs.FirstOrDefault(t => t.IsActive);
     var showAdvancedFilters = Model.HasActiveFilters;
+    var activeLifecycleLabel = string.IsNullOrWhiteSpace(activeLifecycle?.Label) ? "All" : activeLifecycle!.Label;
+    var preferredProjectTypeOrder = new[] { "Simulator", "Proof of Concept", "Product" };
+    var orderedProjectTypeCounts = Model.ProjectTypeCounts
+        .OrderBy(kvp =>
+        {
+            var preferredIndex = Array.FindIndex(preferredProjectTypeOrder, name => string.Equals(name, kvp.Key, StringComparison.OrdinalIgnoreCase));
+            return preferredIndex < 0 ? int.MaxValue : preferredIndex;
+        })
+        .ThenBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+        .ToList();
 
     var activeFilters = new List<string>();
     if (!string.IsNullOrWhiteSpace(Model.Query))
@@ -76,36 +86,55 @@
                         <h1 class="projects-hero__title">Projects</h1>
                         <p class="projects-hero__subtitle">Explore, search and curate the organisation&rsquo;s R&D initiatives.</p>
                     </div>
+                    @* Section: KPI tiles *@
                     <div class="projects-hero__stats">
                         <div class="projects-stat">
-                            <span class="projects-stat__label">Total projects</span>
-                            <span class="projects-stat__value">@Model.TotalCount</span>
-                            @{
-                                var lifecycleHint = string.IsNullOrWhiteSpace(activeLifecycle?.Label)
-                                    ? "All projects"
-                                    : activeLifecycle!.Label;
+                            <span class="projects-stat__label">Projects</span>
+                            <span class="projects-stat__value">@Model.FilteredTotal</span>
+                            <span class="projects-stat__hint">@activeLifecycleLabel</span>
+                            @if (Model.OldCount > 0)
+                            {
+                                <span class="projects-stat__meta">Old: @Model.OldCount</span>
                             }
-                            <span class="projects-stat__hint">@lifecycleHint</span>
                         </div>
                         <div class="projects-stat">
-                            <span class="projects-stat__label">Showing</span>
-                            <span class="projects-stat__value">@(Model.TotalCount == 0 ? "0" : $"{Model.ResultsStart}–{Model.ResultsEnd}")</span>
-                            <span class="projects-stat__hint">of @Model.TotalCount results</span>
+                            <span class="projects-stat__label">Project type</span>
+                            @if (orderedProjectTypeCounts.Count > 0)
+                            {
+                                <div class="projects-stat__chips">
+                                    @foreach (var item in orderedProjectTypeCounts)
+                                    {
+                                        if (string.Equals(item.Key, "Not set", StringComparison.OrdinalIgnoreCase) && item.Value == 0)
+                                        {
+                                            continue;
+                                        }
+                                        <span class="projects-stat__chip">@item.Key: @item.Value</span>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <span class="projects-stat__placeholder text-muted">Project type not configured</span>
+                            }
                         </div>
                         <div class="projects-stat">
-                            <span class="projects-stat__label">Active filters</span>
-                            <span class="projects-stat__value">@activeFilters.Count</span>
-                            <span class="projects-stat__hint">@(activeFilters.Count == 0 ? "None applied" : "Refine below")</span>
+                            <span class="projects-stat__label">Build</span>
+                            <div class="projects-stat__stack">
+                                <span class="projects-stat__chip">Repeat builds: @Model.RepeatBuildCount</span>
+                                <span class="projects-stat__chip">New development: @(Model.FilteredTotal - Model.RepeatBuildCount)</span>
+                            </div>
                         </div>
                     </div>
                 </div>
             </section>
 
+            @* Section: Lifecycle tabs *@
             <nav class="projects-tabs" aria-label="Project lifecycle filters">
                 <ul class="nav nav-pills projects-tabs__list" role="tablist">
                     @foreach (var lifecycle in Model.LifecycleTabs)
                     {
-                        <li class="nav-item" role="presentation">
+                        var isLegacyTab = lifecycle.Filter == ProjectLifecycleFilter.Legacy;
+                        <li class="nav-item @(isLegacyTab ? "projects-tabs__item--legacy" : string.Empty)" role="presentation">
                             <a class="nav-link projects-tabs__link @(lifecycle.IsActive ? "active" : null)"
                                asp-page="./Index"
                                asp-route-Lifecycle="@lifecycle.RouteValue"
@@ -117,6 +146,7 @@
                                asp-route-CompletedYear="@Model.CompletedYear"
                                asp-route-TotStatus="@(Model.TotStatus?.ToString())"
                                asp-route-IncludeArchived="@(Model.IncludeArchived ? "true" : null)"
+                               title="@(isLegacyTab ? "Projects from earlier dataset (legacy records)." : null)"
                                role="tab">
                                 <span class="projects-tabs__label">@lifecycle.Label</span>
                                 <span class="projects-tabs__count">@lifecycle.Count</span>
@@ -206,10 +236,11 @@
                 </div>
             }
 
+            @* Section: Results summary *@
             <div class="projects-results">
                 <div class="projects-results__summary">
-                    <strong>@(Model.TotalCount == 0 ? "No projects" : $"Showing {Model.ResultsStart}–{Model.ResultsEnd}")</strong>
-                    <span class="text-muted">@((Model.TotalCount == 0 ? "matching your criteria" : $"of {Model.TotalCount} projects"))</span>
+                    <strong>@(Model.FilteredTotal == 0 ? "No projects" : $"Showing {Model.ResultsStart}–{Model.ResultsEnd}")</strong>
+                    <span class="text-muted">@((Model.FilteredTotal == 0 ? "matching your criteria" : $"of {Model.FilteredTotal} projects"))</span>
                 </div>
             </div>
 

--- a/wwwroot/css/projects/index.css
+++ b/wwwroot/css/projects/index.css
@@ -86,6 +86,10 @@
     gap: 0.65rem;
 }
 
+/* ===========================
+   Section: KPI tiles
+   =========================== */
+
 .projects-stat {
     position: relative;
     display: grid;
@@ -117,6 +121,39 @@
     opacity: 0.7;
 }
 
+.projects-stat__meta {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--pm-project-ink-muted);
+}
+
+.projects-stat__chips,
+.projects-stat__stack {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.projects-stat__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.7);
+    font-size: 0.74rem;
+    font-weight: 600;
+    color: var(--pm-project-ink-strong);
+    box-shadow: inset 0 0 0 1px rgba(45, 42, 68, 0.08);
+    white-space: nowrap;
+}
+
+.projects-stat__placeholder {
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
 .projects-tabs {
     margin-bottom: 1.5rem;
 }
@@ -124,6 +161,27 @@
 .projects-tabs__list {
     gap: 0.75rem;
     flex-wrap: wrap;
+}
+
+/* ===========================
+   Section: Legacy tab divider
+   =========================== */
+
+.projects-tabs__item--legacy {
+    position: relative;
+    padding-left: 0.5rem;
+    margin-left: 0.25rem;
+}
+
+.projects-tabs__item--legacy::before {
+    content: "";
+    position: absolute;
+    inset-inline-start: -0.25rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+    height: 1.75rem;
+    background-color: rgba(156, 171, 228, 0.6);
 }
 
 .projects-tabs__link {
@@ -595,4 +653,3 @@
     font-size: .85rem;
     color: var(--pm-text-muted);
 }
-


### PR DESCRIPTION
### Motivation

- Ensure KPI tiles reflect the same filtered dataset used for the results so counts are decision-useful rather than global totals.
- Surface composition signals (project type and build mix) in the hero KPIs while keeping a consistent three-tile layout.
- Make the "Old projects" tab visually distinct from lifecycle tabs and add a tooltip describing it as legacy data.
- Reduce redundancy by aligning the "Showing X–Y of Z" text with the filtered totals.

### Description

- Added KPI properties to the page model: `FilteredTotal`, `OldCount`, `ProjectTypeCounts` and `RepeatBuildCount`, and compute them from the same `baseQuery` used for listing results.
- Introduced `BuildProjectTypeCountsAsync` helper and reused `baseQuery` to compute filtered counts with minimal extra DB work, then applied the `Include`s for result projection in `Index.cshtml.cs`.
- Updated `Index.cshtml` to render three KPI tiles (`Projects`, `Project type`, `Build`) using the new model properties and to show `Old: {OldCount}` when present, plus ordering for preferred project types.
- Added a subtle divider/tooltip for the legacy tab and new styles in `wwwroot/css/projects/index.css` for KPI chips and the legacy tab divider (class `projects-tabs__item--legacy`).

### Testing

- No automated tests were executed as part of this change.
- Manual/QA checklist to validate (not executed here) includes verifying `FilteredTotal` updates across tabs/filters and that "Showing X–Y of Z" matches the filtered total.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a30b1c04083298f2eeb2c6bc2c6d9)