### PR TITLE
Harden document repository partial rendering

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs
@@ -86,6 +86,14 @@ namespace ProjectManagement.Areas.DocumentRepository.Pages.Documents
 
         public async Task OnGetAsync()
         {
+            // SECTION: Partial request detection
+            if (!IsPartial &&
+                Request.Headers.TryGetValue("X-Requested-With", out var requestedWith) &&
+                string.Equals(requestedWith.ToString(), "DocRepoPartial", StringComparison.OrdinalIgnoreCase))
+            {
+                IsPartial = true;
+            }
+
             // SECTION: Feature flags
             EnableListViewUxUpgrade = _configuration.GetValue<bool>("DocRepo:EnableListViewUxUpgrade");
 

--- a/wwwroot/js/docrepo-ui.js
+++ b/wwwroot/js/docrepo-ui.js
@@ -346,7 +346,7 @@ async function fetchAndSwapResults(targetUrl, options = {}) {
     };
 
     const requestUrl = new URL(targetUrl, window.location.origin);
-    requestUrl.searchParams.set("partial", "1");
+    requestUrl.searchParams.set("partial", "true");
 
     setUpdating(true);
 
@@ -362,7 +362,23 @@ async function fetchAndSwapResults(targetUrl, options = {}) {
         }
 
         const html = await response.text();
-        results.innerHTML = html;
+
+        // SECTION: Partial response guard
+        const isFullDocument = /<\s*html[\s>]/i.test(html) || /<\s*body[\s>]/i.test(html);
+        if (isFullDocument) {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, "text/html");
+            const nextResults = doc.querySelector("#docrepoResults");
+
+            if (nextResults) {
+                results.innerHTML = nextResults.innerHTML;
+            } else {
+                window.location.assign(targetUrl);
+                return;
+            }
+        } else {
+            results.innerHTML = html;
+        }
 
         if (updateHistory) {
             const cleanUrl = new URL(targetUrl, window.location.origin);


### PR DESCRIPTION
### Motivation
- Fix nested UI rendering when AJAX partial requests were interpreted as full-page responses due to query boolean binding differences. 
- Ensure the server reliably recognises partial AJAX requests even if query binding is misinterpreted. 
- Add a client-side guard so a full HTML response cannot be naively injected into the results container.

### Description
- Server: honor the `X-Requested-With: DocRepoPartial` header and set `IsPartial` when present in `Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs`. 
- Client: continue sending `partial=true` and add a guard in `fetchAndSwapResults` to detect full documents and extract `#docrepoResults` or fall back to a full navigation in `wwwroot/js/docrepo-ui.js`. 
- Both changes protect against regressions where the `partial` query parameter might not bind to a boolean on the server. 

### Testing
- No automated tests were executed for this change. 
- A commit was created and files changed are `Areas/DocumentRepository/Pages/Documents/Index.cshtml.cs` and `wwwroot/js/docrepo-ui.js`. 
- No CI or build verification was run as part of this PR. 
- Manual runtime verification was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965222dd0508329b99254ec62351dbe)