### PR TITLE
Add table view toggle for Ongoing Projects and compute IPA/AoN/PDC in service

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -8,6 +8,9 @@
     ViewData["Title"] = "Ongoing projects – progress & timelines";
     ViewData["UseFullWidth"] = true;
 
+    // SECTION: View state
+    var isTableView = string.Equals(Model.View, "table", StringComparison.OrdinalIgnoreCase);
+
     // turn <span class="remark-mention">…</span> into a small pill
     string RenderRemark(string? text)
     {
@@ -25,6 +28,26 @@
 
         return replaced;
     }
+
+    // SECTION: Table helpers
+    string FormatDate(DateOnly? date)
+        => date.HasValue ? date.Value.ToString("dd-MMM-yyyy") : "N/A";
+
+    string FormatValue(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "N/A" : value;
+
+    string TruncateRemark(string? remark, int maxLength = 110)
+    {
+        if (string.IsNullOrWhiteSpace(remark))
+        {
+            return "N/A";
+        }
+
+        var trimmed = remark.Trim();
+        return trimmed.Length <= maxLength
+            ? trimmed
+            : $"{trimmed[..maxLength].Trim()}…";
+    }
 }
 
 <!-- SECTION: Page header -->
@@ -37,6 +60,8 @@
       method="get"
       class="row g-3 align-items-end mb-4"
       novalidate>
+    <!-- SECTION: Persist view selection -->
+    <input type="hidden" asp-for="View" />
     <div class="col-12 col-md-3">
         <label asp-for="ProjectCategoryId" class="form-label">Project category</label>
         <select asp-for="ProjectCategoryId"
@@ -53,7 +78,28 @@
         <label asp-for="Search" class="form-label">Search by project name</label>
         <input asp-for="Search" class="form-control form-control-sm" />
     </div>
-    <div class="col-12 col-md-3 d-flex gap-2 justify-content-md-end">
+    <div class="col-12 col-md-3 d-flex gap-2 justify-content-md-end align-items-center">
+        <!-- SECTION: View toggle -->
+        <div class="btn-group btn-group-sm me-1" role="group" aria-label="View switcher">
+            <a asp-page="./Index"
+               asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
+               asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
+               asp-route-Search="@Model.Search"
+               asp-route-View="timeline"
+               class="btn @(isTableView ? "btn-outline-primary" : "btn-primary")"
+               aria-pressed="@(!isTableView)">
+                Timeline view
+            </a>
+            <a asp-page="./Index"
+               asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
+               asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
+               asp-route-Search="@Model.Search"
+               asp-route-View="table"
+               class="btn @(isTableView ? "btn-primary" : "btn-outline-primary")"
+               aria-pressed="@isTableView">
+                Table view
+            </a>
+        </div>
         <button type="submit" class="btn btn-sm btn-primary">
             <i class="bi bi-funnel" aria-hidden="true"></i>
             <span>Filter</span>
@@ -63,6 +109,7 @@
            asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
            asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
            asp-route-Search="@Model.Search"
+           asp-route-View="@Model.View"
            class="btn btn-sm btn-outline-secondary">
             Export
         </a>
@@ -75,7 +122,8 @@
 }
 else
 {
-    <div class="row g-3">
+    <!-- SECTION: Timeline view -->
+    <section class="row g-3" @(isTableView ? "hidden" : string.Empty)>
         @foreach (var item in Model.Items)
         {
             // SECTION: Identify current stage index using the present snapshot first
@@ -110,7 +158,7 @@ else
             <div class="col-12">
                 <article class="ongoing-card card border-0 shadow-sm h-100">
                     <div class="card-body p-0">
-                        <!-- header -->
+                        <!-- SECTION: Timeline card header -->
                         <header class="ongoing-card__header">
                             <div>
                                 <h2 class="ongoing-card__title mb-1">
@@ -152,16 +200,16 @@ else
                         </header>
 
                         @{
-                            // at top of the foreach (or just before this block) we can have:
+                            // SECTION: Timeline helper values
                             var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
                         }
-                        <!-- current stage line -->
+                        <!-- SECTION: Current stage line -->
                         <div class="ongoing-card__info">
                             @{
                                 var cur = item.Stages[currentIdx];
                                 var presentStage = item.PresentStage;
 
-                                // 2. days to PDC / overdue
+                                // SECTION: Days to PDC / overdue
                                 int? daysToPdc = null;
                                 bool isOverdue = false;
                                 if (cur.PlannedDue.HasValue)
@@ -202,7 +250,7 @@ else
                                     }
                                 }
 
-                                @* extra line for stage age *@
+                                <!-- SECTION: Stage age -->
                                 <span class="ms-2 text-muted ongoing-card__stage-chip">
                                     @if (presentStage.DaysSinceStartOrLastCompletion.HasValue)
                                     {
@@ -239,7 +287,7 @@ else
                         </div>
 
 
-                        <!-- Timeline -->
+                        <!-- SECTION: Timeline -->
                         <div class="d-flex align-items-center flex-wrap gap-2 px-4 py-3 border-top">
                             @{
                                 // show stages from start up to current stage
@@ -308,7 +356,7 @@ else
                             }
                         </div>
 
-                        <!-- remarks -->
+                        <!-- SECTION: Remarks -->
                         <section class="ongoing-remarks border-top">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <span class="ongoing-remarks__title">Recent internal remarks (last 10 days)</span>
@@ -347,7 +395,119 @@ else
                 </article>
             </div>
         }
-    </div>
+    </section>
+
+    <!-- SECTION: Table view -->
+    <section @(isTableView ? string.Empty : "hidden")>
+        @{
+            var orderedCategories = Model.ProjectCategoryOptions
+                .Where(option => !string.IsNullOrWhiteSpace(option.Value))
+                .Select(option => new
+                {
+                    Id = int.TryParse(option.Value, out var id) ? id : 0,
+                    option.Text
+                })
+                .Where(option => option.Id > 0)
+                .ToList();
+
+            var itemsByCategory = Model.Items
+                .GroupBy(item => item.ProjectCategoryId)
+                .ToDictionary(group => group.Key, group => group.OrderBy(x => x.ProjectName).ToList());
+
+            itemsByCategory.TryGetValue(null, out var uncategorizedItems);
+        }
+
+        <div class="pm-card-table shadow-sm border-0">
+            <div class="pm-table-wrap table-responsive">
+                <table class="table pm-table pm-table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Project name</th>
+                            <th>Category</th>
+                            <th>IPA date</th>
+                            <th>AoN date</th>
+                            <th>Present stage</th>
+                            <th>Present stage PDC</th>
+                            <th>Latest external remark</th>
+                            <th>Project Officer</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var category in orderedCategories)
+                        {
+                            if (!itemsByCategory.TryGetValue(category.Id, out var rows) || rows.Count == 0)
+                            {
+                                continue;
+                            }
+
+                            <tr class="table-light">
+                                <td colspan="8" class="fw-semibold text-uppercase text-muted small">
+                                    @category.Text (@rows.Count)
+                                </td>
+                            </tr>
+
+                            @foreach (var row in rows)
+                            {
+                                <tr>
+                                    <td>
+                                        <a asp-page="/Projects/Overview"
+                                           asp-route-id="@row.ProjectId"
+                                           class="text-decoration-none fw-semibold">
+                                            @row.ProjectName
+                                        </a>
+                                    </td>
+                                    <td>@FormatValue(row.ProjectCategoryName)</td>
+                                    <td>@FormatDate(row.IpaDate)</td>
+                                    <td>@FormatDate(row.AonDate)</td>
+                                    <td>@FormatValue(row.PresentStage.DisplayName)</td>
+                                    <td>@FormatDate(row.PresentStagePdc)</td>
+                                    <td class="text-truncate" title="@row.LatestExternalRemark">
+                                        @TruncateRemark(row.LatestExternalRemark)
+                                    </td>
+                                    <td>@FormatValue(row.LeadPoName)</td>
+                                </tr>
+                            }
+                        }
+
+                        @if (uncategorizedItems is { Count: > 0 })
+                        {
+                            <tr class="table-light">
+                                <td colspan="8" class="fw-semibold text-uppercase text-muted small">
+                                    Uncategorized (@uncategorizedItems.Count)
+                                </td>
+                            </tr>
+
+                            foreach (var row in uncategorizedItems)
+                            {
+                                <tr>
+                                    <td>
+                                        <a asp-page="/Projects/Overview"
+                                           asp-route-id="@row.ProjectId"
+                                           class="text-decoration-none fw-semibold">
+                                            @row.ProjectName
+                                        </a>
+                                    </td>
+                                    <td>@FormatValue(row.ProjectCategoryName)</td>
+                                    <td>@FormatDate(row.IpaDate)</td>
+                                    <td>@FormatDate(row.AonDate)</td>
+                                    <td>@FormatValue(row.PresentStage.DisplayName)</td>
+                                    <td>@FormatDate(row.PresentStagePdc)</td>
+                                    <td class="text-truncate" title="@row.LatestExternalRemark">
+                                        @TruncateRemark(row.LatestExternalRemark)
+                                    </td>
+                                    <td>@FormatValue(row.LeadPoName)</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+}
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/components/pm-table.css" asp-append-version="true" />
 }
 
 @section Scripts {

--- a/Pages/Projects/Ongoing/Index.cshtml.cs
+++ b/Pages/Projects/Ongoing/Index.cshtml.cs
@@ -48,6 +48,10 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         [BindProperty(SupportsGet = true)]
         public string? Search { get; set; }
 
+        // SECTION: View selector (timeline/table)
+        [BindProperty(SupportsGet = true)]
+        public string? View { get; set; }
+
         public IReadOnlyList<SelectListItem> ProjectCategoryOptions { get; private set; }
             = Array.Empty<SelectListItem>();
 
@@ -67,6 +71,7 @@ namespace ProjectManagement.Pages.Projects.Ongoing
 
         public async Task OnGetAsync(CancellationToken cancellationToken)
         {
+            View = NormalizeView(View);
             await LoadCategoriesAsync(cancellationToken);
 
             var officerId = Normalize(ProjectOfficerId);
@@ -224,6 +229,17 @@ namespace ProjectManagement.Pages.Projects.Ongoing
 
         private static string? Normalize(string? value)
             => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        // SECTION: View normalization
+        private static string NormalizeView(string? value)
+        {
+            if (string.Equals(value, "table", StringComparison.OrdinalIgnoreCase))
+            {
+                return "table";
+            }
+
+            return "timeline";
+        }
     }
 
     // SECTION: DTOs

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -198,6 +198,11 @@ namespace ProjectManagement.Services.Projects
 
                 stageDtos[currentIndex].IsCurrent = true;
 
+                // SECTION: Timeline-independent stage lookups (full list)
+                var ipaDate = ResolveStageMilestoneDate(stageDtos, "IPA");
+                var aonDate = ResolveStageMilestoneDate(stageDtos, "AON");
+                var presentStagePdc = stageDtos[currentIndex].PlannedDue;
+
                 var stageSnapshots = stageDtos
                     .Select((stage, idx) => new ProjectStageStatusSnapshot(
                         stage.Code,
@@ -260,6 +265,9 @@ namespace ProjectManagement.Services.Projects
                     LastCompletedStageName = lastCompletedName,
                     LastCompletedStageDate = lastCompletedDate,
                     PresentStage = presentStage,
+                    IpaDate = ipaDate,
+                    AonDate = aonDate,
+                    PresentStagePdc = presentStagePdc,
                     Stages = stageDtos,
                     RecentInternalRemarks = recentInternal,
                     LatestExternalRemark = latestExternal
@@ -351,6 +359,17 @@ namespace ProjectManagement.Services.Projects
 
             return collectedIds.ToArray();
         }
+
+        // SECTION: Stage milestone helpers
+        private static DateOnly? ResolveStageMilestoneDate(
+            IEnumerable<OngoingProjectStageDto> stages,
+            string stageCode)
+        {
+            var stage = stages.FirstOrDefault(s =>
+                string.Equals(s.Code, stageCode, StringComparison.OrdinalIgnoreCase));
+
+            return stage?.ActualCompletedOn ?? stage?.ActualStart;
+        }
     }
 
     public sealed class OngoingProjectRowDto
@@ -369,6 +388,10 @@ namespace ProjectManagement.Services.Projects
         public DateOnly? LastCompletedStageDate { get; init; }
 
         public PresentStageSnapshot PresentStage { get; init; } = PresentStageSnapshot.Empty;
+
+        public DateOnly? IpaDate { get; init; }
+        public DateOnly? AonDate { get; init; }
+        public DateOnly? PresentStagePdc { get; init; }
 
         public IReadOnlyList<OngoingProjectStageDto> Stages { get; init; } = Array.Empty<OngoingProjectStageDto>();
 


### PR DESCRIPTION
### Motivation

- Provide a compact, scannable `Table view` alternative to the existing timeline cards on `/Projects/Ongoing` so users can review many projects quickly.  
- Ensure IPA and AoN milestone dates are available for the table even when timeline stage lists are trimmed for performance.  
- Let users switch between `timeline` and `table` views without losing current filters and have the selection persist in the query string.  
- Reuse existing table styles for a professional, responsive layout and handle long remarks via truncation + tooltip.

### Description

- Added a GET-bound view selector `View` to the page model (`Pages/Projects/Ongoing/Index.cshtml.cs`) and normalised allowed values to `timeline` and `table`.  
- Implemented a view toggle in the Razor (`Pages/Projects/Ongoing/Index.cshtml`) that preserves filters by including `asp-route-*` parameters and a hidden `View` field, and renders either the timeline section or a new grouped table server-side.  
- Introduced a grouped table layout that orders categories according to the page category list and shows the requested columns including `Project name`, `Category`, `IPA date`, `AoN date`, `Present stage`, `Present stage PDC`, `Latest external remark` (truncated with `title` tooltip), and `Project Officer`.  
- Extended the read service (`Services/Projects/OngoingProjectsReadService.cs`) and DTO (`OngoingProjectRowDto`) to compute and expose `IpaDate`, `AonDate`, and `PresentStagePdc` from the full `stageDtos` list via a `ResolveStageMilestoneDate` helper while keeping the existing timeline stage limiting logic unchanged.

### Testing

- No automated unit or integration tests were executed as part of this change.  
- A headless UI check using Playwright was attempted to capture `/Projects/Ongoing` but failed with `net::ERR_EMPTY_RESPONSE` in the current environment.  
- The change was committed locally and a PR body was prepared; no further CI runs were observed.  
- Manual quick-test checklist (recommended): switch views with and without filters, verify category grouping and counts, confirm IPA/AoN/PDC appear for projects with many stages, and check remark truncation and tooltips.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9e569b508329a9cf75fe855d055c)