### PR TITLE
Adjust document list column widths

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml
@@ -136,6 +136,15 @@
         {
             <div class="docrepo-list-wrapper">
                 <table class="table docrepo-list">
+                    <!-- SECTION: Column sizing -->
+                    <colgroup>
+                        <col class="col-subject" />
+                        <col class="col-category" />
+                        <col class="col-office" />
+                        <col class="col-date" />
+                        <col class="col-ocr" />
+                        <col class="col-actions" />
+                    </colgroup>
                     <thead>
                         <tr>
                             <th>Subject</th>

--- a/wwwroot/css/docrepo-ui.css
+++ b/wwwroot/css/docrepo-ui.css
@@ -567,6 +567,31 @@
     margin-bottom: 0;
 }
 
+/* SECTION: Column sizing */
+.docrepo-list col.col-subject {
+    width: auto;
+}
+
+.docrepo-list col.col-category {
+    width: 18rem;
+}
+
+.docrepo-list col.col-office {
+    width: 12rem;
+}
+
+.docrepo-list col.col-date {
+    width: 10rem;
+}
+
+.docrepo-list col.col-ocr {
+    width: 11rem;
+}
+
+.docrepo-list col.col-actions {
+    width: 4.25rem;
+}
+
 /* SECTION: Cell truncation + wrapping */
 .docrepo-list th,
 .docrepo-list td:not(.docrepo-actions) {
@@ -699,7 +724,7 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.35rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 .docrepo-actions__dropdown {


### PR DESCRIPTION
### Motivation
- Fix unpredictable column sizing in the list view caused by `table-layout: fixed` without explicit column widths.
- Make the `Subject` column take the majority of available space while keeping `Category`, `Office`, `Date`, `OCR` and `Actions` columns predictable.
- Prevent the actions cell from expanding due to wrapped action controls so the `Actions` column remains compact and stable.

### Description
- Add a `<colgroup>` with column classes (`col-subject`, `col-category`, `col-office`, `col-date`, `col-ocr`, `col-actions`) to the document list table in `Areas/DocumentRepository/Pages/Documents/_ResultsBlock.cshtml`.
- Define explicit column width rules in `wwwroot/css/docrepo-ui.css` under a `/* SECTION: Column sizing */` block, including `col-subject { width: auto; }` and fixed widths for the other columns.
- Change `.docrepo-actions` from `flex-wrap: wrap;` to `flex-wrap: nowrap;` to keep action controls on a single line.
- Keep existing truncation and overflow rules so cells continue to ellipsize content under the fixed layout.

### Testing
- No automated unit or integration tests were executed for this change.
- An automated Playwright attempt to capture a screenshot of the list view failed with `net::ERR_EMPTY_RESPONSE` because the local site at `http://localhost:7130` was not reachable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a7b9272c83299350bcb610ca8a5c)