### PR TITLE
Fix ongoing projects category grouping

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -410,11 +410,16 @@ else
                 .Where(option => option.Id > 0)
                 .ToList();
 
+            // SECTION: Group categorized and uncategorized items
             var itemsByCategory = Model.Items
-                .GroupBy(item => item.ProjectCategoryId)
+                .Where(item => item.ProjectCategoryId.HasValue)
+                .GroupBy(item => item.ProjectCategoryId!.Value)
                 .ToDictionary(group => group.Key, group => group.OrderBy(x => x.ProjectName).ToList());
 
-            itemsByCategory.TryGetValue(null, out var uncategorizedItems);
+            var uncategorizedItems = Model.Items
+                .Where(item => !item.ProjectCategoryId.HasValue)
+                .OrderBy(item => item.ProjectName)
+                .ToList();
         }
 
         <div class="pm-card-table shadow-sm border-0">


### PR DESCRIPTION
### Motivation
- Prevent runtime issues and incorrect grouping caused by using nullable `ProjectCategoryId` as a dictionary key. 
- Ensure uncategorized projects are handled explicitly instead of relying on `null` dictionary keys. 
- Provide consistent, predictable ordering for uncategorized rows in the table.

### Description
- Changed grouping logic to only include items with `ProjectCategoryId.HasValue` and group by `ProjectCategoryId.Value` in `Pages/Projects/Ongoing/Index.cshtml`.
- Created a separate `uncategorizedItems` list (`Model.Items.Where(...).OrderBy(...)`) for projects without a category. 
- Kept per-category ordering by `ProjectName` when building the category dictionary.
- Added a section comment to clarify the categorized vs uncategorized grouping logic.

### Testing
- No automated tests were run for this change.
- It is recommended to run the test suite with `dotnet test` to validate behavior across the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695affbfb9708329b905312fec9b2b0c)