### PR TITLE
Projects: add page-size selector with “All” support and preserve selection across tabs

### DIFF
--- a/Pages/Projects/Index.cshtml
+++ b/Pages/Projects/Index.cshtml
@@ -338,6 +338,8 @@
                             <a class="nav-link projects-tabs__link @(lifecycle.IsActive ? "active" : null)"
                                asp-page="./Index"
                                asp-route-Lifecycle="@lifecycle.RouteValue"
+                               asp-route-PageSize="@Model.PageSize"
+                               asp-route-p="1"
                                asp-route-Query="@Model.Query"
                                asp-route-CategoryId="@Model.CategoryId"
                                asp-route-TechnicalCategoryId="@Model.TechnicalCategoryId"
@@ -364,6 +366,8 @@
             </nav>
 
             <form method="get" class="projects-filter shadow-sm">
+                @* Section: Reset to first page when filters change *@
+                <input type="hidden" name="p" value="1" />
                 <input type="hidden" name="Lifecycle" value="@Model.Lifecycle" />
                 @if (Model.ProjectTypeId.HasValue)
                 {
@@ -402,6 +406,16 @@
                         </div>
                     </div>
                     <div class="projects-filter__actions">
+                        @* Section: Page size selector *@
+                        <div class="projects-filter__page-size">
+                            <label asp-for="PageSize" class="form-label">Page size</label>
+                            <select asp-for="PageSize" class="form-select">
+                                <option value="25">25</option>
+                                <option value="50">50</option>
+                                <option value="100">100</option>
+                                <option value="0">All</option>
+                            </select>
+                        </div>
                         <button class="btn btn-outline-secondary projects-filter__toggle" type="button" data-bs-toggle="collapse" data-bs-target="#advancedProjectFilters" aria-expanded="@showAdvancedFilters.ToString().ToLowerInvariant()" aria-controls="advancedProjectFilters">
                             <i class="bi bi-sliders" aria-hidden="true"></i>
                             <span>Advanced filters</span>


### PR DESCRIPTION
### Motivation

- Provide users a page-size control (25, 50, 100, All) on the Projects index to improve pagination UX.
- Support a true “All” mode so the filtered result set can be shown on a single page without artificial truncation.
- Preserve the selected page size across lifecycle tab switches and ensure changing size resets to page 1 to avoid out-of-range pages.
- Avoid division-by-zero and incorrect skip/take behaviour when “All” is selected by computing paging metadata for the all-results mode.

### Description

- Updated server-side paging in `Pages/Projects/Index.cshtml.cs` by adding `DefaultPageSize`, `MaxPageSize`, and `AllPageSizeValue` constants and treating `PageSize == 0` as the All mode (`isAll`).
- Changed normalization and metadata: clamp page sizes to allowed values when not All, set `TotalPages = 1` and `CurrentPage = 1` for All, avoid `Skip/Take` when All by loading the full filtered query, and adjust `ResultsStart`/`ResultsEnd` accordingly.
- Updated the UI in `Pages/Projects/Index.cshtml` to add a Page size selector (`25`, `50`, `100`, `All`), added a hidden `p=1` input so filter submissions reset to the first page, and added `asp-route-PageSize` and `asp-route-p="1"` to lifecycle tab links so page size is preserved and tab switches land on page 1.
- Left existing pager links intact (they already preserved `PageSize`), and ensured the pager is hidden when `TotalPages <= 1` so the All mode shows no pagination controls.

### Testing

- No automated tests were executed against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7a7cc7488329b6642f2371461980)