### PR TITLE
Use boolean query value for ProjectTypeUnclassified

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -74,7 +74,8 @@
         AddValue("IncludeCategoryDescendants", Model.IncludeCategoryDescendants ? "true" : null);
         AddValue("Build", Model.Build);
         AddValue("ProjectTypeId", Model.ProjectTypeId);
-        AddValue("ProjectTypeUnclassified", Model.ProjectTypeUnclassified ? "1" : null);
+        // Section: Project type unclassified expects boolean string for model binding.
+        AddValue("ProjectTypeUnclassified", Model.ProjectTypeUnclassified ? "true" : null);
         AddValue("PageSize", Model.PageSize);
 
         return values;
@@ -182,7 +183,7 @@
                                     {
                                         var unclassifiedRouteValues = BaseRouteValues();
                                         unclassifiedRouteValues["ProjectTypeId"] = null;
-                                        unclassifiedRouteValues["ProjectTypeUnclassified"] = selectedProjectTypeUnclassified ? null : "1";
+                                        unclassifiedRouteValues["ProjectTypeUnclassified"] = selectedProjectTypeUnclassified ? null : "true";
                                         unclassifiedRouteValues["p"] = "1";
                                         if (selectedProjectTypeUnclassified)
                                         {
@@ -351,7 +352,7 @@
                                asp-route-IncludeArchived="@(Model.IncludeArchived ? "true" : null)"
                                asp-route-Build="@Model.Build"
                                asp-route-ProjectTypeId="@Model.ProjectTypeId"
-                               asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "1" : null)"
+                               asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "true" : null)"
                                title="@(isLegacyTab ? "Projects from earlier dataset (legacy records)." : null)"
                                role="tab">
                                 <span class="projects-tabs__label">@lifecycle.Label</span>
@@ -370,7 +371,7 @@
                 }
                 @if (Model.ProjectTypeUnclassified)
                 {
-                    <input type="hidden" name="ProjectTypeUnclassified" value="1" />
+                    <input type="hidden" name="ProjectTypeUnclassified" value="true" />
                 }
                 @if (!string.IsNullOrWhiteSpace(Model.Build))
                 {
@@ -666,7 +667,7 @@
                                    asp-route-IncludeArchived="@(Model.IncludeArchived ? "true" : null)"
                                    asp-route-Build="@Model.Build"
                                    asp-route-ProjectTypeId="@Model.ProjectTypeId"
-                                   asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "1" : null)"
+                                   asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "true" : null)"
                                    aria-label="Previous"
                                    aria-disabled="@(Model.CurrentPage <= 1)">
                                     <i class="bi bi-chevron-left" aria-hidden="true"></i>
@@ -694,7 +695,7 @@
                                        asp-route-IncludeArchived="@(Model.IncludeArchived ? "true" : null)"
                                        asp-route-Build="@Model.Build"
                                        asp-route-ProjectTypeId="@Model.ProjectTypeId"
-                                       asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "1" : null)">@i</a>
+                                       asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "true" : null)">@i</a>
                                 </li>
                             }
                             <li class="page-item @(Model.CurrentPage >= Model.TotalPages ? "disabled" : null)">
@@ -717,7 +718,7 @@
                                    asp-route-IncludeArchived="@(Model.IncludeArchived ? "true" : null)"
                                    asp-route-Build="@Model.Build"
                                    asp-route-ProjectTypeId="@Model.ProjectTypeId"
-                                   asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "1" : null)"
+                                   asp-route-ProjectTypeUnclassified="@(Model.ProjectTypeUnclassified ? "true" : null)"
                                    aria-label="Next"
                                    aria-disabled="@(Model.CurrentPage >= Model.TotalPages)">
                                     <i class="bi bi-chevron-right" aria-hidden="true"></i>


### PR DESCRIPTION
### Motivation
- Align query-string behaviour so `ProjectTypeUnclassified` is passed as a boolean string (`true`) for correct model binding instead of numeric values like `1` or `0`.
- Ensure consistency across filter links, lifecycle tabs and pagination so the same format is used everywhere in the index page.
- Avoid surprises when clearing the filter by emitting `null` (omitting the parameter) rather than a numeric value.

### Description
- Updated `Pages/Projects/Index.cshtml` to use `"true"` for `ProjectTypeUnclassified` in `BaseRouteValues()` and in link route-value assignments instead of `"1"`.
- Replaced the hidden input value for `ProjectTypeUnclassified` from `1` to `true` so the form emits `ProjectTypeUnclassified=true` when selected.
- Aligned lifecycle tab links and all pagination link route attributes to use `@(Model.ProjectTypeUnclassified ? "true" : null)`.
- Added a short comment near the `BaseRouteValues()` setup noting that `ProjectTypeUnclassified` expects a boolean string for model binding.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6724a39c8329bcaa1d1909efb25c)