### PR TITLE
Fix ongoing analytics: add numeric helper, chip-based category filters, and chart resilience

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -43,13 +43,18 @@
                     <!-- SECTION: Stage chart controls -->
                     <div class="analytics-chart-controls" data-chart-controls-for="ongoing-by-stage-chart">
                         <div class="analytics-chart-controls__group">
-                            <label class="form-label analytics-chart-controls__label" for="ongoingStageCategories">
+                            <label class="form-label analytics-chart-controls__label" for="ongoingStageCategoriesChips">
                                 Categories
                             </label>
-                            <select id="ongoingStageCategories"
-                                    class="form-select form-select-sm analytics-chart-controls__select"
-                                    multiple
-                                    data-chart-category-multiselect></select>
+                            <div id="ongoingStageCategoriesChips"
+                                 class="analytics-chip-picker"
+                                 data-chart-category-chips
+                                 aria-label="Category filter"></div>
+                            <div class="analytics-chart-controls__hint text-muted"
+                                 data-chart-category-hint
+                                 hidden>
+                                At least one category must remain selected.
+                            </div>
                             <div class="analytics-chart-controls__actions">
                                 <button type="button"
                                         class="btn btn-sm btn-outline-secondary"
@@ -58,8 +63,9 @@
                                 </button>
                                 <button type="button"
                                         class="btn btn-sm btn-outline-secondary"
-                                        data-chart-clear>
-                                    Clear
+                                        data-chart-clear
+                                        title="Reset selection to all categories">
+                                    Reset
                                 </button>
                             </div>
                         </div>
@@ -105,13 +111,18 @@
                     <!-- SECTION: Stage duration chart controls -->
                     <div class="analytics-chart-controls" data-chart-controls-for="ongoing-stage-duration-chart">
                         <div class="analytics-chart-controls__group">
-                            <label class="form-label analytics-chart-controls__label" for="ongoingDurationCategories">
+                            <label class="form-label analytics-chart-controls__label" for="ongoingDurationCategoriesChips">
                                 Categories
                             </label>
-                            <select id="ongoingDurationCategories"
-                                    class="form-select form-select-sm analytics-chart-controls__select"
-                                    multiple
-                                    data-chart-category-multiselect></select>
+                            <div id="ongoingDurationCategoriesChips"
+                                 class="analytics-chip-picker"
+                                 data-chart-category-chips
+                                 aria-label="Category filter"></div>
+                            <div class="analytics-chart-controls__hint text-muted"
+                                 data-chart-category-hint
+                                 hidden>
+                                At least one category must remain selected.
+                            </div>
                             <div class="analytics-chart-controls__actions">
                                 <button type="button"
                                         class="btn btn-sm btn-outline-secondary"
@@ -120,8 +131,9 @@
                                 </button>
                                 <button type="button"
                                         class="btn btn-sm btn-outline-secondary"
-                                        data-chart-clear>
-                                    Clear
+                                        data-chart-clear
+                                        title="Reset selection to all categories">
+                                    Reset
                                 </button>
                             </div>
                         </div>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -324,7 +324,8 @@
 
 .analytics-chart-controls__group {
   min-width: 240px;
-  max-width: 380px;
+  max-width: 560px;
+  flex: 1 1 420px;
 }
 
 .analytics-chart-controls__label {
@@ -332,29 +333,72 @@
   font-size: 0.85rem;
 }
 
-.analytics-chart-controls__select {
-  min-height: 72px;
-  max-height: 120px;
-  overflow: auto;
-}
-
 .analytics-chart-controls__actions {
   display: flex;
   gap: 8px;
   margin-top: 6px;
+  flex-wrap: wrap;
 }
 
 .analytics-chart-controls__toggles {
   display: flex;
   gap: 12px;
   align-items: center;
-  margin-top: 22px;
+  margin-top: 0;
+  margin-left: auto;
 }
 
 @media (max-width: 992px) {
   .analytics-chart-controls__toggles {
-    margin-top: 0;
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
   }
+}
+/* END SECTION */
+
+/* SECTION: Analytics chart category chips */
+.analytics-chip-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  padding: .35rem .25rem;
+  min-height: 44px;
+}
+
+.analytics-chip-picker .chip {
+  cursor: pointer;
+  border: 1px solid var(--pm-border);
+  background: var(--pm-card);
+  color: var(--pm-text-secondary);
+  user-select: none;
+  transition: background-color .12s ease, border-color .12s ease, color .12s ease;
+}
+
+.analytics-chip-picker .chip.is-selected {
+  background: rgba(37, 99, 235, .10);
+  border-color: rgba(37, 99, 235, .35);
+  color: var(--pm-text);
+}
+
+.analytics-chip-picker .chip:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, .35);
+  outline-offset: 2px;
+}
+
+.analytics-chart-controls__hint {
+  margin-top: 6px;
+  font-size: .85rem;
+}
+/* END SECTION */
+
+/* SECTION: Analytics chart error state */
+.analytics-error-state {
+  border: 1px dashed rgba(239, 68, 68, 0.4);
+  border-radius: 0.75rem;
+  padding: 1rem 1.1rem;
+  color: var(--pm-text-secondary);
+  background: rgba(239, 68, 68, 0.05);
 }
 /* END SECTION */
 


### PR DESCRIPTION
### Motivation
- Charts in the Ongoing analytics tab failed to initialise due to an undefined numeric helper, causing blank charts and missing category UI.
- Improve category filtering UX to a professional, accessible chip-based picker while enforcing a non-empty selection (never-empty chart requirement).
- Harden chart initialisation so a single chart failure doesn't leave a blank card and provide a clear fallback message.

### Description
- Added a shared numeric helper `toNumber(value)` and updated dataset construction to attach `$categoryId` to category datasets for reliable filtering (`wwwroot/js/analytics-projects.js`).
- Replaced multi-select category controls with accessible chip pickers and a subtle hint message; renamed `Clear` to `Reset` and made it reset-to-all instead of emptying selection (`Pages/Analytics/Partials/_OngoingAnalytics.cshtml`).
- Implemented chip rendering, selection state helpers, persistent storage helpers, and a `persistAndApplyCategorySelection` flow that enforces at least one category selected and validates stored selections (`wwwroot/js/analytics-projects.js`).
- Improved label rendering to avoid cramped labels, added dated chart download filenames, and adjusted value-label formatting for stacked and grouped charts (`wwwroot/js/analytics-projects.js`).
- Isolated per-chart initialisation in `try/catch` blocks and added `renderChartErrorState` to show a user-facing fallback message instead of a blank canvas (`wwwroot/js/analytics-projects.js`).
- Added analytics-specific chip CSS and control layout improvements to match PRISM look-and-feel (`wwwroot/css/analytics.css`).
- Kept code modular with section comments and followed CSP/offline deployment guidance (no inline scripts added).

### Testing
- Ran `npm test` — all tests passed (11/11). 
- Ran `node --check wwwroot/js/analytics-projects.js` — no syntax errors reported.
- Ran `npm run lint:views` — lint failed, but failure is due to pre-existing inline-style violations elsewhere in the repo and not introduced by this change.
- Attempted `dotnet test` in this environment but the .NET SDK is not available.
- Attempted a Playwright page capture of `/Analytics?tab=Ongoing` but the local app server was not running (`ERR_EMPTY_RESPONSE`), so visual verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974fa50a9848329a17bd1e86dd76404)