### PR TITLE
Fix route values typing for filter chips and correct project-type chip query

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -3,7 +3,6 @@
 @using System
 @using System.Linq
 @using System.Globalization
-@using Microsoft.AspNetCore.Routing
 @using ProjectManagement.Models
 @using ProjectManagement.Models.Execution
 @using ProjectManagement.Models.Stages
@@ -40,28 +39,45 @@
     }
 
     // Section: Shared route values for filter links
-    RouteValueDictionary BaseRouteValues()
+    IDictionary<string, string> BaseRouteValues()
     {
-        return new RouteValueDictionary
+        var values = new Dictionary<string, string>();
+
+        void AddValue(string key, object? value)
         {
-            ["Query"] = Model.Query,
-            ["CategoryId"] = Model.CategoryId,
-            ["TechnicalCategoryId"] = Model.TechnicalCategoryId,
-            ["LeadPoUserId"] = Model.LeadPoUserId,
-            ["HodUserId"] = Model.HodUserId,
-            ["Lifecycle"] = Model.Lifecycle == ProjectLifecycleFilter.All ? null : Model.Lifecycle.ToString(),
-            ["CompletedYear"] = Model.CompletedYear,
-            ["TotStatus"] = Model.TotStatus?.ToString(),
-            ["IncludeArchived"] = Model.IncludeArchived ? "true" : null,
-            ["StageCode"] = Model.StageCode,
-            ["StageCompletedMonth"] = Model.StageCompletedMonth,
-            ["SlipBucket"] = Model.SlipBucket,
-            ["IncludeCategoryDescendants"] = Model.IncludeCategoryDescendants ? "true" : null,
-            ["Build"] = Model.Build,
-            ["ProjectTypeId"] = Model.ProjectTypeId,
-            ["ProjectTypeUnclassified"] = Model.ProjectTypeUnclassified ? "1" : null,
-            ["PageSize"] = Model.PageSize
-        };
+            if (value is null)
+            {
+                return;
+            }
+
+            var text = value.ToString();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            values[key] = text;
+        }
+
+        AddValue("Query", Model.Query);
+        AddValue("CategoryId", Model.CategoryId);
+        AddValue("TechnicalCategoryId", Model.TechnicalCategoryId);
+        AddValue("LeadPoUserId", Model.LeadPoUserId);
+        AddValue("HodUserId", Model.HodUserId);
+        AddValue("Lifecycle", Model.Lifecycle == ProjectLifecycleFilter.All ? null : Model.Lifecycle.ToString());
+        AddValue("CompletedYear", Model.CompletedYear);
+        AddValue("TotStatus", Model.TotStatus?.ToString());
+        AddValue("IncludeArchived", Model.IncludeArchived ? "true" : null);
+        AddValue("StageCode", Model.StageCode);
+        AddValue("StageCompletedMonth", Model.StageCompletedMonth);
+        AddValue("SlipBucket", Model.SlipBucket);
+        AddValue("IncludeCategoryDescendants", Model.IncludeCategoryDescendants ? "true" : null);
+        AddValue("Build", Model.Build);
+        AddValue("ProjectTypeId", Model.ProjectTypeId);
+        AddValue("ProjectTypeUnclassified", Model.ProjectTypeUnclassified ? "1" : null);
+        AddValue("PageSize", Model.PageSize);
+
+        return values;
     }
 
     var activeFilters = new List<string>();

--- a/Pages/Projects/Index.cshtml.cs
+++ b/Pages/Projects/Index.cshtml.cs
@@ -269,13 +269,14 @@ namespace ProjectManagement.Pages.Projects
                 .AsNoTracking()
                 .OrderBy(t => t.SortOrder)
                 .ThenBy(t => t.Name)
+                .ToListAsync();
+
+            return types
                 .Select(t => new ProjectTypeChipViewModel(
                     t.Id,
                     t.Name,
                     countLookup.TryGetValue(t.Id, out var count) ? count : 0))
-                .ToListAsync();
-
-            return types;
+                .ToList();
         }
 
         private async Task<IQueryable<Project>> BuildFilteredQueryAsync(


### PR DESCRIPTION
### Motivation

- Resolve compile errors where tag helpers expected `IDictionary<string,string>` but code produced a `RouteValueDictionary` and where an expression tree contained an `out` variable declaration. 
- Ensure route values passed to `asp-all-route-data` are string-keyed and omit null/empty entries to avoid type conversion issues. 
- Avoid EF expression-tree constructs that cannot be translated (the `out` variable from `TryGetValue`) when building the project type chip view models. 

### Description

- Replaced the `BaseRouteValues()` helper to return `IDictionary<string,string>` and implemented an `AddValue` helper that skips null or whitespace values, ensuring only string entries are returned. 
- Removed the unused `@using Microsoft.AspNetCore.Routing` directive from `Index.cshtml`. 
- Modified `BuildProjectTypeChipsAsync` to materialize the `ProjectTypes` with `ToListAsync()` and then project to `ProjectTypeChipViewModel` in-memory to avoid expression-tree `out` variable usage. 
- Minor code tidy and formatting adjustments related to the above changes. 

### Testing

- No automated tests were run as part of this change. 
- A full build and unit test run is recommended to confirm the compile errors are resolved and no regressions are introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a640d46248329a2529f0485377cce)