### PR TITLE
Prevent full reload on document scope switch

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml
@@ -52,6 +52,7 @@ else
                 <!-- SECTION: Navigation rail -->
                 <nav class="docrepo-rail" aria-label="Document scopes">
                     <a class="docrepo-rail__item @(Model.IsDefaultScope ? "is-active" : string.Empty)"
+                       data-scope=""
                        asp-page="./Index"
                        asp-route-view="@Model.ViewMode"
                        asp-route-page="1"
@@ -62,6 +63,7 @@ else
                         <span class="docrepo-rail__label">Documents</span>
                     </a>
                     <a class="docrepo-rail__item @(Model.IsFavouritesScope ? "is-active" : string.Empty)"
+                       data-scope="favourites"
                        asp-page="./Index"
                        asp-route-scope="favourites"
                        asp-route-view="@Model.ViewMode"
@@ -73,6 +75,7 @@ else
                         <span class="docrepo-rail__label">Favourites</span>
                     </a>
                     <a class="docrepo-rail__item @(Model.IsAotsScope ? "is-active" : string.Empty)"
+                       data-scope="aots"
                        asp-page="./Index"
                        asp-route-scope="aots"
                        asp-route-view="@Model.ViewMode"


### PR DESCRIPTION
### Motivation

- Scope navigation in the Document Repository performed full-page navigations because rail links were plain anchors, causing the shell (filters, toolbar) to reload instead of only refreshing results.
- The UX needs scope switches (Documents / Favourites / AOTS) to update only the results block (`#docrepoResults`) via the existing partial-fetch mechanism.

### Description

- Add `data-scope` attributes to the scope rail links in `Areas/DocumentRepository/Pages/Documents/Index.cshtml` so JS can map links to scopes reliably.
- Add `syncScopeUiFromLocation()` and `initScopeNavigation()` to `wwwroot/js/docrepo-ui.js` to intercept left-clicks on `.docrepo-rail__item`, prevent default navigation, call `fetchAndSwapResults(...)`, update `.is-active` state, and sync hidden `input[name="scope"]` values.
- Call `syncScopeUiFromLocation()` after swapping results in `fetchAndSwapResults()` and on `popstate`, and initialize scope syncing/navigation on `DOMContentLoaded` so back/forward and history updates keep the rail and hidden inputs consistent.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965203561b08329886379355bb9be82)