### PR TITLE
Improve cover photo empty state with role-based CTAs

### DIFF
--- a/Pages/Projects/Photos/Upload.cshtml.cs
+++ b/Pages/Projects/Photos/Upload.cshtml.cs
@@ -51,7 +51,7 @@ public class UploadModel : PageModel
         _ => "Unknown"
     };
 
-    public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
+    public async Task<IActionResult> OnGetAsync(int id, bool cover, CancellationToken cancellationToken)
     {
         var userId = _userContext.UserId;
         if (string.IsNullOrEmpty(userId))
@@ -76,6 +76,9 @@ public class UploadModel : PageModel
         Input.ProjectId = project.Id;
         Input.RowVersion = Convert.ToBase64String(project.RowVersion);
         Input.LinkToTot = false;
+
+        // SECTION: Default cover selection when launched from cover CTA.
+        Input.SetAsCover = cover;
 
         return Page();
     }

--- a/Pages/Projects/_ProjectOverviewCard.cshtml
+++ b/Pages/Projects/_ProjectOverviewCard.cshtml
@@ -103,8 +103,41 @@
                         }
                         else
                         {
-                            <div class="d-flex align-items-center justify-content-center w-100 h-100 rounded border bg-light text-muted">
-                                <span>No cover photo</span>
+                            @* SECTION: Cover photo empty-state with role-based actions. *@
+                            <div class="project-photo-cover-empty text-center">
+                                <div class="project-photo-cover-empty__icon" aria-hidden="true">
+                                    <i class="bi bi-image"></i>
+                                </div>
+
+                                @if (canManagePhotos)
+                                {
+                                    <div class="project-photo-cover-empty__title">Add a cover photo</div>
+                                    <div class="project-photo-cover-empty__hint text-muted small">
+                                        Optional. Helps recognise the project quickly.
+                                    </div>
+
+                                    <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
+                                        <a class="btn btn-sm btn-primary"
+                                           asp-page="/Projects/Photos/Upload"
+                                           asp-route-id="@Model.Project!.Id"
+                                           asp-route-cover="true">
+                                            Upload cover photo
+                                        </a>
+
+                                        <a class="btn btn-sm btn-outline-secondary"
+                                           asp-page="/Projects/Photos/Index"
+                                           asp-route-id="@Model.Project!.Id">
+                                            Manage photos
+                                        </a>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="project-photo-cover-empty__title">No cover photo</div>
+                                    <div class="project-photo-cover-empty__hint text-muted small">
+                                        A cover image has not been set for this project.
+                                    </div>
+                                }
                             </div>
                         }
                     </div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -4644,6 +4644,43 @@ body.has-expanded-project-photo-editor {
   display: block;
 }
 
+/* ---------- Cover photo empty-state (Option B) ---------- */
+.project-photo-cover-empty {
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px dashed var(--pm-border);
+  background: var(--pm-card);
+}
+
+.project-photo-cover-empty__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 0.75rem;
+  border: 1px solid var(--pm-border);
+  background: rgba(15, 23, 42, 0.03);
+  color: var(--pm-text-secondary);
+}
+
+.project-photo-cover-empty__title {
+  font-weight: 600;
+}
+
+.project-photo-cover-empty__hint {
+  margin-top: 0.25rem;
+}
+
+.project-photo-cover-frame .project-photo-cover-empty {
+  /* SECTION: Ensure a balanced empty-state height within the cover frame. */
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .project-photo-preview-frame {
   position: relative;
   width: 100%;


### PR DESCRIPTION
### Motivation

- Replace the ambiguous centered “No cover photo” placeholder with an intentional empty-state that communicates the area is for a cover photo and surfaces direct actions for authorised users while remaining read-only for others.
- Ensure the Upload flow launched from the empty-state CTA pre-checks the `Set as cover photo` option and preserve the existing no-aspect-ratio-lock behavior.

### Description

- Implement the Option B empty-state in `Pages/Projects/_ProjectOverviewCard.cshtml` with an icon, title, helper text, and two CTAs for authorised users: `Upload cover photo` (routes to `/Projects/{id}/Photos/Upload?cover=true`) and `Manage photos`, while showing read-only messaging for non-authorised users.
- Add a `cover` query-bound parameter to the Upload page GET handler by changing the signature to `OnGetAsync(int id, bool cover, CancellationToken cancellationToken)` in `Pages/Projects/Photos/Upload.cshtml.cs` and set `Input.SetAsCover = cover` after existing GET defaults.
- Add new CSS rules in `wwwroot/css/site.css` for `.project-photo-cover-empty*`, including a dashed border, icon styling, title/hint styles and a `min-height` and vertical centering so the empty-state reads as an intentional component.
- Preserve the existing cover-photo rendering path and the current aspect-ratio behaviour when a cover photo exists.

### Testing

- Ran `npm run test` (front-end unit tests) and all tests passed (`11/11`).
- Attempted `dotnet test ProjectManagement.sln` but the .NET SDK was not available in the environment so it could not be executed.
- Attempted an automated Playwright navigation/screenshot for visual verification but the application was not reachable at the expected URL, so the check failed to complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974da823c24832990310f05ca994952)