### PR TITLE
Polish Dashboard contrast and clarify Ops Signals tile interactions

### DIFF
--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -6,6 +6,17 @@
     --dashboard-gap-large: 1.5rem; /* 3 & 4 */
 }
 
+/* Dashboard-only elevation tuning: reduces washed-out feel */
+.dashboard .card {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard .card.shadow-sm {
+    /* override Bootstrap shadow-sm to match dashboard elevation */
+    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08) !important;
+}
+
 /* Base shell for dashboard cards to match Analytics polish */
 .dashboard-card-shell,
 .ppulse,
@@ -22,7 +33,14 @@
 
 /* Light, cool dashboard canvas behind the cards */
 .analytics-main {
-    background-color: var(--pm-page-bg);
+    background: linear-gradient(
+        180deg,
+        rgba(226, 232, 240, 0.55) 0%,
+        var(--pm-page-bg) 42%,
+        var(--pm-page-bg) 100%
+    );
+    min-height: 100vh;
+    padding: 24px;
 }
 /* END SECTION */
 

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -36,13 +36,13 @@
   flex-direction: column;
   gap: var(--ops-gap-xs);
   background-color: var(--pm-card);
-  border: 1px solid color-mix(in oklab, var(--pm-border-muted) 78%, black);
+  border: 1px solid rgba(15, 23, 42, 0.10);
   border-radius: 16px;
   padding: 1rem 1.1rem;
   color: inherit;
   text-decoration: none;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07);
-  transition: box-shadow 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+  transition: box-shadow 0.18s ease, border-color 0.18s ease, transform 0.18s ease, background 0.18s ease;
   min-height: 120px;
   position: relative;
   overflow: hidden;
@@ -53,32 +53,47 @@
   content: "";
   position: absolute;
   inset: 0 0 auto 0;
-  height: 46px;
+  height: 44px;
   background: linear-gradient(
-    180deg,
-    color-mix(in oklab, var(--pm-primary) 8%, white) 0%,
-    rgba(255, 255, 255, 0) 100%
+    90deg,
+    rgba(37, 99, 235, 0.10) 0%,
+    rgba(37, 99, 235, 0.04) 55%,
+    rgba(37, 99, 235, 0.00) 100%
   );
   pointer-events: none;
 }
 /* END SECTION */
 
-    .ops-signals__tile:hover {
-        /* Fallback for tools / old browsers */
-        border-color: var(--pm-primary);
-        /* Modern browsers */
-        border-color: color-mix(in oklab, var(--pm-primary) 26%, var(--pm-border-muted));
-        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.12);
-        transform: translateY(-1px);
-    }
+/* SECTION: Tile content layering */
+.ops-signals__head,
+.ops-signals__value,
+.ops-signals__caption,
+.ops-signals__spark,
+.ops-signals__delta {
+  position: relative;
+  z-index: 1;
+}
+/* END SECTION */
 
-    .ops-signals__tile:focus-visible {
-        /* Fallback */
-        outline: 3px solid var(--pm-primary);
-        /* Modern browsers */
-        outline: 3px solid color-mix(in oklab, var(--pm-primary) 52%, white);
-        outline-offset: 2px;
-    }
+/* SECTION: Tile interactions */
+.ops-signals__tile:hover {
+  border-color: rgba(37, 99, 235, 0.35);
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.10), 0 10px 22px rgba(37, 99, 235, 0.10);
+  transform: translateY(-2px);
+  background: rgba(248, 250, 252, 0.55);
+}
+
+.ops-signals__tile:active {
+  transform: translateY(0);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.10);
+}
+
+.ops-signals__tile:focus-visible {
+  outline: none;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.10), 0 0 0 4px rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+/* END SECTION */
 
 
 .ops-signals__head {


### PR DESCRIPTION
### Motivation

- Improve the Dashboard’s perceived contrast and reduce the “washed-out” look of cards without changing layout, data, or component contracts. 
- Make KPI (Ops Signals) tiles read as clearly interactive and keyboard-accessible so users perceive them as clickable anchors. 

### Description

- Updated `wwwroot/css/pages/dashboard.css` to add a subtle top-to-bottom gradient to `.analytics-main` and set `min-height`/`padding` to establish page canvas depth. 
- Added dashboard-scoped elevation tuning via `.dashboard .card` and `.dashboard .card.shadow-sm` to strengthen borders and shadows only on the Dashboard. 
- Updated `wwwroot/css/widgets/ops-signals.css` to replace the tile border with a stronger `rgba(15,23,42,0.10)`, add a header band using `::before`, and reduce the band `height` to `44px`. 
- Layered tile content (`.ops-signals__head`, `.ops-signals__value`, `.ops-signals__caption`, `.ops-signals__spark`, `.ops-signals__delta`) with `z-index` to ensure content sits above the band, and introduced improved hover, active, and `:focus-visible` states for clearer interactivity and keyboard focus. 

### Testing

- No automated tests were executed in this environment. 
- A smoke attempt to run the app with `dotnet run` was performed but failed because the `dotnet` runtime is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e23e9213c83299a6724bc1915342b)