### PR TITLE
Add Full HD chart download buttons to Analytics cards

### DIFF
--- a/Pages/Analytics/Partials/_CoeAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CoeAnalytics.cshtml
@@ -22,11 +22,21 @@
         <div class="analytics-layout__row analytics-layout__row--coe-grid">
             <!-- SECTION: CoE stage chart -->
             <article class="analytics-card">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Ongoing CoE projects by current stage</h2>
-                    <p class="analytics-card__meta">
-                        Current stage distribution for active CoE projects.
-                    </p>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Ongoing CoE projects by current stage</h2>
+                        <p class="analytics-card__meta">
+                            Current stage distribution for active CoE projects.
+                        </p>
+                    </div>
+
+                    <button type="button"
+                            class="analytics-chart-download-btn"
+                            data-chart-download-target="coe-by-stage-chart"
+                            aria-label="Download chart as PNG"
+                            title="Download chart as PNG">
+                        <i class="bi bi-download" aria-hidden="true"></i>
+                    </button>
                 </header>
                 <div class="analytics-card__body">
                     @if (!Model.HasCoeProjects)
@@ -49,11 +59,21 @@
 
             <!-- SECTION: CoE sub-category lifecycle chart -->
             <article class="analytics-card analytics-card--coe-subcategories">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">CoE sub-categories by lifecycle</h2>
-                    <p class="analytics-card__meta">
-                        Distribution of CoE sub-categories across lifecycle statuses.
-                    </p>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">CoE sub-categories by lifecycle</h2>
+                        <p class="analytics-card__meta">
+                            Distribution of CoE sub-categories across lifecycle statuses.
+                        </p>
+                    </div>
+
+                    <button type="button"
+                            class="analytics-chart-download-btn"
+                            data-chart-download-target="coe-subcategories-by-lifecycle-chart"
+                            aria-label="Download chart as PNG"
+                            title="Download chart as PNG">
+                        <i class="bi bi-download" aria-hidden="true"></i>
+                    </button>
                 </header>
                 <div class="analytics-card__body">
                     @if (!Model.HasSubcategoryBreakdown)

--- a/Pages/Analytics/Partials/_CompletedAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CompletedAnalytics.cshtml
@@ -18,11 +18,21 @@
     <div class="analytics-grid analytics-grid--completed">
         <!-- SECTION: Projects completed per year -->
         <article class="analytics-card analytics-card--wide">
-            <header class="analytics-card__header">
-                <h2 class="analytics-card__title">Projects completed per year</h2>
-                <p class="analytics-card__subtitle">
-                    Year-wise view of projects reaching completion, broken down by parent project category.
-                </p>
+            <header class="analytics-card__header analytics-card__header--with-actions">
+                <div class="analytics-card__header-text">
+                    <h2 class="analytics-card__title">Projects completed per year</h2>
+                    <p class="analytics-card__subtitle">
+                        Year-wise view of projects reaching completion, broken down by parent project category.
+                    </p>
+                </div>
+
+                <button type="button"
+                        class="analytics-chart-download-btn"
+                        data-chart-download-target="completedPerYearChart"
+                        aria-label="Download chart as PNG"
+                        title="Download chart as PNG">
+                    <i class="bi bi-download" aria-hidden="true"></i>
+                </button>
             </header>
 
             <div class="analytics-card__body">
@@ -35,11 +45,21 @@
 
         <!-- SECTION: Completed projects by category -->
         <article class="analytics-card">
-            <header class="analytics-card__header">
-                <h2 class="analytics-card__title">Completed projects by category</h2>
-                <p class="analytics-card__subtitle">
-                    Breakdown of completed projects in each project category.
-                </p>
+            <header class="analytics-card__header analytics-card__header--with-actions">
+                <div class="analytics-card__header-text">
+                    <h2 class="analytics-card__title">Completed projects by category</h2>
+                    <p class="analytics-card__subtitle">
+                        Breakdown of completed projects in each project category.
+                    </p>
+                </div>
+
+                <button type="button"
+                        class="analytics-chart-download-btn"
+                        data-chart-download-target="completedByCategoryChart"
+                        aria-label="Download chart as PNG"
+                        title="Download chart as PNG">
+                    <i class="bi bi-download" aria-hidden="true"></i>
+                </button>
             </header>
 
             <div class="analytics-card__body">
@@ -52,11 +72,21 @@
 
         <!-- SECTION: Completed projects by technical category -->
         <article class="analytics-card">
-            <header class="analytics-card__header">
-                <h2 class="analytics-card__title">Completed projects by technical category</h2>
-                <p class="analytics-card__subtitle">
-                    Number of completed projects in each technical category.
-                </p>
+            <header class="analytics-card__header analytics-card__header--with-actions">
+                <div class="analytics-card__header-text">
+                    <h2 class="analytics-card__title">Completed projects by technical category</h2>
+                    <p class="analytics-card__subtitle">
+                        Number of completed projects in each technical category.
+                    </p>
+                </div>
+
+                <button type="button"
+                        class="analytics-chart-download-btn"
+                        data-chart-download-target="completedByTechnicalChart"
+                        aria-label="Download chart as PNG"
+                        title="Download chart as PNG">
+                    <i class="bi bi-download" aria-hidden="true"></i>
+                </button>
             </header>
 
             <div class="analytics-card__body">

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -22,9 +22,19 @@
 
             <!-- Card: category distribution -->
             <article class="analytics-card">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Ongoing projects by category</h2>
-                    <p class="analytics-card__meta">Breakdown of ongoing projects in each project category.</p>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Ongoing projects by category</h2>
+                        <p class="analytics-card__meta">Breakdown of ongoing projects in each project category.</p>
+                    </div>
+
+                    <button type="button"
+                            class="analytics-chart-download-btn"
+                            data-chart-download-target="ongoing-by-category-chart"
+                            aria-label="Download chart as PNG"
+                            title="Download chart as PNG">
+                        <i class="bi bi-download" aria-hidden="true"></i>
+                    </button>
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">
@@ -38,9 +48,19 @@
 
             <!-- Card: stage distribution -->
             <article class="analytics-card">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Ongoing projects by current stage</h2>
-                    <p class="analytics-card__meta">How many ongoing projects are currently in each stage.</p>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Ongoing projects by current stage</h2>
+                        <p class="analytics-card__meta">How many ongoing projects are currently in each stage.</p>
+                    </div>
+
+                    <button type="button"
+                            class="analytics-chart-download-btn"
+                            data-chart-download-target="ongoing-by-stage-chart"
+                            aria-label="Download chart as PNG"
+                            title="Download chart as PNG">
+                        <i class="bi bi-download" aria-hidden="true"></i>
+                    </button>
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">
@@ -54,11 +74,21 @@
 
             <!-- Card: time-in-stage -->
             <article class="analytics-card analytics-card--wide">
-                <header class="analytics-card__header">
-                    <h2 class="analytics-card__title">Average time spent in each stage</h2>
-                    <p class="analytics-card__meta">
-                        Average number of days ongoing projects spend in each stage.
-                    </p>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Average time spent in each stage</h2>
+                        <p class="analytics-card__meta">
+                            Average number of days ongoing projects spend in each stage.
+                        </p>
+                    </div>
+
+                    <button type="button"
+                            class="analytics-chart-download-btn"
+                            data-chart-download-target="ongoing-stage-duration-chart"
+                            aria-label="Download chart as PNG"
+                            title="Download chart as PNG">
+                        <i class="bi bi-download" aria-hidden="true"></i>
+                    </button>
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">

--- a/Pages/Analytics/Partials/_ProjectManagementInsights.cshtml
+++ b/Pages/Analytics/Partials/_ProjectManagementInsights.cshtml
@@ -21,16 +21,16 @@
     <div class="analytics-layout analytics-layout--shell">
         <div class="analytics-layout__row">
             <article class="analytics-card analytics-card--wide">
-                <header class="analytics-card__header">
-                    <div class="d-flex justify-content-between align-items-start gap-3">
-                        <div>
-                            <h2 class="analytics-card__title">Stage cycle time by Project Cost Band</h2>
-                            <p class="analytics-card__meta">
-                                Median days spent in each completed stage, grouped by the latest recorded procurement cost bucket.
-                                Active stages from ongoing projects are excluded until those stages finish.
-                            </p>
-                        </div>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Stage cycle time by Project Cost Band</h2>
+                        <p class="analytics-card__meta">
+                            Median days spent in each completed stage, grouped by the latest recorded procurement cost bucket.
+                            Active stages from ongoing projects are excluded until those stages finish.
+                        </p>
+                    </div>
 
+                    <div class="analytics-card__header-actions">
                         <!-- SECTION: Project category filter -->
                         <form method="get" asp-page="./Index" class="analytics-card__filters">
                             <input type="hidden" name="tab" value="Insights" />
@@ -65,6 +65,14 @@
                             </div>
                         </form>
                         <!-- END SECTION -->
+
+                        <button type="button"
+                                class="analytics-chart-download-btn"
+                                data-chart-download-target="stage-time-by-cost-chart"
+                                aria-label="Download chart as PNG"
+                                title="Download chart as PNG">
+                            <i class="bi bi-download" aria-hidden="true"></i>
+                        </button>
                     </div>
                 </header>
 
@@ -99,15 +107,15 @@
 
         <div class="analytics-layout__row">
             <article class="analytics-card analytics-card--wide analytics-card--insights-hotspots">
-                <header class="analytics-card__header">
-                    <div class="d-flex justify-content-between align-items-start gap-3">
-                        <div>
-                            <h2 class="analytics-card__title">Stage delay hotspots</h2>
-                            <p class="analytics-card__meta">
-                                Median days taken to complete each project stage. Ongoing stages are only included after they finish.
-                            </p>
-                        </div>
+                <header class="analytics-card__header analytics-card__header--with-actions">
+                    <div class="analytics-card__header-text">
+                        <h2 class="analytics-card__title">Stage delay hotspots</h2>
+                        <p class="analytics-card__meta">
+                            Median days taken to complete each project stage. Ongoing stages are only included after they finish.
+                        </p>
+                    </div>
 
+                    <div class="analytics-card__header-actions">
                         <!-- SECTION: Shared project category filter -->
                         <form method="get" asp-page="./Index" class="analytics-card__filters">
                             <input type="hidden" name="tab" value="Insights" />
@@ -142,6 +150,14 @@
                             </div>
                         </form>
                         <!-- END SECTION -->
+
+                        <button type="button"
+                                class="analytics-chart-download-btn"
+                                data-chart-download-target="stage-hotspots-chart"
+                                aria-label="Download chart as PNG"
+                                title="Download chart as PNG">
+                            <i class="bi bi-download" aria-hidden="true"></i>
+                        </button>
                     </div>
                 </header>
 

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -237,6 +237,44 @@
   margin-bottom: 0.75rem;
 }
 
+/* SECTION: Analytics card header actions */
+.analytics-card__header--with-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.analytics-card__header-text {
+  min-width: 0;
+}
+
+.analytics-card__header-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.analytics-chart-download-btn {
+  border: 0;
+  background: transparent;
+  padding: 6px;
+  line-height: 1;
+  border-radius: 8px;
+  color: var(--pm-text, #1f2937);
+  cursor: pointer;
+}
+
+.analytics-chart-download-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.analytics-chart-download-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+/* END SECTION */
+
 .analytics-card__title {
   margin: 0;
   font-size: 1rem;

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -1293,6 +1293,126 @@ function initStageHotspotsChart() {
 }
 // END SECTION
 
+// SECTION: Analytics chart export helpers
+function getCssVar(name, fallback) {
+  const css = getComputedStyle(document.documentElement);
+  const value = css.getPropertyValue(name);
+  return value ? value.trim() : fallback;
+}
+
+function sanitizeFilename(name) {
+  return (name || 'chart')
+    .trim()
+    .replace(/[\\/:*?"<>|]+/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+}
+
+function cloneForExport(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneForExport);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  const out = {};
+  Object.keys(value).forEach((key) => {
+    out[key] = cloneForExport(value[key]);
+  });
+  return out;
+}
+
+function exportChartAsPngFullHd(chart, opts = {}) {
+  const width = opts.width ?? 1920;
+  const height = opts.height ?? 1080;
+  const backgroundColor = opts.backgroundColor ?? getCssVar('--pm-card', '') || '#ffffff';
+
+  const offscreen = document.createElement('canvas');
+  offscreen.width = width;
+  offscreen.height = height;
+
+  const exportConfig = {
+    type: chart.config.type,
+    data: cloneForExport(chart.config.data),
+    options: cloneForExport(chart.config.options),
+    plugins: Array.isArray(chart.config.plugins) ? [...chart.config.plugins] : []
+  };
+
+  exportConfig.options = exportConfig.options || {};
+  exportConfig.options.responsive = false;
+  exportConfig.options.animation = false;
+
+  exportConfig.plugins.push({
+    id: 'exportBackgroundFill',
+    beforeDraw(c) {
+      const ctx = c.ctx;
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-over';
+      ctx.fillStyle = backgroundColor;
+      ctx.fillRect(0, 0, c.width, c.height);
+      ctx.restore();
+    }
+  });
+
+  const exportChart = new Chart(offscreen.getContext('2d'), exportConfig);
+  const dataUrl = offscreen.toDataURL('image/png', 1.0);
+
+  exportChart.destroy();
+  return dataUrl;
+}
+
+function triggerDownload(dataUrl, filenameBase) {
+  const today = new Date().toISOString().slice(0, 10);
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = `${filenameBase}-${today}.png`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+function initAnalyticsChartDownloads() {
+  const buttons = document.querySelectorAll('[data-chart-download-target]');
+  if (!buttons.length) {
+    return;
+  }
+
+  buttons.forEach((btn) => {
+    const targetId = btn.dataset.chartDownloadTarget;
+    const canvas = targetId ? document.getElementById(targetId) : null;
+
+    if (!canvas) {
+      btn.disabled = true;
+      return;
+    }
+
+    const chartInstance = Chart.getChart(canvas);
+    btn.disabled = !chartInstance;
+
+    btn.addEventListener('click', () => {
+      const chart = Chart.getChart(canvas);
+      if (!chart) {
+        return;
+      }
+
+      const card = btn.closest('.analytics-card');
+      const titleEl = card ? card.querySelector('.analytics-card__title') : null;
+      const titleText = titleEl ? titleEl.textContent : 'chart';
+      const filenameBase = sanitizeFilename(titleText);
+
+      const png = exportChartAsPngFullHd(chart, { width: 1920, height: 1080 });
+      triggerDownload(png, filenameBase);
+    });
+  });
+}
+// END SECTION
+
 // SECTION: Analytics bootstrap
 function hydrateAnalytics() {
   const page = document.querySelector('.analytics-page');
@@ -1309,6 +1429,8 @@ function hydrateAnalytics() {
   } else if (document.querySelector('.analytics-panel--insights')) {
     initStageTimeInsights();
   }
+
+  initAnalyticsChartDownloads();
 }
 
 function initAnalyticsBootstrap() {


### PR DESCRIPTION
### Motivation

- Provide users a consistent, high-quality way to export Analytics charts as Full HD PNGs suitable for documents and slides.
- Ensure exports are independent of on-screen size by rendering an offscreen Chart.js instance at 1920×1080 so screenshots and small canvas buffers do not reduce output quality.

### Description

- Added a download icon button to each analytics card header across the Ongoing, Completed, CoE, and Project Management Insights partials using the existing canvas IDs (`ongoing-by-category-chart`, `ongoing-by-stage-chart`, `ongoing-stage-duration-chart`, `completedPerYearChart`, `completedByCategoryChart`, `completedByTechnicalChart`, `coe-by-stage-chart`, `coe-subcategories-by-lifecycle-chart`, `stage-time-by-cost-chart`, and `stage-hotspots-chart`) in `Pages/Analytics/Partials/*`.
- Introduced header layout and button styles in `wwwroot/css/analytics.css` (`.analytics-card__header--with-actions`, `.analytics-chart-download-btn`, hover/disabled states) to keep the UI consistent and accessible.
- Implemented offscreen Full HD export helpers in `wwwroot/js/analytics-projects.js` including `exportChartAsPngFullHd`, deep-clone utility `cloneForExport`, filename sanitiser `sanitizeFilename`, CSS variable reader `getCssVar`, and `triggerDownload` to save PNGs with a date-stamped filename.
- Wired up `initAnalyticsChartDownloads()` to run after `hydrateAnalytics()` so buttons are disabled when the target canvas or Chart.js instance is not present, and use `--pm-card` (fallback white) for a non-transparent background.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b037bd408329ac1a6a521ae4e0a6)