### PR TITLE
Refine ongoing project card header hierarchy

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -6342,7 +6342,7 @@ body.has-project-photo-preview-dialog {
 
 /* --- SECTION: Ongoing projects cards --- */
 .ongoing-card {
-    background: #fff;
+    background: var(--pm-card);
     border-radius: 0.85rem;
     border-left: 2px solid transparent;
     /* SECTION: Timeline card header layout constants */
@@ -6376,7 +6376,8 @@ body.has-project-photo-preview-dialog {
     gap: 12px 18px;
     padding: 1.25rem 1.25rem 1rem 1.25rem;
     align-items: start;
-    border-bottom: 1px solid rgba(0,0,0,.035);
+    background: var(--pm-surface-subtle);
+    border-bottom: 1px solid var(--pm-border-subtle);
 }
 
 /* SECTION: Ongoing timeline header thumbnail */


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy and scannability of the Ongoing projects timeline by providing a subtle neutral header surface and using existing theme tokens for consistent surfaces and dividers.

### Description
- Update `wwwroot/css/site.css` to set `.ongoing-card` background to `var(--pm-card)` and to give `.ongoing-card__header` a subtle surface with `background: var(--pm-surface-subtle)` and `border-bottom: 1px solid var(--pm-border-subtle)` to replace hard-coded colors.

### Testing
- Attempted to run the app with `dotnet run --project ProjectManagement.csproj` for visual verification but the command failed because `dotnet` is not available in the environment, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da50030dc832997852cfd70cfcb00)