### PR TITLE
FFC: persist and edit linked project progress remarks (surface remark id & raw text)

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml
@@ -50,6 +50,7 @@ else
                     {
                         var row = group.Rows[index];
                         var progressText = row.ProgressText ?? string.Empty;
+                        var progressTextRaw = row.ProgressTextRaw ?? progressText;
                         var progressHasValue = !string.IsNullOrWhiteSpace(progressText);
                         var isProgressEditable = canEdit && row.IsProgressEditable;
                         <tr>
@@ -81,6 +82,8 @@ else
                             @* SECTION: Progress cell *@
                             <td data-kind="progress"
                                 data-ffc-project-id="@row.FfcProjectId"
+                                data-linked-project-id="@(row.LinkedProjectId?.ToString() ?? string.Empty)"
+                                data-external-remark-id="@(row.ExternalRemarkId?.ToString() ?? string.Empty)"
                                 data-editable="@isProgressEditable.ToString().ToLowerInvariant()"
                                 data-maxlen="2000"
                                 data-empty-text="No progress recorded.">
@@ -93,7 +96,7 @@ else
                                         <span class="inline-status text-success small ms-2 d-none" role="status"></span>
                                     </div>
                                     <div class="editor d-none">
-                                        <textarea class="form-control form-control-sm" rows="3" maxlength="2000">@progressText</textarea>
+                                        <textarea class="form-control form-control-sm" rows="3" maxlength="2000">@progressTextRaw</textarea>
                                         <div class="mt-2 d-flex gap-2">
                                             <button type="button" class="btn btn-sm btn-primary js-inline-save">Save</button>
                                             <button type="button" class="btn btn-sm btn-outline-secondary js-inline-cancel">Cancel</button>

--- a/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
+++ b/wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js
@@ -169,6 +169,8 @@
         const textarea = cell.querySelector(selectors.textarea);
         const payload = textarea ? textarea.value : "";
         const token = getToken();
+        const linkedProjectId = cell.dataset.linkedProjectId ? Number(cell.dataset.linkedProjectId) : null;
+        const externalRemarkId = cell.dataset.externalRemarkId ? Number(cell.dataset.externalRemarkId) : null;
 
         const response = await fetch(endpoints[kind], {
             method: "POST",
@@ -179,7 +181,12 @@
             body: JSON.stringify(
                 kind === "overall"
                     ? { ffcRecordId: Number(cell.dataset.ffcRecordId), overallRemarks: payload }
-                    : { ffcProjectId: Number(cell.dataset.ffcProjectId), progressText: payload }
+                    : {
+                        ffcProjectId: Number(cell.dataset.ffcProjectId),
+                        progressText: payload,
+                        linkedProjectId,
+                        externalRemarkId
+                    }
             )
         });
 
@@ -216,6 +223,9 @@
                     : data.renderedProgressText ?? data.progressText;
 
                 endEdit(cell, rawValue, displayValue);
+                if (cell.dataset.kind === "progress" && data.externalRemarkId) {
+                    cell.dataset.externalRemarkId = String(data.externalRemarkId);
+                }
                 return;
             }
 


### PR DESCRIPTION
### Motivation

- Fix the user-visible issue where inline edits to "Progress / Present Status" for linked projects disappear after refresh because the FFC query filtered external remarks by the report-year window while inline saves created a remark dated today.

### Description

- Query layer: `LoadRemarkSummariesAsync` was changed to load the latest external remark per linked project regardless of the report `from/to` window and to return a `RemarkSummary` (raw body, display text and remark id), and `FfcDetailedRowVm` now exposes `ProgressTextRaw` and `ExternalRemarkId` (files: `Services/Ffc/FfcQueryService.cs`).
- UI model & view: detailed rows now include the remark id/raw text and the progress textarea is populated with the raw text so editing updates the actual external remark (file: `Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml`).
- Inline update handler: `OnPostUpdateProgressAsync` now accepts `linkedProjectId` and `externalRemarkId`, validates the linked-project reference, edits the existing external remark when `externalRemarkId` is present (via `IRemarkService.EditRemarkAsync`) or creates a new one otherwise, and returns the `externalRemarkId` in the JSON response (file: `Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs`).
- Hardening & logging: added structured error handling and server-side logging for failures during linked-progress updates and injected an `ILogger` to record diagnostic details when `500` errors occur (file: `Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs`).
- Client JS: inline edit script now sends `linkedProjectId` and `externalRemarkId` with the AJAX payload and updates the cell `data-external-remark-id` on success (file: `wwwroot/js/pages/project-office-reports/ffc/ffc-map-table-detailed-inline-edit.js`).

### Testing

- Automated tests: none executed for this change (`No automated tests were run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a743b96788329aec23bdc56fdc613)