### PR TITLE
Fix QueryBuilder nullability warnings in document partials

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml
@@ -15,7 +15,7 @@
     var filteredQuery = new QueryBuilder(
         queryParams
             .Where(kvp => !string.Equals(kvp.Key, "partial", StringComparison.OrdinalIgnoreCase))
-            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string?>(kvp.Key, value))
+            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string>(kvp.Key, value ?? string.Empty))
     );
     var returnUrl = $"{Context.Request.Path}{filteredQuery}";
     var readerUrl = Model.IsActive ? Url.Page("./Reader", new { id = Model.Id, returnUrl }) : string.Empty;

--- a/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml
@@ -15,7 +15,7 @@
     var filteredQuery = new QueryBuilder(
         queryParams
             .Where(kvp => !string.Equals(kvp.Key, "partial", StringComparison.OrdinalIgnoreCase))
-            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string?>(kvp.Key, value))
+            .SelectMany(kvp => kvp.Value, (kvp, value) => new KeyValuePair<string, string>(kvp.Key, value ?? string.Empty))
     );
     var returnUrl = $"{Context.Request.Path}{filteredQuery}";
     var readerUrl = Model.IsActive ? Url.Page("./Reader", new { id = Model.Id, returnUrl }) : string.Empty;


### PR DESCRIPTION
### Motivation
- Remove `CS8620` nullability warnings by coercing nullable query parameter values to non-null strings before passing them into `QueryBuilder`.

### Description
- Updated the `SelectMany` projection in `Areas/DocumentRepository/Pages/Documents/_DocumentList.cshtml` and `Areas/DocumentRepository/Pages/Documents/_DocumentCard.cshtml` to create `KeyValuePair<string, string>` using `value ?? string.Empty` so the `QueryBuilder` receives non-null values.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a589b5fe48329813f592d6bb953da)