### PR TITLE
Fix ongoing projects filter state check

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -19,7 +19,7 @@
         && Model.ProjectCategoryId == Model.ChipOtherRdCategoryId;
     // SECTION: Filter state
     var hasFilters = Model.ProjectCategoryId.HasValue
-        || Model.ProjectOfficerId.HasValue
+        || !string.IsNullOrWhiteSpace(Model.ProjectOfficerId)
         || !string.IsNullOrWhiteSpace(Model.Search);
 
     // SECTION: Inline remark defaults


### PR DESCRIPTION
### Motivation
- Resolve the CS1061 Razor/IntelliSense error caused by calling `.HasValue` on the `string` property `ProjectOfficerId` in `Pages/Projects/Ongoing/Index.cshtml` so the filter state is computed correctly.

### Description
- Replace `Model.ProjectOfficerId.HasValue` with `!string.IsNullOrWhiteSpace(Model.ProjectOfficerId)` in `Pages/Projects/Ongoing/Index.cshtml` to perform a proper string emptiness check.

### Testing
- No automated tests were run for this change; this is a one-line view fix addressing a compile-time/IntelliSense error and should be validated with a `dotnet build` or the project's test suite after pulling the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d5d66b6b88329955d33aa3c6edc5b)