### PR TITLE
Fix present stage name binding in ongoing projects view

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -459,7 +459,7 @@ else
                                     <td>@FormatValue(row.ProjectCategoryName)</td>
                                     <td>@FormatDate(row.IpaDate)</td>
                                     <td>@FormatDate(row.AonDate)</td>
-                                    <td>@FormatValue(row.PresentStage.DisplayName)</td>
+                                    <td>@FormatValue(row.PresentStage.CurrentStageName)</td>
                                     <td>@FormatDate(row.PresentStagePdc)</td>
                                     <td class="text-truncate" title="@row.LatestExternalRemark">
                                         @TruncateRemark(row.LatestExternalRemark)
@@ -490,7 +490,7 @@ else
                                     <td>@FormatValue(row.ProjectCategoryName)</td>
                                     <td>@FormatDate(row.IpaDate)</td>
                                     <td>@FormatDate(row.AonDate)</td>
-                                    <td>@FormatValue(row.PresentStage.DisplayName)</td>
+                                    <td>@FormatValue(row.PresentStage.CurrentStageName)</td>
                                     <td>@FormatDate(row.PresentStagePdc)</td>
                                     <td class="text-truncate" title="@row.LatestExternalRemark">
                                         @TruncateRemark(row.LatestExternalRemark)


### PR DESCRIPTION
### Motivation
- The Razor view referenced a non-existent `DisplayName` property on `PresentStageSnapshot`, causing `CS1061` build errors in `Pages/Projects/Ongoing/Index.cshtml`.
- The `PresentStageSnapshot` record exposes the stage name as `CurrentStageName`, so the view should use that property instead.

### Description
- Replaced `row.PresentStage.DisplayName` with `row.PresentStage.CurrentStageName` in two places in `Pages/Projects/Ongoing/Index.cshtml`.
- No changes were made to the `PresentStageSnapshot` record or service code, which remains in `Services/Projects/PresentStageHelper.cs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa159ef508329a84506e67bded3f1)