### PR TITLE
Fix ongoing analytics stage series typing

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -1,4 +1,5 @@
 @model ProjectManagement.Models.Analytics.OngoingAnalyticsVm
+@using System.Linq
 @using System.Text.Json
 
 @{
@@ -9,8 +10,8 @@
     };
 
     var stageSeries = Model.ByStageByParentCategory.Count > 0
-        ? Model.ByStageByParentCategory
-        : Model.ByStage;
+        ? Model.ByStageByParentCategory.Cast<object>().ToList()
+        : Model.ByStage.Cast<object>().ToList();
     // END SECTION
 }
 


### PR DESCRIPTION
### Motivation
- Resolve compiler error `CS0173` in `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` by ensuring the ternary expression selecting the stage series returns a single common sequence type when `ByStageByParentCategory` and `ByStage` have different generic element types.

### Description
- Add `@using System.Linq` and change the `stageSeries` selection to cast both branches to `List<object>` via `.Cast<object>().ToList()` so the conditional expression has a consistent type, modifying `Pages/Analytics/Partials/_OngoingAnalytics.cshtml`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975894eb0448329baf97b07c502b0a0)