### PR TITLE
Fix docrepo list Actions dropdown clipping

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
@@ -134,7 +134,7 @@
     {
         if (Model.IsListView)
         {
-            <div class="table-responsive docrepo-list-wrapper">
+            <div class="docrepo-list-wrapper">
                 <table class="table docrepo-list">
                     <thead>
                         <tr>

--- a/wwwroot/css/docrepo-ui.css
+++ b/wwwroot/css/docrepo-ui.css
@@ -557,13 +557,31 @@
     border-radius: 0.75rem;
     border: 1px solid rgba(15, 23, 42, 0.08);
     background: var(--pm-card);
-    overflow-x: auto;
-    overflow-y: visible;
+    overflow: visible;
     max-height: none;
 }
 
 .docrepo-list {
+    width: 100%;
+    table-layout: fixed;
     margin-bottom: 0;
+}
+
+/* SECTION: Cell truncation + wrapping */
+.docrepo-list th,
+.docrepo-list td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.docrepo-list th:first-child,
+.docrepo-list td:first-child {
+    white-space: normal;
+}
+
+.docrepo-list th:not(:first-child),
+.docrepo-list td:not(:first-child) {
+    white-space: nowrap;
 }
 
 .docrepo-list thead th {
@@ -578,6 +596,11 @@
 .docrepo-list tbody td {
     padding: 0.45rem 0.6rem;
     vertical-align: middle;
+}
+
+/* SECTION: Dropdown overlay stacking */
+.docrepo-list .dropdown-menu {
+    z-index: 2000;
 }
 
 /* SECTION: Row density + hover */


### PR DESCRIPTION
### Motivation

- The Actions dropdown in Documents list view was being clipped by the responsive scroll container, preventing the menu from rendering fully.
- The responsive wrapper (`table-responsive`) created an overflowing/clipping context that interfered with overlay positioning.
- Dropdowns and overlays must render above the table without changing desktop layout or introducing unintended horizontal scrolling.

### Description

- Removed the responsive wrapper by updating `Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml` to drop the `table-responsive` class around the table wrapper.  
- Updated `wwwroot/css/docrepo-ui.css` to set `.docrepo-list-wrapper { overflow: visible; }` and keep the wrapper styling.  
- Added table stability rules `width: 100%` and `table-layout: fixed` and cell truncation/wrapping rules for predictable column behaviour.  
- Ensured dropdowns render above the table by adding `.docrepo-list .dropdown-menu { z-index: 2000; }`.

### Testing

- Attempted an automated Playwright visual check to capture the list view and verify the dropdown, but the browser navigation failed with `net::ERR_EMPTY_RESPONSE` and the screenshot could not be produced.  
- No other automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965290bbd348329bb87241fa0e02a25)