### PR TITLE
Preserve activity Id on Edit POST to prevent accidental Create

### DIFF
--- a/Pages/Activities/Edit.cshtml
+++ b/Pages/Activities/Edit.cshtml
@@ -21,6 +21,8 @@
     <h1 class="h3 mb-3">@(isEdit ? "Edit activity" : "Add activity")</h1>
 
     <form method="post" class="needs-validation" novalidate enctype="multipart/form-data">
+        <!-- Section: Activity identity -->
+        <input type="hidden" asp-for="Input.Id" />
         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
         <div class="card mb-3">

--- a/Pages/Activities/Edit.cshtml.cs
+++ b/Pages/Activities/Edit.cshtml.cs
@@ -126,7 +126,7 @@ public sealed class EditModel : PageModel
         return Page();
     }
 
-    public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken)
+    public async Task<IActionResult> OnPostAsync(int? id, CancellationToken cancellationToken)
     {
         if (!IsManager(User))
         {
@@ -134,6 +134,11 @@ public sealed class EditModel : PageModel
         }
 
         Input ??= new InputModel();
+        // Section: Resolve activity identity
+        if (!Input.Id.HasValue && id.HasValue)
+        {
+            Input.Id = id;
+        }
         Activity? existing = null;
 
         if (Input.Id.HasValue)


### PR DESCRIPTION
### Motivation

- Editing an activity could turn into a create because the form did not post the activity `Id`, causing `Input.Id` to be null on POST and the handler to treat the submission as a new activity.
- The result was duplicate-title validation and the UI flipping to the Add flow instead of remaining in Edit mode.

### Description

- Add a hidden id field to the edit form by inserting `<input type="hidden" asp-for="Input.Id" />` in `Pages/Activities/Edit.cshtml` so the activity identity is posted back with the form.
- Accept the route `id` in the POST handler and fallback to it by changing the signature to `OnPostAsync(int? id, CancellationToken cancellationToken)` and assigning `Input.Id = id` when the bound model is missing the Id in `Pages/Activities/Edit.cshtml.cs`.
- Document the identity resolution in the code with a short section comment to improve readability and future maintenance.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9f1dab408329b2891640616686b4)