### PR TITLE
Fix overview cost selection for legacy meta costs

### DIFF
--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -383,11 +383,11 @@ namespace ProjectManagement.Pages.Projects
             decimal? rdOrL1CostLakhs = null;
 
             // Prefer PNC cost, then L1 cost, then project R&D cost
-            if (Procurement.PncCost.HasValue)
+            if (Procurement.PncCost is > 0m)
             {
                 rdOrL1CostLakhs = Procurement.PncCost.Value / 1_00_000m;
             }
-            else if (Procurement.L1Cost.HasValue)
+            else if (Procurement.L1Cost is > 0m)
             {
                 rdOrL1CostLakhs = Procurement.L1Cost.Value / 1_00_000m;
             }


### PR DESCRIPTION
### Motivation
- Legacy projects' meta `R&D / L1 cost` saved to `project.CostLakhs` was being overridden by procurement placeholder rows that exist but contain `0` values. 
- The overview logic used `.HasValue` on nullable procurement fields so a zero value still took precedence over the project meta cost. 
- That caused the Overview card to show `0 lakh` even when legacy Meta Edit had a non-zero value. 
- The change ensures legacy meta cost surfaces on Overview unless a real (greater-than-zero) procurement value exists. 

### Description
- Replace `.HasValue` checks with `is > 0m` for `Procurement.PncCost` and `Procurement.L1Cost` in `Pages/Projects/Overview.cshtml.cs`. 
- Compute `rdOrL1CostLakhs` from procurement values only when they are greater than zero and otherwise fall back to `project.CostLakhs`. 
- Keep existing unit conversion (`/ 1_00_000m`) and the rest of the cost-summary logic unchanged. 
- Changes are restricted to the cost-summary selection block to avoid impacting other features. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f01eb3108329bef4dc710d235d02)