### PR TITLE
Add pending approvals count badge to navigation

### DIFF
--- a/Pages/Shared/Components/PendingApprovalsBadge/Default.cshtml
+++ b/Pages/Shared/Components/PendingApprovalsBadge/Default.cshtml
@@ -1,0 +1,9 @@
+@model ProjectManagement.ViewModels.Navigation.PendingApprovalsBadgeViewModel
+
+@* ---------- Pending approvals badge ---------- *@
+@if (Model.ShowBadge)
+{
+    <span class="badge rounded-pill bg-danger pm-drawer__badge" aria-label="@Model.AriaLabel">
+        @Model.DisplayText
+    </span>
+}

--- a/Services/Approvals/ApprovalQueueService.cs
+++ b/Services/Approvals/ApprovalQueueService.cs
@@ -101,6 +101,30 @@ public sealed class ApprovalQueueService : IApprovalQueueService
             .ToList();
     }
 
+    // SECTION: Pending approvals count
+    public async Task<int> GetPendingCountAsync(
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ApprovalAuthorization.CanApproveProjectChanges(user.IsInRole("Admin"), user.IsInRole("HoD")))
+        {
+            return 0;
+        }
+
+        var query = new ApprovalQueueQuery();
+        var total = 0;
+
+        total += await BuildStageChangeQuery(query).CountAsync(cancellationToken);
+        total += await BuildMetaChangeQuery(query).CountAsync(cancellationToken);
+        total += await BuildPlanApprovalQuery(query).CountAsync(cancellationToken);
+        total += await BuildDocumentRequestQuery(query).CountAsync(cancellationToken);
+        total += await BuildTotRequestQuery(query).CountAsync(cancellationToken);
+        total += await BuildProliferationYearlyQuery(query).CountAsync(cancellationToken);
+        total += await BuildProliferationGranularQuery(query).CountAsync(cancellationToken);
+
+        return total;
+    }
+
     // SECTION: Pending approval detail
     public async Task<ApprovalQueueDetailVm?> GetDetailAsync(
         ApprovalQueueType type,

--- a/Services/Approvals/IApprovalQueueService.cs
+++ b/Services/Approvals/IApprovalQueueService.cs
@@ -14,6 +14,11 @@ public interface IApprovalQueueService
         ClaimsPrincipal user,
         CancellationToken cancellationToken = default);
 
+    // SECTION: Pending approvals count
+    Task<int> GetPendingCountAsync(
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken = default);
+
     // SECTION: Pending approval detail
     Task<ApprovalQueueDetailVm?> GetDetailAsync(
         ApprovalQueueType type,

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -118,6 +118,7 @@ public class RoleBasedNavigationProvider : INavigationProvider
                 Text = "Pending approvals",
                 Page = "/Approvals/Pending/Index",
                 RequiredRoles = new[] { "Admin", "HoD" },
+                BadgeViewComponentName = "PendingApprovalsBadge",
                 Icon = "bi-check2-square"
             },
         };

--- a/ViewComponents/PendingApprovalsBadgeViewComponent.cs
+++ b/ViewComponents/PendingApprovalsBadgeViewComponent.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using ProjectManagement.Services.Approvals;
+using ProjectManagement.ViewModels.Navigation;
+
+namespace ProjectManagement.ViewComponents;
+
+public sealed class PendingApprovalsBadgeViewComponent : ViewComponent
+{
+    // SECTION: Dependencies
+    private readonly IApprovalQueueService _queueService;
+
+    public PendingApprovalsBadgeViewComponent(IApprovalQueueService queueService)
+    {
+        _queueService = queueService ?? throw new ArgumentNullException(nameof(queueService));
+    }
+
+    // SECTION: View component entry point
+    public async Task<IViewComponentResult> InvokeAsync(CancellationToken cancellationToken = default)
+    {
+        var count = await _queueService.GetPendingCountAsync(HttpContext.User, cancellationToken);
+        var model = BuildViewModel(count);
+
+        return View(model);
+    }
+
+    // SECTION: View model builder
+    private static PendingApprovalsBadgeViewModel BuildViewModel(int count)
+    {
+        if (count <= 0)
+        {
+            return new PendingApprovalsBadgeViewModel
+            {
+                ShowBadge = false,
+            };
+        }
+
+        var displayText = count > 99 ? "99+" : count.ToString();
+
+        return new PendingApprovalsBadgeViewModel
+        {
+            ShowBadge = true,
+            DisplayText = displayText,
+            AriaLabel = $"Pending approvals: {count}"
+        };
+    }
+}

--- a/ViewModels/Navigation/PendingApprovalsBadgeViewModel.cs
+++ b/ViewModels/Navigation/PendingApprovalsBadgeViewModel.cs
@@ -1,0 +1,11 @@
+namespace ProjectManagement.ViewModels.Navigation;
+
+public sealed record PendingApprovalsBadgeViewModel
+{
+    // SECTION: Badge state
+    public bool ShowBadge { get; init; }
+
+    public string DisplayText { get; init; } = string.Empty;
+
+    public string? AriaLabel { get; init; }
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -3491,6 +3491,15 @@ summary::marker {
     margin-left: auto;
 }
 
+/* ===========================
+   Drawer badges
+   =========================== */
+.pm-drawer__badge {
+    min-width: 2rem;
+    font-weight: 600;
+    letter-spacing: .02em;
+}
+
 .pm-drawer__caret {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
### Motivation

- Surface a single, accurate `PendingApprovalsCount` in the left navigation so `Admin` and `HoD` users see outstanding approvals without opening the Pending page.
- Ensure the count mirrors the existing consolidated approvals queue sources and is cheap to compute (uses `COUNT` queries, `AsNoTracking`).
- Keep the badge hidden when the count is zero and cap display at `99+` for large values.

### Description

- Added `Task<int> GetPendingCountAsync(ClaimsPrincipal user, CancellationToken ct)` to `IApprovalQueueService` and implemented it in `ApprovalQueueService` to sum `CountAsync` results from each pending source using the same query builders used by the queue list and returning `0` for non-approver roles.
- Introduced a `PendingApprovalsBadgeViewComponent` plus `PendingApprovalsBadgeViewModel` and a Razor view at `Pages/Shared/Components/PendingApprovalsBadge/Default.cshtml` to render the badge when `count > 0` and show `99+` when the count exceeds 99.
- Wired the badge into the navigation by setting `BadgeViewComponentName = "PendingApprovalsBadge"` for the "Pending approvals" `NavigationItem` in `RoleBasedNavigationProvider` and added minimal CSS (`.pm-drawer__badge`) to `wwwroot/css/site.css`.
- Role gating is enforced in the service so non-`Admin`/`HoD` users do not trigger DB queries.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f53bfc888329b7557b20f79d6385)