### PR TITLE
Fix KPI chip click handlers on ongoing projects

### DIFF
--- a/wwwroot/js/projects/ongoing.js
+++ b/wwwroot/js/projects/ongoing.js
@@ -19,7 +19,7 @@
   }
 
   // SECTION: KPI chip interactions
-  const kpiChips = form.querySelectorAll('.js-kpi-chip');
+  const kpiChips = document.querySelectorAll('.js-kpi-chip');
 
   kpiChips.forEach((chip) => {
     chip.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- KPI chips were rendered outside `#ongoingProjectsFilterForm`, so the original `form.querySelectorAll('.js-kpi-chip')` selection didn't attach click handlers and chip clicks did nothing.

### Description
- Change `wwwroot/js/projects/ongoing.js` to select chips with `document.querySelectorAll('.js-kpi-chip')` so clicks set the `ProjectCategoryId` dropdown and call the existing form `requestSubmit()` logic.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d6384826c8329a2d359784636596a)