### PR TITLE
Simplify pending approvals filters to Type + Search

### DIFF
--- a/Pages/Approvals/Pending/Index.cshtml
+++ b/Pages/Approvals/Pending/Index.cshtml
@@ -19,21 +19,9 @@
                     <label class="form-label" asp-for="Type">Type</label>
                     <select class="form-select" asp-for="Type" asp-items="Model.TypeOptions"></select>
                 </div>
-                <div class="col-12 col-md-3">
-                    <label class="form-label" asp-for="Module">Module</label>
-                    <select class="form-select" asp-for="Module" asp-items="Model.ModuleOptions"></select>
-                </div>
-                <div class="col-12 col-md-2">
-                    <label class="form-label" asp-for="From">From</label>
-                    <input type="date" class="form-control" asp-for="From" />
-                </div>
-                <div class="col-12 col-md-2">
-                    <label class="form-label" asp-for="To">To</label>
-                    <input type="date" class="form-control" asp-for="To" />
-                </div>
-                <div class="col-12 col-md-4">
+                <div class="col-12 col-md-5">
                     <label class="form-label" asp-for="Search">Search</label>
-                    <input type="search" class="form-control" asp-for="Search" placeholder="Project, requester, request id" />
+                    <input type="search" class="form-control" asp-for="Search" placeholder="Project, requester, request id, summary" />
                 </div>
                 <div class="col-12 col-md-2 d-grid">
                     <button type="submit" class="btn btn-primary">Apply filters</button>

--- a/Pages/Approvals/Pending/Index.cshtml.cs
+++ b/Pages/Approvals/Pending/Index.cshtml.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,17 +28,6 @@ public class IndexModel : PageModel
     public string? Type { get; set; }
 
     [BindProperty(SupportsGet = true)]
-    public string? Module { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    [DataType(DataType.Date)]
-    public DateTime? From { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    [DataType(DataType.Date)]
-    public DateTime? To { get; set; }
-
-    [BindProperty(SupportsGet = true)]
     public string? Search { get; set; }
 
     // SECTION: View model state
@@ -48,19 +35,13 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<SelectListItem> TypeOptions { get; private set; } = Array.Empty<SelectListItem>();
 
-    public IReadOnlyList<SelectListItem> ModuleOptions { get; private set; } = Array.Empty<SelectListItem>();
-
     public async Task OnGetAsync(CancellationToken cancellationToken)
     {
         var parsedType = ParseEnum<ApprovalQueueType>(Type);
-        var parsedModule = ParseEnum<ApprovalQueueModule>(Module);
 
         var query = new ApprovalQueueQuery
         {
             Type = parsedType,
-            Module = parsedModule,
-            FromUtc = From?.ToUniversalTime(),
-            ToUtc = To?.ToUniversalTime().AddDays(1).AddTicks(-1),
             Search = Search
         };
 
@@ -77,7 +58,6 @@ public class IndexModel : PageModel
             .ToList();
 
         TypeOptions = BuildEnumOptions<ApprovalQueueType>(parsedType, "All types");
-        ModuleOptions = BuildEnumOptions<ApprovalQueueModule>(parsedModule, "All modules");
     }
 
     // SECTION: Helpers

--- a/ViewModels/ApprovalQueueViewModels.cs
+++ b/ViewModels/ApprovalQueueViewModels.cs
@@ -26,9 +26,6 @@ public enum ApprovalQueueModule
 public sealed record ApprovalQueueQuery
 {
     public ApprovalQueueType? Type { get; init; }
-    public ApprovalQueueModule? Module { get; init; }
-    public DateTimeOffset? FromUtc { get; init; }
-    public DateTimeOffset? ToUtc { get; init; }
     public string? Search { get; init; }
 }
 


### PR DESCRIPTION
### Motivation

- Reduce UI and backend complexity on the Pending Approvals page by keeping only `Type` and free-text `Search` filters while still loading all pending items by default. 
- Remove module and date-range filtering surface and related plumbing which were rarely used and add lightweight search improvements to maintain discoverability.

### Description

- Removed `Module`, `FromUtc` and `ToUtc` from the query model (`ApprovalQueueQuery`) and eliminated the date range and module bindings from the page model (`Pages/Approvals/Pending/Index.cshtml.cs`).
- Updated the Razor UI (`Pages/Approvals/Pending/Index.cshtml`) to remove the Module dropdown and From/To date inputs, expanded the Search input width, and changed its placeholder to `Project, requester, request id, summary`.
- Simplified `ApprovalQueueService.GetPendingAsync` to ignore module/date filtering, removed the `ApplyDateRange` helpers, and adjusted `ShouldIncludeType` to consider only `Type`; also changed default ordering to oldest first (`OrderBy(item => item.RequestedAtUtc)`).
- Enhanced `ApplySearch` to search additional summary-related fields and parse common enum/ID tokens (e.g. `StageCode`, `RequestedStatus`, `VersionNo`, `ProjectDocumentRequestType`, `ProjectTotStatus`, `ProliferationSource`, year/quantity and GUIDs) so search still finds relevant items without module/date filters.

### Testing

- No automated test suite was executed in this environment. 
- An attempt to run the application with `dotnet run` failed because the `dotnet` SDK is not available in the current environment, so no runtime verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f2e0083c83298e25733bb19a21b3)