### PR TITLE
Fix document repository partial updates (send boolean partial flag)

### DIFF
--- a/wwwroot/js/docrepo-ui.js
+++ b/wwwroot/js/docrepo-ui.js
@@ -346,7 +346,7 @@ async function fetchAndSwapResults(targetUrl, options = {}) {
     };
 
     const requestUrl = new URL(targetUrl, window.location.origin);
-    requestUrl.searchParams.set("partial", "1");
+    requestUrl.searchParams.set("partial", "true");
 
     setUpdating(true);
 


### PR DESCRIPTION
### Motivation
- Prevent nested layouts and incorrect full-page renders when updating results via AJAX by ensuring the server receives an explicit boolean partial flag. 
- Address UI issues observed when the client requested a partial results block but the server interpreted the flag incorrectly. 
- Keep client-side partial fetch logic aligned with server expectations for the `partial` query parameter. 

### Description
- Changed the AJAX partial request parameter from `partial=1` to `partial=true` in `fetchAndSwapResults` within `wwwroot/js/docrepo-ui.js`. 
- The function continues to fetch the partial HTML and swap the `#docrepoResults` inner content, and still removes the `partial` parameter before pushing history. 
- No other functional changes were made to the fetch logic, back/forward handling, or UI sync behavior. 

### Testing
- No automated tests were executed for this change. 
- Project build or runtime verification was not run as part of this change. 
- Manual verification was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965222dd0508329b99254ec62351dbe)