### PR TITLE
Declutter Partner Details: move Add flows to offcanvas drawers and remove project link dates

### DIFF
--- a/Pages/Projects/Partners/Details.cshtml
+++ b/Pages/Projects/Partners/Details.cshtml
@@ -17,6 +17,11 @@
     };
 }
 
+@section Styles
+{
+    <link rel="stylesheet" href="~/css/partners-ui.css" asp-append-version="true" />
+}
+
 <div class="container-xxl py-4">
     <!-- SECTION: Header -->
     <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
@@ -31,83 +36,112 @@
                 }
             </div>
         </div>
-        <div class="d-flex gap-2">
+        <div class="d-flex flex-wrap gap-2 justify-content-lg-end">
             <a class="btn btn-outline-secondary" asp-page="/Projects/Partners/Index">Back to list</a>
             <authorize policy="@Policies.Partners.Manage">
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocAddContact"
+                        aria-controls="ocAddContact">
+                    Add contact
+                </button>
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocAddAttachment"
+                        aria-controls="ocAddAttachment">
+                    Upload attachment
+                </button>
                 <a class="btn btn-primary" asp-page="/Projects/Partners/Edit" asp-route-id="@Model.Partner.Id">Edit partner</a>
+            </authorize>
+            <authorize policy="@Policies.Partners.LinkToProject">
+                <button type="button"
+                        class="btn btn-outline-primary"
+                        data-bs-toggle="offcanvas"
+                        data-bs-target="#ocLinkProject"
+                        aria-controls="ocLinkProject">
+                    Link project
+                </button>
             </authorize>
         </div>
     </div>
 
-    <!-- SECTION: Tabs -->
-    <ul class="nav nav-tabs mb-3">
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Overview" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Overview">Overview</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Contacts" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Contacts">Contacts</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Attachments" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Attachments">Attachments</a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link @(activeTab == "Projects" ? "active" : string.Empty)"
-               asp-page="/Projects/Partners/Details"
-               asp-route-id="@Model.Partner.Id"
-               asp-route-tab="Projects">Associated projects</a>
-        </li>
-    </ul>
+    <!-- SECTION: Layout -->
+    <div class="row g-4">
+        <!-- SECTION: Left rail navigation -->
+        <div class="col-lg-3 col-xxl-2">
+            <nav class="list-group partner-rail" aria-label="Partner sections">
+                <a class="list-group-item list-group-item-action @(activeTab == "Overview" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Overview">Overview</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Contacts" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Contacts">Contacts</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Attachments" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Attachments">Attachments</a>
+                <a class="list-group-item list-group-item-action @(activeTab == "Projects" ? "active" : string.Empty)"
+                   asp-page="/Projects/Partners/Details"
+                   asp-route-id="@Model.Partner.Id"
+                   asp-route-tab="Projects">Associated projects</a>
+            </nav>
+        </div>
 
-    <!-- SECTION: Tab content -->
-    @if (activeTab == "Overview")
-    {
-        <div class="card pm-card pm-shadow">
-            <div class="card-body">
-                <div class="row g-4">
-                    <div class="col-lg-6">
-                        <h2 class="h6 text-uppercase text-muted">Address</h2>
-                        <p class="mb-2">@(string.IsNullOrWhiteSpace(Model.Partner.AddressText) ? "—" : Model.Partner.AddressText)</p>
-                        <p class="text-muted mb-0">
-                            @(string.IsNullOrWhiteSpace(Model.Partner.City) ? "" : Model.Partner.City)
-                            @(string.IsNullOrWhiteSpace(Model.Partner.State) ? "" : $", {Model.Partner.State}")
-                            @(string.IsNullOrWhiteSpace(Model.Partner.Pincode) ? "" : $" - {Model.Partner.Pincode}")
-                        </p>
-                    </div>
-                    <div class="col-lg-6">
-                        <h2 class="h6 text-uppercase text-muted">Website</h2>
-                        <p class="mb-3">
-                            @if (!string.IsNullOrWhiteSpace(Model.Partner.Website))
-                            {
-                                <a href="@Model.Partner.Website" target="_blank" rel="noopener">@Model.Partner.Website</a>
-                            }
-                            else
-                            {
-                                <span>—</span>
-                            }
-                        </p>
-                        <h2 class="h6 text-uppercase text-muted">Notes</h2>
-                        <p class="mb-0">@(string.IsNullOrWhiteSpace(Model.Partner.Notes) ? "—" : Model.Partner.Notes)</p>
+        <!-- SECTION: Tab content -->
+        <div class="col-lg-9 col-xxl-10">
+            @if (activeTab == "Overview")
+            {
+                <div class="card pm-card pm-shadow">
+                    <div class="card-body">
+                        <div class="row g-4">
+                            <div class="col-lg-6">
+                                <h2 class="h6 text-uppercase text-muted">Address</h2>
+                                <p class="mb-2">@(string.IsNullOrWhiteSpace(Model.Partner.AddressText) ? "—" : Model.Partner.AddressText)</p>
+                                <p class="text-muted mb-0">
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.City) ? "" : Model.Partner.City)
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.State) ? "" : $", {Model.Partner.State}")
+                                    @(string.IsNullOrWhiteSpace(Model.Partner.Pincode) ? "" : $" - {Model.Partner.Pincode}")
+                                </p>
+                            </div>
+                            <div class="col-lg-6">
+                                <h2 class="h6 text-uppercase text-muted">Website</h2>
+                                <p class="mb-3">
+                                    @if (!string.IsNullOrWhiteSpace(Model.Partner.Website))
+                                    {
+                                        <a href="@Model.Partner.Website" target="_blank" rel="noopener">@Model.Partner.Website</a>
+                                    }
+                                    else
+                                    {
+                                        <span>—</span>
+                                    }
+                                </p>
+                                <h2 class="h6 text-uppercase text-muted">Notes</h2>
+                                <p class="mb-0">@(string.IsNullOrWhiteSpace(Model.Partner.Notes) ? "—" : Model.Partner.Notes)</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Contacts")
-    {
-        <div class="row g-4">
-            <div class="col-lg-7">
+            }
+            else if (activeTab == "Contacts")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Contacts</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Contacts</h2>
+                            <authorize policy="@Policies.Partners.Manage">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocAddContact"
+                                        aria-controls="ocAddContact">
+                                    Add contact
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Partner.Contacts.Any())
@@ -185,68 +219,23 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-5">
-                <authorize policy="@Policies.Partners.Manage">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Add contact</h2>
-                        </div>
-                        <div class="card-body">
-                            <form method="post" asp-page-handler="AddContact" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="Contact.Name" class="form-label">Name</label>
-                                    <input asp-for="Contact.Name" class="form-control" />
-                                    <span asp-validation-for="Contact.Name" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Designation" class="form-label">Designation</label>
-                                    <input asp-for="Contact.Designation" class="form-control" />
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Email" class="form-label">Email</label>
-                                    <input asp-for="Contact.Email" class="form-control" />
-                                </div>
-                                <div class="row g-3">
-                                    <div class="col-12">
-                                        <label asp-for="Contact.MobilePhone" class="form-label">Mobile</label>
-                                        <input asp-for="Contact.MobilePhone" class="form-control" />
-                                        <span asp-validation-for="Contact.MobilePhone" class="text-danger"></span>
-                                    </div>
-                                    <div class="col-12">
-                                        <label asp-for="Contact.OfficePhone" class="form-label">Office</label>
-                                        <input asp-for="Contact.OfficePhone" class="form-control" />
-                                        <span asp-validation-for="Contact.OfficePhone" class="text-danger"></span>
-                                    </div>
-                                    <div class="col-12">
-                                        <label asp-for="Contact.WhatsAppPhone" class="form-label">WhatsApp</label>
-                                        <input asp-for="Contact.WhatsAppPhone" class="form-control" />
-                                        <span asp-validation-for="Contact.WhatsAppPhone" class="text-danger"></span>
-                                    </div>
-                                </div>
-                                <div class="form-check">
-                                    <input asp-for="Contact.IsPrimary" class="form-check-input" />
-                                    <label asp-for="Contact.IsPrimary" class="form-check-label">Set as primary</label>
-                                </div>
-                                <div>
-                                    <label asp-for="Contact.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="Contact.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Save contact</button>
-                            </form>
-                        </div>
-                    </div>
-                </authorize>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Attachments")
-    {
-        <div class="row g-4">
-            <div class="col-lg-7">
+            }
+            else if (activeTab == "Attachments")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Attachments</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Attachments</h2>
+                            <authorize policy="@Policies.Partners.Manage">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocAddAttachment"
+                                        aria-controls="ocAddAttachment">
+                                    Upload attachment
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Attachments.Any())
@@ -276,53 +265,23 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-5">
-                <authorize policy="@Policies.Partners.Manage">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Upload attachment</h2>
-                        </div>
-                        <div class="card-body">
-                            <form method="post" enctype="multipart/form-data" asp-page-handler="AddAttachment" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="Attachment.File" class="form-label">File</label>
-                                    <input asp-for="Attachment.File" type="file" class="form-control" />
-                                    <span asp-validation-for="Attachment.File" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.Title" class="form-label">Title</label>
-                                    <input asp-for="Attachment.Title" class="form-control" />
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.AttachmentType" class="form-label">Type</label>
-                                    <select asp-for="Attachment.AttachmentType" class="form-select">
-                                        <option value="">Select</option>
-                                        @foreach (var type in Model.AttachmentTypeOptions)
-                                        {
-                                            <option value="@type">@type</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div>
-                                    <label asp-for="Attachment.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="Attachment.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Upload</button>
-                            </form>
-                        </div>
-                    </div>
-                </authorize>
-            </div>
-        </div>
-    }
-    else if (activeTab == "Projects")
-    {
-        <div class="row g-4">
-            <div class="col-lg-8">
+            }
+            else if (activeTab == "Projects")
+            {
                 <div class="card pm-card pm-shadow">
                     <div class="card-header">
-                        <h2 class="h5 mb-0">Associated projects</h2>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Associated projects</h2>
+                            <authorize policy="@Policies.Partners.LinkToProject">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="offcanvas"
+                                        data-bs-target="#ocLinkProject"
+                                        aria-controls="ocLinkProject">
+                                    Link project
+                                </button>
+                            </authorize>
+                        </div>
                     </div>
                     <div class="card-body">
                         @if (!Model.Partner.ProjectLinks.Any())
@@ -338,8 +297,6 @@
                                             <th>Project</th>
                                             <th>Role</th>
                                             <th>Status</th>
-                                            <th>From</th>
-                                            <th>To</th>
                                             <th>Notes</th>
                                             <th class="text-end">Actions</th>
                                         </tr>
@@ -384,29 +341,7 @@
                                                         }
                                                     </authorize>
                                                 </td>
-                                                <td>
-                                                    <authorize policy="@Policies.Partners.LinkToProject">
-                                                        <input name="ProjectLink.FromDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.FromDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
-                                                    </authorize>
-                                                    <authorize policy="@Policies.Partners.View">
-                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
-                                                        {
-                                                            <span>@(link.FromDate?.ToString("dd MMM yyyy") ?? "—")</span>
-                                                        }
-                                                    </authorize>
-                                                </td>
-                                                <td>
-                                                    <authorize policy="@Policies.Partners.LinkToProject">
-                                                        <input name="ProjectLink.ToDate" form="@updateFormId" type="date" class="form-control form-control-sm" value="@(link.ToDate?.ToString("yyyy-MM-dd") ?? string.Empty)" />
-                                                    </authorize>
-                                                    <authorize policy="@Policies.Partners.View">
-                                                        @if (!User.IsInRole(RoleNames.Admin) && !User.IsInRole(RoleNames.HoD) && !User.IsInRole(RoleNames.Mco) && !User.IsInRole(RoleNames.ProjectOfficer))
-                                                        {
-                                                            <span>@(link.ToDate?.ToString("dd MMM yyyy") ?? "—")</span>
-                                                        }
-                                                    </authorize>
-                                                </td>
-                                                <td class="text-wrap" style="max-width: 220px;">
+                                                <td class="text-wrap" style="max-width: 340px;">
                                                     <authorize policy="@Policies.Partners.LinkToProject">
                                                         <textarea name="ProjectLink.Notes" form="@updateFormId" class="form-control form-control-sm" rows="2">@link.Notes</textarea>
                                                     </authorize>
@@ -444,69 +379,193 @@
                         }
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-4">
-                <authorize policy="@Policies.Partners.LinkToProject">
-                    <div class="card pm-card pm-shadow">
-                        <div class="card-header">
-                            <h2 class="h5 mb-0">Link project</h2>
+            }
+        </div>
+    </div>
+
+    <!-- SECTION: Offcanvas state -->
+    @{
+        string? autoOpen = null;
+
+        if (!ViewData.ModelState.IsValid)
+        {
+            if (activeTab == "Contacts" && ViewData.ModelState.Keys.Any(k => k.StartsWith("Contact.", StringComparison.Ordinal)))
+            {
+                autoOpen = "ocAddContact";
+            }
+            else if (activeTab == "Attachments" && ViewData.ModelState.Keys.Any(k => k.StartsWith("Attachment.", StringComparison.Ordinal)))
+            {
+                autoOpen = "ocAddAttachment";
+            }
+            else if (activeTab == "Projects" &&
+                     (ViewData.ModelState.Keys.Any(k => k.StartsWith("ProjectLink.", StringComparison.Ordinal)) ||
+                      ViewData.ModelState.ContainsKey(string.Empty)))
+            {
+                autoOpen = "ocLinkProject";
+            }
+        }
+    }
+    <div class="d-none" data-partner-offcanvas="@autoOpen"></div>
+
+    <!-- SECTION: Offcanvas drawers -->
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocAddContact" aria-labelledby="ocAddContactLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocAddContactLabel">Add contact</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.Manage">
+                <form method="post" asp-page-handler="AddContact" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="Contact.Name" class="form-label">Name</label>
+                        <input asp-for="Contact.Name" class="form-control" />
+                        <span asp-validation-for="Contact.Name" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Designation" class="form-label">Designation</label>
+                        <input asp-for="Contact.Designation" class="form-control" />
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Email" class="form-label">Email</label>
+                        <input asp-for="Contact.Email" class="form-control" />
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label asp-for="Contact.MobilePhone" class="form-label">Mobile</label>
+                            <input asp-for="Contact.MobilePhone" class="form-control" />
+                            <span asp-validation-for="Contact.MobilePhone" class="text-danger"></span>
                         </div>
-                        <div class="card-body">
-                            <form method="post" asp-page-handler="LinkProject" asp-route-id="@Model.Partner.Id" class="vstack gap-3">
-                                <div>
-                                    <label asp-for="ProjectLink.ProjectId" class="form-label">Project</label>
-                                    <select asp-for="ProjectLink.ProjectId" class="form-select">
-                                        <option value="">Select project</option>
-                                        @foreach (var project in Model.ProjectOptions)
-                                        {
-                                            <option value="@project.Id">@project.Name (@project.LifecycleStatus)</option>
-                                        }
-                                    </select>
-                                    <span asp-validation-for="ProjectLink.ProjectId" class="text-danger"></span>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Role" class="form-label">Role</label>
-                                    <select asp-for="ProjectLink.Role" class="form-select">
-                                        @foreach (var role in Model.RoleOptions)
-                                        {
-                                            <option value="@role">@role</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Status" class="form-label">Status</label>
-                                    <select asp-for="ProjectLink.Status" class="form-select">
-                                        @foreach (var status in Model.StatusOptions)
-                                        {
-                                            <option value="@status">@status</option>
-                                        }
-                                    </select>
-                                </div>
-                                <div class="row g-3">
-                                    <div class="col-6">
-                                        <label asp-for="ProjectLink.FromDate" class="form-label">From</label>
-                                        <input asp-for="ProjectLink.FromDate" type="date" class="form-control" />
-                                    </div>
-                                    <div class="col-6">
-                                        <label asp-for="ProjectLink.ToDate" class="form-label">To</label>
-                                        <input asp-for="ProjectLink.ToDate" type="date" class="form-control" />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label asp-for="ProjectLink.Notes" class="form-label">Notes</label>
-                                    <textarea asp-for="ProjectLink.Notes" class="form-control" rows="3"></textarea>
-                                </div>
-                                <button type="submit" class="btn btn-primary">Link partner</button>
-                            </form>
+                        <div class="col-12">
+                            <label asp-for="Contact.OfficePhone" class="form-label">Office</label>
+                            <input asp-for="Contact.OfficePhone" class="form-control" />
+                            <span asp-validation-for="Contact.OfficePhone" class="text-danger"></span>
+                        </div>
+                        <div class="col-12">
+                            <label asp-for="Contact.WhatsAppPhone" class="form-label">WhatsApp</label>
+                            <input asp-for="Contact.WhatsAppPhone" class="form-control" />
+                            <span asp-validation-for="Contact.WhatsAppPhone" class="text-danger"></span>
                         </div>
                     </div>
-                </authorize>
-            </div>
+                    <div class="form-check">
+                        <input asp-for="Contact.IsPrimary" class="form-check-input" />
+                        <label asp-for="Contact.IsPrimary" class="form-check-label">Set as primary</label>
+                    </div>
+                    <div>
+                        <label asp-for="Contact.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="Contact.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Save contact</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
         </div>
-    }
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocAddAttachment" aria-labelledby="ocAddAttachmentLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocAddAttachmentLabel">Upload attachment</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.Manage">
+                <form method="post"
+                      enctype="multipart/form-data"
+                      asp-page-handler="AddAttachment"
+                      asp-route-id="@Model.Partner.Id"
+                      class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="Attachment.File" class="form-label">File</label>
+                        <input asp-for="Attachment.File" type="file" class="form-control" />
+                        <span asp-validation-for="Attachment.File" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.Title" class="form-label">Title</label>
+                        <input asp-for="Attachment.Title" class="form-control" />
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.AttachmentType" class="form-label">Type</label>
+                        <select asp-for="Attachment.AttachmentType" class="form-select">
+                            <option value="">Select</option>
+                            @foreach (var type in Model.AttachmentTypeOptions)
+                            {
+                                <option value="@type">@type</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="Attachment.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="Attachment.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Upload</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
+        </div>
+    </div>
+
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="ocLinkProject" aria-labelledby="ocLinkProjectLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="ocLinkProjectLabel">Link project</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <authorize policy="@Policies.Partners.LinkToProject">
+                <form method="post"
+                      asp-page-handler="LinkProject"
+                      asp-route-id="@Model.Partner.Id"
+                      class="vstack gap-3">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div>
+                        <label asp-for="ProjectLink.ProjectId" class="form-label">Project</label>
+                        <select asp-for="ProjectLink.ProjectId" class="form-select">
+                            <option value="">Select project</option>
+                            @foreach (var project in Model.ProjectOptions)
+                            {
+                                <option value="@project.Id">@project.Name (@project.LifecycleStatus)</option>
+                            }
+                        </select>
+                        <span asp-validation-for="ProjectLink.ProjectId" class="text-danger"></span>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Role" class="form-label">Role</label>
+                        <select asp-for="ProjectLink.Role" class="form-select">
+                            @foreach (var role in Model.RoleOptions)
+                            {
+                                <option value="@role">@role</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Status" class="form-label">Status</label>
+                        <select asp-for="ProjectLink.Status" class="form-select">
+                            @foreach (var status in Model.StatusOptions)
+                            {
+                                <option value="@status">@status</option>
+                            }
+                        </select>
+                    </div>
+                    <div>
+                        <label asp-for="ProjectLink.Notes" class="form-label">Notes</label>
+                        <textarea asp-for="ProjectLink.Notes" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Link project</button>
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="offcanvas">Cancel</button>
+                    </div>
+                </form>
+            </authorize>
+        </div>
+    </div>
 </div>
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/partners-details.js" asp-append-version="true"></script>
 }

--- a/Pages/Projects/Partners/Details.cshtml.cs
+++ b/Pages/Projects/Partners/Details.cshtml.cs
@@ -144,10 +144,6 @@ public class DetailsModel : PageModel
         [MaxLength(40)]
         public string Status { get; set; } = IndustryPartnerAssociationStatuses.Active;
 
-        public DateOnly? FromDate { get; set; }
-
-        public DateOnly? ToDate { get; set; }
-
         [MaxLength(1000)]
         public string? Notes { get; set; }
     }
@@ -436,8 +432,6 @@ public class DetailsModel : PageModel
             ProjectId = ProjectLink.ProjectId,
             Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role,
             Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status,
-            FromDate = ProjectLink.FromDate,
-            ToDate = ProjectLink.ToDate,
             Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim(),
             CreatedAtUtc = now,
             CreatedByUserId = userId
@@ -497,8 +491,6 @@ public class DetailsModel : PageModel
 
         link.Role = string.IsNullOrWhiteSpace(ProjectLink.Role) ? IndustryPartnerRoles.JointDevelopmentPartner : ProjectLink.Role;
         link.Status = string.IsNullOrWhiteSpace(ProjectLink.Status) ? IndustryPartnerAssociationStatuses.Active : ProjectLink.Status;
-        link.FromDate = ProjectLink.FromDate;
-        link.ToDate = ProjectLink.ToDate;
         link.Notes = string.IsNullOrWhiteSpace(ProjectLink.Notes) ? null : ProjectLink.Notes.Trim();
         link.UpdatedAtUtc = _clock.UtcNow.UtcDateTime;
         link.UpdatedByUserId = _users.GetUserId(User) ?? string.Empty;

--- a/wwwroot/css/partners-ui.css
+++ b/wwwroot/css/partners-ui.css
@@ -1,0 +1,18 @@
+/* SECTION: Partner details rail */
+.partner-rail {
+    position: sticky;
+    top: 1rem;
+}
+
+.partner-rail .list-group-item {
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.partner-rail .list-group-item.active {
+    background-color: var(--bs-primary-bg-subtle);
+    color: var(--bs-primary-text-emphasis);
+    border-color: var(--bs-primary-border-subtle);
+}

--- a/wwwroot/js/partners-details.js
+++ b/wwwroot/js/partners-details.js
@@ -1,0 +1,22 @@
+(function () {
+    "use strict";
+
+    // SECTION: Offcanvas auto-open
+    var marker = document.querySelector("[data-partner-offcanvas]");
+    if (!marker || !window.bootstrap) {
+        return;
+    }
+
+    var targetId = marker.getAttribute("data-partner-offcanvas");
+    if (!targetId) {
+        return;
+    }
+
+    var target = document.getElementById(targetId);
+    if (!target) {
+        return;
+    }
+
+    var offcanvas = bootstrap.Offcanvas.getOrCreateInstance(target);
+    offcanvas.show();
+})();


### PR DESCRIPTION
### Motivation
- Reduce layout clutter by removing right-column “Add” forms from Contacts, Attachments, and Projects in `Pages/Projects/Partners/Details.cshtml`.
- Provide a consistent entry point for add actions using a header action cluster and Bootstrap offcanvas drawers to match existing app patterns.
- Remove partner-side project association date fields so linking is done without `FromDate`/`ToDate` on the partner details page.
- Preserve existing handlers and permission checks while changing where forms are displayed.

### Description
- Replaced the top tab bar with a left rail navigation in `Pages/Projects/Partners/Details.cshtml` and added a `@section Styles` to include `~/css/partners-ui.css` for rail styling.
- Moved Add actions into header buttons that open offcanvas drawers and removed the embedded right-column add forms for Contacts, Attachments, and Projects; new drawers are `#ocAddContact`, `#ocAddAttachment`, and `#ocLinkProject` in `Details.cshtml`.
- Removed `FromDate` and `ToDate` from the `ProjectLinkInput` model and removed assignments to those fields in `OnPostLinkProjectAsync` and `OnPostUpdateProjectAsync` in `Pages/Projects/Partners/Details.cshtml.cs`.
- Added `wwwroot/js/partners-details.js` to auto-open the appropriate offcanvas when server-side validation fails and added `wwwroot/css/partners-ui.css` for the left-rail styling, and updated the page to reference these assets.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665f0a85648329a65a662ff170f4c4)