### PR TITLE
Improve ongoing projects table UX: remove inner scroll, highlight stages, show full remarks

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -36,18 +36,6 @@
     string FormatValue(string? value)
         => string.IsNullOrWhiteSpace(value) ? "N/A" : value;
 
-    string TruncateRemark(string? remark, int maxLength = 110)
-    {
-        if (string.IsNullOrWhiteSpace(remark))
-        {
-            return "N/A";
-        }
-
-        var trimmed = remark.Trim();
-        return trimmed.Length <= maxLength
-            ? trimmed
-            : $"{trimmed[..maxLength].Trim()}…";
-    }
 }
 
 <!-- SECTION: Page header -->
@@ -423,17 +411,27 @@ else
         }
 
         <div class="pm-card-table shadow-sm border-0">
-            <div class="pm-table-wrap table-responsive">
-                <table class="table pm-table pm-table-sm align-middle mb-0">
+            <div class="pm-table-wrap table-responsive ongoing-table-wrap">
+                <table class="table pm-table pm-table-sm align-middle mb-0 ongoing-table">
+                    <colgroup>
+                        <col />
+                        <col />
+                        <col />
+                        <col />
+                        <col class="col-stage" />
+                        <col class="col-stage" />
+                        <col />
+                        <col />
+                    </colgroup>
                     <thead>
                         <tr>
                             <th>Project name</th>
                             <th>Category</th>
                             <th>IPA date</th>
                             <th>AoN date</th>
-                            <th>Present stage</th>
-                            <th>Present stage PDC</th>
-                            <th>Latest external remark</th>
+                            <th class="col-stage">Present stage</th>
+                            <th class="col-stage">Present stage PDC</th>
+                            <th class="col-remarks">Remarks</th>
                             <th>Project Officer</th>
                         </tr>
                     </thead>
@@ -464,11 +462,9 @@ else
                                     <td>@FormatValue(row.ProjectCategoryName)</td>
                                     <td>@FormatDate(row.IpaDate)</td>
                                     <td>@FormatDate(row.AonDate)</td>
-                                    <td>@FormatValue(row.PresentStage.CurrentStageName)</td>
-                                    <td>@FormatDate(row.PresentStagePdc)</td>
-                                    <td class="text-truncate" title="@row.LatestExternalRemark">
-                                        @TruncateRemark(row.LatestExternalRemark)
-                                    </td>
+                                    <td class="col-stage">@FormatValue(row.PresentStage.CurrentStageName)</td>
+                                    <td class="col-stage">@FormatDate(row.PresentStagePdc)</td>
+                                    <td class="col-remarks">@FormatValue(row.LatestExternalRemark)</td>
                                     <td>@FormatValue(row.LeadPoName)</td>
                                 </tr>
                             }
@@ -495,11 +491,9 @@ else
                                     <td>@FormatValue(row.ProjectCategoryName)</td>
                                     <td>@FormatDate(row.IpaDate)</td>
                                     <td>@FormatDate(row.AonDate)</td>
-                                    <td>@FormatValue(row.PresentStage.CurrentStageName)</td>
-                                    <td>@FormatDate(row.PresentStagePdc)</td>
-                                    <td class="text-truncate" title="@row.LatestExternalRemark">
-                                        @TruncateRemark(row.LatestExternalRemark)
-                                    </td>
+                                    <td class="col-stage">@FormatValue(row.PresentStage.CurrentStageName)</td>
+                                    <td class="col-stage">@FormatDate(row.PresentStagePdc)</td>
+                                    <td class="col-remarks">@FormatValue(row.LatestExternalRemark)</td>
                                     <td>@FormatValue(row.LeadPoName)</td>
                                 </tr>
                             }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -5856,6 +5856,30 @@ body.has-project-photo-preview-dialog {
     overflow: auto;
 }
 
+/* --- SECTION: Ongoing projects table view --- */
+.ongoing-table-wrap {
+    overflow-y: visible;
+    overflow-x: auto;
+    max-height: none;
+    height: auto;
+}
+
+.ongoing-table th.col-stage,
+.ongoing-table td.col-stage {
+    background-color: var(--pm-surface-foam);
+}
+
+.ongoing-table tbody tr:hover td.col-stage {
+    background-color: var(--pm-surface-foam);
+}
+
+.ongoing-table td.col-remarks {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    word-break: break-word;
+}
+
 .table.pm-table {
     margin: 0;
 }


### PR DESCRIPTION
### Motivation
- Stop the table from creating its own vertical scrollbar so the page scrolls normally and long rows expand instead of truncating content.
- Visually emphasise the decision-critical `Present stage` and `Present stage PDC` columns so they are easier to scan.
- Replace the truncated “Latest external remark” column with a `Remarks` column that displays full remark text and allows wrapping.

### Description
- Updated `Pages/Projects/Ongoing/Index.cshtml` to add a `<colgroup>` and apply `col-stage` and `col-remarks` classes, rename the header to `Remarks`, and remove per-cell truncation by replacing `@TruncateRemark(...)` and `class="text-truncate"` with `@FormatValue(...)` and `class="col-remarks"`.
- Removed the server-side truncation helper `TruncateRemark` from the page to ensure full remarks are rendered.
- Added CSS rules in `wwwroot/css/site.css` for `.ongoing-table-wrap` to disable vertical overflow and permit horizontal scrolling, for `.ongoing-table .col-stage` to apply a subtle background tint, and for `.ongoing-table td.col-remarks` to allow wrapped, untruncated remark text.
- Kept table header/sticky behaviour intact and ensured hover styling does not clash with stage column tint.

### Testing
- Attempted an automated UI capture using Playwright to visit `http://127.0.0.1:7130/Projects/Ongoing?View=table`, but the request failed with `ERR_EMPTY_RESPONSE` and no screenshot could be captured.
- No unit or integration test suite was executed as part of this change.
- Local static checks and searches were used to locate table markup and CSS before applying the patch and the changes were committed successfully.
- Manual runtime verification on a live server is recommended to confirm scrolling, column tinting, and remark wrapping behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b18a4e1288329ae27c355d885b9e7)