### PR TITLE
Ongoing analytics: stacked-by-category charts, category controls, labels, and download

### DIFF
--- a/Models/Analytics/CompletedAnalyticsVm.cs
+++ b/Models/Analytics/CompletedAnalyticsVm.cs
@@ -20,4 +20,20 @@ public sealed record AnalyticsStageDurationPoint(string StageCode, string Name, 
 public sealed record CompletedPerYearPoint(int Year, int Count);
 
 public sealed record CompletedPerYearByParentCategoryPoint(int Year, string CategoryName, int Count);
+
+// SECTION: Ongoing analytics category breakdown DTOs
+public sealed record OngoingStageCountByCategoryPoint(
+    string StageCode,
+    string StageName,
+    int ParentCategoryId,
+    string CategoryName,
+    int Count);
+
+public sealed record OngoingStageDurationByCategoryPoint(
+    string StageCode,
+    string StageName,
+    int ParentCategoryId,
+    string CategoryName,
+    double Days);
+// END SECTION
 // END SECTION

--- a/Models/Analytics/OngoingAnalyticsVm.cs
+++ b/Models/Analytics/OngoingAnalyticsVm.cs
@@ -13,5 +13,11 @@ public sealed class OngoingAnalyticsVm
 
     public IReadOnlyList<AnalyticsStageDurationPoint> AvgStageDurations { get; init; } =
         Array.Empty<AnalyticsStageDurationPoint>();
+
+    public IReadOnlyList<OngoingStageCountByCategoryPoint> ByStageByCategory { get; init; } =
+        Array.Empty<OngoingStageCountByCategoryPoint>();
+
+    public IReadOnlyList<OngoingStageDurationByCategoryPoint> AvgStageDurationsByCategory { get; init; } =
+        Array.Empty<OngoingStageDurationByCategoryPoint>();
 }
 // END SECTION

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -34,15 +34,61 @@
             <!-- Card: stage distribution -->
             <article class="analytics-card">
                 <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Ongoing projects by current stage</h2>
-                    <p class="analytics-card__meta">How many ongoing projects are currently in each stage.</p>
+                    <div class="analytics-card__title-block">
+                        <h2 class="analytics-card__title">Ongoing projects by current stage</h2>
+                        <p class="analytics-card__meta">
+                            How many ongoing projects are currently in each stage, split by category.
+                        </p>
+                    </div>
+                    <!-- SECTION: Stage chart controls -->
+                    <div class="analytics-chart-controls" data-chart-controls-for="ongoing-by-stage-chart">
+                        <div class="analytics-chart-controls__group">
+                            <label class="form-label analytics-chart-controls__label" for="ongoingStageCategories">
+                                Categories
+                            </label>
+                            <select id="ongoingStageCategories"
+                                    class="form-select form-select-sm analytics-chart-controls__select"
+                                    multiple
+                                    data-chart-category-multiselect></select>
+                            <div class="analytics-chart-controls__actions">
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary"
+                                        data-chart-select-all>
+                                    Select all
+                                </button>
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary"
+                                        data-chart-clear>
+                                    Clear
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="analytics-chart-controls__toggles">
+                            <div class="form-check form-switch analytics-chart-controls__toggle">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       id="ongoingStageShowLabels"
+                                       data-chart-show-labels />
+                                <label class="form-check-label" for="ongoingStageShowLabels">Show labels</label>
+                            </div>
+
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary"
+                                    data-chart-download>
+                                Download
+                            </button>
+                        </div>
+                    </div>
+                    <!-- END SECTION -->
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">
                         <canvas id="ongoing-by-stage-chart"
                                 aria-label="Ongoing projects by current stage"
                                 role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByStage, jsonOptions))'></canvas>
+                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByStage, jsonOptions))'
+                                data-series-by-category='@Html.Raw(JsonSerializer.Serialize(Model.ByStageByCategory, jsonOptions))'></canvas>
                     </div>
                 </div>
             </article>
@@ -50,17 +96,61 @@
             <!-- Card: time-in-stage -->
             <article class="analytics-card analytics-card--wide">
                 <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Average time spent in each stage</h2>
-                    <p class="analytics-card__meta">
-                        Average number of days ongoing projects spend in each stage.
-                    </p>
+                    <div class="analytics-card__title-block">
+                        <h2 class="analytics-card__title">Average time spent in each stage</h2>
+                        <p class="analytics-card__meta">
+                            Average number of days ongoing projects spend in each stage, grouped by category.
+                        </p>
+                    </div>
+                    <!-- SECTION: Stage duration chart controls -->
+                    <div class="analytics-chart-controls" data-chart-controls-for="ongoing-stage-duration-chart">
+                        <div class="analytics-chart-controls__group">
+                            <label class="form-label analytics-chart-controls__label" for="ongoingDurationCategories">
+                                Categories
+                            </label>
+                            <select id="ongoingDurationCategories"
+                                    class="form-select form-select-sm analytics-chart-controls__select"
+                                    multiple
+                                    data-chart-category-multiselect></select>
+                            <div class="analytics-chart-controls__actions">
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary"
+                                        data-chart-select-all>
+                                    Select all
+                                </button>
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary"
+                                        data-chart-clear>
+                                    Clear
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="analytics-chart-controls__toggles">
+                            <div class="form-check form-switch analytics-chart-controls__toggle">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       id="ongoingDurationShowLabels"
+                                       data-chart-show-labels />
+                                <label class="form-check-label" for="ongoingDurationShowLabels">Show labels</label>
+                            </div>
+
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary"
+                                    data-chart-download>
+                                Download
+                            </button>
+                        </div>
+                    </div>
+                    <!-- END SECTION -->
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">
                         <canvas id="ongoing-stage-duration-chart"
                                 aria-label="Average time spent in each stage"
                                 role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.AvgStageDurations, jsonOptions))'></canvas>
+                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.AvgStageDurations, jsonOptions))'
+                                data-series-by-category='@Html.Raw(JsonSerializer.Serialize(Model.AvgStageDurationsByCategory, jsonOptions))'></canvas>
                     </div>
                 </div>
             </article>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -235,7 +235,17 @@
 
 .analytics-card__header {
   margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
+
+/* SECTION: Analytics card header title block */
+.analytics-card__title-block {
+  display: flex;
+  flex-direction: column;
+}
+/* END SECTION */
 
 .analytics-card__title {
   margin: 0;
@@ -301,6 +311,52 @@
   width: 100%;
   height: 100%;
 }
+
+/* SECTION: Analytics chart controls */
+.analytics-chart-controls {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.analytics-chart-controls__group {
+  min-width: 240px;
+  max-width: 380px;
+}
+
+.analytics-chart-controls__label {
+  margin-bottom: 4px;
+  font-size: 0.85rem;
+}
+
+.analytics-chart-controls__select {
+  min-height: 72px;
+  max-height: 120px;
+  overflow: auto;
+}
+
+.analytics-chart-controls__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.analytics-chart-controls__toggles {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 22px;
+}
+
+@media (max-width: 992px) {
+  .analytics-chart-controls__toggles {
+    margin-top: 0;
+  }
+}
+/* END SECTION */
 
 
 /* SECTION: Analytics roadmap / subcategory listing */


### PR DESCRIPTION
### Motivation

- Provide stacked visualisation of ongoing projects by parent category and give users quick, in-card controls to filter categories, toggle value labels, and download charts without full page reloads.
- Keep behaviour backward-compatible by preserving existing single-series fallbacks when category breakdowns are not available.

### Description

- Added DTOs `OngoingStageCountByCategoryPoint` and `OngoingStageDurationByCategoryPoint` and extended `OngoingAnalyticsVm` with `ByStageByCategory` and `AvgStageDurationsByCategory` to carry per-category series to the view.
- Implemented server-side aggregations `BuildOngoingStageDistributionByParentCategoryAsync` and `BuildOngoingStageDurationsByParentCategoryAsync` (including `ResolveParentCategoryId` and `BuildStageOrderLookup`) to compute counts and average durations grouped by parent category.
- Updated the `_OngoingAnalytics.cshtml` partial to emit `data-series-by-category` JSON and to add aligned, CSP-safe in-card controls (multi-select, select all/clear, show labels toggle, and download button) for each chart.
- Added responsive styles in `wwwroot/css/analytics.css` to lay out the controls cleanly within chart card headers.
- Implemented client-side support in `wwwroot/js/analytics-projects.js`: `parseSeriesByCategory`, `buildCategoryDatasets`, `createStackedBarChart`/`createGroupedBarChart`, a small `valueLabels` plugin, a `bindCategoryControls` helper (multi-select persistence via `localStorage`), PNG download via `canvas.toBlob`, and updated `initOngoingAnalytics` to prefer the new category series while keeping legacy fallbacks.

### Testing

- Ran `node --check wwwroot/js/analytics-projects.js` to validate the modified JavaScript syntax, which succeeded.
- Attempted `dotnet build` to validate C# changes but the .NET SDK is not available in this environment, so a full compile/test could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974eedb29608329b5515431e125a8b6)