### PR TITLE
Allow freeform project photo crops and raise upload limit to 10 MB

### DIFF
--- a/Pages/Projects/Photos/Upload.cshtml
+++ b/Pages/Projects/Photos/Upload.cshtml
@@ -126,7 +126,8 @@
 
     <fieldset class="border rounded p-3 mb-3">
         <legend class="float-none w-auto fs-6 px-2">Crop &amp; preview</legend>
-        <p class="text-muted small project-photo-editor__fallback">JavaScript is disabled, so the photo will be centre-cropped automatically.</p>
+        @* SECTION: Non-JavaScript fallback guidance. *@
+        <p class="text-muted small project-photo-editor__fallback">JavaScript is disabled, so the photo will be uploaded as-is without interactive cropping.</p>
         <div class="project-photo-editor"
              data-photo-editor
              data-photo-editor-input="#Input_File"
@@ -135,9 +136,10 @@
                 <img data-photo-editor-image alt="Selected photo ready for cropping" />
             </div>
             <div class="d-flex flex-column gap-3">
+                @* SECTION: Freeform crop guidance. *@
                 <p class="text-muted mb-0 project-photo-editor__placeholder"
                    id="project-photo-editor-placeholder"
-                   data-photo-editor-placeholder>Select a photo to enable cropping. The crop box is locked to a 4:3 aspect ratio and must stay completely within the photo.</p>
+                   data-photo-editor-placeholder>Select a photo to enable cropping. Keep the crop selection within the photo bounds.</p>
                 <div class="project-photo-preview-grid" data-photo-editor-previews aria-describedby="project-photo-preview-helper">
                     <div class="project-photo-preview-item">
                         <div class="project-photo-preview-frame" data-photo-editor-preview="xl" data-width="@coverOptions.Width" data-height="@coverOptions.Height">

--- a/Pages/Projects/Photos/Upload.cshtml.cs
+++ b/Pages/Projects/Photos/Upload.cshtml.cs
@@ -182,8 +182,9 @@ public class UploadModel : PageModel
         catch (InvalidOperationException ex)
         {
             _logger.LogWarning(ex, "Invalid crop selection while uploading photo for project {ProjectId}", id);
+            // SECTION: Crop validation messaging without aspect-ratio constraints.
             ModelState.AddModelError(string.Empty,
-                "We couldn't process that crop. Keep the crop box inside the image, maintain the 4:3 ratio, and try again.");
+                "We couldn't process that crop. Keep the crop selection within the image bounds and try again.");
             return Page();
         }
         catch (Exception ex)

--- a/Pages/Projects/_ProjectOverviewCard.cshtml
+++ b/Pages/Projects/_ProjectOverviewCard.cshtml
@@ -86,7 +86,8 @@
         <div class="row g-4 align-items-start">
             <div class="col-12 col-lg-5 col-xl-4">
                 <div class="project-photo-cover">
-                    <div class="ratio ratio-4x3 w-100">
+                    @* SECTION: Cover photo frame without aspect-ratio lock. *@
+                    <div class="project-photo-cover-frame w-100">
                         @if (coverPhoto != null)
                         {
                             <picture>
@@ -94,8 +95,6 @@
                                         srcset="@coverSrcSet"
                                         sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw" />
                                 <img class="w-100 h-100 object-fit-cover rounded border"
-                                     width="360"
-                                     height="270"
                                      src="@coverXs"
                                      srcset="@coverSrcSet"
                                      sizes="(min-width: 1200px) 360px, (min-width: 992px) 320px, 100vw"

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -30,7 +30,7 @@
     "MaxFileSizeBytes": 20971520
   },
   "ProjectPhotos": {
-    "MaxFileSizeBytes": 5242880,
+    "MaxFileSizeBytes": 10485760,
     "MinWidth": 720,
     "MinHeight": 540,
     "AllowedContentTypes": [

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -35,7 +35,7 @@
   },
   "ProjectPhotos": {
     "StorageRoot": "D:/ProjectManagementData/uploads",
-    "MaxFileSizeBytes": 5242880,
+    "MaxFileSizeBytes": 10485760,
     "MinWidth": 720,
     "MinHeight": 540,
     "AllowedContentTypes": [

--- a/appsettings.json
+++ b/appsettings.json
@@ -53,7 +53,7 @@
     "BindTokensToUser": true
   },
   "ProjectPhotos": {
-    "MaxFileSizeBytes": 5242880,
+    "MaxFileSizeBytes": 10485760,
     "MinWidth": 720,
     "MinHeight": 540,
     "AllowedContentTypes": [

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -4627,10 +4627,26 @@ body.has-expanded-project-photo-editor {
   gap: 0.5rem;
 }
 
+.project-photo-cover-frame {
+  /* SECTION: Stable cover frame without aspect-ratio lock. */
+  width: 100%;
+  max-height: 360px;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 1px solid var(--pm-border);
+  background: var(--pm-card);
+}
+
+.project-photo-cover-frame img {
+  /* SECTION: Preserve natural aspect ratio while fitting the frame. */
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
 .project-photo-preview-frame {
   position: relative;
   width: 100%;
-  aspect-ratio: 4 / 3;
   border-radius: 0.5rem;
   overflow: hidden;
   border: 1px solid var(--pm-border);


### PR DESCRIPTION
### Motivation

- Increase the photo upload limit from 5 MB to 10 MB to allow larger images.
- Remove all server- and client-side 4:3 aspect-ratio constraints so users can upload and crop images in any aspect ratio.
- Prevent derivative image distortion by preserving original aspect ratios during resizing.
- Update UI copy and framing to reflect the new freeform cropping behaviour while keeping layout stable.

### Description

- Updated configuration values in `appsettings.json`, `appsettings.Development.json`, and `appsettings.Production.json` to set `ProjectPhotos:MaxFileSizeBytes` to `10485760` (10 MB).
- Removed the enforced 4:3 validation in `Services/Projects/ProjectPhotoService.cs` by deleting the 4:3 check in `ValidateCrop(...)` and keeping only positive-dimensions and bounds checks, and replaced `CalculateDefaultCrop(...)` to return the full image (`new Rectangle(0,0,width,height)`).
- Prevented stretching of derivatives by switching the image resize mode from `ResizeMode.Stretch` to `ResizeMode.Max` in the derivative-generation code path in `Services/Projects/ProjectPhotoService.cs` so outputs preserve aspect ratio.
- Unlocked client-side cropping by removing the hard-coded `ASPECT_RATIO` and updating `wwwroot/js/widgets/project-photo-gallery.js` to set `selection.aspectRatio = NaN`, remove `aspectRatio` init options, and replace `quantizeCropBox(...)` with a simplified integer-rounding and bounds-clamping implementation (no ratio math or 4:3 candidate logic).
- Removed 4:3 UI framing: replaced the `ratio-4x3` wrapper with a responsive `project-photo-cover-frame` in `Pages/Projects/_ProjectOverviewCard.cshtml`, added supporting CSS in `wwwroot/css/site.css`, and removed `aspect-ratio: 4 / 3` from preview frames.
- Updated upload UX and error messaging to remove references to 4:3 in `Pages/Projects/Photos/Upload.cshtml` and `Pages/Projects/Photos/Upload.cshtml.cs` and added short section comments in modified code to clarify intentions.

### Testing

- Verified the edited JSON configuration files parse by loading `appsettings.json`, `appsettings.Development.json`, and `appsettings.Production.json` with Python's `json.load()` (succeeded).
- Attempted to run the test suite with `dotnet test`, but the runtime was not available in the environment so the command could not execute (failure due to missing `dotnet`).
- Performed automated searches to confirm removal/replacement of common 4:3 markers (e.g. `ASPECT_RATIO`, `ratio-4x3`, `aspect-ratio: 4 / 3`) and verified the expected replacements exist in the modified files (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d1b08db48329beba33dd07678ab8)