### PR TITLE
Fix FFC remark update handlers and snapshot types

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
@@ -22,6 +22,7 @@ using ProjectManagement.Services.Remarks;
 namespace ProjectManagement.Areas.ProjectOfficeReports.Pages.FFC;
 
 [Authorize]
+[ValidateAntiForgeryToken]
 public class MapTableDetailedModel : PageModel
 {
     private readonly ApplicationDbContext _db;
@@ -184,10 +185,13 @@ public class MapTableDetailedModel : PageModel
     }
 
     // SECTION: Inline editing handlers
-    [Authorize(Roles = "HoD,Admin")]
-    [ValidateAntiForgeryToken]
     public async Task<IActionResult> OnPostUpdateOverallRemarksAsync([FromBody] UpdateOverallRemarksRequest request, CancellationToken cancellationToken)
     {
+        if (!User.IsInRole("Admin") && !User.IsInRole("HoD"))
+        {
+            return Forbid();
+        }
+
         if (request is null)
         {
             return BadRequest(new { message = "Request payload is missing." });
@@ -227,10 +231,13 @@ public class MapTableDetailedModel : PageModel
         });
     }
 
-    [Authorize(Roles = "HoD,Admin")]
-    [ValidateAntiForgeryToken]
     public async Task<IActionResult> OnPostUpdateProgressAsync([FromBody] UpdateProgressRequest request, CancellationToken cancellationToken)
     {
+        if (!User.IsInRole("Admin") && !User.IsInRole("HoD"))
+        {
+            return Forbid();
+        }
+
         if (request is null)
         {
             return BadRequest(new { message = "Request payload is missing." });
@@ -607,7 +614,7 @@ public class MapTableDetailedModel : PageModel
         int ProjectId,
         RemarkScope Scope,
         DateOnly EventDate,
-        int? StageRef,
+        string? StageRef,
         string? StageNameSnapshot,
         byte[] RowVersion,
         DateTime CreatedAtUtc,


### PR DESCRIPTION
### Motivation
- Resolve compiler errors and Razor warnings caused by mismatched types in the external remark snapshot and unsupported handler-level MVC attributes.
- Ensure anti-forgery validation is applied correctly and inline update handlers enforce role authorization at runtime.

### Description
- Applied `[ValidateAntiForgeryToken]` at the page model level and removed handler-level `[ValidateAntiForgeryToken]` and `[Authorize(Roles = ...)]` attributes from the inline update handlers.
- Added explicit runtime role checks using `User.IsInRole("Admin")` / `User.IsInRole("HoD")` at the start of `OnPostUpdateOverallRemarksAsync` and `OnPostUpdateProgressAsync`, returning `Forbid()` when unauthorized.
- Changed the `ExternalRemarkSnapshot` record `StageRef` type from `int?` to `string?` to align with the remark model/service contracts and fix `CS1503` type conversion errors.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0d0231c88329bff54fd37c6cfb22)