### PR TITLE
Polish Ongoing Projects UI accents and hierarchy

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -56,6 +56,27 @@
     string FormatValue(string? value)
         => string.IsNullOrWhiteSpace(value) ? "N/A" : value;
 
+    // SECTION: Category accent helper
+    string GetCategoryAccentClass(int? categoryId)
+    {
+        if (!categoryId.HasValue)
+        {
+            return "ongoing-card--other";
+        }
+
+        if (Model.ChipCoECategoryId.HasValue && categoryId == Model.ChipCoECategoryId)
+        {
+            return "ongoing-card--coe";
+        }
+
+        if (Model.ChipDcdCategoryId.HasValue && categoryId == Model.ChipDcdCategoryId)
+        {
+            return "ongoing-card--dcd";
+        }
+
+        return "ongoing-card--other";
+    }
+
 }
 
 <!-- SECTION: Ongoing projects top area -->
@@ -234,7 +255,7 @@ else
             }
 
             <div class="col-12">
-                <article class="ongoing-card card border-0 shadow-sm h-100">
+                <article class="ongoing-card @GetCategoryAccentClass(item.ProjectCategoryId) card border-0 shadow-sm h-100">
                     <div class="card-body p-0">
                         @{
                             // SECTION: Timeline helper values
@@ -292,10 +313,10 @@ else
                                 </p>
                                 <div class="ongoing-card__stage-summary">
                                     <p class="mb-0">
-                                        <span class="ongoing-card__label">Current stage</span>
+                                        <span class="ongoing-card__current-label">Current stage</span>
                                         @if (cur.Status == StageStatus.Completed)
                                         {
-                                            <span class="fw-medium">@cur.Name</span>
+                                            <span class="ongoing-card__current-value">@cur.Name</span>
                                             @if (cur.ActualCompletedOn.HasValue)
                                             {
                                                 @: (@cur.ActualCompletedOn.Value.ToString("dd-MMM-yyyy"))
@@ -307,7 +328,7 @@ else
                                         }
                                         else
                                         {
-                                            <span class="fw-medium">@cur.Name</span>
+                                            <span class="ongoing-card__current-value">@cur.Name</span>
                                             @if (cur.PlannedDue.HasValue)
                                             {
                                                 @: (PDC: @cur.PlannedDue.Value.ToString("dd-MMM-yyyy"))
@@ -339,15 +360,15 @@ else
                                                 }
                                                 else
                                                 {
-                                                    <span class="ms-2 text-danger ongoing-card__stage-chip">
+                                                    <span class="ms-2 oc-pill oc-pill--danger">
                                                         overdue by @daysToPdc day@(daysToPdc == 1 ? "" : "s")
                                                     </span>
                                                 }
                                             }
                                             else
                                             {
-                                                <span class="ms-2 text-muted ongoing-card__stage-chip">
-                                                    • no PDC set
+                                                <span class="ms-2 oc-pill oc-pill--neutral">
+                                                    no PDC set
                                                 </span>
                                             }
                                         }
@@ -357,11 +378,11 @@ else
 
                             <!-- SECTION: Header right meta -->
                             <div class="ongoing-card__right">
-                                <p class="ongoing-card__label mb-0">Last completed</p>
+                                <p class="ongoing-card__lc-label mb-0">Last completed</p>
                                 <p class="ongoing-card__last mb-0">
                                     @if (!string.IsNullOrEmpty(item.LastCompletedStageName))
                                     {
-                                        @item.LastCompletedStageName
+                                        <span class="ongoing-card__lc-value">@item.LastCompletedStageName</span>
                                         if (item.LastCompletedStageDate.HasValue)
                                         {
                                             @: (@item.LastCompletedStageDate.Value.ToString("dd-MMM-yy"))
@@ -455,7 +476,7 @@ else
                                 <span class="ongoing-remarks__title">Recent internal remarks (last 10 days)</span>
                                 @if (!string.IsNullOrWhiteSpace(item.LatestExternalRemark?.Body))
                                 {
-                                    <span class="badge bg-body-secondary text-muted">has external note</span>
+                                    <span class="oc-pill oc-pill--neutral">has external note</span>
                                 }
                             </div>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -137,6 +137,11 @@
     --pm-accent-gold-dark: #5f4800;
     --pm-accent-mint: #7cc4a5;
     --pm-accent-lavender: #b89ce5;
+    /* -- SECTION: RGB tokens for subtle accents -- */
+    --pm-accent-rgb: 59, 130, 246;
+    --pm-success-rgb: 22, 163, 74;
+    --pm-danger-rgb: 185, 28, 28;
+    --pm-purple-rgb: 139, 92, 246;
     /* -- SECTION: Project palette -- */
     --pm-project-hero-gradient-start: #f6e9ff;
     --pm-project-hero-gradient-mid: #e8f5ff;
@@ -6182,6 +6187,20 @@ body.has-project-photo-preview-dialog {
     width: auto;
 }
 
+/* --- SECTION: Ongoing projects table polish --- */
+.ongoing-table thead th {
+    background: rgba(15, 23, 42, 0.03);
+    border-bottom: 1px solid var(--pm-border);
+}
+
+.ongoing-table tbody tr:not(.table-light):nth-child(even) {
+    background: rgba(15, 23, 42, 0.015);
+}
+
+.ongoing-table tbody tr:not(.table-light):hover td {
+    background: rgba(37, 99, 235, 0.04);
+}
+
 /* --- SECTION: Ongoing projects table cell rules --- */
 .ongoing-table td.col-date,
 .ongoing-table td.col-pdc {
@@ -6199,7 +6218,7 @@ body.has-project-photo-preview-dialog {
 }
 
 .ongoing-table tbody tr:hover td.col-stage {
-    background-color: var(--pm-surface-foam);
+    background-color: rgba(37, 99, 235, 0.04);
 }
 
 .ongoing-table td.col-remarks {
@@ -6321,12 +6340,26 @@ body.has-project-photo-preview-dialog {
     margin: 0;
 }
 
-/* ongoing projects cards */
+/* --- SECTION: Ongoing projects cards --- */
 .ongoing-card {
     background: #fff;
     border-radius: 0.85rem;
+    border-left: 2px solid transparent;
     /* SECTION: Timeline card header layout constants */
     --thumb-size: 80px;
+}
+
+/* --- SECTION: Ongoing projects card category accents --- */
+.ongoing-card--coe {
+    border-left-color: rgba(var(--pm-accent-rgb), 0.45);
+}
+
+.ongoing-card--dcd {
+    border-left-color: rgba(var(--pm-success-rgb), 0.45);
+}
+
+.ongoing-card--other {
+    border-left-color: rgba(var(--pm-purple-rgb), 0.4);
 }
 
 /* SECTION: Timeline card header layout constants (small screens) */
@@ -6402,15 +6435,24 @@ body.has-project-photo-preview-dialog {
 }
 
 .ongoing-card__meta {
-    font-size: 0.8rem;
-    color: #6c757d;
+    font-size: 0.82rem;
+    color: var(--pm-muted);
 }
 
-.ongoing-card__label {
+/* --- SECTION: Ongoing projects card header labels & values --- */
+.ongoing-card__lc-label,
+.ongoing-card__current-label {
     font-size: 0.65rem;
     text-transform: uppercase;
-    letter-spacing: .04em;
-    color: #6c757d;
+    letter-spacing: 0.04em;
+    color: var(--pm-muted);
+}
+
+.ongoing-card__lc-value,
+.ongoing-card__current-value {
+    font-size: 0.78rem;
+    color: var(--pm-text);
+    font-weight: 500;
 }
 
 .ongoing-card__last {
@@ -6425,6 +6467,33 @@ body.has-project-photo-preview-dialog {
 /* stage metadata chips */
 .ongoing-card__stage-chip {
     font-size: 0.7rem;
+}
+
+/* --- SECTION: Ongoing projects status pills --- */
+.oc-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.18rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 500;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: rgba(15, 23, 42, 0.04);
+    color: var(--pm-text);
+    white-space: nowrap;
+}
+
+.oc-pill--danger {
+    background: rgba(var(--pm-danger-rgb), 0.1);
+    border-color: rgba(var(--pm-danger-rgb), 0.22);
+    color: rgb(var(--pm-danger-rgb));
+}
+
+.oc-pill--neutral {
+    background: rgba(15, 23, 42, 0.04);
+    border-color: rgba(15, 23, 42, 0.1);
+    color: var(--pm-muted);
 }
 
 /* SECTION: Timeline card header responsive layout */
@@ -6510,7 +6579,7 @@ body.has-project-photo-preview-dialog {
 .ongoing-timeline__line {
     width: 50px;
     height: 2px;
-    background: rgba(0,0,0,.08);
+    background: rgba(15, 23, 42, 0.12);
     border-radius: 999px;
 }
 
@@ -8313,6 +8382,10 @@ body {
 
 .ongoing-top {
     margin-bottom: 1rem;
+    background: var(--pm-surface-soft);
+    border: 1px solid var(--pm-border);
+    border-radius: 14px;
+    padding: 16px 16px 12px 16px;
 }
 
 .ongoing-top__header {
@@ -8338,6 +8411,7 @@ body {
     justify-content: flex-end;
 }
 
+/* -- SECTION: Ongoing projects KPI chips -- */
 .kpi-chip {
     display: inline-flex;
     align-items: center;
@@ -8350,7 +8424,12 @@ body {
     font-weight: 600;
     color: #0f172a;
     cursor: pointer;
-    transition: border-color 0.2s ease, background-color 0.2s ease;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.kpi-chip:hover {
+    background: rgba(15, 23, 42, 0.04);
+    border-color: rgba(15, 23, 42, 0.16);
 }
 
 .kpi-chip__label {
@@ -8371,9 +8450,11 @@ body {
     color: rgba(15, 23, 42, 0.55);
 }
 
+/* Active chip should look filled, not just bordered */
 .kpi-chip.is-active {
-    border-color: rgba(15, 23, 42, 0.25);
-    background: rgba(148, 163, 184, 0.28);
+    background: rgba(var(--pm-accent-rgb), 0.1);
+    border-color: rgba(var(--pm-accent-rgb), 0.3);
+    color: var(--pm-primary-strong);
 }
 
 .kpi-chip.is-active .kpi-chip__close {
@@ -8381,12 +8462,13 @@ body {
 }
 
 /* Command Bar container */
+/* -- SECTION: Ongoing projects filters container -- */
 .cmdbar {
     margin-top: 1rem;
     padding: 1rem;
     border-radius: 12px;
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    background: #fff;
+    border: 1px solid var(--pm-border);
+    background: var(--pm-card);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 


### PR DESCRIPTION
### Motivation

- Make the Ongoing projects page read as a deliberate, ERP-grade control surface with subtle visual hierarchy rather than a flat list. 
- Provide lightweight category cues on project cards and standardise small status indicators so users can scan category, PDC and overdue state quickly. 
- Improve KPI chip affordance and table/timeline visual consistency while keeping colours muted and using existing theme tokens.

### Description

- Added RGB accent tokens `--pm-accent-rgb`, `--pm-success-rgb`, `--pm-danger-rgb` and `--pm-purple-rgb` to `wwwroot/css/site.css` for safe muted-rgba usage. 
- Turned the top control zone into a subtle panel by updating `.ongoing-top` and made the filters card (`.cmdbar`) use `var(--pm-card)` with a border, padding and radius to anchor controls. 
- Introduced 2px left-border category accents on timeline cards via `.ongoing-card--coe`, `.ongoing-card--dcd`, and `.ongoing-card--other` and added a server-side helper `GetCategoryAccentClass` in `Pages/Projects/Ongoing/Index.cshtml` to apply them. 
- Reworked micro-typography on cards by introducing `.ongoing-card__lc-label`, `.ongoing-card__current-label`, `.ongoing-card__lc-value` and `.ongoing-card__current-value` and adjusted `.ongoing-card__meta` to use `var(--pm-muted)`. 
- Standardised small status indicators as muted pills with `.oc-pill`, `.oc-pill--danger`, and `.oc-pill--neutral`, and replaced inline `text-danger`/badges for overdue/no PDC/external notes in `Index.cshtml`. 
- Improved KPI chip interaction visuals (hover/active) and made the active chip filled using the new RGB accent tokens in `site.css`. 
- Polished timeline connector contrast (`.ongoing-timeline__line`) and applied subtle table header background, faint zebra rows and hover tint for table rows under `#oprTableRoot`/`.ongoing-table` in `site.css`.

### Testing

- Attempted to run the site locally with `dotnet run --project ProjectManagement.csproj` but the run failed because `dotnet` is not available in the environment (`bash: command not found: dotnet`), so no runtime verification was executed. 
- No automated test suite was executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8e9180788329a21936f1ac9d4839)