### PR TITLE
Fix project purge audit logging and improve trash delete error handling

### DIFF
--- a/wwwroot/js/admin/project-trash.js
+++ b/wwwroot/js/admin/project-trash.js
@@ -8,20 +8,33 @@
         return;
     }
 
+    // SECTION: Error handling helpers
     function parseErrorResponse(response) {
         if (!response) {
             return Promise.resolve('Unable to complete the request.');
         }
 
-        return response.json().then((data) => {
-            if (data && typeof data.error === 'string' && data.error.trim().length > 0) {
-                return data.error;
-            }
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+            const statusLabel = response.statusText || 'Error';
+            return Promise.resolve(`HTTP ${response.status} ${statusLabel}`);
+        }
 
-            return 'Unable to complete the request.';
-        }).catch(() => 'Unable to complete the request.');
+        return response.json()
+            .then((data) => {
+                if (data && typeof data.error === 'string' && data.error.trim().length > 0) {
+                    return data.error;
+                }
+
+                return 'Unable to complete the request.';
+            })
+            .catch(() => {
+                const statusLabel = response.statusText || 'Error';
+                return `HTTP ${response.status} ${statusLabel}`;
+            });
     }
 
+    // SECTION: Modal helpers
     function updateModalProject(modal, trigger) {
         if (!modal) {
             return;
@@ -66,6 +79,7 @@
         }
     }
 
+    // SECTION: Request helpers
     async function sendModerationRequest(url, payload) {
         const response = await fetch(url, {
             method: 'POST',
@@ -84,6 +98,7 @@
         return parseErrorResponse(response);
     }
 
+    // SECTION: Event wiring
     function attachModalHandlers() {
         const restoreModal = document.getElementById('projectRestoreModal');
         if (restoreModal) {
@@ -106,6 +121,7 @@
         }
     }
 
+    // SECTION: Submission handling
     async function handleSubmit(button) {
         const action = button.getAttribute('data-action');
         const projectId = button.getAttribute('data-project-id');
@@ -162,6 +178,7 @@
         }
     }
 
+    // SECTION: Bootstrap initialization
     attachModalHandlers();
 
     document.querySelectorAll('[data-admin-project-submit]').forEach((button) => {


### PR DESCRIPTION
### Motivation
- Purging a project previously deleted the Projects row then attempted to insert a `ProjectAudit` referencing that deleted row, causing a DB FK violation and a 500 response.
- Purge operations must be auditable even after the project row is removed, so audit entries need to be written to a global audit table instead of a project-scoped table.
- The admin Trash UI showed a generic error when the server returned non-JSON 500 responses, making troubleshooting harder.
- Capture useful purge context (includeAssets, source, reason, metadata) with the audit entry for operator visibility.

### Description
- Inject `IAuditService` into `ProjectModerationService` and add `WritePurgeAuditAsync` which logs purge events to global `AuditLogs` (action `Projects.Purge`) with structured data instead of writing `ProjectAudits` after the project row is removed.
- Update `PurgeAsync` and `PurgeExpiredAsync` to call `WritePurgeAuditAsync` (and stop writing `ProjectAudits` after deletion), and include purge context such as `IncludeAssets` and `Source`.
- Improve the admin trash frontend by enhancing `parseErrorResponse` in `wwwroot/js/admin/project-trash.js` to show `HTTP {status} {statusText}` for non-JSON responses and to more robustly parse JSON error payloads.
- Adjusted `ProjectModerationServiceTests` to assert the presence of a global `AuditLog` entry for purge and to provide an `AuditService` instance when creating the service under test.

### Testing
- Updated unit test `ProjectModerationServiceTests.PurgeExpiredAsync_RemovesExpiredProjects` to expect an `AuditLog` entry with action `Projects.Purge` and updated the test service construction.
- No automated test runner was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ed1ee69c832989fc116397d529c3)