### PR TITLE
Guard analytics category persistence against localStorage failures

### DIFF
--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -1115,7 +1115,11 @@ function readStoredList(key) {
 }
 
 function storeList(key, list) {
-  localStorage.setItem(key, JSON.stringify(list));
+  try {
+    window.localStorage.setItem(key, JSON.stringify(list));
+  } catch (error) {
+    console.warn('Unable to store analytics category selection.', error);
+  }
 }
 
 function readStoredBoolean(key, fallback) {


### PR DESCRIPTION
### Motivation
- `localStorage.setItem` can throw (e.g. storage blocked or quota exceeded) and was aborting the analytics category selection flow, causing a regression. 
- Make `storeList` consistent with the existing resilient read helpers so analytics UI continues to work even when storage is unavailable.

### Description
- Wrap the `storeList` body in a `try/catch` and call `window.localStorage.setItem` inside the `try` block. 
- Emit a concise `console.warn` when storage fails so the failure is visible but does not stop chart rendering or selection logic.

### Testing
- Ran `npm test`, which completed successfully and the JS tests passed. 
- Attempted `dotnet test ProjectManagement.sln`, but this environment lacks the `dotnet` runtime so the command failed. 
- Ran `./tools/check-views.sh`, which reported pre-existing inline style attribute issues in unrelated views and did not reflect this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697500f7ef2c8329b3af8310d0da581a)