### PR TITLE
Add inline editing for FFC detailed table remarks (row + overall)

### DIFF
--- a/Areas/ProjectOfficeReports/Domain/FfcProject.cs
+++ b/Areas/ProjectOfficeReports/Domain/FfcProject.cs
@@ -9,6 +9,9 @@ public class FfcProject
     public long FfcRecordId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string? Remarks { get; set; }
+    public string? ProgressRemarks { get; set; }
+    public DateTimeOffset? ProgressRemarksUpdatedAtUtc { get; set; }
+    public string? ProgressRemarksUpdatedByUserId { get; set; }
     public int? LinkedProjectId { get; set; }
     public int Quantity { get; set; } = 1;
     public bool IsDelivered { get; set; }
@@ -17,6 +20,7 @@ public class FfcProject
     public DateOnly? InstalledOn { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
 
     public FfcRecord Record { get; set; } = null!;
     public Project? LinkedProject { get; set; }

--- a/Areas/ProjectOfficeReports/Domain/FfcRecord.cs
+++ b/Areas/ProjectOfficeReports/Domain/FfcRecord.cs
@@ -23,6 +23,8 @@ public class FfcRecord
     public string? InstallationRemarks { get; set; }
 
     public string? OverallRemarks { get; set; }
+    public DateTimeOffset? OverallRemarksUpdatedAtUtc { get; set; }
+    public string? OverallRemarksUpdatedByUserId { get; set; }
     public bool IsDeleted { get; set; }
     public string? CreatedByUserId { get; set; }
     public DateTimeOffset CreatedAt { get; set; }

--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
@@ -30,7 +30,18 @@
 
     <div class="pm-card pm-card--content">
         <div class="pm-card__body">
+            @* SECTION: Inline edit anti-forgery token *@
+            <form method="post" class="d-none" id="ffc-inline-edit-token">
+                @Html.AntiForgeryToken()
+            </form>
             <partial name="_DetailedTablePartial" model="Model.Groups" />
         </div>
     </div>
 </div>
+
+@section Scripts {
+    @* SECTION: Page scripts *@
+    <script src="~/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js"
+            asp-append-version="true"
+            defer></script>
+}

--- a/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
@@ -1,6 +1,9 @@
 @using System.Linq
-@using System.Text.Encodings.Web
 @model IReadOnlyList<ProjectManagement.Services.Ffc.FfcDetailedGroupVm>
+
+@{
+    var canEditRemarks = User.IsInRole("HoD") || User.IsInRole("Admin");
+}
 
 @if (Model is null || !Model.Any())
 {
@@ -40,14 +43,17 @@ else
 
                     var overallRemarks = group.OverallRemarks ?? string.Empty;
                     var remarksProvided = !string.IsNullOrWhiteSpace(overallRemarks);
-                    var remarksCell = remarksProvided
-                        ? HtmlEncoder.Default.Encode(overallRemarks)
-                        : "<span class=\"ffc-dtable__remarks-empty\">No overall remarks recorded.</span>";
                     var rowSpan = group.Rows.Count;
 
                     for (var index = 0; index < group.Rows.Count; index++)
                     {
                         var row = group.Rows[index];
+                        var progressDisplay = string.IsNullOrWhiteSpace(row.ProgressRemarks)
+                            ? row.Progress ?? string.Empty
+                            : row.ProgressRemarks;
+                        var progressPlaceholder = string.IsNullOrWhiteSpace(row.Progress)
+                            ? "Add remarks"
+                            : row.Progress;
                         <tr>
                             <td class="text-muted">@row.Serial</td>
                             <td>
@@ -74,10 +80,84 @@ else
                             </td>
                             <td class="text-end">@row.Quantity</td>
                             <td>@row.Status</td>
-                            <td>@row.Progress</td>
+                            <td class="align-top @(canEditRemarks ? "ffc-dtable__editable-cell" : string.Empty)"
+                                data-edit-kind="row"
+                                data-id="@row.FfcProjectId"
+                                data-rowversion="@row.RowVersionBase64"
+                                data-derived="@row.Progress">
+                                @if (canEditRemarks)
+                                {
+                                    <div class="ffc-dtable__remark-display">
+                                        @if (!string.IsNullOrWhiteSpace(progressDisplay))
+                                        {
+                                            <div class="ffc-dtable__remark-text">@progressDisplay</div>
+                                        }
+                                        else
+                                        {
+                                            <span class="ffc-dtable__remarks-empty">No progress remarks recorded.</span>
+                                        }
+                                        <span class="ffc-dtable__saved-badge d-none" role="status">Saved</span>
+                                    </div>
+                                    <div class="ffc-dtable__remark-editor d-none">
+                                        <textarea class="form-control form-control-sm ffc-remark-input"
+                                                  rows="4"
+                                                  maxlength="2000"
+                                                  placeholder="@progressPlaceholder">@row.ProgressRemarks</textarea>
+                                        <div class="ffc-dtable__edit-controls">
+                                            <button type="button" class="btn btn-sm btn-primary ffc-remark-save">Save</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary ffc-remark-cancel">Cancel</button>
+                                            <span class="ffc-dtable__save-indicator d-none" role="status"></span>
+                                        </div>
+                                        <div class="ffc-dtable__error text-danger small d-none" role="alert"></div>
+                                    </div>
+                                }
+                                else
+                                {
+                                    @progressDisplay
+                                }
+                            </td>
                             @if (index == 0)
                             {
-                                <td rowspan="@rowSpan" class="align-top">@Html.Raw(remarksCell)</td>
+                                <td rowspan="@rowSpan"
+                                    class="align-top @(canEditRemarks ? "ffc-dtable__editable-cell" : string.Empty)"
+                                    data-edit-kind="overall"
+                                    data-id="@group.FfcRecordId"
+                                    data-rowversion="@group.RowVersionBase64">
+                                    @if (canEditRemarks)
+                                    {
+                                    <div class="ffc-dtable__remark-display">
+                                        @if (remarksProvided)
+                                        {
+                                            <div class="ffc-dtable__remark-text">@overallRemarks</div>
+                                        }
+                                        else
+                                        {
+                                            <span class="ffc-dtable__remarks-empty">No overall remarks recorded.</span>
+                                        }
+                                        <span class="ffc-dtable__saved-badge d-none" role="status">Saved</span>
+                                    </div>
+                                        <div class="ffc-dtable__remark-editor d-none">
+                                            <textarea class="form-control form-control-sm ffc-remark-input"
+                                                      rows="6"
+                                                      maxlength="4000"
+                                                      placeholder="Add overall remarks">@overallRemarks</textarea>
+                                            <div class="ffc-dtable__edit-controls">
+                                                <button type="button" class="btn btn-sm btn-primary ffc-remark-save">Save</button>
+                                                <button type="button" class="btn btn-sm btn-outline-secondary ffc-remark-cancel">Cancel</button>
+                                                <span class="ffc-dtable__save-indicator d-none" role="status"></span>
+                                            </div>
+                                            <div class="ffc-dtable__error text-danger small d-none" role="alert"></div>
+                                        </div>
+                                    }
+                                    else if (remarksProvided)
+                                    {
+                                        @overallRemarks
+                                    }
+                                    else
+                                    {
+                                        <span class="ffc-dtable__remarks-empty">No overall remarks recorded.</span>
+                                    }
+                                </td>
                             }
                         </tr>
                     }

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -760,6 +760,7 @@ namespace ProjectManagement.Data
                 entity.Property(x => x.InstallationYes).HasDefaultValue(false);
                 entity.Property(x => x.IsDeleted).HasDefaultValue(false);
                 entity.Property(x => x.CreatedByUserId).HasMaxLength(450);
+                entity.Property(x => x.OverallRemarksUpdatedByUserId).HasMaxLength(450);
                 entity.Property(x => x.CreatedAt).HasDefaultValueSql("now() at time zone 'utc'");
                 entity.Property(x => x.UpdatedAt).HasDefaultValueSql("now() at time zone 'utc'");
 
@@ -767,6 +768,7 @@ namespace ProjectManagement.Data
                 {
                     entity.Property(x => x.CreatedAt).HasColumnType("timestamp with time zone");
                     entity.Property(x => x.UpdatedAt).HasColumnType("timestamp with time zone");
+                    entity.Property(x => x.OverallRemarksUpdatedAtUtc).HasColumnType("timestamp with time zone");
                 }
 
                 entity.HasIndex(x => new { x.CountryId, x.Year })
@@ -800,9 +802,12 @@ namespace ProjectManagement.Data
 
             builder.Entity<FfcProject>(entity =>
             {
+                ConfigureRowVersion(entity);
                 entity.ToTable("FfcProjects");
                 entity.Property(x => x.Name).HasMaxLength(256).IsRequired();
                 entity.Property(x => x.Remarks).HasColumnType("text");
+                entity.Property(x => x.ProgressRemarks).HasMaxLength(2000);
+                entity.Property(x => x.ProgressRemarksUpdatedByUserId).HasMaxLength(450);
                 entity.Property(x => x.Quantity).HasDefaultValue(1);
                 entity.Property(x => x.IsDelivered).HasDefaultValue(false);
                 entity.Property(x => x.IsInstalled).HasDefaultValue(false);
@@ -813,6 +818,7 @@ namespace ProjectManagement.Data
                 {
                     entity.Property(x => x.CreatedAt).HasColumnType("timestamp with time zone");
                     entity.Property(x => x.UpdatedAt).HasColumnType("timestamp with time zone");
+                    entity.Property(x => x.ProgressRemarksUpdatedAtUtc).HasColumnType("timestamp with time zone");
                 }
 
                 entity.HasIndex(x => x.FfcRecordId)

--- a/Migrations/20261125120000_AddFfcInlineRemarks.cs
+++ b/Migrations/20261125120000_AddFfcInlineRemarks.cs
@@ -1,0 +1,80 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125120000_AddFfcInlineRemarks")]
+    public partial class AddFfcInlineRemarks : Migration
+    {
+        // SECTION: Add inline remark columns
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProgressRemarks",
+                table: "FfcProjects",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ProgressRemarksUpdatedAtUtc",
+                table: "FfcProjects",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProgressRemarksUpdatedByUserId",
+                table: "FfcProjects",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "FfcProjects",
+                type: "bytea",
+                nullable: false,
+                defaultValue: new byte[16]);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "OverallRemarksUpdatedAtUtc",
+                table: "FfcRecords",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OverallRemarksUpdatedByUserId",
+                table: "FfcRecords",
+                maxLength: 450,
+                nullable: true);
+        }
+
+        // SECTION: Remove inline remark columns
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProgressRemarks",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "ProgressRemarksUpdatedAtUtc",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "ProgressRemarksUpdatedByUserId",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "FfcProjects");
+
+            migrationBuilder.DropColumn(
+                name: "OverallRemarksUpdatedAtUtc",
+                table: "FfcRecords");
+
+            migrationBuilder.DropColumn(
+                name: "OverallRemarksUpdatedByUserId",
+                table: "FfcRecords");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -311,8 +311,24 @@ namespace ProjectManagement.Migrations
                         .HasColumnType("integer")
                         .HasDefaultValue(1);
 
+                    b.Property<string>("ProgressRemarks")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<DateTimeOffset?>("ProgressRemarksUpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ProgressRemarksUpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
                     b.Property<string>("Remarks")
                         .HasColumnType("text");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .IsRequired()
+                        .HasColumnType("bytea");
 
                     b.Property<DateTimeOffset>("UpdatedAt")
                         .ValueGeneratedOnAdd()
@@ -408,6 +424,13 @@ namespace ProjectManagement.Migrations
 
                     b.Property<string>("OverallRemarks")
                         .HasColumnType("text");
+
+                    b.Property<DateTimeOffset?>("OverallRemarksUpdatedAtUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("OverallRemarksUpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
 
                     b.Property<byte[]>("RowVersion")
                         .IsConcurrencyToken()

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -949,6 +949,55 @@ main[role="main"] {
         background-color: #ffffff;
     }
 
+/* SECTION: FFC detailed table inline remarks */
+.ffc-dtable__editable-cell {
+    cursor: text;
+    transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.ffc-dtable__editable-cell:hover {
+    background-color: rgba(59, 130, 246, 0.06);
+}
+
+.ffc-dtable__editable-cell.editing {
+    background-color: rgba(59, 130, 246, 0.08);
+    box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+
+.ffc-dtable__remark-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.ffc-dtable__edit-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.ffc-dtable__save-indicator {
+    font-size: 0.75rem;
+    color: #16a34a;
+}
+
+.ffc-dtable__saved-badge {
+    display: inline-flex;
+    align-items: center;
+    margin-top: 0.35rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.5rem;
+    background-color: rgba(34, 197, 94, 0.12);
+    color: #15803d;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.ffc-dtable__error {
+    margin-top: 0.35rem;
+}
+
 
 .ffc-record-card__section-title {
     font-size: .75rem;

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
@@ -1,0 +1,261 @@
+// SECTION: FFC inline remark editor
+(() => {
+    const selector = {
+        table: '.ffc-detailed-table',
+        editableCell: '.ffc-dtable__editable-cell',
+        display: '.ffc-dtable__remark-display',
+        editor: '.ffc-dtable__remark-editor',
+        textarea: '.ffc-remark-input',
+        saveButton: '.ffc-remark-save',
+        cancelButton: '.ffc-remark-cancel',
+        status: '.ffc-dtable__save-indicator',
+        error: '.ffc-dtable__error',
+        savedBadge: '.ffc-dtable__saved-badge',
+        tokenInput: '#ffc-inline-edit-token input[name="__RequestVerificationToken"]'
+    };
+
+    const handlers = {
+        row: 'UpdateRowRemark',
+        overall: 'UpdateOverallRemark'
+    };
+
+    let activeCell = null;
+
+    const getToken = () => {
+        const input = document.querySelector(selector.tokenInput);
+        return input ? input.value : '';
+    };
+
+    const toggleEditor = (cell, isEditing) => {
+        const display = cell.querySelector(selector.display);
+        const editor = cell.querySelector(selector.editor);
+
+        if (!display || !editor) {
+            return;
+        }
+
+        display.classList.toggle('d-none', isEditing);
+        editor.classList.toggle('d-none', !isEditing);
+        cell.classList.toggle('editing', isEditing);
+
+        if (isEditing) {
+            const textarea = cell.querySelector(selector.textarea);
+            textarea?.focus();
+        }
+    };
+
+    const setStatus = (cell, message, isError = false) => {
+        const status = cell.querySelector(selector.status);
+        const error = cell.querySelector(selector.error);
+
+        if (status) {
+            status.textContent = isError ? '' : message;
+            status.classList.toggle('d-none', isError || !message);
+        }
+
+        if (error) {
+            error.textContent = isError ? message : '';
+            error.classList.toggle('d-none', !isError || !message);
+        }
+    };
+
+    const showSavedBadge = (cell) => {
+        const badge = cell.querySelector(selector.savedBadge);
+        if (!badge) {
+            return;
+        }
+
+        badge.classList.remove('d-none');
+        window.setTimeout(() => badge.classList.add('d-none'), 2000);
+    };
+
+    const enterEdit = (cell) => {
+        if (activeCell && activeCell !== cell) {
+            return;
+        }
+
+        activeCell = cell;
+        cell.dataset.originalDisplay = cell.querySelector(selector.display)?.innerHTML ?? '';
+        cell.dataset.originalValue = cell.querySelector(selector.textarea)?.value ?? '';
+        setStatus(cell, '');
+        toggleEditor(cell, true);
+    };
+
+    const exitEdit = (cell, restoreOriginal) => {
+        if (!cell) {
+            return;
+        }
+
+        const display = cell.querySelector(selector.display);
+        const textarea = cell.querySelector(selector.textarea);
+
+        if (restoreOriginal) {
+            if (display) {
+                display.innerHTML = cell.dataset.originalDisplay ?? '';
+            }
+            if (textarea) {
+                textarea.value = cell.dataset.originalValue ?? '';
+            }
+        }
+
+        setStatus(cell, '');
+        toggleEditor(cell, false);
+        activeCell = null;
+    };
+
+    const buildDisplayMarkup = (cell, remark) => {
+        const hasRemark = Boolean(remark?.trim());
+        const derived = cell.dataset.editKind === 'row' ? (cell.dataset.derived ?? '') : '';
+        const hasDerived = Boolean(derived.trim());
+        const emptyMessage = cell.dataset.editKind === 'overall'
+            ? 'No overall remarks recorded.'
+            : 'No progress remarks recorded.';
+
+        if (hasRemark || hasDerived) {
+            return '<div class="ffc-dtable__remark-text"></div><span class="ffc-dtable__saved-badge d-none" role="status">Saved</span>';
+        }
+
+        return `<span class="ffc-dtable__remarks-empty">${emptyMessage}</span>`
+            + '<span class="ffc-dtable__saved-badge d-none" role="status">Saved</span>';
+    };
+
+    const updateDisplayContent = (cell, remark) => {
+        const display = cell.querySelector(selector.display);
+        if (!display) {
+            return;
+        }
+
+        display.innerHTML = buildDisplayMarkup(cell, remark);
+        const remarkNode = display.querySelector('.ffc-dtable__remark-text');
+
+        if (remarkNode) {
+            const derived = cell.dataset.editKind === 'row' ? (cell.dataset.derived ?? '') : '';
+            const content = remark?.trim() ? remark : derived;
+            remarkNode.textContent = content;
+        }
+    };
+
+    const saveRemark = async (cell) => {
+        const kind = cell.dataset.editKind;
+        const handler = handlers[kind];
+        const id = Number(cell.dataset.id);
+        const rowVersion = cell.dataset.rowversion;
+        const textarea = cell.querySelector(selector.textarea);
+        const token = getToken();
+
+        if (!handler || !id || !rowVersion || !textarea) {
+            setStatus(cell, 'Unable to save. Missing data.', true);
+            return;
+        }
+
+        const payload = {
+            remark: textarea.value,
+            rowVersion
+        };
+
+        if (kind === 'row') {
+            payload.ffcProjectId = id;
+        } else {
+            payload.ffcRecordId = id;
+        }
+
+        setStatus(cell, 'Saving...');
+        textarea.disabled = true;
+        cell.querySelector(selector.saveButton)?.setAttribute('disabled', 'disabled');
+        cell.querySelector(selector.cancelButton)?.setAttribute('disabled', 'disabled');
+
+        try {
+            const response = await fetch(`${window.location.pathname}?handler=${handler}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'RequestVerificationToken': token
+                },
+                body: JSON.stringify(payload)
+            });
+
+            const data = await response.json().catch(() => ({}));
+
+            if (!response.ok) {
+                let message = data?.message || 'Unable to save remarks.';
+                if (response.status === 401 || response.status === 403) {
+                    message = 'Not authorised.';
+                } else if (response.status === 409) {
+                    message = 'Someone else updated this record. Please refresh.';
+                }
+
+                setStatus(cell, message, true);
+                return;
+            }
+
+            cell.dataset.rowversion = data?.rowVersion || rowVersion;
+            updateDisplayContent(cell, data?.remark ?? '');
+            textarea.value = data?.remark ?? '';
+            exitEdit(cell, false);
+            showSavedBadge(cell);
+        } catch (error) {
+            setStatus(cell, 'Unable to save remarks right now.', true);
+        } finally {
+            textarea.disabled = false;
+            cell.querySelector(selector.saveButton)?.removeAttribute('disabled');
+            cell.querySelector(selector.cancelButton)?.removeAttribute('disabled');
+        }
+    };
+
+    const init = () => {
+        const table = document.querySelector(selector.table);
+        if (!table) {
+            return;
+        }
+
+        table.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            const cell = target.closest(selector.editableCell);
+            if (!cell || cell.classList.contains('editing')) {
+                return;
+            }
+
+            if (target.closest(selector.saveButton) || target.closest(selector.cancelButton)) {
+                return;
+            }
+
+            enterEdit(cell);
+        });
+
+        table.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            const saveButton = target.closest(selector.saveButton);
+            const cancelButton = target.closest(selector.cancelButton);
+            const cell = target.closest(selector.editableCell);
+
+            if (!cell) {
+                return;
+            }
+
+            if (saveButton) {
+                event.preventDefault();
+                saveRemark(cell);
+                return;
+            }
+
+            if (cancelButton) {
+                event.preventDefault();
+                exitEdit(cell, true);
+            }
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
### Motivation

- Enable HoD/Admin to edit per-project `ProgressRemarks` and per-country-year `OverallRemarks` inline in the detailed FFC table with safe persistence, concurrency protection and audit metadata.

### Description

- Domain & schema: added `ProgressRemarks`, `ProgressRemarksUpdatedAtUtc`, `ProgressRemarksUpdatedByUserId` and `RowVersion` to `FfcProject`, and added `OverallRemarksUpdatedAtUtc` and `OverallRemarksUpdatedByUserId` to `FfcRecord`, updated `ApplicationDbContext` configuration and included a migration `20261125120000_AddFfcInlineRemarks.cs` to apply these columns.
- Query / view models: extended `FfcQueryService` and the `FfcDetailedRowVm`/`FfcDetailedGroupVm` to include `FfcProjectId`, `FfcRecordId`, `ProgressRemarks` and `RowVersionBase64` and to prefer persisted `ProgressRemarks` over derived progress when present.
- Page handlers & server logic: added `OnPostUpdateRowRemarkAsync` and `OnPostUpdateOverallRemarkAsync` handlers to `MapTableDetailedModel` with `Authorize(Roles = "HoD,Admin")`, anti-forgery, input normalization/length checks (`MAX_ROW_REMARK_LEN = 2000`, `MAX_OVERALL_REMARK_LEN = 4000`), row-version concurrency checks and audit updates, and return JSON with updated `rowVersion`.
- UI & client: updated `_DetailedTablePartial.cshtml` and `MapTableDetailed.cshtml` to render editable cells only for HoD/Admin, included an anti-forgery token form, added `wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js` implementing single-active inline edit UX, error handling and token header, and added minimal CSS in `wwwroot/css/site.css` for affordances and saved indicators.

### Testing

- No automated unit/integration tests were executed in this environment because the `dotnet` CLI and app server were not available to run `dotnet test` or apply/verify migrations (no tests run).
- An automated browser capture attempt with Playwright was performed but failed because the local app endpoint was unreachable, so end-to-end verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a561e7b48832995b8c9821cc1d2b5)