### PR TITLE
Polish Pending Approvals UI — KPI strip, filter bar, table and decision UX

### DIFF
--- a/Pages/Approvals/Pending/Decide.cshtml.cs
+++ b/Pages/Approvals/Pending/Decide.cshtml.cs
@@ -35,6 +35,12 @@ public class DecideModel : PageModel
             return RedirectToDetails();
         }
 
+        if (action == ApprovalDecisionAction.Reject && string.IsNullOrWhiteSpace(Input.Remarks))
+        {
+            TempData["Error"] = "Remarks are required when rejecting a request.";
+            return RedirectToDetails();
+        }
+
         var request = new ApprovalDecisionRequest(
             Input.ApprovalType,
             Input.RequestId,

--- a/Pages/Approvals/Pending/Details.cshtml
+++ b/Pages/Approvals/Pending/Details.cshtml
@@ -9,10 +9,16 @@
     string formatDecisionDate(DateTime? value) => value?.ToLocalTime().ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) ?? "—";
 }
 
-<div class="container-fluid">
+<div class="container-fluid approvals-page">
+    @* SECTION: Page header *@
     <div class="mb-4">
         <a class="btn btn-link px-0" asp-page="/Approvals/Pending/Index">&larr; Back to pending approvals</a>
-        <h1 class="h2 mt-2">Pending approval details</h1>
+        <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+            <h1 class="h2 mb-0">Pending approval details</h1>
+            <span class="badge approval-status-badge @GetStatusBadgeClass(Model.CurrentStatus)">
+                @(Model.IsPending ? "Pending decision" : Model.CurrentStatus)
+            </span>
+        </div>
         <p class="text-muted mb-0">@item.Summary</p>
     </div>
 
@@ -30,7 +36,7 @@
 
     <div class="row g-4">
         <div class="col-lg-7">
-            <div class="card border-0 shadow-sm mb-4">
+            <div class="card approval-card mb-4">
                 <div class="card-body">
                     <h2 class="h5">Request summary</h2>
                     <dl class="row mb-0">
@@ -47,14 +53,18 @@
                         <dd class="col-sm-8">@formatDateTime(item.RequestedAtUtc)</dd>
 
                         <dt class="col-sm-4">Status</dt>
-                        <dd class="col-sm-8">@item.Status</dd>
+                        <dd class="col-sm-8">
+                            <span class="badge approval-status-badge @GetStatusBadgeClass(Model.CurrentStatus)">
+                                @Model.CurrentStatus
+                            </span>
+                        </dd>
                     </dl>
                 </div>
             </div>
 
             @if (Model.Detail.StageChange is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Stage change details</h2>
                         <dl class="row mb-0">
@@ -88,7 +98,7 @@
 
             @if (Model.Detail.MetaChange is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Metadata change details</h2>
                         <p class="text-muted mb-3">@Model.Detail.MetaChange.Summary</p>
@@ -127,7 +137,7 @@
 
             @if (Model.Detail.PlanApproval is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Plan approval details</h2>
                         <p class="text-muted mb-3">Submitted @formatDateTime(Model.Detail.PlanApproval.SubmittedOnUtc) by @Model.Detail.PlanApproval.SubmittedBy.</p>
@@ -162,7 +172,7 @@
 
             @if (Model.Detail.DocumentModeration is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Document moderation details</h2>
                         <dl class="row mb-0">
@@ -205,7 +215,7 @@
 
             @if (Model.Detail.TotRequest is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Transfer of Technology details</h2>
                         <div class="table-responsive">
@@ -234,7 +244,7 @@
 
             @if (Model.Detail.ProliferationYearly is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Yearly proliferation details</h2>
                         <dl class="row mb-0">
@@ -266,7 +276,7 @@
 
             @if (Model.Detail.ProliferationGranular is not null)
             {
-                <div class="card border-0 shadow-sm mb-4">
+                <div class="card approval-card mb-4">
                     <div class="card-body">
                         <h2 class="h6 text-uppercase text-muted mb-3">Granular proliferation details</h2>
                         <dl class="row mb-0">
@@ -300,11 +310,14 @@
         </div>
 
         <div class="col-lg-5">
-            <div class="card border-0 shadow-sm">
+            <div class="card approval-card approval-decision-card">
                 <div class="card-body">
                     @if (Model.IsPending)
                     {
-                        <h2 class="h5">Decision</h2>
+                        <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                            <h2 class="h5 mb-0">Decision required</h2>
+                            <span class="badge approval-status-badge approval-status-badge--pending">Pending decision</span>
+                        </div>
                         <p class="text-muted">Approvals apply the change immediately. Rejections require a reason.</p>
 
                         @* SECTION: Decision form *@
@@ -316,7 +329,9 @@
                             <input asp-for="Input.ReturnUrl" type="hidden" />
 
                             <div>
-                                <label class="form-label" asp-for="Input.Remarks"></label>
+                                <label class="form-label" asp-for="Input.Remarks">
+                                    Remarks <span class="text-muted">(required for rejection)</span>
+                                </label>
                                 <textarea class="form-control" asp-for="Input.Remarks" rows="4" placeholder="Add context for the requester"></textarea>
                                 <div class="form-text">Remarks are required when rejecting.</div>
                             </div>
@@ -329,16 +344,20 @@
                     }
                     else
                     {
-                        <h2 class="h5">Decision recorded</h2>
+                        <h2 class="h5">Decision summary</h2>
                         <p class="text-muted mb-4">This request has already been processed and is no longer actionable.</p>
 
                         @* SECTION: Decision summary *@
                         <dl class="row mb-4">
                             <dt class="col-sm-4">Status</dt>
-                            <dd class="col-sm-8">@Model.CurrentStatus</dd>
+                            <dd class="col-sm-8">
+                                <span class="badge approval-status-badge @GetStatusBadgeClass(Model.CurrentStatus)">
+                                    @Model.CurrentStatus
+                                </span>
+                            </dd>
 
                             <dt class="col-sm-4">Decided by</dt>
-                            <dd class="col-sm-8">@Model.DecidedByName</dd>
+                            <dd class="col-sm-8">@Model.DecidedByName ?? "—"</dd>
 
                             <dt class="col-sm-4">Decided at</dt>
                             <dd class="col-sm-8">@formatDecisionDate(Model.DecidedAt)</dd>
@@ -351,7 +370,7 @@
                         </dl>
 
                         <div class="d-grid">
-                            <a class="btn btn-outline-primary" asp-page="/Approvals/Pending/Index">Back to pending approvals</a>
+                            <a class="btn btn-primary" asp-page="/Approvals/Pending/Index">Back to pending approvals</a>
                         </div>
                     }
                 </div>
@@ -359,3 +378,17 @@
         </div>
     </div>
 </div>
+
+@functions {
+    // SECTION: Status helpers
+    private static string GetStatusBadgeClass(string? status)
+    {
+        return status?.ToLowerInvariant() switch
+        {
+            "approved" => "approval-status-badge--approved",
+            "rejected" => "approval-status-badge--rejected",
+            "pending" => "approval-status-badge--pending",
+            _ => "approval-status-badge--neutral"
+        };
+    }
+}

--- a/Pages/Approvals/Pending/Index.cshtml
+++ b/Pages/Approvals/Pending/Index.cshtml
@@ -4,7 +4,8 @@
     ViewData["Title"] = "Pending approvals";
 }
 
-<div class="container-fluid">
+<div class="container-fluid approvals-page">
+    @* SECTION: Page header *@
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
         <div>
             <h1 class="h2 mb-1">Pending approvals</h1>
@@ -18,28 +19,61 @@
         <div class="alert alert-success" role="alert">@Model.SuccessMessage</div>
     }
 
-    <div class="card border-0 shadow-sm mb-4">
+    @* SECTION: KPI strip *@
+    <div class="approvals-kpi-grid mb-4">
+        <div class="approvals-kpi-card">
+            <div class="approvals-kpi-label">Total pending</div>
+            <div class="approvals-kpi-value">@Model.TotalPendingCount</div>
+            <div class="approvals-kpi-meta">@Model.FilterContextLabel</div>
+        </div>
+        <div class="approvals-kpi-card">
+            <div class="approvals-kpi-label">Oldest pending</div>
+            <div class="approvals-kpi-value">@Model.OldestPendingDisplay</div>
+            <div class="approvals-kpi-meta">Oldest request in view</div>
+        </div>
+        <div class="approvals-kpi-card">
+            <div class="approvals-kpi-label">By module</div>
+            <div class="approvals-kpi-value">Projects: @Model.ProjectsPendingCount</div>
+            <div class="approvals-kpi-meta">Project office: @Model.ProjectOfficePendingCount</div>
+        </div>
+        <div class="approvals-kpi-card">
+            <div class="approvals-kpi-label">Top type</div>
+            <div class="approvals-kpi-value">@Model.TopTypeDisplay</div>
+            <div class="approvals-kpi-meta">@Model.TopTypeMeta</div>
+        </div>
+    </div>
+
+    @* SECTION: Filters *@
+    <div class="card approval-card approvals-filter-bar mb-4">
         <div class="card-body">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                <div class="fw-semibold">Filters</div>
+                @if (Model.HasActiveFilters)
+                {
+                    <span class="badge approvals-filter-badge">Filters active</span>
+                }
+            </div>
             <form method="get" class="row g-3 align-items-end">
-                <div class="col-12 col-md-3">
+                <div class="col-12 col-lg-3">
                     <label class="form-label" asp-for="Type">Type</label>
                     <select class="form-select" asp-for="Type" asp-items="Model.TypeOptions"></select>
                 </div>
-                <div class="col-12 col-md-5">
+                <div class="col-12 col-lg-5">
                     <label class="form-label" asp-for="Search">Search</label>
                     <input type="search" class="form-control" asp-for="Search" placeholder="Project, requester, request id, summary" />
                 </div>
-                <div class="col-12 col-md-2 d-grid">
+                <div class="col-12 col-md-3 col-lg-2 d-grid">
                     <button type="submit" class="btn btn-primary">Apply filters</button>
                 </div>
-                <div class="col-12 col-md-2 d-grid">
+                <div class="col-12 col-md-3 col-lg-2 d-grid">
                     <a class="btn btn-outline-secondary" asp-page="/Approvals/Pending/Index">Clear</a>
                 </div>
             </form>
         </div>
     </div>
 
-    <div class="card border-0 shadow-sm">
+    @* SECTION: Results *@
+    <div class="card approval-card">
         <div class="card-body">
             @if (Model.Items.Count == 0)
             {
@@ -50,8 +84,14 @@
             }
             else
             {
+                <div class="approvals-table-header mb-3">
+                    <div class="approvals-table-summary">
+                        <span class="fw-semibold">Showing @Model.Items.Count pending approvals</span>
+                        <span class="text-muted">Sorted by oldest first</span>
+                    </div>
+                </div>
                 <div class="table-responsive">
-                    <table class="table table-striped align-middle">
+                    <table class="table align-middle approvals-table">
                         <thead>
                             <tr>
                                 <th scope="col">Type</th>
@@ -66,15 +106,18 @@
                         <tbody>
                             @foreach (var item in Model.Items)
                             {
-                                <tr>
+                                <tr class="approvals-table-row">
                                     <td>
-                                        <span class="fw-semibold">@item.ApprovalType</span>
+                                        <span class="approval-type-chip">@Model.GetTypeLabel(item.ApprovalType)</span>
+                                        <a class="stretched-link approval-row-link" href="@item.DetailsUrl">
+                                            <span class="visually-hidden">View details</span>
+                                        </a>
                                     </td>
                                     <td>
                                         @if (item.ProjectId.HasValue)
                                         {
-                                            <div class="fw-semibold">@item.ProjectName</div>
-                                            <div class="text-muted small">Project #@item.ProjectId</div>
+                                            <div class="approval-project-name">@item.ProjectName</div>
+                                            <div class="approval-project-id">Project #@item.ProjectId</div>
                                         }
                                         else
                                         {
@@ -83,12 +126,12 @@
                                     </td>
                                     <td>@item.RequestedByName</td>
                                     <td>@item.RequestedAtUtc.ToLocalTime().ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture)</td>
-                                    <td>@item.Summary</td>
-                                    <td>@item.Module</td>
                                     <td>
-                                        <div class="d-flex flex-wrap gap-2">
-                                            <a class="btn btn-sm btn-outline-primary" href="@item.DetailsUrl">View details</a>
-                                        </div>
+                                        <div class="approval-summary">@item.Summary</div>
+                                    </td>
+                                    <td class="text-muted">@Model.GetModuleLabel(item.Module)</td>
+                                    <td>
+                                        <a class="btn btn-sm btn-link approvals-action-link" href="@item.DetailsUrl">View details</a>
                                     </td>
                                 </tr>
                             }

--- a/Pages/Approvals/Pending/Index.cshtml.cs
+++ b/Pages/Approvals/Pending/Index.cshtml.cs
@@ -46,6 +46,23 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<SelectListItem> TypeOptions { get; private set; } = Array.Empty<SelectListItem>();
 
+    // SECTION: KPI state
+    public int TotalPendingCount { get; private set; }
+
+    public string OldestPendingDisplay { get; private set; } = "—";
+
+    public int ProjectsPendingCount { get; private set; }
+
+    public int ProjectOfficePendingCount { get; private set; }
+
+    public string TopTypeDisplay { get; private set; } = "—";
+
+    public string TopTypeMeta { get; private set; } = "No pending items";
+
+    public bool HasActiveFilters => !string.IsNullOrWhiteSpace(Type) || !string.IsNullOrWhiteSpace(Search);
+
+    public string FilterContextLabel => HasActiveFilters ? "Filtered by current criteria" : "All pending approvals";
+
     public async Task OnGetAsync(CancellationToken cancellationToken)
     {
         var parsedType = ParseEnum<ApprovalQueueType>(Type);
@@ -66,12 +83,23 @@ public class IndexModel : PageModel
                     id = item.RequestId
                 })
             })
+            .OrderBy(item => item.RequestedAtUtc)
             .ToList();
 
         TypeOptions = BuildEnumOptions<ApprovalQueueType>(parsedType, "All types");
+
+        BuildKpis(Items);
     }
 
     // SECTION: Helpers
+    public string GetTypeLabel(ApprovalQueueType type) => SplitEnumLabel(type.ToString());
+
+    public string GetModuleLabel(ApprovalQueueModule module) => module switch
+    {
+        ApprovalQueueModule.ProjectOfficeReports => "Project office",
+        _ => SplitEnumLabel(module.ToString())
+    };
+
     private static TEnum? ParseEnum<TEnum>(string? value) where TEnum : struct
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -117,5 +145,33 @@ public class IndexModel : PageModel
 
         return string.Concat(value.Select((ch, index) =>
             index > 0 && char.IsUpper(ch) ? $" {ch}" : ch.ToString()));
+    }
+
+    private void BuildKpis(IReadOnlyList<ApprovalQueueItemVm> items)
+    {
+        TotalPendingCount = items.Count;
+        ProjectsPendingCount = items.Count(item => item.Module == ApprovalQueueModule.Projects);
+        ProjectOfficePendingCount = items.Count(item => item.Module == ApprovalQueueModule.ProjectOfficeReports);
+
+        if (items.Count == 0)
+        {
+            OldestPendingDisplay = "—";
+            TopTypeDisplay = "—";
+            TopTypeMeta = "No pending items";
+            return;
+        }
+
+        var oldestRequested = items.Min(item => item.RequestedAtUtc);
+        var ageDays = (int)Math.Floor((DateTimeOffset.UtcNow - oldestRequested).TotalDays);
+        OldestPendingDisplay = ageDays <= 0 ? "Today" : $"{ageDays} days";
+
+        var topType = items
+            .GroupBy(item => item.ApprovalType)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key.ToString())
+            .First();
+
+        TopTypeDisplay = SplitEnumLabel(topType.Key.ToString());
+        TopTypeMeta = $"{topType.Count()} pending";
     }
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1503,6 +1503,182 @@ main[role="main"] {
     gap: .35rem;
 }
 
+/* ---------- Approvals: Pending approvals UI ---------- */
+/* -- SECTION: KPI strip -- */
+.approvals-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: .85rem;
+}
+
+.approvals-kpi-card {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+    padding: .95rem 1.1rem;
+    border-radius: .9rem;
+    border: 1px solid var(--pm-border);
+    background: var(--pm-card);
+    box-shadow: var(--pm-shadow);
+}
+
+.approvals-kpi-label {
+    font-size: .75rem;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: var(--pm-text-muted);
+    font-weight: 600;
+}
+
+.approvals-kpi-value {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--pm-text);
+}
+
+.approvals-kpi-meta {
+    font-size: .8rem;
+    color: var(--pm-text-secondary);
+}
+
+/* -- SECTION: Filters -- */
+.approvals-filter-bar .form-label {
+    font-size: .8rem;
+    color: var(--pm-text-muted);
+}
+
+.approvals-filter-badge {
+    background: var(--pm-surface-contrast);
+    color: var(--pm-text-muted);
+    border: 1px solid var(--pm-border);
+    font-weight: 600;
+}
+
+/* -- SECTION: Table -- */
+.approvals-table {
+    margin-bottom: 0;
+}
+
+.approvals-table thead th {
+    font-size: .72rem;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: var(--pm-text-muted);
+}
+
+.approvals-table tbody tr:nth-of-type(even) {
+    background: var(--pm-surface-veil);
+}
+
+.approvals-table tbody tr {
+    transition: background-color .15s ease;
+}
+
+.approvals-table tbody tr:hover {
+    background: var(--pm-surface-contrast);
+}
+
+.approvals-table-row {
+    position: relative;
+    cursor: pointer;
+}
+
+.approval-row-link {
+    position: relative;
+    z-index: 1;
+}
+
+.approvals-action-link {
+    position: relative;
+    z-index: 2;
+    font-weight: 600;
+}
+
+.approvals-table-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: .5rem;
+}
+
+.approvals-table-summary {
+    display: flex;
+    flex-direction: column;
+    gap: .1rem;
+}
+
+.approval-type-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: .25rem .6rem;
+    border-radius: 999px;
+    border: 1px solid var(--pm-chip-border);
+    background: var(--pm-chip-bg);
+    color: var(--pm-chip-text);
+    font-weight: 600;
+    font-size: .75rem;
+}
+
+.approval-project-name {
+    font-weight: 700;
+    color: var(--pm-text);
+}
+
+.approval-project-id {
+    font-size: .8rem;
+    color: var(--pm-text-muted);
+}
+
+.approval-summary {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    color: var(--pm-text-secondary);
+}
+
+/* -- SECTION: Cards and badges -- */
+.approval-card {
+    border: 1px solid var(--pm-border);
+    border-radius: .9rem;
+    box-shadow: var(--pm-shadow);
+}
+
+.approval-decision-card {
+    background: var(--pm-surface-contrast);
+}
+
+.approval-status-badge {
+    font-weight: 600;
+    border-radius: 999px;
+    border: 1px solid var(--pm-border);
+    background: var(--pm-surface-contrast);
+    color: var(--pm-text-secondary);
+}
+
+.approval-status-badge--pending {
+    background: var(--pm-status-warning-bg);
+    color: var(--pm-status-warning-text);
+    border-color: var(--pm-status-warning-bg);
+}
+
+.approval-status-badge--approved {
+    background: var(--pm-status-success-bg);
+    color: var(--pm-status-success-text);
+    border-color: var(--pm-status-success-bg);
+}
+
+.approval-status-badge--rejected {
+    background: var(--pm-status-danger-bg);
+    color: var(--pm-status-danger-text);
+    border-color: var(--pm-status-danger-bg);
+}
+
+.approval-status-badge--neutral {
+    background: var(--pm-surface-contrast);
+    color: var(--pm-text-secondary);
+}
+
 /* ---------- Proliferation summary ---------- */
 .prol-grid {
     margin-top: 2rem;


### PR DESCRIPTION
### Motivation

- Improve visual hierarchy and scanability of the Pending approvals list while keeping existing data/logic intact.
- Surface operational KPIs (total, oldest, by module, top type) so HoD/Admins can triage quickly without scanning rows.
- Make the details page decision workflow clearer and reduce post-decision confusion by emphasising pending state and hiding actions when decided.

### Description

- Added a KPI strip and compact filter bar to the list page and introduced approval-specific card, chip and badge styling in `wwwroot/css/site.css`.
- Refactored the list page markup in `Pages/Approvals/Pending/Index.cshtml` to include KPI cards, a compact filter bar, an approvals-styled results card, type chips, two-line summary truncation, hover/zebra row affordances and a stretched row link to make rows clickable while keeping `View details` as a secondary action.
- Implemented KPI computation and list tweaks in `Pages/Approvals/Pending/Index.cshtml.cs`, including `BuildKpis(...)`, properties for KPI values, default sort by oldest requested (`OrderBy(item => item.RequestedAtUtc)`), and helper label methods `GetTypeLabel` and `GetModuleLabel`.
- Polished the details page in `Pages/Approvals/Pending/Details.cshtml` to show a prominent status badge in the header, a stronger right-aligned decision card when pending, a read-only decision summary when decided, and a small helper `GetStatusBadgeClass` for badge classes.
- Enforced remarks validation for rejections in `Pages/Approvals/Pending/Decide.cshtml.cs` to ensure a rejection includes a remark before the decision is sent to the service.

### Testing

- No automated tests were executed as part of this change (UI/markup and styling changes only). 
- Changes were committed locally and are ready for manual UI verification (list empty/non-empty, KPI updates with filters, row click vs View details, approve/reject flow and post-decision summary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fac6d2208329b424f50c092f19f5)