### PR TITLE
Fix analytics chart export background fallback

### DIFF
--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -1331,7 +1331,7 @@ function cloneForExport(value) {
 function exportChartAsPngFullHd(chart, opts = {}) {
   const width = opts.width ?? 1920;
   const height = opts.height ?? 1080;
-  const backgroundColor = opts.backgroundColor ?? getCssVar('--pm-card', '') || '#ffffff';
+    const backgroundColor = (opts.backgroundColor ?? getCssVar('--pm-card', '')) || '#ffffff';
 
   const offscreen = document.createElement('canvas');
   offscreen.width = width;


### PR DESCRIPTION
### Motivation
- Fix a JavaScript syntax error in `wwwroot/js/analytics-projects.js` where mixing `??` with `||` caused the module to fail to parse and prevented chart initialization (resulting in blank charts).

### Description
- Update the fallback expression in `exportChartAsPngFullHd` to use parentheses so the precedence is explicit: `const backgroundColor = (opts.backgroundColor ?? getCssVar('--pm-card', '')) || '#ffffff';` which preserves the intended fallback behavior (empty string will fall back to `#ffffff`).

### Testing
- Ran `node --check wwwroot/js/analytics-projects.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b37007fc83298943ce4110a08f0e)