### PR TITLE
Fix docrepo favourite toggle URL handling

### DIFF
--- a/wwwroot/js/docrepo-ui.js
+++ b/wwwroot/js/docrepo-ui.js
@@ -633,7 +633,11 @@ function initFavouriteToggles() {
         setButtonState(button, !wasFavourite);
 
         try {
-            const response = await fetch(`${toggleUrl}?id=${encodeURIComponent(documentId)}`, {
+            // SECTION: Toggle endpoint with query-safe id
+            const endpoint = new URL(toggleUrl, window.location.origin);
+            endpoint.searchParams.set("id", documentId);
+
+            const response = await fetch(endpoint.toString(), {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",


### PR DESCRIPTION
### Motivation
- The favourite toggle endpoint was being called by concatenating `?id=` onto `data-toggle-url`, which can already contain query parameters and produced malformed URLs that caused the toggle to fail. 
- This led to the UI showing "Unable to update favourite" and preventing users from marking/unmarking favourites. 

### Description
- Updated `wwwroot/js/docrepo-ui.js` in `initFavouriteToggles` to construct the POST URL using the `URL` constructor and `searchParams.set("id", ...)` instead of string concatenation. 
- The fetch now uses `endpoint.toString()` so the `id` query parameter is reliably encoded and appended. 
- Added a short section comment `// SECTION: Toggle endpoint with query-safe id` to improve readability. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f4d76308832980d6ac7701012acd)