### PR TITLE
Add per-user Favourites (star toggle) to Document Repository with left-rail navigation

### DIFF
--- a/Areas/DocumentRepository/Models/DocumentListItemVm.cs
+++ b/Areas/DocumentRepository/Models/DocumentListItemVm.cs
@@ -18,4 +18,7 @@ public sealed class DocumentListItemVm
     // SECTION: Status metadata
     public DocOcrStatus OcrStatus { get; set; }
     public bool IsActive { get; set; }
+
+    // SECTION: Personalization
+    public bool IsFavourite { get; set; }
 }

--- a/Areas/DocumentRepository/Models/DocumentSearchResultVm.cs
+++ b/Areas/DocumentRepository/Models/DocumentSearchResultVm.cs
@@ -30,4 +30,7 @@ public sealed class DocumentSearchResultVm
 
     // SECTION: Status
     public bool IsActive { get; set; }
+
+    // SECTION: Personalization
+    public bool IsFavourite { get; set; }
 }

--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml
@@ -37,10 +37,43 @@ else
             </ol>
         </nav>
 
+        <!-- SECTION: Favourite toggle helpers -->
+        <form id="docrepoFavouriteToken" method="post" class="d-none">
+            @Html.AntiForgeryToken()
+        </form>
+        <div class="alert alert-danger d-none docrepo-favourite-alert" id="docrepoFavouriteAlert" role="alert">
+            Unable to update favourite. Try again.
+        </div>
+
         @if (Model.EnableListViewUxUpgrade)
         {
             <!-- SECTION: Shell layout -->
             <div class="docrepo-shell">
+                <!-- SECTION: Navigation rail -->
+                <nav class="docrepo-rail" aria-label="Document scopes">
+                    <a class="docrepo-rail__item @(!Model.IsFavouritesScope ? "is-active" : string.Empty)"
+                       asp-page="./Index"
+                       asp-route-view="@Model.ViewMode"
+                       asp-route-page="1"
+                       asp-route-pageSize="@Model.PageSize"
+                       title="Documents"
+                       aria-label="Documents">
+                        <i class="bi bi-folder"></i>
+                        <span class="docrepo-rail__label">Documents</span>
+                    </a>
+                    <a class="docrepo-rail__item @(Model.IsFavouritesScope ? "is-active" : string.Empty)"
+                       asp-page="./Index"
+                       asp-route-scope="favourites"
+                       asp-route-view="@Model.ViewMode"
+                       asp-route-page="1"
+                       asp-route-pageSize="@Model.PageSize"
+                       title="Favourites"
+                       aria-label="Favourites">
+                        <i class="bi bi-star-fill"></i>
+                        <span class="docrepo-rail__label">Favourites</span>
+                    </a>
+                </nav>
+
                 <!-- SECTION: Filters panel -->
                 <aside class="docrepo-filters" id="docrepoFilters">
                     <div class="docrepo-filters__header">
@@ -62,6 +95,7 @@ else
                         <!-- SECTION: Apply-only params -->
                         <input type="hidden" name="q" value="@Model.Q" />
                         <input type="hidden" name="view" value="@Model.ViewMode" />
+                        <input type="hidden" name="scope" value="@Model.Scope" />
                         <input type="hidden" name="page" value="1" />
                         <input type="hidden" name="pageSize" value="@Model.PageSize" />
 
@@ -189,6 +223,7 @@ else
                         <div class="docrepo-facet__actions">
                             <a class="btn btn-outline-secondary btn-sm w-100"
                                asp-page="./Index"
+                               asp-route-scope="@Model.Scope"
                                asp-route-page="1"
                                asp-route-pageSize="@Model.PageSize"
                                asp-route-view="@Model.ViewMode">
@@ -228,6 +263,7 @@ else
                             <input type="hidden" name="page" value="1" />
                             <input type="hidden" name="pageSize" value="@Model.PageSize" />
                             <input type="hidden" name="view" value="@Model.ViewMode" />
+                            <input type="hidden" name="scope" value="@Model.Scope" />
                             <input type="hidden" name="tag" value="@Model.Tag" />
                             <input type="hidden" name="officeCategoryId" value="@(Model.OfficeCategoryId?.ToString() ?? string.Empty)" />
                             <input type="hidden" name="documentCategoryId" value="@(Model.DocumentCategoryId?.ToString() ?? string.Empty)" />
@@ -257,7 +293,7 @@ else
                         </div>
                     </div>
 
-                    <div id="docrepoResults">
+                    <div id="docrepoResults" data-toggle-url="@Url.Page("./Index", "ToggleFavourite", new { area = "DocumentRepository" })">
                         <partial name="_ResultsBlock" model="Model" />
                     </div>
                 </main>
@@ -289,6 +325,7 @@ else
 
                     <input type="hidden" name="page" value="1" />
                     <input type="hidden" name="pageSize" value="@Model.PageSize" />
+                    <input type="hidden" name="scope" value="@Model.Scope" />
                     <input type="hidden" name="tag" value="@Model.Tag" />
                     <input type="hidden" name="officeCategoryId" value="@Model.OfficeCategoryId" />
                     <input type="hidden" name="documentCategoryId" value="@Model.DocumentCategoryId" />
@@ -300,7 +337,7 @@ else
                 </form>
             </div>
 
-            <div id="docrepoResults">
+            <div id="docrepoResults" data-toggle-url="@Url.Page("./Index", "ToggleFavourite", new { area = "DocumentRepository" })">
                 <partial name="_ResultsBlock" model="Model" />
             </div>
         }
@@ -321,6 +358,7 @@ else
                             <input type="hidden" name="q" value="@Model.Q" />
                             <input type="hidden" name="page" value="1" />
                             <input type="hidden" name="pageSize" value="@Model.PageSize" />
+                            <input type="hidden" name="scope" value="@Model.Scope" />
 
                             <div class="mb-3">
                                 <label class="form-label" for="tagInput">Tag</label>

--- a/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
@@ -28,13 +28,24 @@
             }
         </div>
 
-        <div class="text-end">
-            @if (Model.Rank.HasValue)
-            {
-                <div class="mb-1">
+        <div class="doc-card__meta text-end">
+            <div class="doc-card__meta-row" data-no-row-nav>
+                <authorize policy="DocRepo.View">
+                    <button type="button"
+                            class="docrepo-star docrepo-star--card"
+                            data-docid="@Model.Id"
+                            data-fav="@(Model.IsFavourite ? "true" : "false")"
+                            title="@(Model.IsFavourite ? "Remove from favourites" : "Add to favourites")"
+                            aria-label="@(Model.IsFavourite ? "Remove from favourites" : "Add to favourites")"
+                            data-no-row-nav>
+                        <i class="bi @(Model.IsFavourite ? "bi-star-fill" : "bi-star")"></i>
+                    </button>
+                </authorize>
+                @if (Model.Rank.HasValue)
+                {
                     <span class="badge bg-light text-muted">Relevance @Model.Rank.Value.ToString("0.00")</span>
-                </div>
-            }
+                }
+            </div>
 
             <span class="doc-card__stamp @(Model.OcrStatus switch
                   {

--- a/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
@@ -18,6 +18,17 @@
     <td>
         <div class="d-flex flex-column gap-1">
             <div class="d-flex align-items-center gap-2">
+                <authorize policy="DocRepo.View">
+                    <button type="button"
+                            class="docrepo-star"
+                            data-docid="@Model.Id"
+                            data-fav="@(Model.IsFavourite ? "true" : "false")"
+                            title="@(Model.IsFavourite ? "Remove from favourites" : "Add to favourites")"
+                            aria-label="@(Model.IsFavourite ? "Remove from favourites" : "Add to favourites")"
+                            data-no-row-nav>
+                        <i class="bi @(Model.IsFavourite ? "bi-star-fill" : "bi-star")"></i>
+                    </button>
+                </authorize>
                 @if (Model.IsActive)
                 {
                     <a asp-page="./Reader" asp-route-id="@Model.Id" asp-route-returnUrl="@returnUrl" class="docrepo-subject-link">

--- a/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
@@ -2,21 +2,19 @@
 
 @{
     // SECTION: Shared view state
-    var hasAnyFilter = false;
+    var hasAnyFilter =
+        !string.IsNullOrWhiteSpace(Model.Q) ||
+        !string.IsNullOrWhiteSpace(Model.Tag) ||
+        Model.OfficeCategoryId.HasValue ||
+        Model.DocumentCategoryId.HasValue ||
+        Model.Year.HasValue ||
+        Model.IncludeInactive;
     var officeLabel = "All";
     var typeLabel = "All";
     var httpRequest = ViewContext.HttpContext.Request;
 
     if (Model.EnableListViewUxUpgrade)
     {
-        hasAnyFilter =
-            !string.IsNullOrWhiteSpace(Model.Q) ||
-            !string.IsNullOrWhiteSpace(Model.Tag) ||
-            Model.OfficeCategoryId.HasValue ||
-            Model.DocumentCategoryId.HasValue ||
-            Model.Year.HasValue ||
-            Model.IncludeInactive;
-
         officeLabel = Model.OfficeCategoryId.HasValue
             ? (Model.OfficeCategories.FirstOrDefault(o => o.Id == Model.OfficeCategoryId)?.Name ?? "Selected")
             : "All";
@@ -25,6 +23,8 @@
             ? (Model.DocumentCategories.FirstOrDefault(c => c.Id == Model.DocumentCategoryId)?.Name ?? "Selected")
             : "All";
     }
+
+    var showFavouritesEmptyState = Model.IsFavouritesScope && !Model.IsSearchActive && !hasAnyFilter;
 }
 
 @if (Model.EnableListViewUxUpgrade)
@@ -64,6 +64,7 @@
 
             <a class="docrepo-activefilters__clear"
                asp-page="./Index"
+               asp-route-scope="@Model.Scope"
                asp-route-view="@Model.ViewMode"
                asp-route-pageSize="@Model.PageSize"
                asp-route-page="1">
@@ -90,6 +91,7 @@
                    asp-route-documentCategoryId="@Model.DocumentCategoryId"
                    asp-route-year="@Model.Year"
                    asp-route-includeInactive="@Model.IncludeInactive"
+                   asp-route-scope="@Model.Scope"
                    asp-route-page="1"
                    asp-route-pageSize="@Model.PageSize"
                    asp-route-view="@Model.ViewMode">
@@ -104,11 +106,18 @@
     @if ((Model.IsListView && !Model.ListItems.Any()) ||
          (!Model.IsListView && !Model.Items.Any()))
     {
-        if (Model.IsSearchActive)
+        if (showFavouritesEmptyState)
+        {
+            <div class="alert alert-light border">
+                <strong>No favourites yet.</strong>
+                <div class="text-muted">Star documents you access frequently to see them here.</div>
+            </div>
+        }
+        else if (Model.IsSearchActive)
         {
             <div class="alert alert-info">
                 No documents matched "@Model.Q".
-                <a asp-page="./Index" asp-route-view="@Model.ViewMode">Show all active documents</a>
+                <a asp-page="./Index" asp-route-view="@Model.ViewMode" asp-route-scope="@Model.Scope">Show all active documents</a>
             </div>
         }
         else
@@ -177,6 +186,7 @@ else
                    asp-route-documentCategoryId="@Model.DocumentCategoryId"
                    asp-route-year="@Model.Year"
                    asp-route-includeInactive="@Model.IncludeInactive"
+                   asp-route-scope="@Model.Scope"
                    asp-route-page="1"
                    asp-route-pageSize="@Model.PageSize">
                     Apply tag filter
@@ -189,11 +199,18 @@ else
     <!-- SECTION: Results content -->
     @if (!Model.Items.Any())
     {
-        if (Model.IsSearchActive)
+        if (showFavouritesEmptyState)
+        {
+            <div class="alert alert-light border">
+                <strong>No favourites yet.</strong>
+                <div class="text-muted">Star documents you access frequently to see them here.</div>
+            </div>
+        }
+        else if (Model.IsSearchActive)
         {
             <div class="alert alert-info">
                 No documents matched "@Model.Q".
-                <a asp-page="./Index">Show all active documents</a>
+                <a asp-page="./Index" asp-route-scope="@Model.Scope">Show all active documents</a>
             </div>
         }
         else

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -130,6 +130,7 @@ namespace ProjectManagement.Data
         public DbSet<DocRepoAudit> DocRepoAudits => Set<DocRepoAudit>();
         public DbSet<OfficeCategory> OfficeCategories => Set<OfficeCategory>();
         public DbSet<DocumentCategory> DocumentCategories => Set<DocumentCategory>();
+        public DbSet<DocRepoFavourite> DocRepoFavourites => Set<DocRepoFavourite>();
 
         // SECTION: PostgreSQL text search helpers
         public static string TsHeadline(string config, string text, NpgsqlTsQuery query, string options) => throw new NotSupportedException();
@@ -294,6 +295,18 @@ namespace ProjectManagement.Data
                 e.Property(x => x.ActorUserId).HasMaxLength(450).IsRequired();
                 e.Property(x => x.DetailsJson).HasColumnType("jsonb");
                 e.HasIndex(x => new { x.DocumentId, x.OccurredAtUtc });
+            });
+
+            // SECTION: Document repository favourites
+            builder.Entity<DocRepoFavourite>(e =>
+            {
+                e.Property(x => x.UserId).HasMaxLength(64).IsRequired();
+                e.Property(x => x.CreatedAtUtc).IsRequired();
+                e.HasIndex(x => new { x.UserId, x.DocumentId }).IsUnique();
+                e.HasOne(x => x.Document)
+                    .WithMany()
+                    .HasForeignKey(x => x.DocumentId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             builder.Entity<Project>(e =>

--- a/Data/DocRepo/DocRepoFavourite.cs
+++ b/Data/DocRepo/DocRepoFavourite.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Data.DocRepo;
+
+// SECTION: Document repository favourites
+public class DocRepoFavourite
+{
+    public long Id { get; set; }
+
+    [Required, MaxLength(64)]
+    public string UserId { get; set; } = null!;
+
+    public Guid DocumentId { get; set; }
+
+    public Document Document { get; set; } = null!;
+
+    public DateTime CreatedAtUtc { get; set; }
+}

--- a/Migrations/20261119120000_AddDocRepoFavourites.cs
+++ b/Migrations/20261119120000_AddDocRepoFavourites.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261119120000_AddDocRepoFavourites")]
+    public partial class AddDocRepoFavourites : Migration
+    {
+        // SECTION: Add document repository favourites
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DocRepoFavourites",
+                columns: table => new
+                {
+                    Id = table.Column<long>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(maxLength: 64, nullable: false),
+                    DocumentId = table.Column<Guid>(nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DocRepoFavourites", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DocRepoFavourites_Documents_DocumentId",
+                        column: x => x.DocumentId,
+                        principalTable: "Documents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocRepoFavourites_DocumentId",
+                table: "DocRepoFavourites",
+                column: "DocumentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocRepoFavourites_UserId_DocumentId",
+                table: "DocRepoFavourites",
+                columns: new[] { "UserId", "DocumentId" },
+                unique: true);
+        }
+
+        // SECTION: Remove document repository favourites
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DocRepoFavourites");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1629,6 +1629,35 @@ namespace ProjectManagement.Migrations
                     b.ToTable("DocRepoExternalLinks", (string)null);
                 });
 
+            modelBuilder.Entity("ProjectManagement.Data.DocRepo.DocRepoFavourite", b =>
+                {
+                    b.Property<long>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<Guid>("DocumentId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DocumentId");
+
+                    b.HasIndex("UserId", "DocumentId")
+                        .IsUnique();
+
+                    b.ToTable("DocRepoFavourites");
+                });
+
             modelBuilder.Entity("ProjectManagement.Data.DocRepo.Document", b =>
                 {
                     b.Property<Guid>("Id")
@@ -5968,6 +5997,17 @@ namespace ProjectManagement.Migrations
                 {
                     b.HasOne("ProjectManagement.Data.DocRepo.Document", "Document")
                         .WithMany("ExternalLinks")
+                        .HasForeignKey("DocumentId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Document");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Data.DocRepo.DocRepoFavourite", b =>
+                {
+                    b.HasOne("ProjectManagement.Data.DocRepo.Document", "Document")
+                        .WithMany()
                         .HasForeignKey("DocumentId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();

--- a/wwwroot/css/docrepo-ui.css
+++ b/wwwroot/css/docrepo-ui.css
@@ -314,6 +314,55 @@
     align-items: flex-start;
 }
 
+/* SECTION: Navigation rail */
+.docrepo-rail {
+    width: 64px;
+    flex: 0 0 64px;
+    background: var(--pm-card);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 0.85rem;
+    padding: 0.5rem;
+    position: sticky;
+    top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.docrepo-rail__item {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.45rem 0.35rem;
+    border-radius: 0.7rem;
+    text-decoration: none;
+    color: var(--pm-text-muted);
+    font-size: 0.62rem;
+    transition: background-color 120ms ease-in-out, color 120ms ease-in-out;
+}
+
+.docrepo-rail__item i {
+    font-size: 1rem;
+}
+
+.docrepo-rail__item:hover {
+    color: var(--pm-primary-strong);
+    background: var(--pm-primary-soft);
+}
+
+.docrepo-rail__item.is-active {
+    color: var(--pm-primary-strong);
+    background: var(--pm-primary-soft);
+    font-weight: 600;
+}
+
+.docrepo-rail__label {
+    text-align: center;
+}
+
 .docrepo-filters {
     width: 300px;
     flex: 0 0 300px;
@@ -410,6 +459,40 @@
     display: flex;
     flex-direction: column;
     gap: 0.45rem;
+}
+
+/* SECTION: Favourite stars */
+.docrepo-star {
+    border: none;
+    background: transparent;
+    color: var(--pm-text-muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem;
+    border-radius: 9999px;
+    transition: color 120ms ease-in-out, background-color 120ms ease-in-out;
+}
+
+.docrepo-star:hover {
+    color: var(--pm-primary-strong);
+    background: var(--pm-primary-soft);
+}
+
+.docrepo-star[data-fav="true"] {
+    color: var(--pm-primary-strong);
+}
+
+.docrepo-star--card {
+    margin-left: auto;
+}
+
+.doc-card__meta-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+    margin-bottom: 0.25rem;
 }
 
 .docrepo-check {
@@ -576,6 +659,18 @@
 @media (max-width: 992px) {
     .docrepo-shell {
         flex-direction: column;
+    }
+
+    .docrepo-rail {
+        width: 100%;
+        flex: 1 1 auto;
+        flex-direction: row;
+        justify-content: flex-start;
+        position: static;
+    }
+
+    .docrepo-rail__item {
+        flex: 1 1 auto;
     }
 
     .docrepo-filters {


### PR DESCRIPTION
### Motivation

- Provide per-user document favourites so users can quickly access frequently used documents without changing existing document schemas or workflows.
- Make favouriting fast and non-disruptive by using an AJAX toggle and reusing the existing listing pipeline for the favourites scope.
- Surface favourites in the UI via a left navigation rail item and consistent star controls in both List and Cards views.
- Ensure favourites are indexed and cleaned up when documents are deleted by configuring a minimal, efficient DB model.

### Description

- Added the `DocRepoFavourite` entity (`Data/DocRepo/DocRepoFavourite.cs`), `DbSet<DocRepoFavourite>` in `ApplicationDbContext`, `OnModelCreating` mapping with a unique `(UserId, DocumentId)` index and cascade `FK` to `Documents`, and a migration `Migrations/20261119120000_AddDocRepoFavourites.cs`.
- Implemented favourites scope handling and per-page hydration of favourite state in `Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs` including `scope` query param, `IsFavouritesScope`, `OnPostToggleFavouriteAsync(Guid id)` handler and helper methods `ApplyFavouriteStateAsync` / `GetFavouriteIdsAsync` to avoid N+1 queries.
- Updated view models `DocumentListItemVm` and `DocumentSearchResultVm` with `IsFavourite`, added star button markup to `_DocumentList.cshtml` and `_DocumentCard.cshtml`, a left navigation rail entry in `Index.cshtml`, and an empty-state message for empty favourites in `_ResultsBlock.cshtml`.
- Added client-side code (`wwwroot/js/docrepo-ui.js`) with `initFavouriteToggles()` to AJAX-toggle the star (using anti-forgery token) and accompanying styles in `wwwroot/css/docrepo-ui.css` for the rail and star states.

### Testing

- No automated tests were executed in this environment because the runtime/tooling to run the test suite (e.g. `dotnet`) was not available.
- The migration file `Migrations/20261119120000_AddDocRepoFavourites.cs` has been added and should be applied in your environment prior to use via your normal EF migration workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963dd5e05b8832994e13a57a8fc1050)