### PR TITLE
Add stage bucket counts to Ongoing Projects timeline

### DIFF
--- a/Models/Stages/StageBuckets.cs
+++ b/Models/Stages/StageBuckets.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.Models.Stages;
+
+// SECTION: Stage bucket definitions
+public enum StageBucket
+{
+    Approval,
+    Aon,
+    Procurement,
+    Development,
+    Unknown
+}
+
+// SECTION: Stage bucket mapping helper
+public static class StageBuckets
+{
+    private static readonly HashSet<string> ApprovalCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StageCodes.FS,
+        StageCodes.SOW,
+        StageCodes.IPA
+    };
+
+    private static readonly HashSet<string> AonCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StageCodes.AON
+    };
+
+    private static readonly HashSet<string> ProcurementCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StageCodes.BID,
+        StageCodes.TEC,
+        StageCodes.BM,
+        StageCodes.COB,
+        StageCodes.PNC,
+        StageCodes.EAS,
+        StageCodes.SO
+    };
+
+    private static readonly HashSet<string> DevelopmentCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StageCodes.DEVP,
+        StageCodes.ATP,
+        StageCodes.PAYMENT,
+        StageCodes.TOT
+    };
+
+    // SECTION: Bucket resolver
+    public static StageBucket Of(string? stageCode)
+    {
+        if (string.IsNullOrWhiteSpace(stageCode))
+        {
+            return StageBucket.Unknown;
+        }
+
+        if (ApprovalCodes.Contains(stageCode))
+        {
+            return StageBucket.Approval;
+        }
+
+        if (AonCodes.Contains(stageCode))
+        {
+            return StageBucket.Aon;
+        }
+
+        if (ProcurementCodes.Contains(stageCode))
+        {
+            return StageBucket.Procurement;
+        }
+
+        if (DevelopmentCodes.Contains(stageCode))
+        {
+            return StageBucket.Development;
+        }
+
+        return StageBucket.Unknown;
+    }
+}

--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -133,6 +133,37 @@
         </div>
     </div>
 
+    <!-- SECTION: Stage bucket summary -->
+    <div class="ongoing-top__buckets" aria-label="Stage bucket counts">
+        <span class="kpi-chip kpi-chip--static" title="Apvl: FS, SOW, IPA">
+            <span class="kpi-chip__label">Apvl</span>
+            <span class="kpi-chip__count">@Model.BucketApvlCount</span>
+        </span>
+
+        <span class="kpi-chip kpi-chip--static" title="AoN: AON">
+            <span class="kpi-chip__label">AoN</span>
+            <span class="kpi-chip__count">@Model.BucketAonCount</span>
+        </span>
+
+        <span class="kpi-chip kpi-chip--static" title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
+            <span class="kpi-chip__label">GeM / Proc</span>
+            <span class="kpi-chip__count">@Model.BucketProcCount</span>
+        </span>
+
+        <span class="kpi-chip kpi-chip--static" title="Devp: DEVP, ATP, PAYMENT, TOT">
+            <span class="kpi-chip__label">Devp</span>
+            <span class="kpi-chip__count">@Model.BucketDevpCount</span>
+        </span>
+
+        @if (Model.BucketUnknownCount > 0)
+        {
+            <span class="kpi-chip kpi-chip--static" title="Unknown current stage code found">
+                <span class="kpi-chip__label">Unknown</span>
+                <span class="kpi-chip__count">@Model.BucketUnknownCount</span>
+            </span>
+        }
+    </div>
+
     <!-- SECTION: Command bar -->
     <form id="ongoingProjectsFilterForm"
           method="get"

--- a/Pages/Projects/Ongoing/Index.cshtml.cs
+++ b/Pages/Projects/Ongoing/Index.cshtml.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Projects;
 
@@ -69,6 +70,13 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         public int? ChipCoECategoryId { get; private set; }
         public int? ChipDcdCategoryId { get; private set; }
         public int? ChipOtherRdCategoryId { get; private set; }
+
+        // SECTION: Stage bucket counts
+        public int BucketApvlCount { get; private set; }
+        public int BucketAonCount { get; private set; }
+        public int BucketProcCount { get; private set; }
+        public int BucketDevpCount { get; private set; }
+        public int BucketUnknownCount { get; private set; }
 
         public IReadOnlyList<CategoryCountDto> FilteredCategoryCounts { get; private set; }
             = Array.Empty<CategoryCountDto>();
@@ -162,6 +170,37 @@ namespace ProjectManagement.Pages.Projects.Ongoing
             // SECTION: Build filtered totals and category breakdown
             FilteredTotal = Items.Count;
             ChipTotalCount = Items.Count;
+
+            // SECTION: Stage bucket breakdown
+            BucketApvlCount = 0;
+            BucketAonCount = 0;
+            BucketProcCount = 0;
+            BucketDevpCount = 0;
+            BucketUnknownCount = 0;
+
+            foreach (var item in Items)
+            {
+                var bucket = StageBuckets.Of(item.CurrentStageCode);
+
+                switch (bucket)
+                {
+                    case StageBucket.Approval:
+                        BucketApvlCount++;
+                        break;
+                    case StageBucket.Aon:
+                        BucketAonCount++;
+                        break;
+                    case StageBucket.Procurement:
+                        BucketProcCount++;
+                        break;
+                    case StageBucket.Development:
+                        BucketDevpCount++;
+                        break;
+                    default:
+                        BucketUnknownCount++;
+                        break;
+                }
+            }
 
             var categoryLookup = _categories.ToDictionary(c => c.Id);
 

--- a/ProjectManagement.Tests/Stages/StageBucketsTests.cs
+++ b/ProjectManagement.Tests/Stages/StageBucketsTests.cs
@@ -1,0 +1,40 @@
+using ProjectManagement.Models.Stages;
+using Xunit;
+
+namespace ProjectManagement.Tests.Stages;
+
+public class StageBucketsTests
+{
+    // SECTION: Known code coverage
+    [Theory]
+    [InlineData(StageCodes.FS, StageBucket.Approval)]
+    [InlineData(StageCodes.SOW, StageBucket.Approval)]
+    [InlineData(StageCodes.IPA, StageBucket.Approval)]
+    [InlineData(StageCodes.AON, StageBucket.Aon)]
+    [InlineData(StageCodes.BID, StageBucket.Procurement)]
+    [InlineData(StageCodes.TEC, StageBucket.Procurement)]
+    [InlineData(StageCodes.BM, StageBucket.Procurement)]
+    [InlineData(StageCodes.COB, StageBucket.Procurement)]
+    [InlineData(StageCodes.PNC, StageBucket.Procurement)]
+    [InlineData(StageCodes.EAS, StageBucket.Procurement)]
+    [InlineData(StageCodes.SO, StageBucket.Procurement)]
+    [InlineData(StageCodes.DEVP, StageBucket.Development)]
+    [InlineData(StageCodes.ATP, StageBucket.Development)]
+    [InlineData(StageCodes.PAYMENT, StageBucket.Development)]
+    [InlineData(StageCodes.TOT, StageBucket.Development)]
+    public void Of_KnownCodes_MapCorrectly(string code, StageBucket expected)
+    {
+        Assert.Equal(expected, StageBuckets.Of(code));
+    }
+
+    // SECTION: Unknown code coverage
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("XYZ")]
+    public void Of_Unknown_ReturnsUnknown(string? code)
+    {
+        Assert.Equal(StageBucket.Unknown, StageBuckets.Of(code));
+    }
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8412,6 +8412,15 @@ body {
     justify-content: flex-end;
 }
 
+/* -- SECTION: Ongoing projects bucket chips -- */
+.ongoing-top__buckets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    justify-content: flex-end;
+}
+
 /* -- SECTION: Ongoing projects KPI chips -- */
 .kpi-chip {
     display: inline-flex;
@@ -8431,6 +8440,15 @@ body {
 .kpi-chip:hover {
     background: rgba(15, 23, 42, 0.04);
     border-color: rgba(15, 23, 42, 0.16);
+}
+
+.kpi-chip--static {
+    cursor: default;
+}
+
+.kpi-chip--static:hover {
+    background: rgba(148, 163, 184, 0.15);
+    border-color: rgba(15, 23, 42, 0.12);
 }
 
 .kpi-chip__label {


### PR DESCRIPTION
### Motivation
- Provide bucket-wise counts on the Projects → Ongoing timeline so users can see how many visible projects are in Approval / AoN / GeM-Proc / Development groups. 
- Centralise the stage-to-bucket mapping to avoid duplication and ensure consistent analytics across UI and backend.

### Description
- Added a new bucket model and resolver in `Models/Stages/StageBuckets.cs` with `StageBucket` enum and `StageBuckets.Of(...)` to map canonical stage codes to buckets. 
- Exposed bucket count properties on the page model (`Pages/Projects/Ongoing/Index.cshtml.cs`) and compute them inside `BuildHeaderCounts()` using `OngoingProjectRowDto.CurrentStageCode`. 
- Rendered non-interactive KPI chips in the timeline header (`Pages/Projects/Ongoing/Index.cshtml`) and added styling for static chips in `wwwroot/css/site.css`; the `Unknown` chip is shown only when its count is > 0. 
- Added unit tests for the mapping in `ProjectManagement.Tests/Stages/StageBucketsTests.cs` to prevent regressions.

### Testing
- Added unit tests `ProjectManagement.Tests/Stages/StageBucketsTests.cs` which cover known stage codes and unknown inputs. 
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter StageBucketsTests`, but it failed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dab4a9fd88329bae958591990cd2a)