### PR TITLE
Add AOTS viewer list page and surface "Seen by" in Reader

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/AotsViews.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/AotsViews.cshtml
@@ -1,0 +1,73 @@
+@page "{id:guid}"
+@model ProjectManagement.Areas.DocumentRepository.Pages.Documents.AotsViewsModel
+@{
+    ViewData["Title"] = "AOTS viewers";
+}
+
+<div class="container py-4">
+    <!-- SECTION: Header -->
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+        <div>
+            <h2 class="mb-1">Seen by (AOTS)</h2>
+            <div class="text-muted">
+                <span>Document:</span>
+                <span class="fw-semibold">@Model.DocumentTitle</span>
+            </div>
+        </div>
+        <div>
+            <a class="btn btn-sm btn-outline-secondary" href="@Model.ReturnUrl">
+                <i class="bi bi-arrow-left"></i>
+                <span>Back</span>
+            </a>
+        </div>
+    </div>
+
+    <!-- SECTION: Content -->
+    @if (!Model.IsAots)
+    {
+        <div class="alert alert-info" role="alert">
+            This document is not marked as AOTS.
+        </div>
+    }
+    else if (Model.Viewers.Count == 0)
+    {
+        <div class="alert alert-secondary" role="alert">
+            No viewers have opened this document yet.
+        </div>
+    }
+    else
+    {
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <!-- SECTION: Viewer table -->
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col">Ser</th>
+                                <th scope="col">Rank &amp; name</th>
+                                <th scope="col">Username</th>
+                                <th scope="col">First viewed</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (var index = 0; index < Model.Viewers.Count; index++)
+                            {
+                                var viewer = Model.Viewers[index];
+                                var displayName = string.IsNullOrWhiteSpace(viewer.Rank)
+                                    ? viewer.FullName
+                                    : $"{viewer.Rank} {viewer.FullName}";
+                                <tr>
+                                    <td>@(index + 1)</td>
+                                    <td>@displayName</td>
+                                    <td>@viewer.UserName</td>
+                                    <td>@viewer.FirstViewedAtUtc.ToLocalTime().ToString("dd MMM yyyy, HH:mm")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/Areas/DocumentRepository/Pages/Documents/AotsViews.cshtml.cs
+++ b/Areas/DocumentRepository/Pages/Documents/AotsViews.cshtml.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Areas.DocumentRepository.Pages.Documents
+{
+    [Authorize(Policy = "DocRepo.EditMetadata")]
+    public class AotsViewsModel : PageModel
+    {
+        private readonly ApplicationDbContext _db;
+
+        // SECTION: Constructor
+        public AotsViewsModel(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        // SECTION: View data
+        public string DocumentTitle { get; private set; } = "Document";
+
+        public bool IsAots { get; private set; }
+
+        public string ReturnUrl { get; private set; } = string.Empty;
+
+        public IReadOnlyList<AotsViewerVm> Viewers { get; private set; } = Array.Empty<AotsViewerVm>();
+
+        // SECTION: Query
+        [FromQuery(Name = "returnUrl")]
+        public string? ReturnUrlQuery { get; set; }
+
+        // SECTION: Handlers
+        public async Task<IActionResult> OnGetAsync(Guid id, CancellationToken cancellationToken)
+        {
+            var document = await _db.Documents
+                .AsNoTracking()
+                .Where(doc => doc.Id == id)
+                .Select(doc => new
+                {
+                    doc.Subject,
+                    doc.IsAots,
+                    doc.IsDeleted
+                })
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (document == null || document.IsDeleted)
+            {
+                return NotFound();
+            }
+
+            DocumentTitle = string.IsNullOrWhiteSpace(document.Subject)
+                ? "Document"
+                : document.Subject;
+
+            IsAots = document.IsAots;
+
+            // SECTION: Return URL
+            var fallbackUrl = Url.Page("./Reader", new { id }) ?? "/DocumentRepository/Documents";
+            ReturnUrl = Url.IsLocalUrl(ReturnUrlQuery) ? ReturnUrlQuery! : fallbackUrl;
+
+            // SECTION: Viewer query
+            Viewers = await (from view in _db.DocRepoAotsViews.AsNoTracking()
+                             where view.DocumentId == id
+                             join user in _db.Users.AsNoTracking()
+                                 on view.UserId equals user.Id into userGroup
+                             from user in userGroup.DefaultIfEmpty()
+                             orderby view.FirstViewedAtUtc
+                             select new AotsViewerVm
+                             {
+                                 Rank = user != null ? user.Rank : string.Empty,
+                                 FullName = user != null && !string.IsNullOrWhiteSpace(user.FullName)
+                                     ? user.FullName
+                                     : "Unknown user",
+                                 UserName = user != null && !string.IsNullOrWhiteSpace(user.UserName)
+                                     ? user.UserName
+                                     : view.UserId,
+                                 FirstViewedAtUtc = view.FirstViewedAtUtc
+                             })
+                .ToListAsync(cancellationToken);
+
+            return Page();
+        }
+
+        // SECTION: View models
+        public sealed class AotsViewerVm
+        {
+            public string Rank { get; init; } = string.Empty;
+            public string FullName { get; init; } = string.Empty;
+            public string UserName { get; init; } = string.Empty;
+            public DateTime FirstViewedAtUtc { get; init; }
+        }
+    }
+}

--- a/Areas/DocumentRepository/Pages/Documents/Reader.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/Reader.cshtml
@@ -241,8 +241,21 @@
 
                     @if (Model.IsAots)
                     {
+                        <!-- SECTION: AOTS seen status -->
                         <dt class="col-5 text-muted">Seen</dt>
                         <dd class="col-7">@((Model.IsAotsSeen) ? "Yes" : "No")</dd>
+
+                        <!-- SECTION: AOTS viewers -->
+                        @if (Model.CanViewAotsViews)
+                        {
+                            <dt class="col-5 text-muted">Seen by</dt>
+                            <dd class="col-7">
+                                <a class="link-primary"
+                                   href="@Model.AotsViewsUrl">
+                                    Seen by (@Model.AotsViewsCount)
+                                </a>
+                            </dd>
+                        }
                     }
                 </dl>
             </div>


### PR DESCRIPTION
### Motivation
- The system records AOTS view events (`DocRepoAotsViews`) but there is no UI to list which users have seen a document. 
- Provide a simple, secure way for authorized users to view the AOTS viewer audit so the existing stored data is visible. 

### Description
- Added a new page `Areas/DocumentRepository/Pages/Documents/AotsViews.cshtml` and backing model `AotsViews.cshtml.cs` which queries `DocRepoAotsViews` joined to `_db.Users` and renders a compact table of viewers. 
- Reused the existing authorization policy `DocRepo.EditMetadata` on the new page and for the Reader link, so only authorized users can access the audit view. 
- Updated `ReaderModel` (`Reader.cshtml.cs`) to inject `IAuthorizationService`, compute `CanViewAotsViews`, `AotsViewsCount`, and `AotsViewsUrl` for the current document. 
- Updated `Reader.cshtml` to show the new "Seen by (n)" link when the document is AOTS and the user is authorized, linking to the new `AotsViews` page. 

### Testing
- No automated tests were executed for this change. 
- Basic runtime behavior was implemented to preserve existing features and only add the new page and link (no other behavior was altered).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d7713a208329a13969650ee998f9)