### PR TITLE
Normalize placeholder-only remarks in approval details

### DIFF
--- a/Pages/Approvals/Pending/Details.cshtml
+++ b/Pages/Approvals/Pending/Details.cshtml
@@ -7,6 +7,19 @@
     string formatDate(DateOnly? value) => value?.ToString("dd MMM yyyy", System.Globalization.CultureInfo.InvariantCulture) ?? "—";
     string formatDateTime(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) ?? "—";
     string formatDecisionDate(DateTime? value) => value?.ToLocalTime().ToString("dd MMM yyyy, h:mm tt", System.Globalization.CultureInfo.InvariantCulture) ?? "—";
+
+    // SECTION: Display helpers
+    string formatRemarks(string? remarks)
+    {
+        if (string.IsNullOrWhiteSpace(remarks))
+        {
+            return "—";
+        }
+
+        var trimmed = remarks.Trim();
+        var cleaned = trimmed.Trim('?', '"', '“', '”', '-', '–', '—', ' ');
+        return string.IsNullOrWhiteSpace(cleaned) ? "—" : trimmed;
+    }
 }
 
 <div class="container-fluid approvals-page">
@@ -255,7 +268,7 @@
                             <dt class="col-sm-4">Total quantity</dt>
                             <dd class="col-sm-8">@Model.Detail.ProliferationYearly.TotalQuantity</dd>
                             <dt class="col-sm-4">Remarks</dt>
-                            <dd class="col-sm-8">@Model.Detail.ProliferationYearly.Remarks ?? "—"</dd>
+                            <dd class="col-sm-8">@formatRemarks(Model.Detail.ProliferationYearly.Remarks)</dd>
                         </dl>
                         @if (Model.Detail.ProliferationYearly.PreviousSnapshot is not null)
                         {
@@ -265,7 +278,7 @@
                                 <dt class="col-sm-4">Total quantity</dt>
                                 <dd class="col-sm-8">@Model.Detail.ProliferationYearly.PreviousSnapshot.TotalQuantity</dd>
                                 <dt class="col-sm-4">Remarks</dt>
-                                <dd class="col-sm-8">@Model.Detail.ProliferationYearly.PreviousSnapshot.Remarks ?? "—"</dd>
+                                <dd class="col-sm-8">@formatRemarks(Model.Detail.ProliferationYearly.PreviousSnapshot.Remarks)</dd>
                                 <dt class="col-sm-4">Approved on</dt>
                                 <dd class="col-sm-8">@formatDateTime(Model.Detail.ProliferationYearly.PreviousSnapshot.ApprovedOnUtc)</dd>
                             </dl>
@@ -289,7 +302,7 @@
                             <dt class="col-sm-4">Quantity</dt>
                             <dd class="col-sm-8">@Model.Detail.ProliferationGranular.Quantity</dd>
                             <dt class="col-sm-4">Remarks</dt>
-                            <dd class="col-sm-8">@Model.Detail.ProliferationGranular.Remarks ?? "—"</dd>
+                            <dd class="col-sm-8">@formatRemarks(Model.Detail.ProliferationGranular.Remarks)</dd>
                         </dl>
                         @if (Model.Detail.ProliferationGranular.PreviousSnapshot is not null)
                         {
@@ -299,7 +312,7 @@
                                 <dt class="col-sm-4">Quantity</dt>
                                 <dd class="col-sm-8">@Model.Detail.ProliferationGranular.PreviousSnapshot.Quantity</dd>
                                 <dt class="col-sm-4">Remarks</dt>
-                                <dd class="col-sm-8">@Model.Detail.ProliferationGranular.PreviousSnapshot.Remarks ?? "—"</dd>
+                                <dd class="col-sm-8">@formatRemarks(Model.Detail.ProliferationGranular.PreviousSnapshot.Remarks)</dd>
                                 <dt class="col-sm-4">Approved on</dt>
                                 <dd class="col-sm-8">@formatDateTime(Model.Detail.ProliferationGranular.PreviousSnapshot.ApprovedOnUtc)</dd>
                             </dl>


### PR DESCRIPTION
### Motivation
- The approvals details page rendered stored placeholder strings (e.g. literal `"--"` or other characters) as visible text for remarks; the intent is to treat those as empty and show an em dash instead.

### Description
- Added a display helper `formatRemarks(string? remarks)` to `Pages/Approvals/Pending/Details.cshtml` to normalize/trim remark values and return an em dash when the value is empty or only placeholder punctuation.
- Replaced direct `Remarks` rendering with the helper for proliferation entries and their previous snapshots (`ProliferationYearly` and `ProliferationGranular`) so placeholder-only values no longer display verbatim.

### Testing
- No full test suite was run; a quick Playwright-based UI check was attempted but failed because the local app returned an empty response (`net::ERR_EMPTY_RESPONSE`).
- No unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fefb49388329b983fb9ab3a46210)