### PR TITLE
Add centered Stage Pipeline widget to Ongoing Projects header

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -83,9 +83,61 @@
 <div class="ongoing-top">
     <!-- SECTION: Page header + KPI chips -->
     <div class="ongoing-top__header">
+        <!-- SECTION: Page title -->
         <h1 class="ongoing-top__title">Ongoing projects</h1>
+
+        <!-- SECTION: Stage pipeline -->
+        <div class="ongoing-top__pipeline" aria-label="Stage bucket distribution">
+            @if (Model.FilteredTotal > 0)
+            {
+                <div class="stage-pipeline" role="group" aria-label="Stage pipeline">
+                    <div class="stage-pipeline__seg stage-pipeline__seg--apvl"
+                         style="--grow:@Model.BucketApvlCount"
+                         title="Apvl: FS, SOW, IPA">
+                        <span class="stage-pipeline__label">Apvl</span>
+                        <span class="stage-pipeline__count">@Model.BucketApvlCount</span>
+                    </div>
+
+                    <div class="stage-pipeline__seg stage-pipeline__seg--aon"
+                         style="--grow:@Model.BucketAonCount"
+                         title="AoN: AON">
+                        <span class="stage-pipeline__label">AoN</span>
+                        <span class="stage-pipeline__count">@Model.BucketAonCount</span>
+                    </div>
+
+                    <div class="stage-pipeline__seg stage-pipeline__seg--proc"
+                         style="--grow:@Model.BucketProcCount"
+                         title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
+                        <span class="stage-pipeline__label">GeM / Proc</span>
+                        <span class="stage-pipeline__count">@Model.BucketProcCount</span>
+                    </div>
+
+                    <div class="stage-pipeline__seg stage-pipeline__seg--devp"
+                         style="--grow:@Model.BucketDevpCount"
+                         title="Devp: DEVP, ATP, PAYMENT, TOT">
+                        <span class="stage-pipeline__label">Devp</span>
+                        <span class="stage-pipeline__count">@Model.BucketDevpCount</span>
+                    </div>
+                </div>
+
+                @if (Model.BucketUnknownCount > 0)
+                {
+                    <span class="stage-pipeline__unknown"
+                          title="Unknown current stage code found">
+                        Unknown: @Model.BucketUnknownCount
+                    </span>
+                }
+            }
+            else
+            {
+                <div class="stage-pipeline stage-pipeline--empty" aria-label="No projects">
+                    <span class="stage-pipeline__empty-text">No ongoing projects</span>
+                </div>
+            }
+        </div>
+
+        <!-- SECTION: KPI chip filters -->
         <div class="ongoing-top__kpis" aria-label="Project counts">
-            <!-- SECTION: KPI chip filters -->
             <button type="button"
                     class="kpi-chip js-kpi-chip @(isTotalActive ? "is-active" : string.Empty)"
                     data-category-id=""
@@ -131,37 +183,6 @@
                 }
             </button>
         </div>
-    </div>
-
-    <!-- SECTION: Stage bucket summary -->
-    <div class="ongoing-top__buckets" aria-label="Stage bucket counts">
-        <span class="kpi-chip kpi-chip--static" title="Apvl: FS, SOW, IPA">
-            <span class="kpi-chip__label">Apvl</span>
-            <span class="kpi-chip__count">@Model.BucketApvlCount</span>
-        </span>
-
-        <span class="kpi-chip kpi-chip--static" title="AoN: AON">
-            <span class="kpi-chip__label">AoN</span>
-            <span class="kpi-chip__count">@Model.BucketAonCount</span>
-        </span>
-
-        <span class="kpi-chip kpi-chip--static" title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
-            <span class="kpi-chip__label">GeM / Proc</span>
-            <span class="kpi-chip__count">@Model.BucketProcCount</span>
-        </span>
-
-        <span class="kpi-chip kpi-chip--static" title="Devp: DEVP, ATP, PAYMENT, TOT">
-            <span class="kpi-chip__label">Devp</span>
-            <span class="kpi-chip__count">@Model.BucketDevpCount</span>
-        </span>
-
-        @if (Model.BucketUnknownCount > 0)
-        {
-            <span class="kpi-chip kpi-chip--static" title="Unknown current stage code found">
-                <span class="kpi-chip__label">Unknown</span>
-                <span class="kpi-chip__count">@Model.BucketUnknownCount</span>
-            </span>
-        }
     </div>
 
     <!-- SECTION: Command bar -->

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8390,11 +8390,10 @@ body {
 }
 
 .ongoing-top__header {
-    display: flex;
-    align-items: baseline;
-    justify-content: flex-start;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
     gap: 0.75rem;
-    flex-wrap: wrap;
 }
 
 .ongoing-top__title {
@@ -8412,13 +8411,12 @@ body {
     justify-content: flex-end;
 }
 
-/* -- SECTION: Ongoing projects bucket chips -- */
-.ongoing-top__buckets {
+/* -- SECTION: Ongoing projects stage pipeline container -- */
+.ongoing-top__pipeline {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-    margin-top: 0.5rem;
-    justify-content: flex-end;
 }
 
 /* -- SECTION: Ongoing projects KPI chips -- */
@@ -8478,6 +8476,110 @@ body {
 
 .kpi-chip.is-active .kpi-chip__close {
     display: inline-flex;
+}
+
+/* -- SECTION: Ongoing projects stage pipeline -- */
+.stage-pipeline {
+    display: flex;
+    align-items: stretch;
+    height: 34px;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    background: rgba(148, 163, 184, 0.1);
+    min-width: 380px;
+    max-width: 520px;
+}
+
+.stage-pipeline__seg {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0 0.7rem;
+    flex-basis: 0;
+    flex-grow: var(--grow);
+    min-width: 80px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.stage-pipeline__seg:not(:last-child) {
+    border-right: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.stage-pipeline__label {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.stage-pipeline__count {
+    font-size: 0.92rem;
+    font-weight: 800;
+    color: #0f172a;
+}
+
+/* Same accent hue, different opacities. */
+.stage-pipeline__seg--apvl {
+    background: rgba(var(--pm-accent-rgb), 0.06);
+}
+
+.stage-pipeline__seg--aon {
+    background: rgba(var(--pm-accent-rgb), 0.09);
+}
+
+.stage-pipeline__seg--proc {
+    background: rgba(var(--pm-accent-rgb), 0.12);
+}
+
+.stage-pipeline__seg--devp {
+    background: rgba(var(--pm-accent-rgb), 0.15);
+}
+
+.stage-pipeline__seg:hover {
+    filter: brightness(0.985);
+}
+
+.stage-pipeline__unknown {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.stage-pipeline--empty {
+    justify-content: center;
+    min-width: 260px;
+    max-width: 420px;
+}
+
+.stage-pipeline__empty-text {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+/* -- SECTION: Ongoing projects top area responsive -- */
+@media (max-width: 992px) {
+    .ongoing-top__header {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+    }
+
+    .ongoing-top__pipeline {
+        justify-content: flex-start;
+    }
+
+    .ongoing-top__kpis {
+        margin-left: 0;
+        justify-content: flex-start;
+    }
+
+    .stage-pipeline {
+        min-width: 100%;
+        max-width: 100%;
+    }
 }
 
 /* Command Bar container */


### PR DESCRIPTION
### Motivation
- Surface stage-bucket distribution as an analytics widget (not a filter) so users can see pipeline distribution at a glance and avoid confusing it with category filter chips.
- Place the pipeline on the same top row, centered, while keeping category chips aligned to the right to match the intended visual hierarchy.
- Use a restrained single-accent hue with opacity variations and ensure the component stacks cleanly on smaller screens.

### Description
- Update `Pages/Projects/Ongoing/Index.cshtml` to remove the old `.ongoing-top__buckets` chip block and insert a centered `div.ongoing-top__pipeline` inside `.ongoing-top__header` that renders proportional segments using `style="--grow:@Model.BucketXCount"` and shows an empty state when `FilteredTotal == 0`.
- Update `wwwroot/css/site.css` to convert `.ongoing-top__header` from a flex row to a three-column grid, add `.ongoing-top__pipeline` container rules, and add the `.stage-pipeline` component and segment styles with a single-accent opacity scheme and non-clickable appearance.
- Add responsive rules to stack the header (title, pipeline, KPIs) below `992px` so the pipeline flows under the title on small screens.
- Preserve behavior: no JavaScript or model changes were required because the pipeline is rendered server-side and segments use `--grow` for proportional sizing.

### Testing
- An attempt to run the application with `dotnet run --project ProjectManagement.csproj` was executed but failed because the `dotnet` runtime is not available in this environment.
- No automated unit or integration tests were run here due to the missing runtime, so please run `dotnet build` and `dotnet test` in CI or a local environment to validate the changes end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697daf825740832981ab8eb8e0ac2099)