### PR TITLE
Fix document repository partial flag and favourites lookup

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml
@@ -2,13 +2,13 @@
 @model ProjectManagement.Areas.DocumentRepository.Pages.Documents.IndexModel
 @{
     ViewData["Title"] = "Document repository";
-    if (Model.Partial)
+    if (Model.IsPartial)
     {
         Layout = null;
     }
 }
 
-@if (!Model.Partial)
+@if (!Model.IsPartial)
 {
     @section Styles {
         <link rel="stylesheet" href="~/css/docrepo-ui.css" asp-append-version="true" />
@@ -20,7 +20,7 @@
     }
 }
 
-@if (Model.Partial)
+@if (Model.IsPartial)
 {
     <partial name="_ResultsBlock" model="Model" />
 }

--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs
@@ -38,7 +38,7 @@ namespace ProjectManagement.Areas.DocumentRepository.Pages.Documents
         [FromQuery(Name = "year")] public int? Year { get; set; }
         [FromQuery(Name = "includeInactive")] public bool IncludeInactive { get; set; }
         [FromQuery(Name = "view")] public string? View { get; set; }
-        [FromQuery(Name = "partial")] public bool Partial { get; set; }
+        [FromQuery(Name = "partial")] public bool IsPartial { get; set; }
         [FromQuery(Name = "scope")] public string? Scope { get; set; }
 
         // SECTION: View state
@@ -362,11 +362,13 @@ namespace ProjectManagement.Areas.DocumentRepository.Pages.Documents
                 return new HashSet<Guid>();
             }
 
-            return await _db.DocRepoFavourites
+            var favouriteIds = await _db.DocRepoFavourites
                 .AsNoTracking()
                 .Where(favourite => favourite.UserId == userId && documentIds.Contains(favourite.DocumentId))
                 .Select(favourite => favourite.DocumentId)
-                .ToHashSetAsync();
+                .ToListAsync();
+
+            return favouriteIds.ToHashSet();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Address a warning caused by declaring a `Partial` variable that hides the base `PageModel.Partial` member. 
- Fix a compile-time error caused by calling `ToHashSetAsync` on an `IQueryable<Guid>` which is not available in the referenced libraries. 
- Keep view behavior consistent by using a non-conflicting property name and ensure favourites lookup works across target frameworks. 

### Description
- Renamed the query-bound flag from `Partial` to `IsPartial` in `IndexModel` and updated the Razor view to use `Model.IsPartial` to avoid hiding the base member. 
- Replaced the unsupported `ToHashSetAsync()` call in `GetFavouriteIdsAsync` with `ToListAsync()` followed by `ToHashSet()` to materialize the IDs and return a `HashSet<Guid>`. 
- Updated `Areas/DocumentRepository/Pages/Documents/Index.cshtml` and `Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs` accordingly to reflect these fixes. 

### Testing
- No automated tests were executed for this change. 
- Changes were limited to renaming the query property and adjusting the favourites query to avoid using unavailable async extensions. 
- Manual compile/IDE warnings were addressed by the code modifications. 
- Please run the project test suite or build pipeline in your environment to validate further.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696455b840d08329beade09d93114725)