### PR TITLE
Fix ApprovalStatus namespace reference in Approvals Pending Details

### DIFF
--- a/Pages/Approvals/Pending/Details.cshtml.cs
+++ b/Pages/Approvals/Pending/Details.cshtml.cs
@@ -11,6 +11,7 @@ using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Stages;
+using ProjectManagement.Areas.ProjectOfficeReports.Domain;
 using ProjectManagement.Services.Approvals;
 using ProjectManagement.Services.Projects;
 using ProjectManagement.ViewModels;
@@ -272,7 +273,7 @@ public class DetailsModel : PageModel
         }
 
         CurrentStatus = record.ApprovalStatus.ToString();
-        IsPending = record.ApprovalStatus == Areas.ProjectOfficeReports.Domain.ApprovalStatus.Pending;
+        IsPending = record.ApprovalStatus == ApprovalStatus.Pending;
         await PopulateDecisionUserAsync(record.ApprovedByUserId, record.ApprovedOnUtc, cancellationToken);
     }
 
@@ -293,7 +294,7 @@ public class DetailsModel : PageModel
         }
 
         CurrentStatus = record.ApprovalStatus.ToString();
-        IsPending = record.ApprovalStatus == Areas.ProjectOfficeReports.Domain.ApprovalStatus.Pending;
+        IsPending = record.ApprovalStatus == ApprovalStatus.Pending;
         await PopulateDecisionUserAsync(record.ApprovedByUserId, record.ApprovedOnUtc, cancellationToken);
     }
 


### PR DESCRIPTION
### Motivation
- Resolve CS0234 compiler errors by referencing the correct `ApprovalStatus` enum from `ProjectManagement.Areas.ProjectOfficeReports.Domain` so approval state checks compile and behave consistently.

### Description
- Added `using ProjectManagement.Areas.ProjectOfficeReports.Domain;` and replaced `Areas.ProjectOfficeReports.Domain.ApprovalStatus.Pending` comparisons with `ApprovalStatus.Pending` in `Pages/Approvals/Pending/Details.cshtml.cs`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fcec146883299ace7af6ebb3d501)