### PR TITLE
Harden remark edit auditing for legacy data

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs
@@ -366,6 +366,11 @@ public class MapTableDetailedModel : PageModel
             {
                 return BadRequest(new { message = ex.Message });
             }
+            catch (DbUpdateException ex)
+            {
+                LogProgressUpdateFailure(ex, request, linkedProjectId);
+                return StatusCode(500, new { ok = false, message = "Unable to save. See server logs for details." });
+            }
             catch (Exception ex)
             {
                 LogProgressUpdateFailure(ex, request, linkedProjectId);


### PR DESCRIPTION
### Motivation
- Edits to linked projects were causing HTTP 500 because `RemarkAudit` requires non-null `SnapshotAuthorUserId` and `SnapshotBody`, and legacy `Remarks` rows can have `AuthorUserId` or `Body` as NULL. 
- The goal is to make the edit path resilient to legacy/malformed remark rows and to return a clearer error when DB constraint failures occur during inline progress updates.

### Description
- Add `LegacyAuthorUserId = "LEGACY"` constant and perform a small legacy backfill in `RemarkService.EditRemarkAsync` that sets `AuthorUserId` to `LEGACY` when empty and `Body` to `""` when null before creating the audit snapshot. 
- Emit a warning log when a legacy backfill occurs to aid later data cleanup. 
- Add a `catch (DbUpdateException)` branch to `MapTableDetailed.OnPostUpdateProgressAsync` to call `LogProgressUpdateFailure` and return a structured 500 JSON response instead of an uncaught exception. 
- Changes are limited to `Services/Remarks/RemarkService.cs` and `Areas/ProjectOfficeReports/Pages/FFC/MapTableDetailed.cshtml.cs` and do not alter data model constraints.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b185170e0832987836820311d811f)