### PR TITLE
Use short "Tender" label in stage distribution and remove label ellipsis

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -110,8 +110,8 @@
 
                         <div class="stage-pipeline__seg stage-pipeline__seg--proc"
                              style="--grow:@Model.BucketProcCount"
-                             title="GeM/Proc: BID, TEC, BM, COB, PNC, EAS, SO">
-                            <span class="stage-pipeline__label">Tendering</span>
+                             title="Tendering (GeM/Proc): BID, TEC, BM, COB, PNC, EAS, SO">
+                            <span class="stage-pipeline__label">Tender</span>
                             <span class="stage-pipeline__count">@Model.BucketProcCount</span>
                         </div>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8523,7 +8523,7 @@ body {
     padding: 0 0.7rem;
     flex-basis: 0;
     flex-grow: var(--grow);
-    min-width: 64px;
+    min-width: 56px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -8547,12 +8547,13 @@ body {
 }
 
 .stage-pipeline__label {
-    max-width: 86px;
+    /* SECTION: Stage pipeline label text */
+    max-width: none;
     font-size: 0.76rem;
     font-weight: 600;
     color: rgba(15, 23, 42, 0.55);
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: visible;
+    text-overflow: clip;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the third segment label from truncating to “Te…” while preserving the visual proportionality of the stage distribution and keeping full meaning available via tooltip.
- Avoid increasing global `min-width` which would flatten distribution proportions or cause overflow on small screens.

### Description
- Update `Pages/Projects/Ongoing/Index.cshtml` to show the short in-pill label `Tender` and set the full tooltip `title` to `Tendering (GeM/Proc): BID, TEC, BM, COB, PNC, EAS, SO` so the full meaning remains available.
- Adjust `wwwroot/css/site.css` to keep segments compact by reducing `.stage-pipeline__seg` `min-width` from `64px` to `56px` and remove label ellipsis by setting `.stage-pipeline__label` `max-width: none`, `overflow: visible`, and `text-overflow: clip` (plus a section comment).
- These changes preserve the `flex-grow` proportional sizing while preventing short labels from being truncated inside the pill.

### Testing
- No automated tests were run on these changes during this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e07b41a0483298b9dd064c0f3fe8d)