### PR TITLE
Fix docrepo actions dropdown overflow clipping

### DIFF
--- a/wwwroot/css/docrepo-ui.css
+++ b/wwwroot/css/docrepo-ui.css
@@ -569,9 +569,18 @@
 
 /* SECTION: Cell truncation + wrapping */
 .docrepo-list th,
-.docrepo-list td {
+.docrepo-list td:not(.docrepo-actions) {
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+/* SECTION: Actions cell overflow */
+.docrepo-list td.docrepo-actions {
+    overflow: visible;
+}
+
+.docrepo-list td.docrepo-actions .dropdown-menu {
+    z-index: 3000;
 }
 
 .docrepo-list th:first-child,


### PR DESCRIPTION
### Motivation
- Dropdown menus inside the Actions table cell were being clipped because the global truncation rule applied `overflow: hidden` to every `td`, including the `docrepo-actions` cell.
- The change ensures the kebab/action dropdown can render outside the cell so menus are visible and interactive.

### Description
- Updated `wwwroot/css/docrepo-ui.css` to exclude `.docrepo-actions` from the truncation rule by changing `.docrepo-list td` to `.docrepo-list td:not(.docrepo-actions)`.
- Added `.docrepo-list td.docrepo-actions { overflow: visible; }` to allow the dropdown to overflow the cell.
- Raised the dropdown stacking order with `.docrepo-list td.docrepo-actions .dropdown-menu { z-index: 3000; }` to ensure the menu appears above other surfaces.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a2bc8514832984cef8e93e64b883)