### PR TITLE
Enable row click navigation on pending approvals

### DIFF
--- a/Pages/Approvals/Pending/Index.cshtml
+++ b/Pages/Approvals/Pending/Index.cshtml
@@ -106,7 +106,12 @@
                         <tbody>
                             @foreach (var item in Model.Items)
                             {
-                                <tr class="approvals-table-row">
+                                <tr class="approvals-table-row"
+                                    data-approvals-row="true"
+                                    data-approvals-url="@item.DetailsUrl"
+                                    role="link"
+                                    tabindex="0"
+                                    aria-label="View details for @Model.GetTypeLabel(item.ApprovalType) request">
                                     <td>
                                         <span class="approval-type-chip">@Model.GetTypeLabel(item.ApprovalType)</span>
                                         <a class="stretched-link approval-row-link" href="@item.DetailsUrl">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1583,6 +1583,13 @@ main[role="main"] {
     cursor: pointer;
 }
 
+/* -- SECTION: Table focus -- */
+.approvals-table-row:focus-visible {
+    outline: 2px solid var(--pm-border-strong);
+    outline-offset: -2px;
+    background: var(--pm-surface-contrast);
+}
+
 .approval-row-link {
     position: relative;
     z-index: 1;

--- a/wwwroot/js/pages/approvals-pending.js
+++ b/wwwroot/js/pages/approvals-pending.js
@@ -1,0 +1,54 @@
+/* ---------- SECTION: Pending approvals row navigation ---------- */
+
+const INTERACTIVE_SELECTOR = 'a, button, input, select, textarea, label';
+
+function isInteractiveElement(target) {
+  return target.closest(INTERACTIVE_SELECTOR) !== null;
+}
+
+function getRowTarget(row) {
+  const url = row?.dataset?.approvalsUrl;
+  return url && url.trim().length > 0 ? url : null;
+}
+
+function handleRowClick(event) {
+  const row = event.currentTarget;
+  if (isInteractiveElement(event.target)) {
+    return;
+  }
+
+  const target = getRowTarget(row);
+  if (target) {
+    window.location.assign(target);
+  }
+}
+
+function handleRowKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+
+  if (isInteractiveElement(event.target)) {
+    return;
+  }
+
+  event.preventDefault();
+  const row = event.currentTarget;
+  const target = getRowTarget(row);
+  if (target) {
+    window.location.assign(target);
+  }
+}
+
+export function initPendingApprovalsRows() {
+  /* ---------- SECTION: DOM bindings ---------- */
+  const rows = document.querySelectorAll('[data-approvals-row="true"]');
+  if (!rows.length) {
+    return;
+  }
+
+  rows.forEach((row) => {
+    row.addEventListener('click', handleRowClick);
+    row.addEventListener('keydown', handleRowKeydown);
+  });
+}

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,10 +1,19 @@
 import { initSparklines } from './charts/sparkline.js';
 import { initDrawer } from './navigation/drawer.js';
+import { initPendingApprovalsRows } from './pages/approvals-pending.js';
 import { initTooltips } from './utils/tooltips.js';
 
 function boot() {
+  /* ---------- SECTION: Navigation ---------- */
   initDrawer();
+
+  /* ---------- SECTION: Dashboards ---------- */
   initSparklines();
+
+  /* ---------- SECTION: Approvals ---------- */
+  initPendingApprovalsRows();
+
+  /* ---------- SECTION: Utilities ---------- */
   initTooltips();
 }
 


### PR DESCRIPTION
### Motivation
- Pending approval rows were not navigable by clicking or keyboard, making the table rows act like no-ops. 
- Provide an accessible, keyboard-friendly way to open an item's details while preserving existing interactive controls in the row.

### Description
- Mark table rows in `Pages/Approvals/Pending/Index.cshtml` with `data-approvals-row`, `data-approvals-url`, `role="link"`, `tabindex="0"` and an `aria-label` to expose target metadata and keyboard focusability. 
- Add `wwwroot/js/pages/approvals-pending.js` which exports `initPendingApprovalsRows()` and attaches `click` and `keydown` handlers to rows while ignoring clicks/keys that originate from interactive elements (`a, button, input, select, textarea, label`).
- Wire the new initializer into `wwwroot/js/site.js` by importing `initPendingApprovalsRows` and calling it from the page boot flow. 
- Add focus-visible styling in `wwwroot/css/site.css` for `.approvals-table-row:focus-visible` to improve keyboard navigation affordance.

### Testing
- An automated Playwright attempt was run to open `/Approvals/Pending` and capture a screenshot but it failed with `net::ERR_EMPTY_RESPONSE` when loading the local server, so no end-to-end confirmation was captured. 
- No unit tests or other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696900b8ab248329bf120689e5c2ab88)