### PR TITLE
Expand chart palette to 6 accents, merge with fallbacks, and map Unassigned to neutral

### DIFF
--- a/wwwroot/js/theme-colors.js
+++ b/wwwroot/js/theme-colors.js
@@ -13,15 +13,22 @@
 
   // SECTION: Chart palette
   function getChartPalette() {
+    var accents = [
+      getCssVar('--pm-chart-accent-1'),
+      getCssVar('--pm-chart-accent-2'),
+      getCssVar('--pm-chart-accent-3'),
+      getCssVar('--pm-chart-accent-4'),
+      getCssVar('--pm-chart-accent-5'),
+      getCssVar('--pm-chart-accent-6')
+    ]
+      .map(function (value) { return (value || '').trim(); })
+      .filter(Boolean);
+
     return {
       axisColor: getCssVar('--pm-chart-axis'),
       gridColor: getCssVar('--pm-chart-grid'),
-      accents: [
-        getCssVar('--pm-chart-accent-1'),
-        getCssVar('--pm-chart-accent-2'),
-        getCssVar('--pm-chart-accent-3'),
-        getCssVar('--pm-chart-accent-4')
-      ]
+      neutral: getCssVar('--pm-chart-neutral'),
+      accents: accents
     };
   }
   // END SECTION


### PR DESCRIPTION
### Motivation

- Charts were reusing colours because the JS theme palette only exposed 4 accents while CSS declared more, causing deterministic category→colour mapping to wrap and repeat.  
- This caused the same parent categories to appear with repeated colours across Analytics charts, reducing readability.  
- The goal is to increase the available accent slots and harden palette selection so analytics never runs out of unique colours and special buckets (like Unassigned) don't consume accent slots.

### Description

- Read and expose additional theme variables in `wwwroot/js/theme-colors.js` by expanding `getChartPalette()` to collect `--pm-chart-accent-1` through `--pm-chart-accent-6`, trim/filter empty values, and expose a `neutral` value.  
- Harden `getPalette()` in `wwwroot/js/analytics-projects.js` to merge theme accents with the internal `paletteFallback`, remove duplicates, and return combined `accents` plus `axisColor`, `gridColor`, and `neutral` with fallbacks.  
- Update category mapping in `buildCategoryColorMapping(...)` to perform a case-insensitive detection of unassigned labels and map those labels to the `neutral` colour instead of consuming an accent slot.  
- Kept deterministic assignment for normal categories (ranked ordering) while ensuring the combined palette is large enough to avoid early reuse; added/retained section comments for readability.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a9183144832988bbc23bf4e8ced8)