### PR TITLE
Declutter Partner Details: move Add flows to offcanvas drawers and remove project link dates

### DIFF
--- a/Configuration/Policies.cs
+++ b/Configuration/Policies.cs
@@ -2,6 +2,41 @@ namespace ProjectManagement.Configuration;
 
 public static class Policies
 {
+    public static class Partners
+    {
+        public const string View = "Partners.View";
+        public const string Manage = "Partners.Manage";
+        public const string Delete = "Partners.Delete";
+        public const string LinkToProject = "Partners.LinkToProject";
+
+        public static readonly string[] ManageAllowedRoles =
+        {
+            RoleNames.ProjectOffice,
+            RoleNames.ProjectOfficeAlternate,
+            RoleNames.ProjectOfficer,
+            RoleNames.Admin,
+            RoleNames.HoD,
+            RoleNames.Ta,
+            RoleNames.Mco,
+            RoleNames.Comdt
+        };
+
+        public static readonly string[] DeleteAllowedRoles =
+        {
+            RoleNames.Admin,
+            RoleNames.HoD,
+            RoleNames.Comdt
+        };
+
+        public static readonly string[] LinkAllowedRoles =
+        {
+            RoleNames.ProjectOfficer,
+            RoleNames.HoD,
+            RoleNames.Mco,
+            RoleNames.Admin
+        };
+    }
+
     public static class Ipr
     {
         public const string View = "Ipr.View";

--- a/Migrations/20261121120000_AddIndustryPartnersModule.cs
+++ b/Migrations/20261121120000_AddIndustryPartnersModule.cs
@@ -1,0 +1,239 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261121120000_AddIndustryPartnersModule")]
+    public partial class AddIndustryPartnersModule : Migration
+    {
+        // SECTION: Add industry partner module tables
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "IndustryPartners",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FirmName = table.Column<string>(maxLength: 256, nullable: false),
+                    NormalizedFirmName = table.Column<string>(maxLength: 256, nullable: false),
+                    PartnerType = table.Column<string>(maxLength: 80, nullable: true),
+                    AddressText = table.Column<string>(maxLength: 512, nullable: true),
+                    City = table.Column<string>(maxLength: 120, nullable: true),
+                    State = table.Column<string>(maxLength: 120, nullable: true),
+                    Pincode = table.Column<string>(maxLength: 20, nullable: true),
+                    Website = table.Column<string>(maxLength: 256, nullable: true),
+                    Notes = table.Column<string>(maxLength: 2000, nullable: true),
+                    Status = table.Column<string>(maxLength: 40, nullable: false, defaultValue: "Active"),
+                    CreatedByUserId = table.Column<string>(maxLength: 450, nullable: false),
+                    UpdatedByUserId = table.Column<string>(maxLength: 450, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    UpdatedAtUtc = table.Column<DateTime>(nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IndustryPartners", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IndustryPartnerContacts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PartnerId = table.Column<int>(nullable: false),
+                    Name = table.Column<string>(maxLength: 200, nullable: false),
+                    Designation = table.Column<string>(maxLength: 120, nullable: true),
+                    Email = table.Column<string>(maxLength: 200, nullable: true),
+                    IsPrimary = table.Column<bool>(nullable: false, defaultValue: false),
+                    Notes = table.Column<string>(maxLength: 1000, nullable: true),
+                    CreatedByUserId = table.Column<string>(maxLength: 450, nullable: false),
+                    UpdatedByUserId = table.Column<string>(maxLength: 450, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    UpdatedAtUtc = table.Column<DateTime>(nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IndustryPartnerContacts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IndustryPartnerContacts_IndustryPartners_PartnerId",
+                        column: x => x.PartnerId,
+                        principalTable: "IndustryPartners",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IndustryPartnerAttachments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PartnerId = table.Column<int>(nullable: false),
+                    StorageKey = table.Column<string>(maxLength: 260, nullable: false),
+                    OriginalFileName = table.Column<string>(maxLength: 260, nullable: false),
+                    ContentType = table.Column<string>(maxLength: 128, nullable: false),
+                    FileSize = table.Column<long>(nullable: false),
+                    Title = table.Column<string>(maxLength: 200, nullable: true),
+                    AttachmentType = table.Column<string>(maxLength: 80, nullable: true),
+                    Notes = table.Column<string>(maxLength: 1000, nullable: true),
+                    UploadedByUserId = table.Column<string>(maxLength: 450, nullable: false),
+                    UploadedAtUtc = table.Column<DateTime>(nullable: false, defaultValueSql: "now() at time zone 'utc'")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IndustryPartnerAttachments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IndustryPartnerAttachments_IndustryPartners_PartnerId",
+                        column: x => x.PartnerId,
+                        principalTable: "IndustryPartners",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectIndustryPartners",
+                columns: table => new
+                {
+                    ProjectId = table.Column<int>(nullable: false),
+                    PartnerId = table.Column<int>(nullable: false),
+                    Role = table.Column<string>(maxLength: 80, nullable: false, defaultValue: "Joint Development Partner"),
+                    FromDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    ToDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    Status = table.Column<string>(maxLength: 40, nullable: false, defaultValue: "Active"),
+                    Notes = table.Column<string>(maxLength: 1000, nullable: true),
+                    CreatedByUserId = table.Column<string>(maxLength: 450, nullable: false),
+                    UpdatedByUserId = table.Column<string>(maxLength: 450, nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(nullable: false, defaultValueSql: "now() at time zone 'utc'"),
+                    UpdatedAtUtc = table.Column<DateTime>(nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "bytea", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectIndustryPartners", x => new { x.ProjectId, x.PartnerId });
+                    table.ForeignKey(
+                        name: "FK_ProjectIndustryPartners_IndustryPartners_PartnerId",
+                        column: x => x.PartnerId,
+                        principalTable: "IndustryPartners",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectIndustryPartners_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IndustryPartnerContactPhones",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ContactId = table.Column<int>(nullable: false),
+                    PhoneNumber = table.Column<string>(maxLength: 40, nullable: false),
+                    Label = table.Column<string>(maxLength: 32, nullable: false, defaultValue: "Mobile")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IndustryPartnerContactPhones", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IndustryPartnerContactPhones_IndustryPartnerContacts_ContactId",
+                        column: x => x.ContactId,
+                        principalTable: "IndustryPartnerContacts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartnerAttachments_PartnerId",
+                table: "IndustryPartnerAttachments",
+                column: "PartnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartnerAttachments_UploadedAtUtc",
+                table: "IndustryPartnerAttachments",
+                column: "UploadedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartnerContacts_PartnerId",
+                table: "IndustryPartnerContacts",
+                column: "PartnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartnerContacts_PartnerId_IsPrimary",
+                table: "IndustryPartnerContacts",
+                columns: new[] { "PartnerId", "IsPrimary" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_IndustryPartnerContacts_Primary",
+                table: "IndustryPartnerContacts",
+                column: "PartnerId",
+                unique: true,
+                filter: "\"IsPrimary\" = TRUE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartnerContactPhones_ContactId",
+                table: "IndustryPartnerContactPhones",
+                column: "ContactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartners_City",
+                table: "IndustryPartners",
+                column: "City");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartners_FirmName",
+                table: "IndustryPartners",
+                column: "FirmName");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IndustryPartners_Status",
+                table: "IndustryPartners",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_IndustryPartners_NormalizedFirmName",
+                table: "IndustryPartners",
+                column: "NormalizedFirmName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectIndustryPartners_PartnerId",
+                table: "ProjectIndustryPartners",
+                column: "PartnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectIndustryPartners_ProjectId",
+                table: "ProjectIndustryPartners",
+                column: "ProjectId");
+        }
+
+        // SECTION: Remove industry partner module tables
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IndustryPartnerAttachments");
+
+            migrationBuilder.DropTable(
+                name: "IndustryPartnerContactPhones");
+
+            migrationBuilder.DropTable(
+                name: "ProjectIndustryPartners");
+
+            migrationBuilder.DropTable(
+                name: "IndustryPartnerContacts");
+
+            migrationBuilder.DropTable(
+                name: "IndustryPartners");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -3136,6 +3136,324 @@ namespace ProjectManagement.Migrations
                     b.ToTable("UserProjectMutes");
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartner", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("AddressText")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("City")
+                        .HasMaxLength(120)
+                        .HasColumnType("character varying(120)");
+
+                    b.Property<string>("CreatedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now() at time zone 'utc'");
+
+                    b.Property<string>("FirmName")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("NormalizedFirmName")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<string>("PartnerType")
+                        .HasMaxLength(80)
+                        .HasColumnType("character varying(80)");
+
+                    b.Property<string>("Pincode")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .IsRequired()
+                        .HasColumnType("bytea");
+
+                    b.Property<string>("State")
+                        .HasMaxLength(120)
+                        .HasColumnType("character varying(120)");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)")
+                        .HasDefaultValue("Active");
+
+                    b.Property<string>("UpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime?>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Website")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("City")
+                        .HasDatabaseName("IX_IndustryPartners_City");
+
+                    b.HasIndex("FirmName")
+                        .HasDatabaseName("IX_IndustryPartners_FirmName");
+
+                    b.HasIndex("NormalizedFirmName")
+                        .IsUnique()
+                        .HasDatabaseName("UX_IndustryPartners_NormalizedFirmName");
+
+                    b.HasIndex("Status")
+                        .HasDatabaseName("IX_IndustryPartners_Status");
+
+                    b.ToTable("IndustryPartners");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerAttachment", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("AttachmentType")
+                        .HasMaxLength(80)
+                        .HasColumnType("character varying(80)");
+
+                    b.Property<string>("ContentType")
+                        .IsRequired()
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.Property<long>("FileSize")
+                        .HasColumnType("bigint");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(1000)
+                        .HasColumnType("character varying(1000)");
+
+                    b.Property<string>("OriginalFileName")
+                        .IsRequired()
+                        .HasMaxLength(260)
+                        .HasColumnType("character varying(260)");
+
+                    b.Property<int>("PartnerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("StorageKey")
+                        .IsRequired()
+                        .HasMaxLength(260)
+                        .HasColumnType("character varying(260)");
+
+                    b.Property<string>("Title")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("UploadedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime>("UploadedAtUtc")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now() at time zone 'utc'");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PartnerId")
+                        .HasDatabaseName("IX_IndustryPartnerAttachments_PartnerId");
+
+                    b.HasIndex("UploadedAtUtc")
+                        .HasDatabaseName("IX_IndustryPartnerAttachments_UploadedAtUtc");
+
+                    b.ToTable("IndustryPartnerAttachments");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerContact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("CreatedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now() at time zone 'utc'");
+
+                    b.Property<string>("Designation")
+                        .HasMaxLength(120)
+                        .HasColumnType("character varying(120)");
+
+                    b.Property<string>("Email")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<bool>("IsPrimary")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false);
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(1000)
+                        .HasColumnType("character varying(1000)");
+
+                    b.Property<int>("PartnerId")
+                        .HasColumnType("integer");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .IsRequired()
+                        .HasColumnType("bytea");
+
+                    b.Property<string>("UpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime?>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PartnerId")
+                        .HasDatabaseName("IX_IndustryPartnerContacts_PartnerId");
+
+                    b.HasIndex("PartnerId", "IsPrimary")
+                        .HasDatabaseName("IX_IndustryPartnerContacts_PartnerId_IsPrimary");
+
+                    b.HasIndex("PartnerId")
+                        .IsUnique()
+                        .HasDatabaseName("UX_IndustryPartnerContacts_Primary")
+                        .HasFilter("\"IsPrimary\" = TRUE");
+
+                    b.ToTable("IndustryPartnerContacts");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerContactPhone", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("ContactId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Label")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)")
+                        .HasDefaultValue("Mobile");
+
+                    b.Property<string>("PhoneNumber")
+                        .IsRequired()
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ContactId")
+                        .HasDatabaseName("IX_IndustryPartnerContactPhones_ContactId");
+
+                    b.ToTable("IndustryPartnerContactPhones");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.ProjectIndustryPartner", b =>
+                {
+                    b.Property<int>("ProjectId")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PartnerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("CreatedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("now() at time zone 'utc'");
+
+                    b.Property<DateOnly?>("FromDate")
+                        .HasColumnType("date");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(1000)
+                        .HasColumnType("character varying(1000)");
+
+                    b.Property<string>("Role")
+                        .IsRequired()
+                        .HasMaxLength(80)
+                        .HasColumnType("character varying(80)")
+                        .HasDefaultValue("Joint Development Partner");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .IsRequired()
+                        .HasColumnType("bytea");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)")
+                        .HasDefaultValue("Active");
+
+                    b.Property<DateOnly?>("ToDate")
+                        .HasColumnType("date");
+
+                    b.Property<string>("UpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime?>("UpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("ProjectId", "PartnerId");
+
+                    b.HasIndex("PartnerId")
+                        .HasDatabaseName("IX_ProjectIndustryPartners_PartnerId");
+
+                    b.HasIndex("ProjectId")
+                        .HasDatabaseName("IX_ProjectIndustryPartners_ProjectId");
+
+                    b.ToTable("ProjectIndustryPartners");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.Plans.PlanApprovalLog", b =>
                 {
                     b.Property<int>("Id")
@@ -6300,6 +6618,58 @@ namespace ProjectManagement.Migrations
                         .HasForeignKey("ProjectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerAttachment", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Partners.IndustryPartner", "Partner")
+                        .WithMany("Attachments")
+                        .HasForeignKey("PartnerId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Partner");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerContact", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Partners.IndustryPartner", "Partner")
+                        .WithMany("Contacts")
+                        .HasForeignKey("PartnerId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Partner");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.IndustryPartnerContactPhone", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Partners.IndustryPartnerContact", "Contact")
+                        .WithMany("Phones")
+                        .HasForeignKey("ContactId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Contact");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.Partners.ProjectIndustryPartner", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.Partners.IndustryPartner", "Partner")
+                        .WithMany("ProjectLinks")
+                        .HasForeignKey("PartnerId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("ProjectManagement.Models.Project", "Project")
+                        .WithMany()
+                        .HasForeignKey("ProjectId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Partner");
+
+                    b.Navigation("Project");
                 });
 
             modelBuilder.Entity("ProjectManagement.Models.Plans.PlanApprovalLog", b =>

--- a/Models/Partners/IndustryPartner.cs
+++ b/Models/Partners/IndustryPartner.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Models.Partners;
+
+// SECTION: Industry partner master
+public class IndustryPartner
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(256)]
+    public string FirmName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string NormalizedFirmName { get; set; } = string.Empty;
+
+    [MaxLength(80)]
+    public string? PartnerType { get; set; }
+
+    [MaxLength(512)]
+    public string? AddressText { get; set; }
+
+    [MaxLength(120)]
+    public string? City { get; set; }
+
+    [MaxLength(120)]
+    public string? State { get; set; }
+
+    [MaxLength(20)]
+    public string? Pincode { get; set; }
+
+    [MaxLength(256)]
+    public string? Website { get; set; }
+
+    [MaxLength(2000)]
+    public string? Notes { get; set; }
+
+    [Required]
+    [MaxLength(40)]
+    public string Status { get; set; } = IndustryPartnerStatuses.Active;
+
+    [Required]
+    [MaxLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    [MaxLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? UpdatedAtUtc { get; set; }
+
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+
+    public ICollection<IndustryPartnerContact> Contacts { get; set; } = new List<IndustryPartnerContact>();
+
+    public ICollection<IndustryPartnerAttachment> Attachments { get; set; } = new List<IndustryPartnerAttachment>();
+
+    public ICollection<ProjectIndustryPartner> ProjectLinks { get; set; } = new List<ProjectIndustryPartner>();
+}
+
+// SECTION: Partner contacts
+public class IndustryPartnerContact
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int PartnerId { get; set; }
+
+    public IndustryPartner Partner { get; set; } = null!;
+
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(120)]
+    public string? Designation { get; set; }
+
+    [MaxLength(200)]
+    public string? Email { get; set; }
+
+    public bool IsPrimary { get; set; }
+
+    [MaxLength(1000)]
+    public string? Notes { get; set; }
+
+    [Required]
+    [MaxLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    [MaxLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? UpdatedAtUtc { get; set; }
+
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+
+    public ICollection<IndustryPartnerContactPhone> Phones { get; set; } = new List<IndustryPartnerContactPhone>();
+}
+
+// SECTION: Contact phone numbers
+public class IndustryPartnerContactPhone
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int ContactId { get; set; }
+
+    public IndustryPartnerContact Contact { get; set; } = null!;
+
+    [Required]
+    [MaxLength(40)]
+    public string PhoneNumber { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(32)]
+    public string Label { get; set; } = "Mobile";
+}
+
+// SECTION: Partner attachments
+public class IndustryPartnerAttachment
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int PartnerId { get; set; }
+
+    public IndustryPartner Partner { get; set; } = null!;
+
+    [Required]
+    [MaxLength(260)]
+    public string StorageKey { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(260)]
+    public string OriginalFileName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(128)]
+    public string ContentType { get; set; } = string.Empty;
+
+    public long FileSize { get; set; }
+
+    [MaxLength(200)]
+    public string? Title { get; set; }
+
+    [MaxLength(80)]
+    public string? AttachmentType { get; set; }
+
+    [MaxLength(1000)]
+    public string? Notes { get; set; }
+
+    [Required]
+    [MaxLength(450)]
+    public string UploadedByUserId { get; set; } = string.Empty;
+
+    public DateTime UploadedAtUtc { get; set; }
+}
+
+// SECTION: Project association join
+public class ProjectIndustryPartner
+{
+    [Required]
+    public int ProjectId { get; set; }
+
+    public Project Project { get; set; } = null!;
+
+    [Required]
+    public int PartnerId { get; set; }
+
+    public IndustryPartner Partner { get; set; } = null!;
+
+    [Required]
+    [MaxLength(80)]
+    public string Role { get; set; } = IndustryPartnerRoles.JointDevelopmentPartner;
+
+    public DateOnly? FromDate { get; set; }
+
+    public DateOnly? ToDate { get; set; }
+
+    [Required]
+    [MaxLength(40)]
+    public string Status { get; set; } = IndustryPartnerAssociationStatuses.Active;
+
+    [MaxLength(1000)]
+    public string? Notes { get; set; }
+
+    [Required]
+    [MaxLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    [MaxLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? UpdatedAtUtc { get; set; }
+
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+}
+
+// SECTION: Static lookups
+public static class IndustryPartnerStatuses
+{
+    public const string Active = "Active";
+    public const string Inactive = "Inactive";
+    public const string Caution = "Caution";
+    public const string Blacklisted = "Blacklisted";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Active,
+        Inactive,
+        Caution,
+        Blacklisted
+    };
+}
+
+public static class IndustryPartnerTypes
+{
+    public const string Industry = "Industry";
+    public const string Oem = "OEM";
+    public const string Msme = "MSME";
+    public const string Academic = "Academic";
+    public const string Psu = "PSU";
+    public const string Consultant = "Consultant";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Industry,
+        Oem,
+        Msme,
+        Academic,
+        Psu,
+        Consultant
+    };
+}
+
+public static class IndustryPartnerRoles
+{
+    public const string JointDevelopmentPartner = "Joint Development Partner";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        JointDevelopmentPartner
+    };
+}
+
+public static class IndustryPartnerAssociationStatuses
+{
+    public const string Active = "Active";
+    public const string Closed = "Closed";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Active,
+        Closed
+    };
+}
+
+public static class IndustryPartnerAttachmentTypes
+{
+    public const string VisitingCard = "Visiting Card";
+    public const string Brochure = "Brochure";
+    public const string Capability = "Capability";
+    public const string Nda = "NDA";
+    public const string Other = "Other";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        VisitingCard,
+        Brochure,
+        Capability,
+        Nda,
+        Other
+    };
+}

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -307,6 +307,7 @@
             </div>
             <div class="col-lg-4 d-flex flex-column gap-3">
                 <partial name="_ProjectTotPanel" model="Model" />
+                <partial name="_ProjectIndustryPartnersCard" model="Model" />
                 @if (Model.IsDocumentApprover && Model.DocumentPendingRequests.Any())
                 {
                     <div class="card pm-card">

--- a/Pages/Projects/Overview.cshtml.cs
+++ b/Pages/Projects/Overview.cshtml.cs
@@ -22,11 +22,14 @@ using ProjectManagement.Models.Plans;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Models.Remarks;
 using ProjectManagement.Models.Stages;
+using ProjectManagement.Configuration;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Projects;
 using ProjectManagement.Services.Stages;
 using ProjectManagement.Utilities;
 using ProjectManagement.ViewModels;
+using ProjectManagement.Models.Partners;
+using ProjectManagement.ViewModels.Partners;
 
 namespace ProjectManagement.Pages.Projects
 {
@@ -94,6 +97,9 @@ namespace ProjectManagement.Pages.Projects
         public ProjectRemarkSummaryViewModel RemarkSummary { get; private set; } = ProjectRemarkSummaryViewModel.Empty;
         public ProjectTotSummaryViewModel TotSummary { get; private set; } = ProjectTotSummaryViewModel.Empty;
         public ProjectCostSummaryViewModel CostSummary { get; private set; } = ProjectCostSummaryViewModel.Empty;
+        public IReadOnlyList<ProjectIndustryPartnerVm> IndustryPartners { get; private set; } = Array.Empty<ProjectIndustryPartnerVm>();
+        public IReadOnlyList<IndustryPartnerOptionVm> IndustryPartnerOptions { get; private set; } = Array.Empty<IndustryPartnerOptionVm>();
+        public bool CanLinkIndustryPartners { get; private set; }
         public bool CanManageTot { get; private set; }
         public ProjectMediaCollectionViewModel MediaCollections { get; private set; } = ProjectMediaCollectionViewModel.Empty;
         public IReadOnlyCollection<int> AvailableMediaTotIds { get; private set; } = Array.Empty<int>();
@@ -133,6 +139,9 @@ namespace ProjectManagement.Pages.Projects
         [BindProperty]
         public CancelLifecycleInput CancelProjectInput { get; set; } = new();
 
+        [BindProperty]
+        public ProjectIndustryPartnerInput PartnerInput { get; set; } = new();
+
         public sealed class CompleteLifecycleInput
         {
             public int ProjectId { get; set; }
@@ -154,6 +163,21 @@ namespace ProjectManagement.Pages.Projects
             public DateOnly? CancelledOn { get; set; }
 
             public string? Reason { get; set; }
+        }
+
+        public sealed class ProjectIndustryPartnerInput
+        {
+            public int PartnerId { get; set; }
+
+            public string Role { get; set; } = IndustryPartnerRoles.JointDevelopmentPartner;
+
+            public string Status { get; set; } = IndustryPartnerAssociationStatuses.Active;
+
+            public DateOnly? FromDate { get; set; }
+
+            public DateOnly? ToDate { get; set; }
+
+            public string? Notes { get; set; }
         }
 
         public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
@@ -181,6 +205,31 @@ namespace ProjectManagement.Pages.Projects
             var (totSnapshot, totRequestSnapshot) = await LoadTotDataAsync(project.Id, ct);
 
             Project = project;
+
+            // SECTION: Industry partner associations
+            CanLinkIndustryPartners = Policies.Partners.LinkAllowedRoles.Any(User.IsInRole);
+            IndustryPartners = await _db.ProjectIndustryPartners
+                .AsNoTracking()
+                .Include(link => link.Partner)
+                .Where(link => link.ProjectId == project.Id)
+                .OrderByDescending(link => link.Status == IndustryPartnerAssociationStatuses.Active)
+                .ThenBy(link => link.Partner.FirmName)
+                .Select(link => new ProjectIndustryPartnerVm(
+                    link.ProjectId,
+                    link.PartnerId,
+                    link.Partner.FirmName,
+                    link.Role,
+                    link.Status,
+                    link.FromDate,
+                    link.ToDate,
+                    link.Notes))
+                .ToListAsync(ct);
+
+            IndustryPartnerOptions = await _db.IndustryPartners
+                .AsNoTracking()
+                .OrderBy(partner => partner.FirmName)
+                .Select(partner => new IndustryPartnerOptionVm(partner.Id, partner.FirmName, partner.Status))
+                .ToListAsync(ct);
 
             Photos = project.Photos
                 .OrderBy(p => p.Ordinal)
@@ -623,6 +672,120 @@ namespace ProjectManagement.Pages.Projects
             {
                 TempData["Error"] = result.ErrorMessage ?? "Unable to cancel project.";
             }
+
+            return RedirectToPage(new { id });
+        }
+
+        // SECTION: Industry partners link handlers
+        [Authorize(Policy = Policies.Partners.LinkToProject)]
+        public async Task<IActionResult> OnPostLinkPartnerAsync(int id, CancellationToken ct)
+        {
+            if (PartnerInput.PartnerId <= 0)
+            {
+                ModelState.AddModelError(nameof(PartnerInput.PartnerId), "Select a partner to link.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                await OnGetAsync(id, ct);
+                return Page();
+            }
+
+            var existing = await _db.ProjectIndustryPartners
+                .AnyAsync(link => link.ProjectId == id && link.PartnerId == PartnerInput.PartnerId, ct);
+
+            if (existing)
+            {
+                TempData["ToastMessage"] = "Partner is already linked to this project.";
+                return RedirectToPage(new { id });
+            }
+
+            var now = _clock.UtcNow.UtcDateTime;
+            var userId = _users.GetUserId(User) ?? string.Empty;
+
+            var link = new ProjectIndustryPartner
+            {
+                ProjectId = id,
+                PartnerId = PartnerInput.PartnerId,
+                Role = string.IsNullOrWhiteSpace(PartnerInput.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : PartnerInput.Role,
+                Status = string.IsNullOrWhiteSpace(PartnerInput.Status) ? IndustryPartnerAssociationStatuses.Active : PartnerInput.Status,
+                FromDate = PartnerInput.FromDate,
+                ToDate = PartnerInput.ToDate,
+                Notes = string.IsNullOrWhiteSpace(PartnerInput.Notes) ? null : PartnerInput.Notes.Trim(),
+                CreatedAtUtc = now,
+                CreatedByUserId = userId
+            };
+
+            _db.ProjectIndustryPartners.Add(link);
+            await _db.SaveChangesAsync(ct);
+
+            await _audit.LogAsync(
+                "Partners.ProjectLinked",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = id.ToString(CultureInfo.InvariantCulture),
+                    ["PartnerId"] = PartnerInput.PartnerId.ToString(CultureInfo.InvariantCulture)
+                });
+
+            return RedirectToPage(new { id });
+        }
+
+        [Authorize(Policy = Policies.Partners.LinkToProject)]
+        public async Task<IActionResult> OnPostUnlinkPartnerAsync(int id, int partnerId, CancellationToken ct)
+        {
+            var link = await _db.ProjectIndustryPartners
+                .FirstOrDefaultAsync(item => item.ProjectId == id && item.PartnerId == partnerId, ct);
+
+            if (link is null)
+            {
+                return NotFound();
+            }
+
+            _db.ProjectIndustryPartners.Remove(link);
+            await _db.SaveChangesAsync(ct);
+
+            await _audit.LogAsync(
+                "Partners.ProjectUnlinked",
+                userId: _users.GetUserId(User),
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = id.ToString(CultureInfo.InvariantCulture),
+                    ["PartnerId"] = partnerId.ToString(CultureInfo.InvariantCulture)
+                });
+
+            return RedirectToPage(new { id });
+        }
+
+        [Authorize(Policy = Policies.Partners.LinkToProject)]
+        public async Task<IActionResult> OnPostUpdatePartnerAsync(int id, int partnerId, CancellationToken ct)
+        {
+            var link = await _db.ProjectIndustryPartners
+                .FirstOrDefaultAsync(item => item.ProjectId == id && item.PartnerId == partnerId, ct);
+
+            if (link is null)
+            {
+                return NotFound();
+            }
+
+            link.Role = string.IsNullOrWhiteSpace(PartnerInput.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : PartnerInput.Role;
+            link.Status = string.IsNullOrWhiteSpace(PartnerInput.Status) ? IndustryPartnerAssociationStatuses.Active : PartnerInput.Status;
+            link.FromDate = PartnerInput.FromDate;
+            link.ToDate = PartnerInput.ToDate;
+            link.Notes = string.IsNullOrWhiteSpace(PartnerInput.Notes) ? null : PartnerInput.Notes.Trim();
+            link.UpdatedAtUtc = _clock.UtcNow.UtcDateTime;
+            link.UpdatedByUserId = _users.GetUserId(User) ?? string.Empty;
+
+            await _db.SaveChangesAsync(ct);
+
+            await _audit.LogAsync(
+                "Partners.ProjectAssociationUpdated",
+                userId: _users.GetUserId(User),
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = id.ToString(CultureInfo.InvariantCulture),
+                    ["PartnerId"] = partnerId.ToString(CultureInfo.InvariantCulture)
+                });
 
             return RedirectToPage(new { id });
         }

--- a/Pages/Projects/Partners/Create.cshtml
+++ b/Pages/Projects/Partners/Create.cshtml
@@ -1,0 +1,147 @@
+@page "/Projects/Partners/Create"
+@model ProjectManagement.Pages.Projects.Partners.CreateModel
+@{
+    ViewData["Title"] = "Add Industry Partner";
+}
+
+<div class="container-xxl py-4">
+    <!-- SECTION: Page header -->
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+        <div>
+            <p class="text-uppercase text-muted small mb-1">Industry Partners</p>
+            <h1 class="h3 mb-1">Add partner</h1>
+            <p class="text-muted mb-0">Capture partner details and an optional primary contact.</p>
+        </div>
+        <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Index">Back to list</a>
+    </div>
+
+    <form method="post" class="row g-4">
+        <!-- SECTION: Partner details -->
+        <div class="col-lg-7">
+            <div class="card pm-card pm-shadow h-100">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Partner details</h2>
+                </div>
+                <div class="card-body vstack gap-3">
+                    <div>
+                        <label asp-for="Input.FirmName" class="form-label">Firm name</label>
+                        <input asp-for="Input.FirmName" class="form-control" />
+                        <span asp-validation-for="Input.FirmName" class="text-danger"></span>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label asp-for="Input.PartnerType" class="form-label">Partner type</label>
+                            <select asp-for="Input.PartnerType" class="form-select">
+                                <option value="">Select</option>
+                                @foreach (var type in Model.PartnerTypeOptions)
+                                {
+                                    <option value="@type">@type</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.Status" class="form-label">Status</label>
+                            <select asp-for="Input.Status" class="form-select">
+                                @foreach (var status in Model.StatusOptions)
+                                {
+                                    <option value="@status">@status</option>
+                                }
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.AddressText" class="form-label">Address</label>
+                        <textarea asp-for="Input.AddressText" class="form-control" rows="3"></textarea>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label asp-for="Input.City" class="form-label">City</label>
+                            <input asp-for="Input.City" class="form-control" />
+                        </div>
+                        <div class="col-md-4">
+                            <label asp-for="Input.State" class="form-label">State</label>
+                            <input asp-for="Input.State" class="form-control" />
+                        </div>
+                        <div class="col-md-4">
+                            <label asp-for="Input.Pincode" class="form-label">Pincode</label>
+                            <input asp-for="Input.Pincode" class="form-control" />
+                        </div>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.Website" class="form-label">Website</label>
+                        <input asp-for="Input.Website" class="form-control" placeholder="https://" />
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.Notes" class="form-label">Internal notes</label>
+                        <textarea asp-for="Input.Notes" class="form-control" rows="4"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SECTION: Primary contact -->
+        <div class="col-lg-5">
+            <div class="card pm-card pm-shadow h-100">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Primary contact (optional)</h2>
+                </div>
+                <div class="card-body vstack gap-3">
+                    <div>
+                        <label asp-for="Input.ContactName" class="form-label">Name</label>
+                        <input asp-for="Input.ContactName" class="form-control" />
+                        <span asp-validation-for="Input.ContactName" class="text-danger"></span>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.ContactDesignation" class="form-label">Designation</label>
+                        <input asp-for="Input.ContactDesignation" class="form-control" />
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.ContactEmail" class="form-label">Email</label>
+                        <input asp-for="Input.ContactEmail" class="form-control" />
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label asp-for="Input.MobilePhone" class="form-label">Mobile</label>
+                            <input asp-for="Input.MobilePhone" class="form-control" />
+                            <span asp-validation-for="Input.MobilePhone" class="text-danger"></span>
+                        </div>
+                        <div class="col-12">
+                            <label asp-for="Input.OfficePhone" class="form-label">Office</label>
+                            <input asp-for="Input.OfficePhone" class="form-control" />
+                            <span asp-validation-for="Input.OfficePhone" class="text-danger"></span>
+                        </div>
+                        <div class="col-12">
+                            <label asp-for="Input.WhatsAppPhone" class="form-label">WhatsApp</label>
+                            <input asp-for="Input.WhatsAppPhone" class="form-control" />
+                            <span asp-validation-for="Input.WhatsAppPhone" class="text-danger"></span>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.ContactNotes" class="form-label">Notes</label>
+                        <textarea asp-for="Input.ContactNotes" class="form-control" rows="3"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SECTION: Form actions -->
+        <div class="col-12 d-flex justify-content-end gap-2">
+            <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Index">Cancel</a>
+            <button type="submit" class="btn btn-primary">Save partner</button>
+        </div>
+    </form>
+</div>
+
+@section Scripts
+{
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Partners/Create.cshtml.cs
+++ b/Pages/Projects/Partners/Create.cshtml.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Partners;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects.Partners;
+
+[Authorize(Policy = Policies.Partners.Manage)]
+public class CreateModel : PageModel
+{
+    // SECTION: Dependencies
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly IClock _clock;
+    private readonly IAuditService _audit;
+
+    public CreateModel(ApplicationDbContext db, UserManager<ApplicationUser> users, IClock clock, IAuditService audit)
+    {
+        _db = db;
+        _users = users;
+        _clock = clock;
+        _audit = audit;
+    }
+
+    // SECTION: Form state
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public IReadOnlyList<string> StatusOptions => IndustryPartnerStatuses.All;
+
+    public IReadOnlyList<string> PartnerTypeOptions => IndustryPartnerTypes.All;
+
+    public sealed class InputModel
+    {
+        [Required]
+        [MaxLength(256)]
+        public string FirmName { get; set; } = string.Empty;
+
+        [MaxLength(80)]
+        public string? PartnerType { get; set; }
+
+        [MaxLength(512)]
+        public string? AddressText { get; set; }
+
+        [MaxLength(120)]
+        public string? City { get; set; }
+
+        [MaxLength(120)]
+        public string? State { get; set; }
+
+        [MaxLength(20)]
+        public string? Pincode { get; set; }
+
+        [MaxLength(256)]
+        public string? Website { get; set; }
+
+        [MaxLength(2000)]
+        public string? Notes { get; set; }
+
+        [Required]
+        [MaxLength(40)]
+        public string Status { get; set; } = IndustryPartnerStatuses.Active;
+
+        // SECTION: Optional primary contact details
+        [MaxLength(200)]
+        public string? ContactName { get; set; }
+
+        [MaxLength(120)]
+        public string? ContactDesignation { get; set; }
+
+        [MaxLength(200)]
+        public string? ContactEmail { get; set; }
+
+        [MaxLength(40)]
+        public string? MobilePhone { get; set; }
+
+        [MaxLength(40)]
+        public string? OfficePhone { get; set; }
+
+        [MaxLength(40)]
+        public string? WhatsAppPhone { get; set; }
+
+        [MaxLength(1000)]
+        public string? ContactNotes { get; set; }
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync(CancellationToken ct)
+    {
+        // SECTION: Validate model
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var normalizedFirmName = Input.FirmName.Trim().ToUpperInvariant();
+        var duplicate = await _db.IndustryPartners
+            .AnyAsync(p => p.NormalizedFirmName == normalizedFirmName, ct);
+
+        if (duplicate)
+        {
+            ModelState.AddModelError(nameof(Input.FirmName), "A partner with this firm name already exists.");
+            return Page();
+        }
+
+        ValidatePhone(Input.MobilePhone, nameof(Input.MobilePhone));
+        ValidatePhone(Input.OfficePhone, nameof(Input.OfficePhone));
+        ValidatePhone(Input.WhatsAppPhone, nameof(Input.WhatsAppPhone));
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var userId = _users.GetUserId(User) ?? string.Empty;
+        var now = _clock.UtcNow.UtcDateTime;
+
+        // SECTION: Create partner entity
+        var partner = new IndustryPartner
+        {
+            FirmName = Input.FirmName.Trim(),
+            NormalizedFirmName = normalizedFirmName,
+            PartnerType = string.IsNullOrWhiteSpace(Input.PartnerType) ? null : Input.PartnerType,
+            AddressText = string.IsNullOrWhiteSpace(Input.AddressText) ? null : Input.AddressText.Trim(),
+            City = string.IsNullOrWhiteSpace(Input.City) ? null : Input.City.Trim(),
+            State = string.IsNullOrWhiteSpace(Input.State) ? null : Input.State.Trim(),
+            Pincode = string.IsNullOrWhiteSpace(Input.Pincode) ? null : Input.Pincode.Trim(),
+            Website = string.IsNullOrWhiteSpace(Input.Website) ? null : Input.Website.Trim(),
+            Notes = string.IsNullOrWhiteSpace(Input.Notes) ? null : Input.Notes.Trim(),
+            Status = string.IsNullOrWhiteSpace(Input.Status) ? IndustryPartnerStatuses.Active : Input.Status,
+            CreatedAtUtc = now,
+            CreatedByUserId = userId
+        };
+
+        // SECTION: Optional primary contact
+        if (!string.IsNullOrWhiteSpace(Input.ContactName))
+        {
+            var contact = new IndustryPartnerContact
+            {
+                Name = Input.ContactName.Trim(),
+                Designation = string.IsNullOrWhiteSpace(Input.ContactDesignation) ? null : Input.ContactDesignation.Trim(),
+                Email = string.IsNullOrWhiteSpace(Input.ContactEmail) ? null : Input.ContactEmail.Trim(),
+                Notes = string.IsNullOrWhiteSpace(Input.ContactNotes) ? null : Input.ContactNotes.Trim(),
+                IsPrimary = true,
+                CreatedAtUtc = now,
+                CreatedByUserId = userId
+            };
+
+            foreach (var phone in BuildPhones())
+            {
+                contact.Phones.Add(phone);
+            }
+
+            partner.Contacts.Add(contact);
+        }
+
+        _db.IndustryPartners.Add(partner);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.Created",
+            userId: userId,
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["FirmName"] = partner.FirmName,
+                ["Status"] = partner.Status
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id });
+    }
+
+    // SECTION: Helpers
+    private void ValidatePhone(string? phone, string field)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return;
+        }
+
+        var normalized = phone.Trim();
+        if (!Regex.IsMatch(normalized, "^[0-9+()\\-\\s]{7,}$"))
+        {
+            ModelState.AddModelError(field, "Enter a valid phone number with at least 7 digits.");
+        }
+    }
+
+    private IEnumerable<IndustryPartnerContactPhone> BuildPhones()
+    {
+        return new[]
+        {
+            (Input.MobilePhone, "Mobile"),
+            (Input.OfficePhone, "Office"),
+            (Input.WhatsAppPhone, "WhatsApp")
+        }
+        .Where(pair => !string.IsNullOrWhiteSpace(pair.Item1))
+        .Select(pair => new IndustryPartnerContactPhone
+        {
+            PhoneNumber = pair.Item1!.Trim(),
+            Label = pair.Item2
+        });
+    }
+}

--- a/Pages/Projects/Partners/Details.cshtml
+++ b/Pages/Projects/Partners/Details.cshtml
@@ -17,6 +17,11 @@
     };
 }
 
+@section Styles
+{
+    <link rel="stylesheet" href="~/css/partners-ui.css" asp-append-version="true" />
+}
+
 <div class="container-xxl py-4">
     <!-- SECTION: Header -->
     <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
@@ -31,83 +36,112 @@
                 }
             </div>
         </div>
-        <div class="d-flex gap-2">
+        <div class="d-flex flex-wrap gap-2 justify-content-lg-end">
             <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Index">Back to list</a>
             <authorize policy="@Policies.Partners.Manage">
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocAddContact"
+                        aria-controls="ocAddContact">
+                    Add contact
+                </button>
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocAddAttachment"
+                        aria-controls="ocAddAttachment">
+                    Upload attachment
+                </button>
                 <a class="btn btn-primary" asp-page="/Projects/Partners/Edit" asp-route-id="@Model.Partner.Id">Edit partner</a>
+            </authorize>
+            <authorize policy="@Policies.Partners.LinkToProject">
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocLinkProject"
+                        aria-controls="ocLinkProject">
+                    Link project
+                </button>
             </authorize>
         </div>
     </div>
 
-    <!-- SECTION: Tabs -->
-    <ul class="nav nav-tabs mb-3">
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Overview" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Overview">Overview</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Contacts" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Contacts">Contacts</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Attachments" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Attachments">Attachments</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Projects" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Projects">Associated projects</a>
-        </li>
-    </ul>
+    <!-- SECTION: Layout -->
+    <div class="row g-4">
+        <!-- SECTION: Left rail navigation -->
+        <div class="col-lg-3 col-xxl-2">
+            <nav class="list-group partner-rail" aria-label="Partner sections">
+                <a class="list-group-item list-group-item-action @(activeTab == "Overview" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Overview">Overview</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Contacts" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Contacts">Contacts</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Attachments" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Attachments">Attachments</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Projects" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Projects">Associated projects</a>
+            </nav>
+        </div>
 
-    <!-- SECTION: Tab content -->
-    @if (activeTab == "Overview")
-    {
-        <div class="card pm-card pm-shadow">
-            <div class="card-body">
-                <div class="row g-4">
-                    <div class="col-lg-6">
-                        <h2 class="h6 text-uppercase text-muted">Address</h2>
-                        <p class="mb-2">@(string.IsNullOrWhiteSpace(Model.Partner.AddressText) ? "—" : Model.Partner.AddressText)</p>
-                        <p class="text-muted mb-0">
-                            @(string.IsNullOrWhiteSpace(Model.Partner.City) ? "" : Model.Partner.City)
-                            @(string.IsNullOrWhiteSpace(Model.Partner.State) ? "" : $", {Model.Partner.State}")
-                            @(string.IsNullOrWhiteSpace(Model.Partner.Pincode) ? "" : $" - {Model.Partner.Pincode}")
-                        </p>
-                    </div>
-                    <div class="col-lg-6">
-                        <h2 class="h6 text-uppercase text-muted">Website</h2>
-                        <p class="mb-3">
-                            @if (!string.IsNullOrWhiteSpace(Model.Partner.Website))
-                            {
-                                <a href="@Model.Partner.Website" target="_blank" rel="noopener">@Model.Partner.Website</a>
-                            }
-                            else
-                            {
-                                <span>—</span>
-                            }
-                        </p>
-                        <h2 class="h6 text-uppercase text-muted">Notes</h2>
-                        <p class="mb-0">@(string.IsNullOrWhiteSpace(Model.Partner.Notes) ? "—" : Model.Partner.Notes)</p>
+        <!-- SECTION: Tab content -->
+        <div class="col-lg-9 col-xxl-10">
+            @if (activeTab == "Overview")
+            {
+                <div class="card pm-card pm-shadow">
+                    <div class="card-body">
+                        <div class="row g-4">
+                            <div class="col-lg-6">
+                                <h2 class="h6 text-uppercase text-muted">Address</h2>
+                                <p class="mb-2">@(string.IsNullOrWhiteSpace(Model.Partner.AddressText) ? "—" : Model.Partner.AddressText)</p>
+                                <p class="text-muted mb-0">
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.City) ? "" : Model.Partner.City)
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.State) ? "" : $", {Model.Partner.State}")
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.Pincode) ? "" : $" - {Model.Partner.Pincode}")
+                                </p>
+                            </div>
+                            <div class="col-lg-6">
+                                <h2 class="h6 text-uppercase text-muted">Website</h2>
+                                <p class="mb-3">
+                                    @if (!string.IsNullOrWhiteSpace(Model.Partner.Website))
+                                    {
+                                        <a href="@Model.Partner.Website" target="_blank" rel="noopener">@Model.Partner.Website</a>
+                                    }
+                                    else
+                                    {
+                                        <span>—</span>
+                                    }
+                                </p>
+                                <h2 class="h6 text-uppercase text-muted">Notes</h2>
+                                <p class="mb-0">@(string.IsNullOrWhiteSpace(Model.Partner.Notes) ? "—" : Model.Partner.Notes)</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Contacts")
-    {
-        <div class="row g-4">
-            <div class="col-lg-7">
+            }
+            else if (activeTab == "Contacts")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Contacts</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Contacts</h2>
+                            <authorize policy="@Policies.Partners.Manage">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocAddContact"
+                                        aria-controls="ocAddContact">
+                                    Add contact
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Partner.Contacts.Any())
@@ -185,68 +219,23 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-5">
-                <authorize policy="@Policies.Partners.Manage">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Add contact</h2>
-                        </div>
-                        <div class="card-body">
-                            <form method="post" asp-page-handler="AddContact" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="Contact.Name" class="form-label">Name</label>
-                                    <input asp-for="Contact.Name" class="form-control" />
-                                    <span asp-validation-for="Contact.Name" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Designation" class="form-label">Designation</label>
-                                    <input asp-for="Contact.Designation" class="form-control" />
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Email" class="form-label">Email</label>
-                                    <input asp-for="Contact.Email" class="form-control" />
-                                </div>
-                                <div class="row g-3">
-                                    <div class="col-12">
-                                        <label asp-for="Contact.MobilePhone" class="form-label">Mobile</label>
-                                        <input asp-for="Contact.MobilePhone" class="form-control" />
-                                        <span asp-validation-for="Contact.MobilePhone" class="text-danger"></span>
-                                    </div>
-                                    <div class="col-12">
-                                        <label asp-for="Contact.OfficePhone" class="form-label">Office</label>
-                                        <input asp-for="Contact.OfficePhone" class="form-control" />
-                                        <span asp-validation-for="Contact.OfficePhone" class="text-danger"></span>
-                                    </div>
-                                    <div class="col-12">
-                                        <label asp-for="Contact.WhatsAppPhone" class="form-label">WhatsApp</label>
-                                        <input asp-for="Contact.WhatsAppPhone" class="form-control" />
-                                        <span asp-validation-for="Contact.WhatsAppPhone" class="text-danger"></span>
-                                    </div>
-                                </div>
-                                <div class="form-check">
-                                    <input asp-for="Contact.IsPrimary" class="form-check-input" />
-                                    <label asp-for="Contact.IsPrimary" class="form-check-label">Set as primary</label>
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="Contact.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Save contact</button>
-                            </form>
-                        </div>
-                    </div>
-                </authorize>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Attachments")
-    {
-        <div class="row g-4">
-            <div class="col-lg-7">
+            }
+            else if (activeTab == "Attachments")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Attachments</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Attachments</h2>
+                            <authorize policy="@Policies.Partners.Manage">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocAddAttachment"
+                                        aria-controls="ocAddAttachment">
+                                    Upload attachment
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Attachments.Any())
@@ -276,53 +265,23 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-5">
-                <authorize policy="@Policies.Partners.Manage">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Upload attachment</h2>
-                        </div>
-                        <div class="card-body">
-                            <form method="post" enctype="multipart/form-data" asp-page-handler="AddAttachment" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="Attachment.File" class="form-label">File</label>
-                                    <input asp-for="Attachment.File" type="file" class="form-control" />
-                                    <span asp-validation-for="Attachment.File" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.Title" class="form-label">Title</label>
-                                    <input asp-for="Attachment.Title" class="form-control" />
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.AttachmentType" class="form-label">Type</label>
-                                    <select asp-for="Attachment.AttachmentType" class="form-select">
-                                        <option value="">Select</option>
-                                        @foreach (var type in Model.AttachmentTypeOptions)
-                                        {
-                                            <option value="@type">@type</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="Attachment.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Upload</button>
-                            </form>
-                        </div>
-                    </div>
-                </authorize>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Projects")
-    {
-        <div class="row g-4">
-            <div class="col-lg-8">
+            }
+            else if (activeTab == "Projects")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Associated projects</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Associated projects</h2>
+                            <authorize policy="@Policies.Partners.LinkToProject">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocLinkProject"
+                                        aria-controls="ocLinkProject">
+                                    Link project
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Partner.ProjectLinks.Any())
@@ -338,8 +297,6 @@
                                             <th>Project</th>
                                             <th>Role</th>
                                             <th>Status</th>
-                                            <th>From</th>
-                                            <th>To</th>
                                             <th>Notes</th>
                                             <th class="text-end">Actions</th>
                                         </tr>
@@ -384,29 +341,7 @@
                                                         }
                                                     </authorize>
                                                 </td>
-                                                <td>
-                                                    <authorize policy="@Policies.Partners.LinkToProject">
-                                                        <input name="ProjectLink.FromDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.FromDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
-                                                    </authorize>
-                                                    <authorize policy="@Policies.Partners.View">
-                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
-                                                        {
-                                                            <span>@(link.FromDate?.ToString("dd MMM yyyy") ?? "—")</span>
-                                                        }
-                                                    </authorize>
-                                                </td>
-                                                <td>
-                                                    <authorize policy="@Policies.Partners.LinkToProject">
-                                                        <input name="ProjectLink.ToDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.ToDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
-                                                    </authorize>
-                                                    <authorize policy="@Policies.Partners.View">
-                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
-                                                        {
-                                                            <span>@(link.ToDate?.ToString("dd MMM yyyy") ?? "—")</span>
-                                                        }
-                                                    </authorize>
-                                                </td>
-                                                <td class="text-wrap" style="max-width: 220px;">
+                                                <td class="text-wrap" style="max-width: 340px;">
                                                     <authorize policy="@Policies.Partners.LinkToProject">
                                                         <textarea name="ProjectLink.Notes" form="@updateFormId" class="form-control form-control-sm" rows="2">@link.Notes</textarea>
                                                     </authorize>
@@ -444,69 +379,193 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-4">
-                <authorize policy="@Policies.Partners.LinkToProject">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Link project</h2>
+            }
+        </div>
+    </div>
+
+    <!-- SECTION: Offcanvas state -->
+    @{
+        string? autoOpen = null;
+
+        if (!ViewData.ModelState.IsValid)
+        {
+            if (activeTab == "Contacts" && ViewData.ModelState.Keys.Any(k => k.StartsWith("Contact.", StringComparison.Ordinal)))
+            {
+                autoOpen = "ocAddContact";
+            }
+            else if (activeTab == "Attachments" && ViewData.ModelState.Keys.Any(k => k.StartsWith("Attachment.", StringComparison.Ordinal)))
+            {
+                autoOpen = "ocAddAttachment";
+            }
+            else if (activeTab == "Projects" &&
+                     (ViewData.ModelState.Keys.Any(k => k.StartsWith("ProjectLink.", StringComparison.Ordinal)) ||
+                      ViewData.ModelState.ContainsKey(string.Empty)))
+            {
+                autoOpen = "ocLinkProject";
+            }
+        }
+    }
+    <div class="d-none" data-partner-offcanvas="@autoOpen"></div>
+
+    <!-- SECTION: Offcanvas drawers -->
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocAddContact" aria-labelledby="ocAddContactLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocAddContactLabel">Add contact</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.Manage">
+                <form method="post" asp-page-handler="AddContact" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="Contact.Name" class="form-label">Name</label>
+                        <input asp-for="Contact.Name" class="form-control" />
+                        <span asp-validation-for="Contact.Name" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Designation" class="form-label">Designation</label>
+                        <input asp-for="Contact.Designation" class="form-control" />
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Email" class="form-label">Email</label>
+                        <input asp-for="Contact.Email" class="form-control" />
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label asp-for="Contact.MobilePhone" class="form-label">Mobile</label>
+                            <input asp-for="Contact.MobilePhone" class="form-control" />
+                            <span asp-validation-for="Contact.MobilePhone" class="text-danger"></span>
                         </div>
-                        <div class="card-body">
-                            <form method="post" asp-page-handler="LinkProject" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="ProjectLink.ProjectId" class="form-label">Project</label>
-                                    <select asp-for="ProjectLink.ProjectId" class="form-select">
-                                        <option value="">Select project</option>
-                                        @foreach (var project in Model.ProjectOptions)
-                                        {
-                                            <option value="@project.Id">@project.Name (@project.LifecycleStatus)</option>
-                                        }
-                                    </select>
-                                    <span asp-validation-for="ProjectLink.ProjectId" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Role" class="form-label">Role</label>
-                                    <select asp-for="ProjectLink.Role" class="form-select">
-                                        @foreach (var role in Model.RoleOptions)
-                                        {
-                                            <option value="@role">@role</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Status" class="form-label">Status</label>
-                                    <select asp-for="ProjectLink.Status" class="form-select">
-                                        @foreach (var status in Model.StatusOptions)
-                                        {
-                                            <option value="@status">@status</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div class="row g-3">
-                                    <div class="col-6">
-                                        <label asp-for="ProjectLink.FromDate" class="form-label">From</label>
-                                        <input asp-for="ProjectLink.FromDate" type="date" class="form-control" />
-                                    </div>
-                                    <div class="col-6">
-                                        <label asp-for="ProjectLink.ToDate" class="form-label">To</label>
-                                        <input asp-for="ProjectLink.ToDate" type="date" class="form-control" />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="ProjectLink.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Link partner</button>
-                            </form>
+                        <div class="col-12">
+                            <label asp-for="Contact.OfficePhone" class="form-label">Office</label>
+                            <input asp-for="Contact.OfficePhone" class="form-control" />
+                            <span asp-validation-for="Contact.OfficePhone" class="text-danger"></span>
+                        </div>
+                        <div class="col-12">
+                            <label asp-for="Contact.WhatsAppPhone" class="form-label">WhatsApp</label>
+                            <input asp-for="Contact.WhatsAppPhone" class="form-control" />
+                            <span asp-validation-for="Contact.WhatsAppPhone" class="text-danger"></span>
                         </div>
                     </div>
-                </authorize>
-            </div>
+                    <div class="form-check">
+                        <input asp-for="Contact.IsPrimary" class="form-check-input" />
+                        <label asp-for="Contact.IsPrimary" class="form-check-label">Set as primary</label>
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="Contact.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Save contact</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
         </div>
-    }
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocAddAttachment" aria-labelledby="ocAddAttachmentLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocAddAttachmentLabel">Upload attachment</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.Manage">
+                <form method="post"
+                      enctype="multipart/form-data"
+                      asp-page-handler="AddAttachment"
+                      asp-route-id="@Model.Partner.Id"
+                      class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="Attachment.File" class="form-label">File</label>
+                        <input asp-for="Attachment.File" type="file" class="form-control" />
+                        <span asp-validation-for="Attachment.File" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.Title" class="form-label">Title</label>
+                        <input asp-for="Attachment.Title" class="form-control" />
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.AttachmentType" class="form-label">Type</label>
+                        <select asp-for="Attachment.AttachmentType" class="form-select">
+                            <option value="">Select</option>
+                            @foreach (var type in Model.AttachmentTypeOptions)
+                            {
+                                <option value="@type">@type</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="Attachment.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Upload</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
+        </div>
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocLinkProject" aria-labelledby="ocLinkProjectLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocLinkProjectLabel">Link project</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.LinkToProject">
+                <form method="post"
+                      asp-page-handler="LinkProject"
+                      asp-route-id="@Model.Partner.Id"
+                      class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="ProjectLink.ProjectId" class="form-label">Project</label>
+                        <select asp-for="ProjectLink.ProjectId" class="form-select">
+                            <option value="">Select project</option>
+                            @foreach (var project in Model.ProjectOptions)
+                            {
+                                <option value="@project.Id">@project.Name (@project.LifecycleStatus)</option>
+                            }
+                        </select>
+                        <span asp-validation-for="ProjectLink.ProjectId" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Role" class="form-label">Role</label>
+                        <select asp-for="ProjectLink.Role" class="form-select">
+                            @foreach (var role in Model.RoleOptions)
+                            {
+                                <option value="@role">@role</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Status" class="form-label">Status</label>
+                        <select asp-for="ProjectLink.Status" class="form-select">
+                            @foreach (var status in Model.StatusOptions)
+                            {
+                                <option value="@status">@status</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="ProjectLink.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Link project</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
+        </div>
+    </div>
 </div>
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/partners-details.js" asp-append-version="true"></script>
 }

--- a/Pages/Projects/Partners/Details.cshtml
+++ b/Pages/Projects/Partners/Details.cshtml
@@ -1,0 +1,512 @@
+@page "/Projects/Partners/{id:int}"
+@model ProjectManagement.Pages.Projects.Partners.DetailsModel
+@using System
+@using ProjectManagement.Configuration
+@using ProjectManagement.Models.Partners
+@{
+    ViewData["Title"] = Model.Partner.FirmName;
+    var activeTab = string.IsNullOrWhiteSpace(Model.Tab) ? "Overview" : Model.Tab;
+
+    string StatusBadgeClass(string status) => status switch
+    {
+        "Active" => "text-bg-success",
+        "Inactive" => "text-bg-secondary",
+        "Caution" => "text-bg-warning",
+        "Blacklisted" => "text-bg-danger",
+        _ => "text-bg-light"
+    };
+}
+
+<div class="container-xxl py-4">
+    <!-- SECTION: Header -->
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+        <div>
+            <p class="text-uppercase text-muted small mb-1">Industry Partners</p>
+            <h1 class="h3 mb-1">@Model.Partner.FirmName</h1>
+            <div class="d-flex gap-2 flex-wrap">
+                <span class="badge rounded-pill @StatusBadgeClass(Model.Partner.Status)">@Model.Partner.Status</span>
+                @if (!string.IsNullOrWhiteSpace(Model.Partner.PartnerType))
+                {
+                    <span class="badge rounded-pill text-bg-light border">@Model.Partner.PartnerType</span>
+                }
+            </div>
+        </div>
+        <div class="d-flex gap-2">
+            <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Index">Back to list</a>
+            <authorize policy="@Policies.Partners.Manage">
+                <a class="btn btn-primary" asp-page="/Projects/Partners/Edit" asp-route-id="@Model.Partner.Id">Edit partner</a>
+            </authorize>
+        </div>
+    </div>
+
+    <!-- SECTION: Tabs -->
+    <ul class="nav nav-tabs mb-3">
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Overview" ? "active" : string.Empty)"
+               asp-page="/Projects/Partners/Details"
+               asp-route-id="@Model.Partner.Id"
+               asp-route-tab="Overview">Overview</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Contacts" ? "active" : string.Empty)"
+               asp-page="/Projects/Partners/Details"
+               asp-route-id="@Model.Partner.Id"
+               asp-route-tab="Contacts">Contacts</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Attachments" ? "active" : string.Empty)"
+               asp-page="/Projects/Partners/Details"
+               asp-route-id="@Model.Partner.Id"
+               asp-route-tab="Attachments">Attachments</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Projects" ? "active" : string.Empty)"
+               asp-page="/Projects/Partners/Details"
+               asp-route-id="@Model.Partner.Id"
+               asp-route-tab="Projects">Associated projects</a>
+        </li>
+    </ul>
+
+    <!-- SECTION: Tab content -->
+    @if (activeTab == "Overview")
+    {
+        <div class="card pm-card pm-shadow">
+            <div class="card-body">
+                <div class="row g-4">
+                    <div class="col-lg-6">
+                        <h2 class="h6 text-uppercase text-muted">Address</h2>
+                        <p class="mb-2">@(string.IsNullOrWhiteSpace(Model.Partner.AddressText) ? "—" : Model.Partner.AddressText)</p>
+                        <p class="text-muted mb-0">
+                            @(string.IsNullOrWhiteSpace(Model.Partner.City) ? "" : Model.Partner.City)
+                            @(string.IsNullOrWhiteSpace(Model.Partner.State) ? "" : $", {Model.Partner.State}")
+                            @(string.IsNullOrWhiteSpace(Model.Partner.Pincode) ? "" : $" - {Model.Partner.Pincode}")
+                        </p>
+                    </div>
+                    <div class="col-lg-6">
+                        <h2 class="h6 text-uppercase text-muted">Website</h2>
+                        <p class="mb-3">
+                            @if (!string.IsNullOrWhiteSpace(Model.Partner.Website))
+                            {
+                                <a href="@Model.Partner.Website" target="_blank" rel="noopener">@Model.Partner.Website</a>
+                            }
+                            else
+                            {
+                                <span>—</span>
+                            }
+                        </p>
+                        <h2 class="h6 text-uppercase text-muted">Notes</h2>
+                        <p class="mb-0">@(string.IsNullOrWhiteSpace(Model.Partner.Notes) ? "—" : Model.Partner.Notes)</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+    else if (activeTab == "Contacts")
+    {
+        <div class="row g-4">
+            <div class="col-lg-7">
+                <div class="card pm-card pm-shadow">
+                    <div class="card-header">
+                        <h2 class="h5 mb-0">Contacts</h2>
+                    </div>
+                    <div class="card-body">
+                        @if (!Model.Partner.Contacts.Any())
+                        {
+                            <p class="text-muted mb-0">No contacts added yet.</p>
+                        }
+                        else
+                        {
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle">
+                                    <thead>
+                                        <tr>
+                                            <th>Name</th>
+                                            <th>Phone</th>
+                                            <th>Email</th>
+                                            <th class="text-end">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var contact in Model.Partner.Contacts.OrderByDescending(c => c.IsPrimary))
+                                        {
+                                            <tr>
+                                                <td>
+                                                    <div class="fw-semibold">@contact.Name</div>
+                                                    <small class="text-muted">@contact.Designation</small>
+                                                    @if (contact.IsPrimary)
+                                                    {
+                                                        <span class="badge rounded-pill text-bg-primary ms-2">Primary</span>
+                                                    }
+                                                </td>
+                                                <td>
+                                                    @if (contact.Phones.Any())
+                                                    {
+                                                        <div class="d-flex flex-wrap gap-2">
+                                                            @foreach (var phone in contact.Phones)
+                                                            {
+                                                                <span class="badge rounded-pill text-bg-light border">@phone.Label: @phone.PhoneNumber</span>
+                                                            }
+                                                        </div>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span>—</span>
+                                                    }
+                                                </td>
+                                                <td>@(contact.Email ?? "—")</td>
+                                                <td class="text-end">
+                                                    <authorize policy="@Policies.Partners.Manage">
+                                                        @if (!contact.IsPrimary)
+                                                        {
+                                                            <form method="post"
+                                                                  asp-page-handler="SetPrimary"
+                                                                  asp-route-id="@Model.Partner.Id"
+                                                                  asp-route-contactId="@contact.Id"
+                                                                  class="d-inline">
+                                                                <button class="btn btn-outline-secondary btn-sm" type="submit">Set primary</button>
+                                                            </form>
+                                                        }
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.Delete">
+                                                        <form method="post"
+                                                              asp-page-handler="DeleteContact"
+                                                              asp-route-id="@Model.Partner.Id"
+                                                              asp-route-contactId="@contact.Id"
+                                                              class="d-inline">
+                                                            <button class="btn btn-outline-danger btn-sm" type="submit">Delete</button>
+                                                        </form>
+                                                    </authorize>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-5">
+                <authorize policy="@Policies.Partners.Manage">
+                    <div class="card pm-card pm-shadow">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Add contact</h2>
+                        </div>
+                        <div class="card-body">
+                            <form method="post" asp-page-handler="AddContact" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
+                                <div>
+                                    <label asp-for="Contact.Name" class="form-label">Name</label>
+                                    <input asp-for="Contact.Name" class="form-control" />
+                                    <span asp-validation-for="Contact.Name" class="text-danger"></span>
+                                </div>
+                                <div>
+                                    <label asp-for="Contact.Designation" class="form-label">Designation</label>
+                                    <input asp-for="Contact.Designation" class="form-control" />
+                                </div>
+                                <div>
+                                    <label asp-for="Contact.Email" class="form-label">Email</label>
+                                    <input asp-for="Contact.Email" class="form-control" />
+                                </div>
+                                <div class="row g-3">
+                                    <div class="col-12">
+                                        <label asp-for="Contact.MobilePhone" class="form-label">Mobile</label>
+                                        <input asp-for="Contact.MobilePhone" class="form-control" />
+                                        <span asp-validation-for="Contact.MobilePhone" class="text-danger"></span>
+                                    </div>
+                                    <div class="col-12">
+                                        <label asp-for="Contact.OfficePhone" class="form-label">Office</label>
+                                        <input asp-for="Contact.OfficePhone" class="form-control" />
+                                        <span asp-validation-for="Contact.OfficePhone" class="text-danger"></span>
+                                    </div>
+                                    <div class="col-12">
+                                        <label asp-for="Contact.WhatsAppPhone" class="form-label">WhatsApp</label>
+                                        <input asp-for="Contact.WhatsAppPhone" class="form-control" />
+                                        <span asp-validation-for="Contact.WhatsAppPhone" class="text-danger"></span>
+                                    </div>
+                                </div>
+                                <div class="form-check">
+                                    <input asp-for="Contact.IsPrimary" class="form-check-input" />
+                                    <label asp-for="Contact.IsPrimary" class="form-check-label">Set as primary</label>
+                                </div>
+                                <div>
+                                    <label asp-for="Contact.Notes" class="form-label">Notes</label>
+                                    <textarea asp-for="Contact.Notes" class="form-control" rows="3"></textarea>
+                                </div>
+                                <button type="submit" class="btn btn-primary">Save contact</button>
+                            </form>
+                        </div>
+                    </div>
+                </authorize>
+            </div>
+        </div>
+    }
+    else if (activeTab == "Attachments")
+    {
+        <div class="row g-4">
+            <div class="col-lg-7">
+                <div class="card pm-card pm-shadow">
+                    <div class="card-header">
+                        <h2 class="h5 mb-0">Attachments</h2>
+                    </div>
+                    <div class="card-body">
+                        @if (!Model.Attachments.Any())
+                        {
+                            <p class="text-muted mb-0">No attachments uploaded yet.</p>
+                        }
+                        else
+                        {
+                            <div class="list-group list-group-flush">
+                                @foreach (var attachment in Model.Attachments)
+                                {
+                                    <div class="list-group-item d-flex justify-content-between align-items-start">
+                                        <div class="me-3">
+                                            <div class="fw-semibold">@attachment.Title</div>
+                                            <small class="text-muted">@attachment.AttachmentType • @attachment.FileName</small>
+                                            <div class="mt-2">
+                                                <a class="btn btn-outline-secondary btn-sm" href="@attachment.DownloadUrl">Download</a>
+                                            </div>
+                                        </div>
+                                        @if (attachment.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            <img src="@attachment.InlineUrl" alt="@attachment.Title" class="rounded border" style="max-width: 120px;" />
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-5">
+                <authorize policy="@Policies.Partners.Manage">
+                    <div class="card pm-card pm-shadow">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Upload attachment</h2>
+                        </div>
+                        <div class="card-body">
+                            <form method="post" enctype="multipart/form-data" asp-page-handler="AddAttachment" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
+                                <div>
+                                    <label asp-for="Attachment.File" class="form-label">File</label>
+                                    <input asp-for="Attachment.File" type="file" class="form-control" />
+                                    <span asp-validation-for="Attachment.File" class="text-danger"></span>
+                                </div>
+                                <div>
+                                    <label asp-for="Attachment.Title" class="form-label">Title</label>
+                                    <input asp-for="Attachment.Title" class="form-control" />
+                                </div>
+                                <div>
+                                    <label asp-for="Attachment.AttachmentType" class="form-label">Type</label>
+                                    <select asp-for="Attachment.AttachmentType" class="form-select">
+                                        <option value="">Select</option>
+                                        @foreach (var type in Model.AttachmentTypeOptions)
+                                        {
+                                            <option value="@type">@type</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div>
+                                    <label asp-for="Attachment.Notes" class="form-label">Notes</label>
+                                    <textarea asp-for="Attachment.Notes" class="form-control" rows="3"></textarea>
+                                </div>
+                                <button type="submit" class="btn btn-primary">Upload</button>
+                            </form>
+                        </div>
+                    </div>
+                </authorize>
+            </div>
+        </div>
+    }
+    else if (activeTab == "Projects")
+    {
+        <div class="row g-4">
+            <div class="col-lg-8">
+                <div class="card pm-card pm-shadow">
+                    <div class="card-header">
+                        <h2 class="h5 mb-0">Associated projects</h2>
+                    </div>
+                    <div class="card-body">
+                        @if (!Model.Partner.ProjectLinks.Any())
+                        {
+                            <p class="text-muted mb-0">No project links yet.</p>
+                        }
+                        else
+                        {
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle">
+                                    <thead>
+                                        <tr>
+                                            <th>Project</th>
+                                            <th>Role</th>
+                                            <th>Status</th>
+                                            <th>From</th>
+                                            <th>To</th>
+                                            <th>Notes</th>
+                                            <th class="text-end">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var link in Model.Partner.ProjectLinks.OrderByDescending(l => l.Status == IndustryPartnerAssociationStatuses.Active))
+                                        {
+                                            var updateFormId = $"link-update-{link.ProjectId}";
+                                            <tr>
+                                                <td>
+                                                    <a asp-page="/Projects/Overview" asp-route-id="@link.ProjectId">@link.Project?.Name</a>
+                                                </td>
+                                                <td>
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <select name="ProjectLink.Role" form="@updateFormId" class="form-select form-select-sm">
+                                                            @foreach (var role in Model.RoleOptions)
+                                                            {
+                                                                <option value="@role" selected="@(role == link.Role)">@role</option>
+                                                            }
+                                                        </select>
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.View">
+                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
+                                                        {
+                                                            <span>@link.Role</span>
+                                                        }
+                                                    </authorize>
+                                                </td>
+                                                <td>
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <select name="ProjectLink.Status" form="@updateFormId" class="form-select form-select-sm">
+                                                            @foreach (var status in Model.StatusOptions)
+                                                            {
+                                                                <option value="@status" selected="@(status == link.Status)">@status</option>
+                                                            }
+                                                        </select>
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.View">
+                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
+                                                        {
+                                                            <span>@link.Status</span>
+                                                        }
+                                                    </authorize>
+                                                </td>
+                                                <td>
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <input name="ProjectLink.FromDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.FromDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.View">
+                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
+                                                        {
+                                                            <span>@(link.FromDate?.ToString("dd MMM yyyy") ?? "—")</span>
+                                                        }
+                                                    </authorize>
+                                                </td>
+                                                <td>
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <input name="ProjectLink.ToDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.ToDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.View">
+                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
+                                                        {
+                                                            <span>@(link.ToDate?.ToString("dd MMM yyyy") ?? "—")</span>
+                                                        }
+                                                    </authorize>
+                                                </td>
+                                                <td class="text-wrap" style="max-width: 220px;">
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <textarea name="ProjectLink.Notes" form="@updateFormId" class="form-control form-control-sm" rows="2">@link.Notes</textarea>
+                                                    </authorize>
+                                                    <authorize policy="@Policies.Partners.View">
+                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
+                                                        {
+                                                            <span>@link.Notes</span>
+                                                        }
+                                                    </authorize>
+                                                </td>
+                                                <td class="text-end">
+                                                    <authorize policy="@Policies.Partners.LinkToProject">
+                                                        <form method="post"
+                                                              asp-page-handler="UpdateProject"
+                                                              asp-route-id="@Model.Partner.Id"
+                                                              asp-route-projectId="@link.ProjectId"
+                                                              id="@updateFormId"
+                                                              class="d-inline">
+                                                            <button type="submit" class="btn btn-outline-secondary btn-sm">Update</button>
+                                                        </form>
+                                                        <form method="post"
+                                                              asp-page-handler="UnlinkProject"
+                                                              asp-route-id="@Model.Partner.Id"
+                                                              asp-route-projectId="@link.ProjectId"
+                                                              class="d-inline">
+                                                            <button type="submit" class="btn btn-outline-danger btn-sm">Remove</button>
+                                                        </form>
+                                                    </authorize>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <authorize policy="@Policies.Partners.LinkToProject">
+                    <div class="card pm-card pm-shadow">
+                        <div class="card-header">
+                            <h2 class="h5 mb-0">Link project</h2>
+                        </div>
+                        <div class="card-body">
+                            <form method="post" asp-page-handler="LinkProject" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
+                                <div>
+                                    <label asp-for="ProjectLink.ProjectId" class="form-label">Project</label>
+                                    <select asp-for="ProjectLink.ProjectId" class="form-select">
+                                        <option value="">Select project</option>
+                                        @foreach (var project in Model.ProjectOptions)
+                                        {
+                                            <option value="@project.Id">@project.Name (@project.LifecycleStatus)</option>
+                                        }
+                                    </select>
+                                    <span asp-validation-for="ProjectLink.ProjectId" class="text-danger"></span>
+                                </div>
+                                <div>
+                                    <label asp-for="ProjectLink.Role" class="form-label">Role</label>
+                                    <select asp-for="ProjectLink.Role" class="form-select">
+                                        @foreach (var role in Model.RoleOptions)
+                                        {
+                                            <option value="@role">@role</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div>
+                                    <label asp-for="ProjectLink.Status" class="form-label">Status</label>
+                                    <select asp-for="ProjectLink.Status" class="form-select">
+                                        @foreach (var status in Model.StatusOptions)
+                                        {
+                                            <option value="@status">@status</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="row g-3">
+                                    <div class="col-6">
+                                        <label asp-for="ProjectLink.FromDate" class="form-label">From</label>
+                                        <input asp-for="ProjectLink.FromDate" type="date" class="form-control" />
+                                    </div>
+                                    <div class="col-6">
+                                        <label asp-for="ProjectLink.ToDate" class="form-label">To</label>
+                                        <input asp-for="ProjectLink.ToDate" type="date" class="form-control" />
+                                    </div>
+                                </div>
+                                <div>
+                                    <label asp-for="ProjectLink.Notes" class="form-label">Notes</label>
+                                    <textarea asp-for="ProjectLink.Notes" class="form-control" rows="3"></textarea>
+                                </div>
+                                <button type="submit" class="btn btn-primary">Link partner</button>
+                            </form>
+                        </div>
+                    </div>
+                </authorize>
+            </div>
+        </div>
+    }
+</div>
+
+@section Scripts
+{
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Partners/Details.cshtml.cs
+++ b/Pages/Projects/Partners/Details.cshtml.cs
@@ -144,10 +144,6 @@ public class DetailsModel : PageModel
         [MaxLength(40)]
         public string Status { get; set; } = IndustryPartnerAssociationStatuses.Active;
 
-        public DateOnly? FromDate { get; set; }
-
-        public DateOnly? ToDate { get; set; }
-
         [MaxLength(1000)]
         public string? Notes { get; set; }
     }
@@ -436,8 +432,6 @@ public class DetailsModel : PageModel
             ProjectId = ProjectLink.ProjectId,
             Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role,
             Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status,
-            FromDate = ProjectLink.FromDate,
-            ToDate = ProjectLink.ToDate,
             Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim(),
             CreatedAtUtc = now,
             CreatedByUserId = userId
@@ -497,8 +491,6 @@ public class DetailsModel : PageModel
 
         link.Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role;
         link.Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status;
-        link.FromDate = ProjectLink.FromDate;
-        link.ToDate = ProjectLink.ToDate;
         link.Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim();
         link.UpdatedAtUtc = _clock.UtcNow.UtcDateTime;
         link.UpdatedByUserId = _users.GetUserId(User) ?? string.Empty;

--- a/Pages/Projects/Partners/Details.cshtml.cs
+++ b/Pages/Projects/Partners/Details.cshtml.cs
@@ -1,0 +1,595 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Partners;
+using ProjectManagement.Services;
+using ProjectManagement.Services.Storage;
+using ProjectManagement.ViewModels.Partners;
+
+namespace ProjectManagement.Pages.Projects.Partners;
+
+[Authorize(Policy = Policies.Partners.View)]
+public class DetailsModel : PageModel
+{
+    // SECTION: Constants
+    private const long MaxAttachmentSizeBytes = 25 * 1024 * 1024;
+
+    private static readonly HashSet<string> AllowedAttachmentContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf",
+        "image/png",
+        "image/jpeg"
+    };
+
+    // SECTION: Dependencies
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly IClock _clock;
+    private readonly IAuditService _audit;
+    private readonly IUploadRootProvider _uploadRootProvider;
+    private readonly IUploadPathResolver _pathResolver;
+    private readonly IProtectedFileUrlBuilder _fileUrlBuilder;
+
+    public DetailsModel(
+        ApplicationDbContext db,
+        UserManager<ApplicationUser> users,
+        IClock clock,
+        IAuditService audit,
+        IUploadRootProvider uploadRootProvider,
+        IUploadPathResolver pathResolver,
+        IProtectedFileUrlBuilder fileUrlBuilder)
+    {
+        _db = db;
+        _users = users;
+        _clock = clock;
+        _audit = audit;
+        _uploadRootProvider = uploadRootProvider;
+        _pathResolver = pathResolver;
+        _fileUrlBuilder = fileUrlBuilder;
+    }
+
+    // SECTION: View state
+    public IndustryPartner Partner { get; private set; } = null!;
+
+    public IReadOnlyList<ProjectIndustryPartnerVm> ProjectLinks { get; private set; } = Array.Empty<ProjectIndustryPartnerVm>();
+
+    public IReadOnlyList<ProjectOptionVm> ProjectOptions { get; private set; } = Array.Empty<ProjectOptionVm>();
+
+    public IReadOnlyList<AttachmentVm> Attachments { get; private set; } = Array.Empty<AttachmentVm>();
+
+    [BindProperty(SupportsGet = true)]
+    public string? Tab { get; set; }
+
+    // SECTION: Inputs
+    [BindProperty]
+    public ContactInput Contact { get; set; } = new();
+
+    [BindProperty]
+    public AttachmentInput Attachment { get; set; } = new();
+
+    [BindProperty]
+    public ProjectLinkInput ProjectLink { get; set; } = new();
+
+    public IReadOnlyList<string> AttachmentTypeOptions => IndustryPartnerAttachmentTypes.All;
+
+    public IReadOnlyList<string> RoleOptions => IndustryPartnerRoles.All;
+
+    public IReadOnlyList<string> StatusOptions => IndustryPartnerAssociationStatuses.All;
+
+    public sealed class ContactInput
+    {
+        [Required]
+        [MaxLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [MaxLength(120)]
+        public string? Designation { get; set; }
+
+        [MaxLength(200)]
+        public string? Email { get; set; }
+
+        public bool IsPrimary { get; set; }
+
+        [MaxLength(40)]
+        public string? MobilePhone { get; set; }
+
+        [MaxLength(40)]
+        public string? OfficePhone { get; set; }
+
+        [MaxLength(40)]
+        public string? WhatsAppPhone { get; set; }
+
+        [MaxLength(1000)]
+        public string? Notes { get; set; }
+    }
+
+    public sealed class AttachmentInput
+    {
+        [Required]
+        public IFormFile? File { get; set; }
+
+        [MaxLength(200)]
+        public string? Title { get; set; }
+
+        [MaxLength(80)]
+        public string? AttachmentType { get; set; }
+
+        [MaxLength(1000)]
+        public string? Notes { get; set; }
+    }
+
+    public sealed class ProjectLinkInput
+    {
+        [Required]
+        public int ProjectId { get; set; }
+
+        [MaxLength(80)]
+        public string Role { get; set; } = IndustryPartnerRoles.JointDevelopmentPartner;
+
+        [MaxLength(40)]
+        public string Status { get; set; } = IndustryPartnerAssociationStatuses.Active;
+
+        public DateOnly? FromDate { get; set; }
+
+        public DateOnly? ToDate { get; set; }
+
+        [MaxLength(1000)]
+        public string? Notes { get; set; }
+    }
+
+    public sealed record AttachmentVm(
+        int Id,
+        string Title,
+        string AttachmentType,
+        string FileName,
+        string ContentType,
+        long FileSize,
+        string DownloadUrl,
+        string InlineUrl,
+        DateTime UploadedAtUtc,
+        string UploadedByUserId);
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners
+            .Include(p => p.Contacts)
+                .ThenInclude(c => c.Phones)
+            .Include(p => p.Attachments)
+            .Include(p => p.ProjectLinks)
+                .ThenInclude(link => link.Project)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        Partner = partner;
+        ProjectLinks = partner.ProjectLinks
+            .OrderByDescending(link => link.Status == IndustryPartnerAssociationStatuses.Active)
+            .ThenBy(link => link.Project != null ? link.Project.Name : string.Empty)
+            .Select(link => new ProjectIndustryPartnerVm(
+                link.ProjectId,
+                link.PartnerId,
+                partner.FirmName,
+                link.Role,
+                link.Status,
+                link.FromDate,
+                link.ToDate,
+                link.Notes))
+            .ToList();
+
+        Attachments = partner.Attachments
+            .OrderByDescending(a => a.UploadedAtUtc)
+            .Select(a => new AttachmentVm(
+                a.Id,
+                a.Title ?? a.OriginalFileName,
+                a.AttachmentType ?? "Other",
+                a.OriginalFileName,
+                a.ContentType,
+                a.FileSize,
+                _fileUrlBuilder.CreateDownloadUrl(a.StorageKey, a.OriginalFileName, a.ContentType),
+                _fileUrlBuilder.CreateInlineUrl(a.StorageKey, a.OriginalFileName, a.ContentType),
+                a.UploadedAtUtc,
+                a.UploadedByUserId))
+            .ToList();
+
+        ProjectOptions = await _db.Projects
+            .AsNoTracking()
+            .OrderBy(p => p.Name)
+            .Select(p => new ProjectOptionVm(p.Id, p.Name, p.LifecycleStatus.ToString()))
+            .ToListAsync(ct);
+
+        return Page();
+    }
+
+    [Authorize(Policy = Policies.Partners.Manage)]
+    public async Task<IActionResult> OnPostAddContactAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners
+            .Include(p => p.Contacts)
+                .ThenInclude(c => c.Phones)
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        ValidatePhone(Contact.MobilePhone, nameof(Contact.MobilePhone));
+        ValidatePhone(Contact.OfficePhone, nameof(Contact.OfficePhone));
+        ValidatePhone(Contact.WhatsAppPhone, nameof(Contact.WhatsAppPhone));
+
+        if (!ModelState.IsValid)
+        {
+            return await ReloadWithErrorsAsync(partner.Id, "Contacts", ct);
+        }
+
+        var userId = _users.GetUserId(User) ?? string.Empty;
+        var now = _clock.UtcNow.UtcDateTime;
+
+        if (Contact.IsPrimary)
+        {
+            foreach (var existing in partner.Contacts)
+            {
+                existing.IsPrimary = false;
+            }
+        }
+
+        var contact = new IndustryPartnerContact
+        {
+            PartnerId = partner.Id,
+            Name = Contact.Name.Trim(),
+            Designation = string.IsNullOrWhiteSpace(Contact.Designation) ? null : Contact.Designation.Trim(),
+            Email = string.IsNullOrWhiteSpace(Contact.Email) ? null : Contact.Email.Trim(),
+            Notes = string.IsNullOrWhiteSpace(Contact.Notes) ? null : Contact.Notes.Trim(),
+            IsPrimary = Contact.IsPrimary,
+            CreatedAtUtc = now,
+            CreatedByUserId = userId
+        };
+
+        foreach (var phone in BuildPhones())
+        {
+            contact.Phones.Add(phone);
+        }
+
+        partner.Contacts.Add(contact);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ContactAdded",
+            userId: userId,
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["ContactId"] = contact.Id.ToString(),
+                ["ContactName"] = contact.Name
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id, tab = "Contacts" });
+    }
+
+    [Authorize(Policy = Policies.Partners.Manage)]
+    public async Task<IActionResult> OnPostSetPrimaryAsync(int id, int contactId, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners
+            .Include(p => p.Contacts)
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        var target = partner.Contacts.FirstOrDefault(c => c.Id == contactId);
+        if (target is null)
+        {
+            return NotFound();
+        }
+
+        foreach (var contact in partner.Contacts)
+        {
+            contact.IsPrimary = contact.Id == target.Id;
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ContactPrimarySet",
+            userId: _users.GetUserId(User),
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["ContactId"] = target.Id.ToString()
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id, tab = "Contacts" });
+    }
+
+    [Authorize(Policy = Policies.Partners.Delete)]
+    public async Task<IActionResult> OnPostDeleteContactAsync(int id, int contactId, CancellationToken ct)
+    {
+        var contact = await _db.IndustryPartnerContacts
+            .Include(c => c.Phones)
+            .FirstOrDefaultAsync(c => c.Id == contactId && c.PartnerId == id, ct);
+
+        if (contact is null)
+        {
+            return NotFound();
+        }
+
+        _db.IndustryPartnerContactPhones.RemoveRange(contact.Phones);
+        _db.IndustryPartnerContacts.Remove(contact);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ContactDeleted",
+            userId: _users.GetUserId(User),
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = id.ToString(),
+                ["ContactId"] = contactId.ToString()
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id, tab = "Contacts" });
+    }
+
+    [Authorize(Policy = Policies.Partners.Manage)]
+    public async Task<IActionResult> OnPostAddAttachmentAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners
+            .Include(p => p.Attachments)
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        ValidateAttachment(Attachment.File, nameof(Attachment.File));
+        if (!ModelState.IsValid)
+        {
+            return await ReloadWithErrorsAsync(partner.Id, "Attachments", ct);
+        }
+
+        var userId = _users.GetUserId(User) ?? string.Empty;
+        var now = _clock.UtcNow.UtcDateTime;
+        var upload = Attachment.File!;
+        var storageKey = await SaveAttachmentAsync(partner.Id, upload, ct);
+
+        var attachment = new IndustryPartnerAttachment
+        {
+            PartnerId = partner.Id,
+            StorageKey = storageKey,
+            OriginalFileName = Path.GetFileName(upload.FileName),
+            ContentType = upload.ContentType,
+            FileSize = upload.Length,
+            Title = string.IsNullOrWhiteSpace(Attachment.Title) ? null : Attachment.Title.Trim(),
+            AttachmentType = string.IsNullOrWhiteSpace(Attachment.AttachmentType) ? null : Attachment.AttachmentType,
+            Notes = string.IsNullOrWhiteSpace(Attachment.Notes) ? null : Attachment.Notes.Trim(),
+            UploadedAtUtc = now,
+            UploadedByUserId = userId
+        };
+
+        partner.Attachments.Add(attachment);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.AttachmentAdded",
+            userId: userId,
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["AttachmentId"] = attachment.Id.ToString(),
+                ["AttachmentType"] = attachment.AttachmentType
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id, tab = "Attachments" });
+    }
+
+    [Authorize(Policy = Policies.Partners.LinkToProject)]
+    public async Task<IActionResult> OnPostLinkProjectAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners
+            .Include(p => p.ProjectLinks)
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return await ReloadWithErrorsAsync(partner.Id, "Projects", ct);
+        }
+
+        var exists = partner.ProjectLinks.Any(link => link.ProjectId == ProjectLink.ProjectId);
+        if (exists)
+        {
+            ModelState.AddModelError(string.Empty, "This project is already linked.");
+            return await ReloadWithErrorsAsync(partner.Id, "Projects", ct);
+        }
+
+        var userId = _users.GetUserId(User) ?? string.Empty;
+        var now = _clock.UtcNow.UtcDateTime;
+
+        var link = new ProjectIndustryPartner
+        {
+            PartnerId = partner.Id,
+            ProjectId = ProjectLink.ProjectId,
+            Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role,
+            Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status,
+            FromDate = ProjectLink.FromDate,
+            ToDate = ProjectLink.ToDate,
+            Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim(),
+            CreatedAtUtc = now,
+            CreatedByUserId = userId
+        };
+
+        partner.ProjectLinks.Add(link);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ProjectLinked",
+            userId: userId,
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["ProjectId"] = link.ProjectId.ToString(CultureInfo.InvariantCulture)
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id, tab = "Projects" });
+    }
+
+    [Authorize(Policy = Policies.Partners.LinkToProject)]
+    public async Task<IActionResult> OnPostUnlinkProjectAsync(int id, int projectId, CancellationToken ct)
+    {
+        var link = await _db.ProjectIndustryPartners
+            .FirstOrDefaultAsync(p => p.PartnerId == id && p.ProjectId == projectId, ct);
+
+        if (link is null)
+        {
+            return NotFound();
+        }
+
+        _db.ProjectIndustryPartners.Remove(link);
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ProjectUnlinked",
+            userId: _users.GetUserId(User),
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = id.ToString(),
+                ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture)
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id, tab = "Projects" });
+    }
+
+    [Authorize(Policy = Policies.Partners.LinkToProject)]
+    public async Task<IActionResult> OnPostUpdateProjectAsync(int id, int projectId, CancellationToken ct)
+    {
+        var link = await _db.ProjectIndustryPartners
+            .FirstOrDefaultAsync(p => p.PartnerId == id && p.ProjectId == projectId, ct);
+
+        if (link is null)
+        {
+            return NotFound();
+        }
+
+        link.Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role;
+        link.Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status;
+        link.FromDate = ProjectLink.FromDate;
+        link.ToDate = ProjectLink.ToDate;
+        link.Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim();
+        link.UpdatedAtUtc = _clock.UtcNow.UtcDateTime;
+        link.UpdatedByUserId = _users.GetUserId(User) ?? string.Empty;
+
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.ProjectAssociationUpdated",
+            userId: _users.GetUserId(User),
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = id.ToString(),
+                ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture)
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id, tab = "Projects" });
+    }
+
+    // SECTION: Helpers
+    private void ValidatePhone(string? phone, string field)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return;
+        }
+
+        var normalized = phone.Trim();
+        if (!Regex.IsMatch(normalized, "^[0-9+()\\-\\s]{7,}$"))
+        {
+            ModelState.AddModelError(field, "Enter a valid phone number with at least 7 digits.");
+        }
+    }
+
+    private IEnumerable<IndustryPartnerContactPhone> BuildPhones()
+    {
+        return new[]
+        {
+            (Contact.MobilePhone, "Mobile"),
+            (Contact.OfficePhone, "Office"),
+            (Contact.WhatsAppPhone, "WhatsApp")
+        }
+        .Where(pair => !string.IsNullOrWhiteSpace(pair.Item1))
+        .Select(pair => new IndustryPartnerContactPhone
+        {
+            PhoneNumber = pair.Item1!.Trim(),
+            Label = pair.Item2
+        });
+    }
+
+    private void ValidateAttachment(IFormFile? file, string field)
+    {
+        if (file is null)
+        {
+            ModelState.AddModelError(field, "Attachment is required.");
+            return;
+        }
+
+        if (file.Length == 0 || file.Length > MaxAttachmentSizeBytes)
+        {
+            ModelState.AddModelError(field, "Attachment size exceeds the 25MB limit.");
+            return;
+        }
+
+        if (!AllowedAttachmentContentTypes.Contains(file.ContentType))
+        {
+            ModelState.AddModelError(field, "Only PDF, JPG, and PNG files are allowed.");
+        }
+    }
+
+    private async Task<string> SaveAttachmentAsync(int partnerId, IFormFile file, CancellationToken ct)
+    {
+        var safeFileName = Path.GetFileName(file.FileName);
+        var extension = Path.GetExtension(safeFileName);
+        var partnerFolder = Path.Combine(_uploadRootProvider.RootPath, "partners", partnerId.ToString(CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(partnerFolder);
+
+        var storedFileName = $"{Guid.NewGuid():N}{extension}";
+        var absolutePath = Path.Combine(partnerFolder, storedFileName);
+
+        await using (var stream = new FileStream(absolutePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+        {
+            await file.CopyToAsync(stream, ct);
+        }
+
+        return _pathResolver.ToRelative(absolutePath);
+    }
+
+    private async Task<IActionResult> ReloadWithErrorsAsync(int partnerId, string tab, CancellationToken ct)
+    {
+        Tab = tab;
+        var result = await OnGetAsync(partnerId, ct);
+        return result;
+    }
+}

--- a/Pages/Projects/Partners/Edit.cshtml
+++ b/Pages/Projects/Partners/Edit.cshtml
@@ -1,0 +1,108 @@
+@page "/Projects/Partners/{id:int}/Edit"
+@model ProjectManagement.Pages.Projects.Partners.EditModel
+@{
+    ViewData["Title"] = "Edit Industry Partner";
+}
+
+<div class="container-xxl py-4">
+    <!-- SECTION: Page header -->
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+        <div>
+            <p class="text-uppercase text-muted small mb-1">Industry Partners</p>
+            <h1 class="h3 mb-1">Edit @Model.Partner.FirmName</h1>
+            <p class="text-muted mb-0">Update firm details and status.</p>
+        </div>
+        <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Details" asp-route-id="@Model.Partner.Id">Back to partner</a>
+    </div>
+
+    <form method="post" class="row g-4">
+        <!-- SECTION: Partner details -->
+        <div class="col-lg-8">
+            <div class="card pm-card pm-shadow h-100">
+                <div class="card-header">
+                    <h2 class="h5 mb-0">Partner details</h2>
+                </div>
+                <div class="card-body vstack gap-3">
+                    <div>
+                        <label asp-for="Input.FirmName" class="form-label">Firm name</label>
+                        <input asp-for="Input.FirmName" class="form-control" />
+                        <span asp-validation-for="Input.FirmName" class="text-danger"></span>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label asp-for="Input.PartnerType" class="form-label">Partner type</label>
+                            <select asp-for="Input.PartnerType" class="form-select">
+                                <option value="">Select</option>
+                                @foreach (var type in Model.PartnerTypeOptions)
+                                {
+                                    <option value="@type">@type</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label asp-for="Input.Status" class="form-label">Status</label>
+                            <select asp-for="Input.Status" class="form-select">
+                                @foreach (var status in Model.StatusOptions)
+                                {
+                                    <option value="@status">@status</option>
+                                }
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.AddressText" class="form-label">Address</label>
+                        <textarea asp-for="Input.AddressText" class="form-control" rows="3"></textarea>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label asp-for="Input.City" class="form-label">City</label>
+                            <input asp-for="Input.City" class="form-control" />
+                        </div>
+                        <div class="col-md-4">
+                            <label asp-for="Input.State" class="form-label">State</label>
+                            <input asp-for="Input.State" class="form-control" />
+                        </div>
+                        <div class="col-md-4">
+                            <label asp-for="Input.Pincode" class="form-label">Pincode</label>
+                            <input asp-for="Input.Pincode" class="form-control" />
+                        </div>
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.Website" class="form-label">Website</label>
+                        <input asp-for="Input.Website" class="form-control" />
+                    </div>
+
+                    <div>
+                        <label asp-for="Input.Notes" class="form-label">Internal notes</label>
+                        <textarea asp-for="Input.Notes" class="form-control" rows="4"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SECTION: Actions -->
+        <div class="col-lg-4">
+            <div class="card pm-card pm-shadow h-100">
+                <div class="card-header">
+                    <h2 class="h6 mb-0">Actions</h2>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted small">Save changes to update partner metadata.</p>
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-primary">Save changes</button>
+                        <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Details" asp-route-id="@Model.Partner.Id">Cancel</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+@section Scripts
+{
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Projects/Partners/Edit.cshtml.cs
+++ b/Pages/Projects/Partners/Edit.cshtml.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Partners;
+using ProjectManagement.Services;
+
+namespace ProjectManagement.Pages.Projects.Partners;
+
+[Authorize(Policy = Policies.Partners.Manage)]
+public class EditModel : PageModel
+{
+    // SECTION: Dependencies
+    private readonly ApplicationDbContext _db;
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly IClock _clock;
+    private readonly IAuditService _audit;
+
+    public EditModel(ApplicationDbContext db, UserManager<ApplicationUser> users, IClock clock, IAuditService audit)
+    {
+        _db = db;
+        _users = users;
+        _clock = clock;
+        _audit = audit;
+    }
+
+    // SECTION: View state
+    public IndustryPartner Partner { get; private set; } = null!;
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public IReadOnlyList<string> StatusOptions => IndustryPartnerStatuses.All;
+
+    public IReadOnlyList<string> PartnerTypeOptions => IndustryPartnerTypes.All;
+
+    public sealed class InputModel
+    {
+        [Required]
+        [MaxLength(256)]
+        public string FirmName { get; set; } = string.Empty;
+
+        [MaxLength(80)]
+        public string? PartnerType { get; set; }
+
+        [MaxLength(512)]
+        public string? AddressText { get; set; }
+
+        [MaxLength(120)]
+        public string? City { get; set; }
+
+        [MaxLength(120)]
+        public string? State { get; set; }
+
+        [MaxLength(20)]
+        public string? Pincode { get; set; }
+
+        [MaxLength(256)]
+        public string? Website { get; set; }
+
+        [MaxLength(2000)]
+        public string? Notes { get; set; }
+
+        [Required]
+        [MaxLength(40)]
+        public string Status { get; set; } = IndustryPartnerStatuses.Active;
+    }
+
+    public async Task<IActionResult> OnGetAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners.FirstOrDefaultAsync(p => p.Id == id, ct);
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        Partner = partner;
+        Input = new InputModel
+        {
+            FirmName = partner.FirmName,
+            PartnerType = partner.PartnerType,
+            AddressText = partner.AddressText,
+            City = partner.City,
+            State = partner.State,
+            Pincode = partner.Pincode,
+            Website = partner.Website,
+            Notes = partner.Notes,
+            Status = partner.Status
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id, CancellationToken ct)
+    {
+        var partner = await _db.IndustryPartners.FirstOrDefaultAsync(p => p.Id == id, ct);
+        if (partner is null)
+        {
+            return NotFound();
+        }
+
+        Partner = partner;
+
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var normalizedFirmName = Input.FirmName.Trim().ToUpperInvariant();
+        var duplicate = await _db.IndustryPartners
+            .AnyAsync(p => p.Id != partner.Id && p.NormalizedFirmName == normalizedFirmName, ct);
+
+        if (duplicate)
+        {
+            ModelState.AddModelError(nameof(Input.FirmName), "A partner with this firm name already exists.");
+            return Page();
+        }
+
+        var userId = _users.GetUserId(User) ?? string.Empty;
+        var now = _clock.UtcNow.UtcDateTime;
+
+        // SECTION: Update entity
+        partner.FirmName = Input.FirmName.Trim();
+        partner.NormalizedFirmName = normalizedFirmName;
+        partner.PartnerType = string.IsNullOrWhiteSpace(Input.PartnerType) ? null : Input.PartnerType;
+        partner.AddressText = string.IsNullOrWhiteSpace(Input.AddressText) ? null : Input.AddressText.Trim();
+        partner.City = string.IsNullOrWhiteSpace(Input.City) ? null : Input.City.Trim();
+        partner.State = string.IsNullOrWhiteSpace(Input.State) ? null : Input.State.Trim();
+        partner.Pincode = string.IsNullOrWhiteSpace(Input.Pincode) ? null : Input.Pincode.Trim();
+        partner.Website = string.IsNullOrWhiteSpace(Input.Website) ? null : Input.Website.Trim();
+        partner.Notes = string.IsNullOrWhiteSpace(Input.Notes) ? null : Input.Notes.Trim();
+        partner.Status = string.IsNullOrWhiteSpace(Input.Status) ? IndustryPartnerStatuses.Active : Input.Status;
+        partner.UpdatedAtUtc = now;
+        partner.UpdatedByUserId = userId;
+
+        await _db.SaveChangesAsync(ct);
+
+        await _audit.LogAsync(
+            "Partners.Updated",
+            userId: userId,
+            data: new Dictionary<string, string?>
+            {
+                ["PartnerId"] = partner.Id.ToString(),
+                ["FirmName"] = partner.FirmName,
+                ["Status"] = partner.Status
+            });
+
+        return RedirectToPage("/Projects/Partners/Details", new { id = partner.Id });
+    }
+}

--- a/Pages/Projects/Partners/Index.cshtml
+++ b/Pages/Projects/Partners/Index.cshtml
@@ -1,0 +1,195 @@
+@page "/Projects/Partners"
+@model ProjectManagement.Pages.Projects.Partners.IndexModel
+@using ProjectManagement.Configuration
+@{
+    ViewData["Title"] = "Industry Partners";
+
+    string StatusBadgeClass(string status) => status switch
+    {
+        "Active" => "text-bg-success",
+        "Inactive" => "text-bg-secondary",
+        "Caution" => "text-bg-warning",
+        "Blacklisted" => "text-bg-danger",
+        _ => "text-bg-light"
+    };
+}
+
+<div class="container-xxl py-4">
+    <!-- SECTION: Page header -->
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="h3 mb-1">Industry Partners</h1>
+            <p class="text-muted mb-0">Search, review, and manage external partners associated with projects.</p>
+        </div>
+        <authorize policy="@Policies.Partners.Manage">
+            <a class="btn btn-primary" asp-page="/Projects/Partners/Create">
+                <i class="bi bi-plus-lg me-1"></i> Add partner
+            </a>
+        </authorize>
+    </div>
+
+    <!-- SECTION: Search and filters -->
+    <div class="card pm-card pm-shadow mb-4">
+        <div class="card-body">
+            <form method="get" class="row g-3 align-items-end">
+                <div class="col-lg-5">
+                    <label class="form-label" for="partnerSearch">Search</label>
+                    <input id="partnerSearch"
+                           name="Search"
+                           value="@Model.Search"
+                           class="form-control"
+                           placeholder="Firm, contact, phone, email, or city" />
+                </div>
+                <div class="col-lg-3">
+                    <label class="form-label" for="partnerType">Partner type</label>
+                    <select id="partnerType" name="PartnerType" class="form-select">
+                        <option value="">All</option>
+                        @foreach (var type in Model.PartnerTypeOptions)
+                        {
+                            <option value="@type" selected="@(Model.PartnerType == type)">@type</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-lg-2">
+                    <label class="form-label" for="partnerCity">City</label>
+                    <select id="partnerCity" name="City" class="form-select">
+                        <option value="">All</option>
+                        @foreach (var city in Model.CityOptions)
+                        {
+                            <option value="@city" selected="@(Model.City == city)">@city</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-lg-2">
+                    <button type="submit" class="btn btn-primary w-100">Apply</button>
+                </div>
+
+                <div class="col-12">
+                    <details class="mt-2" @(Model.HasFilters ? "open" : string.Empty)>
+                        <summary class="small text-muted">Status filters</summary>
+                        <div class="d-flex flex-wrap gap-3 mt-2">
+                            @foreach (var status in Model.StatusOptions)
+                            {
+                                <div class="form-check">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           name="Statuses"
+                                           value="@status"
+                                           id="status_@status"
+                                           checked="@Model.Statuses.Contains(status)" />
+                                    <label class="form-check-label" for="status_@status">
+                                        @status
+                                    </label>
+                                </div>
+                            }
+                        </div>
+                    </details>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- SECTION: Results table -->
+    <div class="card pm-card pm-shadow">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <h2 class="h5 mb-1">Partners</h2>
+                <p class="text-muted small mb-0">@Model.TotalCount total partners</p>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th>Firm</th>
+                            <th>Primary contact</th>
+                            <th>Phone</th>
+                            <th>Email</th>
+                            <th>City</th>
+                            <th class="text-center">Projects</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (!Model.Items.Any())
+                        {
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-4">
+                                    No partners match your filters. Try adjusting the search criteria.
+                                </td>
+                            </tr>
+                        }
+                        else
+                        {
+                            @foreach (var partner in Model.Items)
+                            {
+                                <tr>
+                                    <td>
+                                        <div class="fw-semibold">@partner.FirmName</div>
+                                        <div class="d-flex gap-2 flex-wrap">
+                                            <span class="badge rounded-pill @StatusBadgeClass(partner.Status)">@partner.Status</span>
+                                            @if (!string.IsNullOrWhiteSpace(partner.PartnerType))
+                                            {
+                                                <span class="badge rounded-pill text-bg-light border">@partner.PartnerType</span>
+                                            }
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div>@(partner.PrimaryContactName ?? "—")</div>
+                                        <small class="text-muted">@(partner.PrimaryContactDesignation ?? "")</small>
+                                    </td>
+                                    <td>@(partner.PrimaryPhone ?? "—")</td>
+                                    <td>@(partner.PrimaryEmail ?? "—")</td>
+                                    <td>@(partner.City ?? "—")</td>
+                                    <td class="text-center">@partner.ProjectCount</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm"
+                                           asp-page="/Projects/Partners/Details"
+                                           asp-route-id="@partner.Id">
+                                            View
+                                        </a>
+                                        <authorize policy="@Policies.Partners.Manage">
+                                            <a class="btn btn-outline-primary btn-sm"
+                                               asp-page="/Projects/Partners/Edit"
+                                               asp-route-id="@partner.Id">
+                                                Edit
+                                            </a>
+                                        </authorize>
+                                    </td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            @if (Model.TotalPages > 1)
+            {
+                <nav class="d-flex justify-content-between align-items-center mt-3" aria-label="Partners pagination">
+                    <span class="text-muted small">Page @Model.PageIndex of @Model.TotalPages</span>
+                    <div class="btn-group">
+                        <a class="btn btn-outline-secondary btn-sm @(Model.PageIndex <= 1 ? "disabled" : string.Empty)"
+                           asp-page="/Projects/Partners/Index"
+                           asp-route-search="@Model.Search"
+                           asp-route-partnerType="@Model.PartnerType"
+                           asp-route-city="@Model.City"
+                           asp-route-statuses="@Model.Statuses"
+                           asp-route-pageIndex="@(Model.PageIndex - 1)">
+                            Previous
+                        </a>
+                        <a class="btn btn-outline-secondary btn-sm @(Model.PageIndex >= Model.TotalPages ? "disabled" : string.Empty)"
+                           asp-page="/Projects/Partners/Index"
+                           asp-route-search="@Model.Search"
+                           asp-route-partnerType="@Model.PartnerType"
+                           asp-route-city="@Model.City"
+                           asp-route-statuses="@Model.Statuses"
+                           asp-route-pageIndex="@(Model.PageIndex + 1)">
+                            Next
+                        </a>
+                    </div>
+                </nav>
+            }
+        </div>
+    </div>
+</div>

--- a/Pages/Projects/Partners/Index.cshtml.cs
+++ b/Pages/Projects/Partners/Index.cshtml.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models.Partners;
+using ProjectManagement.ViewModels.Partners;
+
+namespace ProjectManagement.Pages.Projects.Partners;
+
+[Authorize(Policy = Policies.Partners.View)]
+public class IndexModel : PageModel
+{
+    // SECTION: Constants
+    private const int DefaultPageSize = 20;
+
+    // SECTION: Dependencies
+    private readonly ApplicationDbContext _db;
+
+    public IndexModel(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    // SECTION: Query parameters
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string[] Statuses { get; set; } = Array.Empty<string>();
+
+    [BindProperty(SupportsGet = true)]
+    public string? PartnerType { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? City { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int PageIndex { get; set; } = 1;
+
+    // SECTION: View state
+    public IReadOnlyList<IndustryPartnerSummaryVm> Items { get; private set; } = Array.Empty<IndustryPartnerSummaryVm>();
+
+    public IReadOnlyList<string> StatusOptions => IndustryPartnerStatuses.All;
+
+    public IReadOnlyList<string> PartnerTypeOptions => IndustryPartnerTypes.All;
+
+    public IReadOnlyList<string> CityOptions { get; private set; } = Array.Empty<string>();
+
+    public int TotalCount { get; private set; }
+
+    public int TotalPages { get; private set; }
+
+    public bool HasFilters =>
+        !string.IsNullOrWhiteSpace(Search) ||
+        Statuses.Length > 0 ||
+        !string.IsNullOrWhiteSpace(PartnerType) ||
+        !string.IsNullOrWhiteSpace(City);
+
+    public async Task OnGetAsync(CancellationToken ct)
+    {
+        // SECTION: Base query
+        var query = _db.IndustryPartners
+            .AsNoTracking()
+            .AsQueryable();
+
+        // SECTION: Search
+        var trimmed = Search?.Trim();
+        if (!string.IsNullOrWhiteSpace(trimmed))
+        {
+            var like = $"%{trimmed}%";
+            query = query.Where(p =>
+                EF.Functions.ILike(p.FirmName, like) ||
+                (p.City != null && EF.Functions.ILike(p.City, like)) ||
+                p.Contacts.Any(c =>
+                    EF.Functions.ILike(c.Name, like) ||
+                    (c.Email != null && EF.Functions.ILike(c.Email, like)) ||
+                    (c.Designation != null && EF.Functions.ILike(c.Designation, like)) ||
+                    c.Phones.Any(phone => EF.Functions.ILike(phone.PhoneNumber, like))));
+        }
+
+        // SECTION: Filters
+        if (Statuses.Length > 0)
+        {
+            query = query.Where(p => Statuses.Contains(p.Status));
+        }
+
+        if (!string.IsNullOrWhiteSpace(PartnerType))
+        {
+            query = query.Where(p => p.PartnerType == PartnerType);
+        }
+
+        if (!string.IsNullOrWhiteSpace(City))
+        {
+            query = query.Where(p => p.City == City);
+        }
+
+        // SECTION: Pagination
+        TotalCount = await query.CountAsync(ct);
+        TotalPages = (int)Math.Ceiling(TotalCount / (double)DefaultPageSize);
+        if (PageIndex < 1)
+        {
+            PageIndex = 1;
+        }
+        else if (TotalPages > 0 && PageIndex > TotalPages)
+        {
+            PageIndex = TotalPages;
+        }
+
+        // SECTION: Lookup data
+        CityOptions = await _db.IndustryPartners
+            .AsNoTracking()
+            .Where(p => p.City != null && p.City != string.Empty)
+            .Select(p => p.City!)
+            .Distinct()
+            .OrderBy(p => p)
+            .ToListAsync(ct);
+
+        // SECTION: List projection
+        Items = await query
+            .OrderBy(p => p.FirmName)
+            .Skip((PageIndex - 1) * DefaultPageSize)
+            .Take(DefaultPageSize)
+            .Select(p => new IndustryPartnerSummaryVm(
+                p.Id,
+                p.FirmName,
+                p.Status,
+                p.PartnerType,
+                p.City,
+                p.Contacts.OrderByDescending(c => c.IsPrimary).Select(c => c.Name).FirstOrDefault(),
+                p.Contacts.OrderByDescending(c => c.IsPrimary).Select(c => c.Designation).FirstOrDefault(),
+                p.Contacts.OrderByDescending(c => c.IsPrimary).Select(c => c.Email).FirstOrDefault(),
+                p.Contacts.OrderByDescending(c => c.IsPrimary)
+                    .SelectMany(c => c.Phones)
+                    .Select(phone => phone.PhoneNumber)
+                    .FirstOrDefault(),
+                p.ProjectLinks.Count))
+            .ToListAsync(ct);
+    }
+}

--- a/Pages/Projects/_ProjectIndustryPartnersCard.cshtml
+++ b/Pages/Projects/_ProjectIndustryPartnersCard.cshtml
@@ -1,0 +1,128 @@
+@model ProjectManagement.Pages.Projects.OverviewModel
+@using ProjectManagement.Configuration
+@using ProjectManagement.Models.Partners
+
+<div class="card pm-card">
+    <div class="card-header pm-card-header">
+        <div class="pm-card-heading">
+            <span class="pm-card-icon" aria-hidden="true">
+                <i class="bi bi-buildings"></i>
+            </span>
+            <div>
+                <h3 class="pm-card-title h6 mb-0">Industry partners</h3>
+                <p class="pm-card-subtitle mb-0">Joint development partners linked to this project.</p>
+            </div>
+        </div>
+    </div>
+    <div class="card-body pm-card-body">
+        @if (!Model.IndustryPartners.Any())
+        {
+            <p class="text-muted mb-0">No partners linked yet.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Firm</th>
+                            <th>Role</th>
+                            <th>Status</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var link in Model.IndustryPartners)
+                        {
+                            var updateFormId = $"partner-update-{link.PartnerId}";
+                            <tr>
+                                <td>
+                                    <a asp-page="/Projects/Partners/Details" asp-route-id="@link.PartnerId">
+                                        @link.FirmName
+                                    </a>
+                                </td>
+                                <td>
+                                    @if (Model.CanLinkIndustryPartners)
+                                    {
+                                        <select name="PartnerInput.Role" form="@updateFormId" class="form-select form-select-sm">
+                                            @foreach (var role in IndustryPartnerRoles.All)
+                                            {
+                                                <option value="@role" selected="@(role == link.Role)">@role</option>
+                                            }
+                                        </select>
+                                    }
+                                    else
+                                    {
+                                        <span>@link.Role</span>
+                                    }
+                                </td>
+                                <td>
+                                    @if (Model.CanLinkIndustryPartners)
+                                    {
+                                        <select name="PartnerInput.Status" form="@updateFormId" class="form-select form-select-sm">
+                                            @foreach (var status in IndustryPartnerAssociationStatuses.All)
+                                            {
+                                                <option value="@status" selected="@(status == link.Status)">@status</option>
+                                            }
+                                        </select>
+                                    }
+                                    else
+                                    {
+                                        <span>@link.Status</span>
+                                    }
+                                </td>
+                                <td class="text-end">
+                                    @if (Model.CanLinkIndustryPartners)
+                                    {
+                                        <form method="post"
+                                              asp-page-handler="UpdatePartner"
+                                              asp-route-id="@Model.Project.Id"
+                                              asp-route-partnerId="@link.PartnerId"
+                                              id="@updateFormId"
+                                              class="d-inline">
+                                            <button type="submit" class="btn btn-outline-secondary btn-sm">Update</button>
+                                        </form>
+                                        <form method="post"
+                                              asp-page-handler="UnlinkPartner"
+                                              asp-route-id="@Model.Project.Id"
+                                              asp-route-partnerId="@link.PartnerId"
+                                              class="d-inline">
+                                            <button type="submit" class="btn btn-outline-danger btn-sm">Remove</button>
+                                        </form>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        <authorize policy="@Policies.Partners.LinkToProject">
+            <hr />
+            <form method="post" asp-page-handler="LinkPartner" asp-route-id="@Model.Project.Id" class="vstack gap-2">
+                <div>
+                    <label asp-for="PartnerInput.PartnerId" class="form-label">Link partner</label>
+                    <select asp-for="PartnerInput.PartnerId" class="form-select">
+                        <option value="">Select partner</option>
+                        @foreach (var partner in Model.IndustryPartnerOptions)
+                        {
+                            <option value="@partner.Id">@partner.FirmName (@partner.Status)</option>
+                        }
+                    </select>
+                    <span asp-validation-for="PartnerInput.PartnerId" class="text-danger"></span>
+                </div>
+                <div>
+                    <label asp-for="PartnerInput.Role" class="form-label">Role</label>
+                    <select asp-for="PartnerInput.Role" class="form-select">
+                        @foreach (var role in IndustryPartnerRoles.All)
+                        {
+                            <option value="@role">@role</option>
+                        }
+                    </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Link partner</button>
+            </form>
+        </authorize>
+    </div>
+</div>

--- a/Program.cs
+++ b/Program.cs
@@ -187,6 +187,14 @@ builder.Services.AddAuthorization(options =>
         policy.RequireRole(Policies.Ipr.ViewAllowedRoles));
     options.AddPolicy(Policies.Ipr.Edit, policy =>
         policy.RequireRole(Policies.Ipr.EditAllowedRoles));
+    options.AddPolicy(Policies.Partners.View, policy =>
+        policy.RequireAuthenticatedUser());
+    options.AddPolicy(Policies.Partners.Manage, policy =>
+        policy.RequireRole(Policies.Partners.ManageAllowedRoles));
+    options.AddPolicy(Policies.Partners.Delete, policy =>
+        policy.RequireRole(Policies.Partners.DeleteAllowedRoles));
+    options.AddPolicy(Policies.Partners.LinkToProject, policy =>
+        policy.RequireRole(Policies.Partners.LinkAllowedRoles));
     options.AddPolicy("DocRepo.View", policy =>
     policy.RequireAuthenticatedUser());
 

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -103,6 +103,13 @@ public class RoleBasedNavigationProvider : INavigationProvider
             },
             new()
             {
+                Text = "Industry Partners",
+                Page = "/Projects/Partners/Index",
+                AuthorizationPolicy = Policies.Partners.View,
+                Icon = "bi-buildings"
+            },
+            new()
+            {
                 Text = "Process",
                 Page = "/Process/Index",
                 Icon = "bi-diagram-3"

--- a/ViewModels/Partners/IndustryPartnerViewModels.cs
+++ b/ViewModels/Partners/IndustryPartnerViewModels.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace ProjectManagement.ViewModels.Partners;
+
+// SECTION: List view models
+public sealed record IndustryPartnerSummaryVm(
+    int Id,
+    string FirmName,
+    string Status,
+    string? PartnerType,
+    string? City,
+    string? PrimaryContactName,
+    string? PrimaryContactDesignation,
+    string? PrimaryEmail,
+    string? PrimaryPhone,
+    int ProjectCount);
+
+// SECTION: Lookup options
+public sealed record IndustryPartnerOptionVm(int Id, string FirmName, string Status);
+
+// SECTION: Project lookup options
+public sealed record ProjectOptionVm(int Id, string Name, string LifecycleStatus);
+
+// SECTION: Project association view model
+public sealed record ProjectIndustryPartnerVm(
+    int ProjectId,
+    int PartnerId,
+    string FirmName,
+    string Role,
+    string Status,
+    DateOnly? FromDate,
+    DateOnly? ToDate,
+    string? Notes);

--- a/wwwroot/css/partners-ui.css
+++ b/wwwroot/css/partners-ui.css
@@ -1,0 +1,18 @@
+/* SECTION: Partner details rail */
+.partner-rail {
+    position: sticky;
+    top: 1rem;
+}
+
+.partner-rail .list-group-item {
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.partner-rail .list-group-item.active {
+    background-color: var(--bs-primary-bg-subtle);
+    color: var(--bs-primary-text-emphasis);
+    border-color: var(--bs-primary-border-subtle);
+}

--- a/wwwroot/js/partners-details.js
+++ b/wwwroot/js/partners-details.js
@@ -1,0 +1,22 @@
+(function () {
+    "use strict";
+
+    // SECTION: Offcanvas auto-open
+    var marker = document.querySelector("[data-partner-offcanvas]");
+    if (!marker || !window.bootstrap) {
+        return;
+    }
+
+    var targetId = marker.getAttribute("data-partner-offcanvas");
+    if (!targetId) {
+        return;
+    }
+
+    var target = document.getElementById(targetId);
+    if (!target) {
+        return;
+    }
+
+    var offcanvas = bootstrap.Offcanvas.getOrCreateInstance(target);
+    offcanvas.show();
+})();


### PR DESCRIPTION
### Motivation
- Reduce layout clutter by removing right-column “Add” forms from Contacts, Attachments, and Projects in `Pages/Projects/Partners/Details.cshtml`.
- Provide a consistent entry point for add actions using a header action cluster and Bootstrap offcanvas drawers to match existing app patterns.
- Remove partner-side project association date fields so linking is done without `FromDate`/`ToDate` on the partner details page.
- Preserve existing handlers and permission checks while changing where forms are displayed.

### Description
- Replaced the top tab bar with a left rail navigation in `Pages/Projects/Partners/Details.cshtml` and added a `@section Styles` to include `~/css/partners-ui.css` for rail styling.
- Moved Add actions into header buttons that open offcanvas drawers and removed the embedded right-column add forms for Contacts, Attachments, and Projects; new drawers are `#ocAddContact`, `#ocAddAttachment`, and `#ocLinkProject` in `Details.cshtml`.
- Removed `FromDate` and `ToDate` from the `ProjectLinkInput` model and removed assignments to those fields in `OnPostLinkProjectAsync` and `OnPostUpdateProjectAsync` in `Pages/Projects/Partners/Details.cshtml.cs`.
- Added `wwwroot/js/partners-details.js` to auto-open the appropriate offcanvas when server-side validation fails and added `wwwroot/css/partners-ui.css` for the left-rail styling, and updated the page to reference these assets.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665f0a85648329a65a662ff170f4c4)