### PR TITLE
Filter `partial` from document return URLs in list/card views

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
@@ -1,11 +1,22 @@
 @model ProjectManagement.Areas.DocumentRepository.Models.DocumentSearchResultVm
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.WebUtilities
+@using System
+@using System.Collections.Generic
+@using System.Linq
 @inject IAuthorizationService AuthorizationService
 
 @{
     var canEdit = await AuthorizationService.AuthorizeAsync(User, "DocRepo.EditMetadata");
     var canSoftDelete = await AuthorizationService.AuthorizeAsync(User, "DocRepo.SoftDelete");
-    var returnUrl = $"{Context.Request.Path}{Context.Request.QueryString}";
+    // SECTION: Return URL
+    var queryParams = QueryHelpers.ParseQuery(Context.Request.QueryString.Value);
+    var filteredQuery = new QueryBuilder(
+        queryParams
+            .Where(kvp => !string.Equals(kvp.Key, "partial", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string?>(kvp.Key, value))
+    );
+    var returnUrl = $"{Context.Request.Path}{filteredQuery}";
     var readerUrl = Model.IsActive ? Url.Page("./Reader", new { id = Model.Id, returnUrl }) : string.Empty;
 }
 

--- a/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
@@ -1,11 +1,22 @@
 @model ProjectManagement.Areas.DocumentRepository.Models.DocumentListItemVm
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.WebUtilities
+@using System
+@using System.Collections.Generic
+@using System.Linq
 @inject IAuthorizationService AuthorizationService
 
 @{
     var canEdit = await AuthorizationService.AuthorizeAsync(User, "DocRepo.EditMetadata");
     var canSoftDelete = await AuthorizationService.AuthorizeAsync(User, "DocRepo.SoftDelete");
-    var returnUrl = $"{Context.Request.Path}{Context.Request.QueryString}";
+    // SECTION: Return URL
+    var queryParams = QueryHelpers.ParseQuery(Context.Request.QueryString.Value);
+    var filteredQuery = new QueryBuilder(
+        queryParams
+            .Where(kvp => !string.Equals(kvp.Key, "partial", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string?>(kvp.Key, value))
+    );
+    var returnUrl = $"{Context.Request.Path}{filteredQuery}";
     var readerUrl = Model.IsActive ? Url.Page("./Reader", new { id = Model.Id, returnUrl }) : string.Empty;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the generated `returnUrl` used when opening a document never includes the `partial` query parameter so Reader’s “Back to results” returns to the full `Index` page with layout.
- Preserve other query parameters (scope/view/page) so the reader navigation retains search/context state.

### Description
- Updated `Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml` and `Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml` to replace `var returnUrl = $"{Context.Request.Path}{Context.Request.QueryString}";` with logic that uses `QueryHelpers.ParseQuery` and `QueryBuilder` to rebuild the query string excluding the `partial` parameter.
- Added `@using Microsoft.AspNetCore.WebUtilities`, `@using System`, `@using System.Collections.Generic`, and `@using System.Linq` and a `// SECTION: Return URL` comment to clarify the new logic in each view.
- The `returnUrl` is now `Context.Request.Path` plus the filtered `QueryBuilder`, which preserves all non-`partial` query values.
- No shared helper was introduced; the same filtering logic was applied in both views to ensure consistent behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a53af9748832992e4061c2762f342)