### PR TITLE
Fix project filter route value typing

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -39,9 +39,9 @@
     }
 
     // Section: Shared route values for filter links
-    IDictionary<string, string> BaseRouteValues()
+    IDictionary<string, string?> BaseRouteValues()
     {
-        var values = new Dictionary<string, string>();
+        var values = new Dictionary<string, string?>();
 
         void AddValue(string key, object? value)
         {
@@ -183,7 +183,7 @@
                                         var unclassifiedRouteValues = BaseRouteValues();
                                         unclassifiedRouteValues["ProjectTypeId"] = null;
                                         unclassifiedRouteValues["ProjectTypeUnclassified"] = selectedProjectTypeUnclassified ? null : "1";
-                                        unclassifiedRouteValues["p"] = 1;
+                                        unclassifiedRouteValues["p"] = "1";
                                         if (selectedProjectTypeUnclassified)
                                         {
                                             <a class="projects-stat__chip projects-stat__chip--active"
@@ -207,9 +207,9 @@
                                     @foreach (var chip in topProjectTypeChips)
                                     {
                                         var chipRouteValues = BaseRouteValues();
-                                        chipRouteValues["ProjectTypeId"] = chip.Id;
+                                        chipRouteValues["ProjectTypeId"] = chip.Id.ToString(CultureInfo.InvariantCulture);
                                         chipRouteValues["ProjectTypeUnclassified"] = null;
-                                        chipRouteValues["p"] = 1;
+                                        chipRouteValues["p"] = "1";
                                         var isSelected = selectedProjectTypeId.HasValue && chip.Id == selectedProjectTypeId.Value && !selectedProjectTypeUnclassified;
                                         if (isSelected)
                                         {
@@ -246,9 +246,9 @@
                                                 @foreach (var chip in remainingProjectTypes)
                                                 {
                                                     var chipRouteValues = BaseRouteValues();
-                                                    chipRouteValues["ProjectTypeId"] = chip.Id;
+                                                    chipRouteValues["ProjectTypeId"] = chip.Id.ToString(CultureInfo.InvariantCulture);
                                                     chipRouteValues["ProjectTypeUnclassified"] = null;
-                                                    chipRouteValues["p"] = 1;
+                                                    chipRouteValues["p"] = "1";
                                                     var isSelected = selectedProjectTypeId.HasValue && chip.Id == selectedProjectTypeId.Value && !selectedProjectTypeUnclassified;
                                                     if (isSelected)
                                                     {
@@ -285,7 +285,7 @@
                                 @{
                                     var repeatRouteValues = BaseRouteValues();
                                     repeatRouteValues["Build"] = string.Equals(Model.Build, "Repeat", StringComparison.OrdinalIgnoreCase) ? null : "Repeat";
-                                    repeatRouteValues["p"] = 1;
+                                    repeatRouteValues["p"] = "1";
                                     var isRepeatSelected = string.Equals(Model.Build, "Repeat", StringComparison.OrdinalIgnoreCase);
                                 }
                                 @if (Model.RepeatBuildCount == 0 && !isRepeatSelected)
@@ -305,7 +305,7 @@
                                 @{
                                     var newRouteValues = BaseRouteValues();
                                     newRouteValues["Build"] = string.Equals(Model.Build, "New", StringComparison.OrdinalIgnoreCase) ? null : "New";
-                                    newRouteValues["p"] = 1;
+                                    newRouteValues["p"] = "1";
                                     var isNewSelected = string.Equals(Model.Build, "New", StringComparison.OrdinalIgnoreCase);
                                 }
                                 @if (Model.NewBuildCount == 0 && !isNewSelected)


### PR DESCRIPTION
### Motivation
- Resolve Razor compile-time errors where integer route values and non-nullable string dictionary types produced `CS0029` and nullability warnings (`CS8625`, `CS8601`).
- Ensure shared route-value map used by filter links produces string values compatible with `asp-all-route-data`.
- Prevent potential nullability mismatches when clearing filters or omitting values in route dictionaries.

### Description
- Changed the shared route-values function signature to return `IDictionary<string, string?>` and use a `Dictionary<string, string?>` so entries may be `null` when omitted.
- Stringified numeric route parameters by calling `ToString(CultureInfo.InvariantCulture)` for `ProjectTypeId` and similar numeric values to avoid implicit `int`→`string` conversions.
- Normalised pagination and chip link page parameters to use string values (e.g. set `"p"` to `"1"` instead of `1`).
- No other behavior or UI changes were made; this is strictly a typing/formatting fix for route data preparation.

### Testing
- No automated tests were run as part of this change.
- The change is limited to the Razor page helper and should eliminate the previously reported IntelliSense/compile-time type and nullability warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a64e1054c8329902dbb6236e6122f)