### PR TITLE
Polish dashboard surfaces and fix grid semantics

### DIFF
--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -100,183 +100,185 @@
         </div>
     </div>
 
-    @* SECTION: Critical PDC alerts *@
-    @if (Model.HasMyProjects)
-    {
-        // Flatten all projects assigned to the user
-        var pdcProjects = Model.MyProjectSections
-        .SelectMany(projectSection => projectSection.Items)
-        .ToList();
-
-        // Buckets
-        var overdueProjects = pdcProjects
-        .Where(project => project.StageSummary?.IsOverdue == true)
-        .ToList();
-
-        var dueSoonProjects = pdcProjects
-        .Where(project => project.StageSummary is { IsOverdue: false, DaysToPdc: <= 30, PlannedDue: not null })
-        .ToList();
-
-        var notSetProjects = pdcProjects
-        .Where(project => project.StageSummary is null || project.StageSummary.PlannedDue is null)
-        .ToList();
-
-        if (overdueProjects.Any() || dueSoonProjects.Any() || notSetProjects.Any())
+    <div class="col-12">
+        @* SECTION: Critical PDC alerts *@
+        @if (Model.HasMyProjects)
         {
-            <div class="dashboard-my-projects__pdc-groups pm-scroll" role="list">
-                @* PDC overdue *@
-                @if (overdueProjects.Any())
-                {
-                    <div class="dashboard-my-projects__pdc-group">
-                        <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
-                            PDC overdue
-                        </p>
-                        <div class="dashboard-my-projects__pdc-list" role="list">
-                            @foreach (var project in overdueProjects)
-                            {
-                                var stage = project.StageSummary;
-                                <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
-                                    <a asp-page="/Projects/Overview"
-                                       asp-route-id="@project.ProjectId"
-                                       class="dashboard-my-projects__pdc-link">
-                                        <div class="myproj-stage-widget__pdc-main">
-                                            <div class="d-flex justify-content-between align-items-center mb-1">
-                                                <div class="dashboard-my-projects__pdc-name" title="@project.Name">
-                                                    @project.Name
-                                                </div>
-                                                <span class="badge rounded-pill text-bg-danger">
-                                                    PDC overdue
-                                                </span>
-                                            </div>
+            // Flatten all projects assigned to the user
+            var pdcProjects = Model.MyProjectSections
+            .SelectMany(projectSection => projectSection.Items)
+            .ToList();
 
-                                            <div class="small text-muted">
-                                                @if (stage is not null)
+            // Buckets
+            var overdueProjects = pdcProjects
+            .Where(project => project.StageSummary?.IsOverdue == true)
+            .ToList();
+
+            var dueSoonProjects = pdcProjects
+            .Where(project => project.StageSummary is { IsOverdue: false, DaysToPdc: <= 30, PlannedDue: not null })
+            .ToList();
+
+            var notSetProjects = pdcProjects
+            .Where(project => project.StageSummary is null || project.StageSummary.PlannedDue is null)
+            .ToList();
+
+            if (overdueProjects.Any() || dueSoonProjects.Any() || notSetProjects.Any())
+            {
+                <div class="dashboard-my-projects__pdc-groups pm-scroll" role="list">
+                    @* PDC overdue *@
+                    @if (overdueProjects.Any())
+                    {
+                        <div class="dashboard-my-projects__pdc-group">
+                            <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
+                                PDC overdue
+                            </p>
+                            <div class="dashboard-my-projects__pdc-list" role="list">
+                                @foreach (var project in overdueProjects)
+                                {
+                                    var stage = project.StageSummary;
+                                    <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
+                                        <a asp-page="/Projects/Overview"
+                                           asp-route-id="@project.ProjectId"
+                                           class="dashboard-my-projects__pdc-link">
+                                            <div class="myproj-stage-widget__pdc-main">
+                                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                                    <div class="dashboard-my-projects__pdc-name" title="@project.Name">
+                                                        @project.Name
+                                                    </div>
+                                                    <span class="badge rounded-pill text-bg-danger">
+                                                        PDC overdue
+                                                    </span>
+                                                </div>
+
+                                                <div class="small text-muted">
+                                                    @if (stage is not null)
+                                                    {
+                                                        @:Stage: @stage.StageName (@stage.StageCode)
+                                                    }
+                                                    else
+                                                    {
+                                                        <span>Stage data unavailable</span>
+                                                    }
+                                                </div>
+
+                                                @if (stage?.DaysToPdc is { } daysLate)
                                                 {
-                                                    @:Stage: @stage.StageName (@stage.StageCode)
-                                                }
-                                                else
-                                                {
-                                                    <span>Stage data unavailable</span>
+                                                    <div class="small text-danger mt-1">
+                                                        Overdue by @daysLate day@(daysLate == 1 ? string.Empty : "s")
+                                                    </div>
                                                 }
                                             </div>
-
-                                            @if (stage?.DaysToPdc is { } daysLate)
-                                            {
-                                                <div class="small text-danger mt-1">
-                                                    Overdue by @daysLate day@(daysLate == 1 ? string.Empty : "s")
-                                                </div>
-                                            }
-                                        </div>
-                                    </a>
-                                </div>
-                            }
+                                        </a>
+                                    </div>
+                                }
+                            </div>
                         </div>
-                    </div>
-                }
+                    }
 
-                @* PDC in next 30 days *@
-                @if (dueSoonProjects.Any())
-                {
-                    <div class="dashboard-my-projects__pdc-group">
-                        <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
-                            PDC in next 30 days
-                        </p>
-                        <div class="dashboard-my-projects__pdc-list" role="list">
-                            @foreach (var project in dueSoonProjects)
-                            {
-                                var stage = project.StageSummary;
-                                <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
-                                    <a asp-page="/Projects/Overview"
-                                       asp-route-id="@project.ProjectId"
-                                       class="dashboard-my-projects__pdc-link">
-                                        <div class="myproj-stage-widget__pdc-main">
-                                            <div class="d-flex justify-content-between align-items-center mb-1">
-                                                <div class="dashboard-my-projects__pdc-name" title="@project.Name">
-                                                    @project.Name
+                    @* PDC in next 30 days *@
+                    @if (dueSoonProjects.Any())
+                    {
+                        <div class="dashboard-my-projects__pdc-group">
+                            <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
+                                PDC in next 30 days
+                            </p>
+                            <div class="dashboard-my-projects__pdc-list" role="list">
+                                @foreach (var project in dueSoonProjects)
+                                {
+                                    var stage = project.StageSummary;
+                                    <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
+                                        <a asp-page="/Projects/Overview"
+                                           asp-route-id="@project.ProjectId"
+                                           class="dashboard-my-projects__pdc-link">
+                                            <div class="myproj-stage-widget__pdc-main">
+                                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                                    <div class="dashboard-my-projects__pdc-name" title="@project.Name">
+                                                        @project.Name
+                                                    </div>
+                                                    <span class="badge rounded-pill text-bg-success">
+                                                        PDC in next 30 days
+                                                    </span>
                                                 </div>
-                                                <span class="badge rounded-pill text-bg-success">
-                                                    PDC in next 30 days
-                                                </span>
-                                            </div>
 
-                                            <div class="small text-muted">
-                                                @if (stage is not null)
-                                                {
-                                                    @:Stage: @stage.StageName (@stage.StageCode)
-                                                }
-                                                else
-                                                {
-                                                    <span>Stage data unavailable</span>
-                                                }
-                                            </div>
-
-                                            @if (stage?.DaysToPdc is { } daysToGo)
-                                            {
-                                                <div class="small text-success mt-1">
-                                                    @daysToGo day@(daysToGo == 1 ? string.Empty : "s") to PDC
+                                                <div class="small text-muted">
+                                                    @if (stage is not null)
+                                                    {
+                                                        @:Stage: @stage.StageName (@stage.StageCode)
+                                                    }
+                                                    else
+                                                    {
+                                                        <span>Stage data unavailable</span>
+                                                    }
                                                 </div>
-                                            }
-                                        </div>
-                                    </a>
-                                </div>
-                            }
+
+                                                @if (stage?.DaysToPdc is { } daysToGo)
+                                                {
+                                                    <div class="small text-success mt-1">
+                                                        @daysToGo day@(daysToGo == 1 ? string.Empty : "s") to PDC
+                                                    </div>
+                                                }
+                                            </div>
+                                        </a>
+                                    </div>
+                                }
+                            </div>
                         </div>
-                    </div>
-                }
+                    }
 
-                @* PDC not set *@
-                @if (notSetProjects.Any())
-                {
-                    <div class="dashboard-my-projects__pdc-group">
-                        <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
-                            PDC not set
-                        </p>
-                        <div class="dashboard-my-projects__pdc-list" role="list">
-                            @foreach (var project in notSetProjects)
-                            {
-                                var stage = project.StageSummary;
-                                <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
-                                    <a asp-page="/Projects/Overview"
-                                       asp-route-id="@project.ProjectId"
-                                       class="dashboard-my-projects__pdc-link">
-                                        <div class="myproj-stage-widget__pdc-main">
-                                            <div class="d-flex justify-content-between align-items-center mb-1">
-                                                <div class="dashboard-my-projects__pdc-name" title="@project.Name">
-                                                    @project.Name
+                    @* PDC not set *@
+                    @if (notSetProjects.Any())
+                    {
+                        <div class="dashboard-my-projects__pdc-group">
+                            <p class="dashboard-my-projects__pdc-group-title text-uppercase text-secondary fw-semibold small mb-2">
+                                PDC not set
+                            </p>
+                            <div class="dashboard-my-projects__pdc-list" role="list">
+                                @foreach (var project in notSetProjects)
+                                {
+                                    var stage = project.StageSummary;
+                                    <div class="myproj-stage-widget__pdc-row" data-project-id="@project.ProjectId" role="listitem">
+                                        <a asp-page="/Projects/Overview"
+                                           asp-route-id="@project.ProjectId"
+                                           class="dashboard-my-projects__pdc-link">
+                                            <div class="myproj-stage-widget__pdc-main">
+                                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                                    <div class="dashboard-my-projects__pdc-name" title="@project.Name">
+                                                        @project.Name
+                                                    </div>
+                                                    <span class="badge rounded-pill text-bg-secondary">
+                                                        PDC not set
+                                                    </span>
                                                 </div>
-                                                <span class="badge rounded-pill text-bg-secondary">
-                                                    PDC not set
-                                                </span>
-                                            </div>
 
-                                            <div class="small text-muted">
-                                                @if (stage is not null)
-                                                {
-                                                    @:Stage: @stage.StageName (@stage.StageCode)
-                                                }
-                                                else
-                                                {
-                                                    <span>Stage data unavailable</span>
-                                                }
+                                                <div class="small text-muted">
+                                                    @if (stage is not null)
+                                                    {
+                                                        @:Stage: @stage.StageName (@stage.StageCode)
+                                                    }
+                                                    else
+                                                    {
+                                                        <span>Stage data unavailable</span>
+                                                    }
+                                                </div>
                                             </div>
-                                        </div>
-                                    </a>
-                                </div>
-                            }
+                                        </a>
+                                    </div>
+                                }
+                            </div>
                         </div>
-                    </div>
-                }
-            </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <p class="text-secondary small mb-0">No critical PDC alerts right now.</p>
+            }
         }
         else
         {
-            <p class="text-secondary small mb-0">No critical PDC alerts right now.</p>
+            <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
         }
-    }
-    else
-    {
-        <p class="text-secondary small mb-0">Add yourself to a project to see its PDC.</p>
-    }
+    </div>
 
 
 <div class="pm-drawer pm-drawer--end"

--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -31,6 +31,32 @@
     box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
+/* SECTION: Dashboard section & card hierarchy */
+.dashboard-main-content {
+    background: var(--pm-page-bg);
+    padding: 1.25rem 1.25rem 2rem;
+    border-radius: 1.5rem;
+    box-shadow: var(--pm-shadow);
+}
+
+.dashboard-section {
+    border-radius: 1.5rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(148, 163, 184, 0.08);
+    padding: 1.25rem;
+    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.08);
+    margin-bottom: 1.5rem;
+}
+
+.dashboard-card {
+    border-radius: 1.25rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+    background: var(--pm-card);
+}
+/* END SECTION */
+
 /* Light, cool dashboard canvas behind the cards */
 .analytics-main {
     background: linear-gradient(
@@ -523,112 +549,6 @@
     border-color: rgba(37, 99, 235, 0.7);
     background: rgba(37, 99, 235, 0.06);
 }
-
-/* My projects PDC groups */
-.dashboard-my-projects__pdc-groups {
-    margin-top: 0.25rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    max-height: none !important; /* override pm-scroll */
-    overflow-y: visible !important; /* override pm-scroll */
-}
-
-.dashboard-my-projects__pdc-group-title {
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--pm-text-secondary);
-}
-
-/* 2-column grid of PDC cards */
-.dashboard-my-projects__pdc-list {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-}
-
-/* Collapse to 1 column on smaller viewports */
-@media (max-width: 991.98px) {
-    .dashboard-my-projects__pdc-list {
-        grid-template-columns: 1fr;
-    }
-}
-
-/* PDC alert rows – white cards */
-.myproj-stage-widget__pdc-row {
-    background-color: var(--pm-card);
-    border-radius: 1rem;
-    border: 1px solid var(--pm-border-muted);
-    padding: 0.75rem 1rem;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
-    transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.10s ease;
-}
-
-    .myproj-stage-widget__pdc-row:hover,
-    .myproj-stage-widget__pdc-row:focus-within {
-        background-color: rgba(37, 99, 235, 0.02);
-        box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
-        transform: translateY(-1px);
-    }
-
-/* Make the whole card clickable; no extra grey background */
-.dashboard-my-projects__pdc-link {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.6rem;
-    text-decoration: none;
-    color: inherit;
-    background: transparent;
-    box-shadow: none;
-    padding: 0;
-}
-
-.dashboard-my-projects__pdc-text {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-}
-
-.dashboard-my-projects__pdc-name {
-    font-size: 0.9rem;
-    font-weight: 600;
-    line-height: 1.3;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
-.dashboard-my-projects__pdc-stage {
-    font-size: 0.78rem;
-    color: var(--pm-text-muted);
-}
-
-.dashboard-my-projects__pdc-meta {
-    flex-shrink: 0;
-    text-align: right;
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-    white-space: nowrap;
-}
-
-    .dashboard-my-projects__pdc-meta .badge {
-        font-size: 0.7rem;
-    }
-
-/* Active row highlight (optional) */
-.myproj-stage-widget__pdc-row.is-active {
-    border-color: rgba(37, 99, 235, 0.65);
-}
-
-    .myproj-stage-widget__pdc-row.is-active .dashboard-my-projects__pdc-name {
-        font-weight: 600;
-    }
 
 /* Responsive header tweaks */
 @media (max-width: 576px) {

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -31,6 +31,8 @@
 /* END SECTION */
 
 /* SECTION: Tile styles */
+/* SECTION: Clickable tile base */
+.ops-signal__item,
 .ops-signals__tile {
   display: flex;
   flex-direction: column;
@@ -47,6 +49,7 @@
   position: relative;
   overflow: hidden;
 }
+/* END SECTION */
 
 /* SECTION: Tile surface accent */
 .ops-signals__tile::before {
@@ -76,9 +79,12 @@
 /* END SECTION */
 
 /* SECTION: Tile interactions */
-.ops-signals__tile:hover {
-  border-color: rgba(37, 99, 235, 0.35);
-  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.10), 0 10px 22px rgba(37, 99, 235, 0.10);
+.ops-signal__item:hover,
+.ops-signal__item:focus-within,
+.ops-signals__tile:hover,
+.ops-signals__tile:focus-within {
+  border-color: rgba(45, 108, 223, 0.35);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
   transform: translateY(-2px);
   background: rgba(248, 250, 252, 0.55);
 }


### PR DESCRIPTION
### Motivation
- Fix a Bootstrap grid violation in the Dashboard where a non-`col-*` element was a direct child of `.row`, which can cause alignment/gutter issues. 
- Improve the dashboard’s perceived contrast and visual hierarchy to remove a washed-out feel without changing the global theme. 
- Consolidate duplicated PDC widget CSS to reduce maintenance overhead and ensure a single authoritative style. 
- Make KPI tiles’ interactive affordance clearer so clickable tiles communicate intent.

### Description
- Wrapped the PDC alerts block in a full-width column by adding a surrounding `<div class="col-12">` in `Pages/Dashboard/Index.cshtml` so all `.row` children follow Bootstrap’s grid semantics. 
- Reworked Dashboard-only surface and card hierarchy in `wwwroot/css/pages/dashboard.css` by adding `dashboard-main-content`, `dashboard-section`, and `dashboard-card` styles to use a solid grounding surface, stronger borders, and slightly heavier shadows. 
- Removed duplicate/earlier PDC CSS and kept the later “PDC widget refinements” block as the single authoritative definition for selectors such as `.dashboard-my-projects__pdc-groups`, `.dashboard-my-projects__pdc-list`, `.myproj-stage-widget__pdc-row`, `.dashboard-my-projects__pdc-link`, `.dashboard-my-projects__pdc-name`, and related selectors. 
- Strengthened OpsSignals tile interaction rules and added a short clickable-tile helper in `wwwroot/css/widgets/ops-signals.css` by including `.ops-signal__item` and tightening hover/focus styles to `transform: translateY(-2px)`, stronger `box-shadow`, and clearer `border-color` on hover/focus. 
- Small organizational CSS comments/section headers were added to make the dashboard rules easier to find and maintain.

### Testing
- Verified file edits and staged changes via `git status` and created a commit; commit completed successfully. 
- Ran text searches (`rg`) to confirm PDC selectors appear only in the consolidated block and that `dashboard-main-content`/`dashboard-section` rules exist; search checks succeeded. 
- Attempted to run the web app with `dotnet run --project ProjectManagement.csproj` to validate visual results, but `dotnet` is not available in this environment so the app could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2ac6ac3c8329af66fefa0aecfaf3)