### PR TITLE
Rename top nav 'Progress Review' to 'Ongoing Projects' and add 'Progress review' drawer item

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -20,8 +20,7 @@
     @{
         var currentPage = ViewContext.RouteData.Values["page"]?.ToString();
         var currentArea = ViewContext.RouteData.Values["area"]?.ToString();
-        var isProgressReviewPage = string.Equals(currentArea, "ProjectOfficeReports", StringComparison.OrdinalIgnoreCase)
-        && string.Equals(currentPage, "/ProgressReview/Index", StringComparison.OrdinalIgnoreCase);
+        var isOngoingProjectsPage = string.Equals(currentPage, "/Projects/Ongoing/Index", StringComparison.OrdinalIgnoreCase);
         var useFullWidth = (ViewData["UseFullWidth"] as bool?) == true;
         var mainContainerClass = useFullWidth
             ? "container-fluid analytics-shell px-3 px-lg-4 px-xxl-5"
@@ -53,10 +52,9 @@
                        class="pm-top-tabs__item @(string.Equals(currentPage, "/Calendar/Index", StringComparison.OrdinalIgnoreCase) ? "is-active" : string.Empty)">
                         Calendar
                     </a>
-                    <a asp-area="ProjectOfficeReports"
-                       asp-page="/ProgressReview/Index"
-                       class="pm-top-tabs__item @(isProgressReviewPage ? "is-active" : string.Empty)">
-                        Progress Review
+                    <a asp-page="/Projects/Ongoing/Index"
+                       class="pm-top-tabs__item @(isOngoingProjectsPage ? "is-active" : string.Empty)">
+                        Ongoing Projects
                     </a>
                 </nav>
             </div>

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -45,6 +45,9 @@ public class RoleBasedNavigationProvider : INavigationProvider
 
         var roleSet = await GetRoleSetAsync(user);
 
+        // ===========================
+        // PRIMARY NAVIGATION ITEMS
+        // ===========================
         var items = new List<NavigationItem>
         {
             new()
@@ -64,41 +67,53 @@ public class RoleBasedNavigationProvider : INavigationProvider
                 Text = "Miscellaneous activities",
                 Page = "/Activities/Index",
                 Icon = "bi-stars"
+            },
+            // Progress review entry (drawer only).
+            new()
+            {
+                Text = "Progress review",
+                Area = "ProjectOfficeReports",
+                Page = "/ProgressReview/Index",
+                AuthorizationPolicy = ProjectOfficeReportsPolicies.ViewProgressReview,
+                Icon = "bi-graph-up"
             }
         };
+        // ===========================
+        // PROJECT MODULE NAVIGATION
+        // ===========================
         var projectModuleChildren = new List<NavigationItem>
-{
-    new()
-    {
-        Text = "Projects repository",
-        Page = "/Projects/Index",
-        Icon = "bi-collection"
-    },
-    new()
-    {
-        Text = "Ongoing projects",
-        Page = "/Projects/Ongoing/Index",
-        Icon = "bi-clock-history"
-    },
-    new()
-    {
-        Text = "Completed projects summary",
-        Page = "/Projects/CompletedSummary/Index",
-        Icon = "bi-clipboard-data"
-    },
-    new()
-    {
-        Text = "Process",
-        Page = "/Process/Index",
-        Icon = "bi-diagram-3"
-    },
-    new()
-    {
-        Text = "Analytics",
-        Page = "/Analytics/Index",
-        Icon = "bi-graph-up"
-    },
-};
+        {
+            new()
+            {
+                Text = "Projects repository",
+                Page = "/Projects/Index",
+                Icon = "bi-collection"
+            },
+            new()
+            {
+                Text = "Ongoing projects",
+                Page = "/Projects/Ongoing/Index",
+                Icon = "bi-clock-history"
+            },
+            new()
+            {
+                Text = "Completed projects summary",
+                Page = "/Projects/CompletedSummary/Index",
+                Icon = "bi-clipboard-data"
+            },
+            new()
+            {
+                Text = "Process",
+                Page = "/Process/Index",
+                Icon = "bi-diagram-3"
+            },
+            new()
+            {
+                Text = "Analytics",
+                Page = "/Analytics/Index",
+                Icon = "bi-graph-up"
+            },
+        };
 
         items.Add(new NavigationItem
         {


### PR DESCRIPTION
### Motivation

- Move the existing Progress Review entry out of the top navigation and into the left drawer while exposing the ongoing projects page in the top bar. 
- Preserve existing authorization for the Progress Review feature when moving it to the drawer. 
- Make the navigation code easier to read and maintain by adding section comments. 

### Description

- Updated `Pages/Shared/_Layout.cshtml` to replace the top-bar `Progress Review` link with `Ongoing Projects` and point it to `/Projects/Ongoing/Index`, including active-state logic (`isOngoingProjectsPage`).
- Added a root drawer navigation item `Progress review` immediately after `Miscellaneous activities` in `Services/Navigation/RoleBasedNavigationProvider.cs` with `Area = "ProjectOfficeReports"`, `Page = "/ProgressReview/Index"`, `AuthorizationPolicy = ProjectOfficeReportsPolicies.ViewProgressReview`, and icon `bi-graph-up`.
- Inserted section comments (`PRIMARY NAVIGATION ITEMS`, `PROJECT MODULE NAVIGATION`) to clarify structure and improve maintainability.
- Ensured the top nav no longer contains a `Progress Review` link and the drawer entry follows the same authorization checks as the original page.

### Testing

- No automated tests were run against these changes.
- Static inspection and code edits were applied to `Pages/Shared/_Layout.cshtml` and `Services/Navigation/RoleBasedNavigationProvider.cs` only.
- Manual smoke test steps were documented in the dev note but not executed as part of this change.
- CI/build was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a89a010c08329b86a378c7fb106c6)