### PR TITLE
Fix Razor parser errors and Request usage in document results partial

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
@@ -1,10 +1,15 @@
 @model ProjectManagement.Areas.DocumentRepository.Pages.Documents.IndexModel
 
-@if (Model.EnableListViewUxUpgrade)
-{
-    <!-- SECTION: Active filter summary -->
-    @{
-        var hasAnyFilter =
+@{
+    // SECTION: Shared view state
+    var hasAnyFilter = false;
+    var officeLabel = "All";
+    var typeLabel = "All";
+    var httpRequest = ViewContext.HttpContext.Request;
+
+    if (Model.EnableListViewUxUpgrade)
+    {
+        hasAnyFilter =
             !string.IsNullOrWhiteSpace(Model.Q) ||
             !string.IsNullOrWhiteSpace(Model.Tag) ||
             Model.OfficeCategoryId.HasValue ||
@@ -12,14 +17,19 @@
             Model.Year.HasValue ||
             Model.IncludeInactive;
 
-        string officeLabel = Model.OfficeCategoryId.HasValue
+        officeLabel = Model.OfficeCategoryId.HasValue
             ? (Model.OfficeCategories.FirstOrDefault(o => o.Id == Model.OfficeCategoryId)?.Name ?? "Selected")
             : "All";
 
-        string typeLabel = Model.DocumentCategoryId.HasValue
+        typeLabel = Model.DocumentCategoryId.HasValue
             ? (Model.DocumentCategories.FirstOrDefault(c => c.Id == Model.DocumentCategoryId)?.Name ?? "Selected")
             : "All";
     }
+}
+
+@if (Model.EnableListViewUxUpgrade)
+{
+    <!-- SECTION: Active filter summary -->
 
     @if (hasAnyFilter)
     {
@@ -63,7 +73,7 @@
     }
 
     <!-- SECTION: Top pager -->
-    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, Request)" />
+    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, httpRequest)" />
 
     <!-- SECTION: Tag match alert -->
     @if (Model.IsSearchActive && Model.HasTagMatch)
@@ -145,12 +155,12 @@
     }
 
     <!-- SECTION: Bottom pager -->
-    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, Request)" />
+    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, httpRequest)" />
 }
 else
 {
     <!-- SECTION: Top pager -->
-    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, Request)" />
+    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, httpRequest)" />
 
     <!-- SECTION: Tag match alert -->
     @if (Model.IsSearchActive && Model.HasTagMatch)
@@ -204,5 +214,5 @@ else
     }
 
     <!-- SECTION: Bottom pager -->
-    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, Request)" />
+    <partial name="_Pager" model="new PagerModel(Model.PageNumber, Model.PageSize, Model.TotalCount, httpRequest)" />
 }


### PR DESCRIPTION
### Motivation
- Resolve Razor parser errors caused by inline `@{ ... }` usage inside conditionals which triggered RZ1010.
- Fix multiple `CS0103` errors where `Request` was not available in the partial view context.
- Ensure pager components receive the correct HTTP request context when the partial is rendered.

### Description
- Move shared filter and label computation into a top-level Razor code block (`@{ ... }`) to avoid parser issues and reuse values across the view.
- Introduce `var httpRequest = ViewContext.HttpContext.Request` and use it in place of `Request` when constructing `PagerModel` instances.
- Replace `Request` references in `_ResultsBlock.cshtml` with `httpRequest` for all `_Pager` partial invocations.
- Preserve existing section comments and view logic while making the change minimal and targeted.

### Testing
- No automated tests were run.
- Manual validation: changed file compiled by updating the partial to use `ViewContext.HttpContext.Request` to address the previously reported `Request` reference errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d94d07608329b31fd2f81e17d0c5)