### PR TITLE
Roll up ongoing analytics to parent categories and add stacked ongoing-stage chart

### DIFF
--- a/Models/Analytics/CompletedAnalyticsVm.cs
+++ b/Models/Analytics/CompletedAnalyticsVm.cs
@@ -20,4 +20,10 @@ public sealed record AnalyticsStageDurationPoint(string StageCode, string Name, 
 public sealed record CompletedPerYearPoint(int Year, int Count);
 
 public sealed record CompletedPerYearByParentCategoryPoint(int Year, string CategoryName, int Count);
+
+public sealed record OngoingStageByParentCategoryPoint(
+    string StageCode,
+    string StageName,
+    string CategoryName,
+    int Count);
 // END SECTION

--- a/Models/Analytics/OngoingAnalyticsVm.cs
+++ b/Models/Analytics/OngoingAnalyticsVm.cs
@@ -11,6 +11,9 @@ public sealed class OngoingAnalyticsVm
     public IReadOnlyList<AnalyticsStageCountPoint> ByStage { get; init; } =
         Array.Empty<AnalyticsStageCountPoint>();
 
+    public IReadOnlyList<OngoingStageByParentCategoryPoint> ByStageByParentCategory { get; init; } =
+        Array.Empty<OngoingStageByParentCategoryPoint>();
+
     public IReadOnlyList<AnalyticsStageDurationPoint> AvgStageDurations { get; init; } =
         Array.Empty<AnalyticsStageDurationPoint>();
 }

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -7,6 +7,10 @@
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
+
+    var stageSeries = Model.ByStageByParentCategory.Count > 0
+        ? Model.ByStageByParentCategory
+        : Model.ByStage;
     // END SECTION
 }
 
@@ -42,7 +46,7 @@
                         <canvas id="ongoing-by-stage-chart"
                                 aria-label="Ongoing projects by current stage"
                                 role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByStage, jsonOptions))'></canvas>
+                                data-series='@Html.Raw(JsonSerializer.Serialize(stageSeries, jsonOptions))'></canvas>
                     </div>
                 </div>
             </article>


### PR DESCRIPTION
### Motivation

- Ongoing analytics should aggregate children into their parent project category for category charts.  
- The ongoing “current stage” chart should show per-stage stacks broken down by parent category to reveal category composition per stage.

### Description

- Add a new DTO `OngoingStageByParentCategoryPoint` and a new property `ByStageByParentCategory` on `OngoingAnalyticsVm` to carry stage-by-parent-category series.  
- Add `BuildParentCategoryCountsAsync(...)` and switch the ongoing category aggregation to use it so the doughnut now rolls up child categories into parent categories.  
- Add `BuildOngoingStageDistributionByParentCategoryAsync(...)` to aggregate current-stage counts grouped by `(stageCode, parentCategory)` and resolve parent category names; include its result in `BuildOngoingAnalyticsAsync(...)`.  
- Update the ongoing Razor partial to serialize a `stageSeries` that prefers the new stacked series with a fallback to the prior `{ name, count }` shape, and add a stacked chart renderer `createOngoingStageStackedChart(...)` plus detection logic in `initOngoingAnalytics()` to render either the new stacked bar or the legacy bar chart client-side (backwards-compatible).  

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697587b33ad88329b9d11f49bf0da43c)