### PR TITLE
Add clear filters action to ongoing projects

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -17,6 +17,10 @@
         && Model.ProjectCategoryId == Model.ChipDcdCategoryId;
     var isOtherActive = Model.ProjectCategoryId.HasValue
         && Model.ProjectCategoryId == Model.ChipOtherRdCategoryId;
+    // SECTION: Filter state
+    var hasFilters = Model.ProjectCategoryId.HasValue
+        || Model.ProjectOfficerId.HasValue
+        || !string.IsNullOrWhiteSpace(Model.Search);
 
     // SECTION: Inline remark defaults
     var remarkType = RemarkType.External.ToString();
@@ -162,6 +166,17 @@
                     Table view
                 </a>
             </div>
+            @if (hasFilters)
+            {
+                <!-- SECTION: Clear filters -->
+                <a asp-page="./Index"
+                   asp-route-ProjectCategoryId=""
+                   asp-route-ProjectOfficerId=""
+                   asp-route-Search=""
+                   class="cmdbar__link-button">
+                    Clear filters
+                </a>
+            }
             <button type="submit" class="btn btn-sm btn-outline-primary">
                 <i class="bi bi-funnel" aria-hidden="true"></i>
                 <span>Filter</span>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8422,6 +8422,35 @@ body {
     flex-wrap: wrap;
 }
 
+/* -- SECTION: Command bar link button -- */
+.cmdbar__link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.55rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: rgba(13, 110, 253, 0.85);
+    text-decoration: none;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: transparent;
+    transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.cmdbar__link-button:hover,
+.cmdbar__link-button:focus-visible {
+    color: rgba(13, 110, 253, 1);
+    background: rgba(13, 110, 253, 0.08);
+    border-color: rgba(13, 110, 253, 0.15);
+    text-decoration: none;
+}
+
+.cmdbar__link-button:focus-visible {
+    outline: 2px solid rgba(13, 110, 253, 0.35);
+    outline-offset: 2px;
+}
+
 /* Segmented control */
 .segmented {
     display: inline-flex;


### PR DESCRIPTION
### Motivation
- Provide a clear, discoverable way for users to reset any active filters on the Ongoing projects page when `ProjectCategoryId`, `ProjectOfficerId`, or `Search` are set.
- Present the control as a light, link-style secondary action consistent with the command bar UI.

### Description
- Add a `hasFilters` flag to `Pages/Projects/Ongoing/Index.cshtml` that is true when `Model.ProjectCategoryId`, `Model.ProjectOfficerId`, or `Model.Search` are populated.
- Render a conditional `Clear filters` anchor in the `.cmdbar__actions` row that routes back to `./Index` with empty `ProjectCategoryId`, `ProjectOfficerId`, and `Search` query parameters using Razor tag helpers.
- Add a new `.cmdbar__link-button` rule in `wwwroot/css/site.css` to style the control as a light, accessible link-style button with hover and focus-visible states.
- Keep implementation server-side and free of inline scripts to comply with CSP and offline deployment constraints.

### Testing
- Attempted to run the application with `dotnet run --project ProjectManagement.csproj --urls http://0.0.0.0:5000`, but the command failed because `dotnet` is not available in the environment (no runtime tests executed).
- Verified changes statically by inspecting the updated files and committing the patch; no automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d5c3aeedc8329b0b8133434efa132)