### PR TITLE
Flatten dashboard card elevation layers

### DIFF
--- a/Pages/Dashboard/Partials/_SearchHealthWidget.cshtml
+++ b/Pages/Dashboard/Partials/_SearchHealthWidget.cshtml
@@ -24,7 +24,7 @@
     // END SECTION
 }
 
-<div class="card shadow-sm search-health-card dashboard-ocr-card">
+<div class="card search-health-card dashboard-ocr-card">
     <div class="card-body p-3 p-lg-4 search-health-card__body">
 
         @* SECTION: Header *@

--- a/Pages/Shared/_TodoWidget.cshtml
+++ b/Pages/Shared/_TodoWidget.cshtml
@@ -50,7 +50,7 @@
     if (nextSevenCount == 0) nextChipClass += " todo-filter-pill--muted";
 }
 
-<div class="card shadow-sm todo-widget dashboard-todo-card@attentionClass">
+<div class="card todo-widget dashboard-todo-card@attentionClass">
     <div class="card-header mission-panel__header d-flex flex-wrap align-items-center justify-content-between gap-3 py-2">
         <div class="d-flex flex-column gap-1">
             <div class="d-flex flex-wrap align-items-center gap-3">

--- a/wwwroot/css/pages/dashboard.css
+++ b/wwwroot/css/pages/dashboard.css
@@ -8,13 +8,12 @@
 
 /* Dashboard-only elevation tuning: reduces washed-out feel */
 .dashboard .card {
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--pm-border);
+    box-shadow: var(--pm-shadow);
 }
 
-.dashboard .card.shadow-sm {
-    /* override Bootstrap shadow-sm to match dashboard elevation */
-    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08) !important;
+.dashboard .card:hover {
+    transform: translateY(-1px);
 }
 
 /* Base shell for dashboard cards to match Analytics polish */
@@ -33,19 +32,21 @@
 
 /* SECTION: Dashboard section & card hierarchy */
 .dashboard-main-content {
-    background: var(--pm-page-bg);
-    padding: 1.25rem 1.25rem 2rem;
-    border-radius: 1.5rem;
-    box-shadow: var(--pm-shadow);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    overflow: visible;
 }
 
 .dashboard-section {
-    border-radius: 1.5rem;
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    background: rgba(148, 163, 184, 0.08);
-    padding: 1.25rem;
-    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.08);
-    margin-bottom: 1.5rem;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    overflow: visible;
 }
 
 .dashboard-card {

--- a/wwwroot/css/todo-widget.css
+++ b/wwwroot/css/todo-widget.css
@@ -2,7 +2,7 @@
 .todo-widget {
     --mission-panel-surface: var(--pm-surface-elevated);
     --mission-panel-border: var(--pm-border-muted);
-    --mission-panel-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+    --mission-panel-shadow: var(--pm-shadow);
     --mission-panel-header-bg: linear-gradient(135deg, rgba(13, 110, 253, .08), rgba(25, 135, 84, .05));
     --mission-panel-ring-fill: var(--pm-primary-strong);
     --mission-panel-ring-track: rgba(13, 110, 253, .18);

--- a/wwwroot/css/widgets/ops-signals.css
+++ b/wwwroot/css/widgets/ops-signals.css
@@ -43,7 +43,7 @@
   padding: 1rem 1.1rem;
   color: inherit;
   text-decoration: none;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.07);
+  box-shadow: var(--pm-shadow);
   transition: box-shadow 0.18s ease, border-color 0.18s ease, transform 0.18s ease, background 0.18s ease;
   min-height: 120px;
   position: relative;

--- a/wwwroot/css/widgets/project-pulse.css
+++ b/wwwroot/css/widgets/project-pulse.css
@@ -7,7 +7,7 @@
   --pp-border: var(--pm-border-muted, var(--pm-border));
   background-color: var(--pm-card);
   border-radius: 18px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  box-shadow: var(--pm-shadow);
   padding: 1rem 1.25rem 0.9rem;
   border: 1px solid var(--pp-border);
 }
@@ -135,8 +135,8 @@
 .ppulse__card {
   background: transparent;
   border-radius: 14px;
-  border: 1px solid color-mix(in oklab, var(--pp-border) 55%, white);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
+  border: 1px solid var(--pm-border);
+  box-shadow: none;
 }
 
 .ppulse__link {


### PR DESCRIPTION
### Motivation
- The dashboard had multiple overlapping elevation layers causing a nested-card, washed-out appearance due to wrapper shells and dashboard-scoped card overrides.
- Widgets also applied their own shadows inconsistently instead of using the app design tokens, creating visual noise and stacked shadows.
- The goal is to ensure a single elevation per visible surface and to make shadows token-driven and consistent.

### Description
- Neutralized visual chrome on the structural wrappers by making `dashboard-main-content` and `dashboard-section` transparent and removing their borders and shadows in `wwwroot/css/pages/dashboard.css`.
- Replaced the dashboard-wide hard-coded shadow with tokenized styling by changing `.dashboard .card` to use `--pm-border` and `--pm-shadow` and added a subtle hover lift via `.dashboard .card:hover` in `wwwroot/css/pages/dashboard.css`.
- Flattened Project Pulse surfaces by switching the outer wrapper to `box-shadow: var(--pm-shadow)` and removing the inner `.ppulse__card` shadow in `wwwroot/css/widgets/project-pulse.css` so the component is a single elevated surface.
- Standardized Ops Signals tiles to use `box-shadow: var(--pm-shadow)` instead of hard-coded shadows in `wwwroot/css/widgets/ops-signals.css` so individual tiles control elevation consistently.
- Normalized the To-Do widget to use the tokenized shadow (`--pm-shadow`) in `wwwroot/css/todo-widget.css` and removed `shadow-sm` from the dashboard To-Do and Search Health wrappers by editing `Pages/Shared/_TodoWidget.cshtml` and `Pages/Dashboard/Partials/_SearchHealthWidget.cshtml` respectively, preventing stacked shadows.

### Testing
- Attempted to run the app with `dotnet run` to visually validate changes but the `dotnet` CLI is not available in this environment, so the app could not be started and no visual test was executed (failed).
- No automated unit or integration tests were run in this environment after the changes.
- Local repository inspections (`sed`, `rg`, `git status`) and file modifications were performed and the changes were committed successfully as `Flatten dashboard card elevation`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e33b6983c8329b50299ca428d0991)