### PR TITLE
Make stage pipeline read as distribution widget

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -90,43 +90,49 @@
         <div class="ongoing-top__pipeline" aria-label="Stage bucket distribution">
             @if (Model.FilteredTotal > 0)
             {
-                <div class="stage-pipeline" role="group" aria-label="Stage pipeline">
-                    <div class="stage-pipeline__seg stage-pipeline__seg--apvl"
-                         style="--grow:@Model.BucketApvlCount"
-                         title="Apvl: FS, SOW, IPA">
-                        <span class="stage-pipeline__label">Apvl</span>
-                        <span class="stage-pipeline__count">@Model.BucketApvlCount</span>
+                <div class="stage-pipeline-wrap" aria-label="Stage distribution">
+                    <div class="stage-pipeline-wrap__caption">Stage distribution</div>
+
+                    <div class="stage-pipeline" role="group" aria-label="Stage pipeline">
+                        <div class="stage-pipeline__seg stage-pipeline__seg--apvl"
+                             style="--grow:@Model.BucketApvlCount"
+                             title="Apvl: FS, SOW, IPA">
+                            <span class="stage-pipeline__label">Apvl</span>
+                            <span class="stage-pipeline__count">@Model.BucketApvlCount</span>
+                        </div>
+
+                        <div class="stage-pipeline__seg stage-pipeline__seg--aon"
+                             style="--grow:@Model.BucketAonCount"
+                             title="AoN: AON">
+                            <span class="stage-pipeline__label">AoN</span>
+                            <span class="stage-pipeline__count">@Model.BucketAonCount</span>
+                        </div>
+
+                        <div class="stage-pipeline__seg stage-pipeline__seg--proc"
+                             style="--grow:@Model.BucketProcCount"
+                             title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
+                            <span class="stage-pipeline__label">GeM / Proc</span>
+                            <span class="stage-pipeline__count">@Model.BucketProcCount</span>
+                        </div>
+
+                        <div class="stage-pipeline__seg stage-pipeline__seg--devp"
+                             style="--grow:@Model.BucketDevpCount"
+                             title="Devp: DEVP, ATP, PAYMENT, TOT">
+                            <span class="stage-pipeline__label">Devp</span>
+                            <span class="stage-pipeline__count">@Model.BucketDevpCount</span>
+                        </div>
                     </div>
 
-                    <div class="stage-pipeline__seg stage-pipeline__seg--aon"
-                         style="--grow:@Model.BucketAonCount"
-                         title="AoN: AON">
-                        <span class="stage-pipeline__label">AoN</span>
-                        <span class="stage-pipeline__count">@Model.BucketAonCount</span>
-                    </div>
-
-                    <div class="stage-pipeline__seg stage-pipeline__seg--proc"
-                         style="--grow:@Model.BucketProcCount"
-                         title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
-                        <span class="stage-pipeline__label">GeM / Proc</span>
-                        <span class="stage-pipeline__count">@Model.BucketProcCount</span>
-                    </div>
-
-                    <div class="stage-pipeline__seg stage-pipeline__seg--devp"
-                         style="--grow:@Model.BucketDevpCount"
-                         title="Devp: DEVP, ATP, PAYMENT, TOT">
-                        <span class="stage-pipeline__label">Devp</span>
-                        <span class="stage-pipeline__count">@Model.BucketDevpCount</span>
-                    </div>
+                    @if (Model.BucketUnknownCount > 0)
+                    {
+                        <div class="stage-pipeline-wrap__meta">
+                            <span class="stage-pipeline__unknown"
+                                  title="Unknown current stage code found">
+                                Unknown: @Model.BucketUnknownCount
+                            </span>
+                        </div>
+                    }
                 </div>
-
-                @if (Model.BucketUnknownCount > 0)
-                {
-                    <span class="stage-pipeline__unknown"
-                          title="Unknown current stage code found">
-                        Unknown: @Model.BucketUnknownCount
-                    </span>
-                }
             }
             else
             {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8479,30 +8479,65 @@ body {
 }
 
 /* -- SECTION: Ongoing projects stage pipeline -- */
+.stage-pipeline-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+}
+
+.stage-pipeline-wrap__caption {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: rgba(15, 23, 42, 0.55);
+    text-align: center;
+    line-height: 1;
+}
+
+.stage-pipeline-wrap__meta {
+    display: flex;
+    justify-content: center;
+}
+
 .stage-pipeline {
     display: flex;
     align-items: stretch;
-    height: 34px;
+    height: 36px;
     border-radius: 999px;
     overflow: hidden;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background: rgba(148, 163, 184, 0.1);
+    border: 1px solid rgba(15, 23, 42, 0.10);
+    background: var(--pm-card);
     min-width: 380px;
     max-width: 520px;
+    cursor: default;
 }
 
 .stage-pipeline__seg {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.28rem;
     padding: 0 0.7rem;
     flex-basis: 0;
     flex-grow: var(--grow);
-    min-width: 80px;
+    min-width: 72px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: default;
+    user-select: none;
+}
+
+.stage-pipeline__seg::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: rgba(var(--pm-accent-rgb), 0.22);
 }
 
 .stage-pipeline__seg:not(:last-child) {
@@ -8510,9 +8545,9 @@ body {
 }
 
 .stage-pipeline__label {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: rgba(15, 23, 42, 0.65);
+    font-size: 0.78rem;
+    font-weight: 650;
+    color: rgba(15, 23, 42, 0.58);
 }
 
 .stage-pipeline__count {
@@ -8538,8 +8573,20 @@ body {
     background: rgba(var(--pm-accent-rgb), 0.15);
 }
 
-.stage-pipeline__seg:hover {
-    filter: brightness(0.985);
+.stage-pipeline__seg--apvl::before {
+    background: rgba(var(--pm-accent-rgb), 0.22);
+}
+
+.stage-pipeline__seg--aon::before {
+    background: rgba(var(--pm-accent-rgb), 0.28);
+}
+
+.stage-pipeline__seg--proc::before {
+    background: rgba(var(--pm-accent-rgb), 0.34);
+}
+
+.stage-pipeline__seg--devp::before {
+    background: rgba(var(--pm-accent-rgb), 0.40);
 }
 
 .stage-pipeline__unknown {


### PR DESCRIPTION
### Motivation

- The stage pipeline currently reads like a segmented control (tabs) due to hover affordances and visual weight, which conflicts with the intent of showing an analytics-style distribution of project stages. 
- The change should keep existing data and rendering logic while making the UI visually communicate distribution rather than filters.

### Description

- Wrap the existing pipeline markup in a new `.stage-pipeline-wrap` and add a centered caption `Stage distribution`, and move the `Unknown` count into a meta row to preserve alignment.  
- Update CSS to add `.stage-pipeline-wrap` styles, set the pipeline background to `var(--pm-card)`, increase height to `36px`, set `cursor: default`, and reduce segment `min-width` from `80px` to `72px`.  
- Make segments non-interactive by removing the hover brightness effect and disabling pointer affordances, add a thin top distribution strip using `.stage-pipeline__seg::before`, and intensify per-bucket strip opacity with per-segment `::before` overrides.  
- Tweak typography: slightly quieter `.stage-pipeline__label` sizing/weight while keeping `.stage-pipeline__count` unchanged.

### Testing

- No automated unit or integration tests were executed for this UI-only change.  
- An automated headless UI capture attempt via Playwright failed with a connection error because the local app was not reachable (`ERR_EMPTY_RESPONSE`), so rendering verification was not performed.  
- Changes were applied to `Pages/Projects/Ongoing/Index.cshtml` and `wwwroot/css/site.css` and committed to the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dee03f01c8329968831c83c67e922)