### PR TITLE
Inline editing for FFC MapTableDetailed (progress & overall remarks)

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml
@@ -34,3 +34,12 @@
         </div>
     </div>
 </div>
+
+<form method="post" id="ffc-inline-edit-token" class="d-none">
+    @Html.AntiForgeryToken()
+</form>
+
+@section Scripts
+{
+    <script src="~/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js" asp-append-version="true"></script>
+}

--- a/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
@@ -1,6 +1,9 @@
 @using System.Linq
-@using System.Text.Encodings.Web
 @model IReadOnlyList<ProjectManagement.Services.Ffc.FfcDetailedGroupVm>
+
+@{
+    var canEdit = User.IsInRole("HoD") || User.IsInRole("Admin");
+}
 
 @if (Model is null || !Model.Any())
 {
@@ -38,16 +41,17 @@ else
                         </td>
                     </tr>
 
-                    var overallRemarks = group.OverallRemarks ?? string.Empty;
-                    var remarksProvided = !string.IsNullOrWhiteSpace(overallRemarks);
-                    var remarksCell = remarksProvided
-                        ? HtmlEncoder.Default.Encode(overallRemarks)
-                        : "<span class=\"ffc-dtable__remarks-empty\">No overall remarks recorded.</span>";
+                    var overallRemarksText = group.OverallRemarks ?? string.Empty;
+                    var overallRemarksDisplay = group.OverallRemarksDisplay ?? string.Empty;
+                    var overallHasRemarks = !string.IsNullOrWhiteSpace(overallRemarksDisplay);
                     var rowSpan = group.Rows.Count;
 
                     for (var index = 0; index < group.Rows.Count; index++)
                     {
                         var row = group.Rows[index];
+                        var progressText = row.ProgressText ?? string.Empty;
+                        var progressHasValue = !string.IsNullOrWhiteSpace(progressText);
+                        var isProgressEditable = canEdit && row.IsProgressEditable;
                         <tr>
                             <td class="text-muted">@row.Serial</td>
                             <td>
@@ -74,10 +78,71 @@ else
                             </td>
                             <td class="text-end">@row.Quantity</td>
                             <td>@row.Status</td>
-                            <td>@row.Progress</td>
+                            @* SECTION: Progress cell *@
+                            <td data-kind="progress"
+                                data-ffc-project-id="@row.FfcProjectId"
+                                data-editable="@isProgressEditable.ToString().ToLowerInvariant()"
+                                data-maxlen="2000"
+                                data-empty-text="No progress recorded.">
+                                @if (isProgressEditable)
+                                {
+                                    <div class="display-text">
+                                        <span class="display-value@(progressHasValue ? string.Empty : " text-muted fst-italic")">
+                                            @(progressHasValue ? progressText : "No progress recorded.")
+                                        </span>
+                                        <span class="inline-status text-success small ms-2 d-none" role="status"></span>
+                                    </div>
+                                    <div class="editor d-none">
+                                        <textarea class="form-control form-control-sm" rows="3" maxlength="2000">@progressText</textarea>
+                                        <div class="mt-2 d-flex gap-2">
+                                            <button type="button" class="btn btn-sm btn-primary js-inline-save">Save</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary js-inline-cancel">Cancel</button>
+                                        </div>
+                                    </div>
+                                    <div class="inline-error text-danger small mt-1 d-none" role="alert"></div>
+                                }
+                                else
+                                {
+                                    <span class="@(progressHasValue ? string.Empty : "text-muted fst-italic")">
+                                        @(progressHasValue ? progressText : "No progress recorded.")
+                                    </span>
+                                }
+                            </td>
                             @if (index == 0)
                             {
-                                <td rowspan="@rowSpan" class="align-top">@Html.Raw(remarksCell)</td>
+                                var isOverallEditable = canEdit;
+                                @* SECTION: Overall remarks cell *@
+                                <td rowspan="@rowSpan"
+                                    class="align-top"
+                                    data-kind="overall"
+                                    data-ffc-record-id="@group.FfcRecordId"
+                                    data-editable="@isOverallEditable.ToString().ToLowerInvariant()"
+                                    data-maxlen="4000"
+                                    data-empty-text="No overall remarks recorded.">
+                                    @if (isOverallEditable)
+                                    {
+                                        <div class="display-text">
+                                            <span class="display-value@(overallHasRemarks ? string.Empty : " text-muted fst-italic")">
+                                                @(overallHasRemarks ? overallRemarksDisplay : "No overall remarks recorded.")
+                                            </span>
+                                            <span class="inline-status text-success small ms-2 d-none" role="status"></span>
+                                        </div>
+                                        <div class="editor d-none">
+                                            <textarea class="form-control form-control-sm" rows="4" maxlength="4000">@overallRemarksText</textarea>
+                                            <div class="mt-2 d-flex gap-2">
+                                                <button type="button" class="btn btn-sm btn-primary js-inline-save">Save</button>
+                                                <button type="button" class="btn btn-sm btn-outline-secondary js-inline-cancel">Cancel</button>
+                                            </div>
+                                        </div>
+                                        <div class="inline-error text-danger small mt-1 d-none" role="alert"></div>
+                                    }
+                                    else
+                                    {
+                                        <span class="@(overallHasRemarks ? string.Empty : "text-muted fst-italic")">
+                                            @(overallHasRemarks ? overallRemarksDisplay : "No overall remarks recorded.")
+                                        </span>
+                                    }
+                                </td>
                             }
                         </tr>
                     }

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
@@ -1,0 +1,282 @@
+/* SECTION: Inline edit controller */
+(() => {
+    "use strict";
+
+    // SECTION: Constants
+    const selectors = {
+        editableCell: "td[data-editable=\"true\"][data-kind]",
+        display: ".display-text",
+        editor: ".editor",
+        textarea: "textarea",
+        saveButton: ".js-inline-save",
+        cancelButton: ".js-inline-cancel",
+        error: ".inline-error",
+        status: ".inline-status",
+        tokenInput: "#ffc-inline-edit-token input[name=\"__RequestVerificationToken\"]"
+    };
+
+    const endpoints = {
+        overall: "?handler=UpdateOverallRemarks",
+        progress: "?handler=UpdateProgress"
+    };
+
+    // SECTION: State
+    let activeCell = null;
+
+    // SECTION: Utilities
+    const getToken = () => {
+        const input = document.querySelector(selectors.tokenInput);
+        return input ? input.value : "";
+    };
+
+    const normalizeDisplayText = (value) => (value || "").trim();
+
+    const setDisplayValue = (cell, text) => {
+        const displayValue = cell.querySelector(".display-value");
+        if (!displayValue) {
+            return;
+        }
+
+        const emptyText = cell.dataset.emptyText || "";
+        const normalized = normalizeDisplayText(text);
+
+        if (!normalized) {
+            displayValue.textContent = emptyText;
+            displayValue.classList.add("text-muted", "fst-italic");
+        } else {
+            displayValue.textContent = normalized;
+            displayValue.classList.remove("text-muted", "fst-italic");
+        }
+    };
+
+    const showStatus = (cell, message) => {
+        const status = cell.querySelector(selectors.status);
+        if (!status) {
+            return;
+        }
+
+        status.textContent = message;
+        status.classList.remove("d-none");
+        window.setTimeout(() => {
+            status.classList.add("d-none");
+        }, 2000);
+    };
+
+    const setError = (cell, message) => {
+        const error = cell.querySelector(selectors.error);
+        if (!error) {
+            return;
+        }
+
+        if (message) {
+            error.textContent = message;
+            error.classList.remove("d-none");
+        } else {
+            error.textContent = "";
+            error.classList.add("d-none");
+        }
+    };
+
+    const setEditorState = (cell, isEditing) => {
+        const display = cell.querySelector(selectors.display);
+        const editor = cell.querySelector(selectors.editor);
+
+        if (display) {
+            display.classList.toggle("d-none", isEditing);
+        }
+
+        if (editor) {
+            editor.classList.toggle("d-none", !isEditing);
+        }
+    };
+
+    const resetCell = (cell) => {
+        if (!cell) {
+            return;
+        }
+
+        const textarea = cell.querySelector(selectors.textarea);
+        if (textarea) {
+            textarea.value = cell.dataset.originalValue || "";
+        }
+
+        setError(cell, "");
+        setEditorState(cell, false);
+    };
+
+    const beginEdit = (cell) => {
+        if (activeCell && activeCell !== cell) {
+            resetCell(activeCell);
+            activeCell = null;
+        }
+
+        if (activeCell === cell) {
+            return;
+        }
+
+        const textarea = cell.querySelector(selectors.textarea);
+        if (textarea) {
+            cell.dataset.originalValue = textarea.value;
+            textarea.focus();
+            textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+        }
+
+        setError(cell, "");
+        setEditorState(cell, true);
+        activeCell = cell;
+    };
+
+    const endEdit = (cell, rawValue, displayValue) => {
+        if (!cell) {
+            return;
+        }
+
+        const textarea = cell.querySelector(selectors.textarea);
+        if (textarea) {
+            textarea.value = rawValue || "";
+            cell.dataset.originalValue = textarea.value;
+        }
+
+        setDisplayValue(cell, displayValue);
+        setEditorState(cell, false);
+        showStatus(cell, "Saved");
+        setError(cell, "");
+        activeCell = null;
+    };
+
+    const setBusy = (cell, isBusy) => {
+        const textarea = cell.querySelector(selectors.textarea);
+        const saveButton = cell.querySelector(selectors.saveButton);
+        const cancelButton = cell.querySelector(selectors.cancelButton);
+
+        if (textarea) {
+            textarea.disabled = isBusy;
+        }
+
+        if (saveButton) {
+            saveButton.disabled = isBusy;
+            saveButton.textContent = isBusy ? "Saving..." : "Save";
+        }
+
+        if (cancelButton) {
+            cancelButton.disabled = isBusy;
+        }
+    };
+
+    // SECTION: Network
+    const postUpdate = async (cell) => {
+        const kind = cell.dataset.kind;
+        const textarea = cell.querySelector(selectors.textarea);
+        const payload = textarea ? textarea.value : "";
+        const token = getToken();
+
+        const response = await fetch(endpoints[kind], {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "RequestVerificationToken": token
+            },
+            body: JSON.stringify(
+                kind === "overall"
+                    ? { ffcRecordId: Number(cell.dataset.ffcRecordId), overallRemarks: payload }
+                    : { ffcProjectId: Number(cell.dataset.ffcProjectId), progressText: payload }
+            )
+        });
+
+        return response;
+    };
+
+    // SECTION: Event handlers
+    const handleDisplayClick = (event) => {
+        const cell = event.currentTarget.closest("td");
+        if (!cell) {
+            return;
+        }
+
+        beginEdit(cell);
+    };
+
+    const handleSaveClick = async (event) => {
+        const cell = event.currentTarget.closest("td");
+        if (!cell) {
+            return;
+        }
+
+        setBusy(cell, true);
+        setError(cell, "");
+
+        try {
+            const response = await postUpdate(cell);
+
+            if (response.ok) {
+                const data = await response.json();
+                const rawValue = cell.dataset.kind === "overall" ? data.overallRemarks : data.progressText;
+                const displayValue = cell.dataset.kind === "overall"
+                    ? data.renderedOverallRemarks ?? data.overallRemarks
+                    : data.renderedProgressText ?? data.progressText;
+
+                endEdit(cell, rawValue, displayValue);
+                return;
+            }
+
+            if (response.status === 403) {
+                setError(cell, "Not authorised to update this value.");
+                return;
+            }
+
+            if (response.status === 404) {
+                setError(cell, "Record not found.");
+                return;
+            }
+
+            const errorPayload = await response.json().catch(() => null);
+            const message = errorPayload && errorPayload.message
+                ? errorPayload.message
+                : "Unable to save changes. Please try again.";
+
+            setError(cell, message);
+        } catch (error) {
+            setError(cell, "Unable to save changes. Please try again.");
+        } finally {
+            setBusy(cell, false);
+        }
+    };
+
+    const handleCancelClick = (event) => {
+        const cell = event.currentTarget.closest("td");
+        if (!cell) {
+            return;
+        }
+
+        resetCell(cell);
+        activeCell = null;
+    };
+
+    // SECTION: Initialisation
+    const init = () => {
+        const cells = Array.from(document.querySelectorAll(selectors.editableCell));
+        if (cells.length === 0) {
+            return;
+        }
+
+        cells.forEach((cell) => {
+            const display = cell.querySelector(selectors.display);
+            const saveButton = cell.querySelector(selectors.saveButton);
+            const cancelButton = cell.querySelector(selectors.cancelButton);
+
+            if (display) {
+                display.addEventListener("click", handleDisplayClick);
+            }
+
+            if (saveButton) {
+                saveButton.addEventListener("click", handleSaveClick);
+            }
+
+            if (cancelButton) {
+                cancelButton.addEventListener("click", handleCancelClick);
+            }
+        });
+    };
+
+    init();
+})();


### PR DESCRIPTION
### Motivation

- Allow HoD/Admin users to edit `Progress / present status` (row-level) and `OverallRemarks` (group-level) directly in the `/ProjectOfficeReports/FFC/MapTableDetailed` table without navigation while preserving existing sources of truth.
- Ensure edits do not introduce new DB fields and route updates to the same storage used for display (append External remark for linked projects; update `FfcProject.Remarks` for unlinked rows; update `FfcRecord.OverallRemarks` for group-level). 

### Description

- Extend query view models in `Services/Ffc/FfcQueryService.cs` to include `FfcRecordId`, `FfcProjectId`, `ProgressSource`/`IsProgressEditable`, and `OverallRemarksDisplay`, and replace `Progress` with `ProgressText` to drive UI editability and rendering decisions. 
- Update the table partial `Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml` to render data attributes (`data-kind`, `data-ffc-project-id`, `data-ffc-record-id`, `data-editable`, `data-maxlen`), add display/editor blocks (textarea + Save/Cancel) for editable cells, and gate edit affordances to users in roles `HoD` or `Admin`. 
- Add page handlers in `MapTableDetailedModel` (`OnPostUpdateOverallRemarksAsync` and `OnPostUpdateProgressAsync`) protected with `[Authorize(Roles = "HoD,Admin")]` and `[ValidateAntiForgeryToken]`, performing input normalization, length validation, and routing logic so that linked rows append a new external remark via `IRemarkService.CreateRemarkAsync` and unlinked rows update the existing `FfcProject.Remarks` field; group edits update `FfcRecord.OverallRemarks`. 
- Wire an anti-forgery token into the Razor page `MapTableDetailed.cshtml` and add a client-side controller `wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js` which toggles edit mode, enforces single active editor, POSTs JSON with `RequestVerificationToken`, shows saving/ error states, and updates display text from the handler response. 
- Inject `IRemarkService` and `UserManager<ApplicationUser>` into the page model to build a `RemarkActorContext` and create External remarks when needed, and add helpers for remark normalization and display formatting with conservative max lengths (`2000` for progress, `4000` for overall). 

### Testing

- No automated unit or integration tests were executed as part of this change. 
- A quick Playwright UI smoke attempt was run but failed because the local web server was not reachable (`net::ERR_EMPTY_RESPONSE`), so no end-to-end UI verification completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a664330a8832982caafc4e3f343cf)