### PR TITLE
Fix QueryBuilder usings in document repository partials

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
@@ -1,5 +1,6 @@
 @model ProjectManagement.Areas.DocumentRepository.Models.DocumentSearchResultVm
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.WebUtilities
 @using System
 @using System.Collections.Generic

--- a/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
@@ -1,5 +1,6 @@
 @model ProjectManagement.Areas.DocumentRepository.Models.DocumentListItemVm
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Http.Extensions
 @using Microsoft.AspNetCore.WebUtilities
 @using System
 @using System.Collections.Generic


### PR DESCRIPTION
### Motivation
- Resolve `CS0246` errors where the `QueryBuilder` type could not be found in `Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml` and `Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml` by ensuring the correct namespace is imported.

### Description
- Add the missing `@using Microsoft.AspNetCore.Http.Extensions` directive to `Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml` and `Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml` so `QueryBuilder` is available in those Razor partials.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5774ad44832981ca4a7f2fd72375)