### PR TITLE
Fix analytics parent category projection to match ProjectCategory model

### DIFF
--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -803,7 +803,7 @@ namespace ProjectManagement.Pages.Analytics
                 .Select(p => new ProjectStageCategorySnapshot(
                     p.LifecycleStatus,
                     p.CategoryId,
-                    p.Category != null ? p.Category.ParentCategoryId : null,
+                    p.Category != null ? p.Category.ParentId : null,
                     p.ProjectStages
                         .OrderBy(s => s.SortOrder)
                         .ThenBy(s => s.StageCode)
@@ -866,7 +866,7 @@ namespace ProjectManagement.Pages.Analytics
                     s.ActualStart,
                     s.CompletedOn,
                     s.Project!.CategoryId,
-                    ParentCategoryId = s.Project.Category != null ? s.Project.Category.ParentCategoryId : null
+                    ParentCategoryId = s.Project.Category != null ? s.Project.Category.ParentId : null
                 })
                 .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
### Motivation
- Resolve CS1061 errors by aligning analytics projections with the current `ProjectCategory` model which exposes `ParentId` (not `ParentCategoryId`).

### Description
- Replace references to the nonexistent `ProjectCategory.ParentCategoryId` with `ProjectCategory.ParentId` in `Pages/Analytics/Index.cshtml.cs` where parent category IDs are projected for analytics aggregations.
- Change affects two projection sites: the project snapshot projection and the project-stage projection used for duration/grouping calculations.

### Testing
- Attempted to run `dotnet build` in this environment, but the `dotnet` CLI is not available so a local build could not be executed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f2ca30dc8329984c2870469a726c)