### PR TITLE
Harden proliferation report filters, suggestions and Excel export

### DIFF
--- a/Areas/ProjectOfficeReports/Api/ProliferationController.cs
+++ b/Areas/ProjectOfficeReports/Api/ProliferationController.cs
@@ -271,10 +271,10 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Api
 
             if (!string.IsNullOrWhiteSpace(q))
             {
-                var term = $"%{q.Trim()}%";
+                var term = $"%{EscapeLikePattern(q.Trim())}%";
                 projects = projects.Where(p =>
-                    EF.Functions.ILike(p.Name, term) ||
-                    (p.CaseFileNumber != null && EF.Functions.ILike(p.CaseFileNumber, term)));
+                    EF.Functions.ILike(p.Name, term, "\\") ||
+                    (p.CaseFileNumber != null && EF.Functions.ILike(p.CaseFileNumber, term, "\\")));
             }
 
             var results = await projects
@@ -949,6 +949,15 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Api
 
             var escaped = value.Replace("\"", "\"\"");
             return $"\"{escaped}\"";
+        }
+
+        // SECTION: Search helpers
+        private static string EscapeLikePattern(string value)
+        {
+            return value
+                .Replace("\\", "\\\\", StringComparison.Ordinal)
+                .Replace("%", "\\%", StringComparison.Ordinal)
+                .Replace("_", "\\_", StringComparison.Ordinal);
         }
 
         // SECTION: Manage list helpers

--- a/ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs
+++ b/ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Areas.ProjectOfficeReports.Api;
+using ProjectManagement.Areas.ProjectOfficeReports.Application;
+using ProjectManagement.Areas.ProjectOfficeReports.Domain;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Utilities.Reporting;
+using Xunit;
+
+namespace ProjectManagement.Tests
+{
+    // SECTION: Proliferation report export tests
+    public sealed class ProliferationReportsServiceExportTests
+    {
+        [Fact]
+        public async Task ExportAsync_GranularLedger_WritesTypedDateAndNumberAndFriendlyFilters()
+        {
+            // SECTION: Arrange
+            using var context = CreateContext();
+
+            var projectCategory = new ProjectCategory
+            {
+                Id = 1,
+                Name = "Readiness",
+                SortOrder = 1,
+                IsActive = true,
+                CreatedByUserId = "seed",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var technicalCategory = new TechnicalCategory
+            {
+                Id = 7,
+                Name = "Simulation",
+                SortOrder = 1,
+                IsActive = true,
+                CreatedByUserId = "seed",
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var project = new Project
+            {
+                Id = 42,
+                Name = "Simulator Expansion",
+                CaseFileNumber = "SIM-042",
+                CreatedByUserId = "seed",
+                LifecycleStatus = ProjectLifecycleStatus.Completed,
+                CategoryId = projectCategory.Id,
+                TechnicalCategoryId = technicalCategory.Id
+            };
+
+            var granular = new ProliferationGranular
+            {
+                Id = Guid.NewGuid(),
+                ProjectId = project.Id,
+                Source = ProliferationSource.Sdd,
+                UnitName = "Alpha",
+                ProliferationDate = new DateOnly(2024, 3, 15),
+                Quantity = 70,
+                ApprovalStatus = ApprovalStatus.Approved,
+                SubmittedByUserId = "seed",
+                CreatedOnUtc = DateTime.UtcNow,
+                LastUpdatedOnUtc = DateTime.UtcNow,
+                RowVersion = Guid.NewGuid().ToByteArray()
+            };
+
+            context.ProjectCategories.Add(projectCategory);
+            context.TechnicalCategories.Add(technicalCategory);
+            context.Projects.Add(project);
+            context.ProliferationGranularEntries.Add(granular);
+            await context.SaveChangesAsync();
+
+            var service = new ProliferationReportsService(context, new ProliferationReportExcelWorkbookBuilder());
+
+            // SECTION: Act
+            var (contentBytes, fileName) = await service.ExportAsync(new ProliferationReportQueryDto
+            {
+                Report = ProliferationReportKind.GranularLedger,
+                Source = ProliferationSource.Sdd,
+                ProjectId = project.Id,
+                ProjectCategoryId = projectCategory.Id,
+                TechnicalCategoryId = technicalCategory.Id,
+                FromDateUtc = new DateTime(2024, 1, 1),
+                ToDateUtc = new DateTime(2024, 12, 31),
+                ApprovalStatus = "Approved",
+                Page = 1,
+                PageSize = 50
+            }, CancellationToken.None);
+
+            // SECTION: Assert (file)
+            Assert.NotNull(contentBytes);
+            Assert.NotEmpty(contentBytes);
+            Assert.EndsWith(".xlsx", fileName, StringComparison.OrdinalIgnoreCase);
+
+            using var stream = new MemoryStream(contentBytes);
+            using var workbook = new XLWorkbook(stream);
+            var sheet = workbook.Worksheet("Report");
+
+            // SECTION: Assert (filters)
+            Assert.Equal("Readiness", FindFilterValue(sheet, "Project category"));
+            Assert.Equal("Simulation", FindFilterValue(sheet, "Technical category"));
+            Assert.Equal("Simulator Expansion (SIM-042)", FindFilterValue(sheet, "Project"));
+            Assert.Equal("SDD", FindFilterValue(sheet, "Source"));
+
+            // SECTION: Assert (typed cells)
+            var headerRow = FindHeaderRow(sheet, "Project", "Proliferation date");
+            Assert.True(headerRow > 0);
+
+            var dataRow = headerRow + 1;
+
+            Assert.Equal("Simulator Expansion", sheet.Cell(dataRow, 1).GetString());
+            Assert.Equal("SIM-042", sheet.Cell(dataRow, 2).GetString());
+            Assert.Equal("SDD", sheet.Cell(dataRow, 3).GetString());
+
+            Assert.Equal(new DateTime(2024, 3, 15), sheet.Cell(dataRow, 4).GetDateTime().Date);
+            Assert.Equal("Alpha", sheet.Cell(dataRow, 5).GetString());
+            Assert.Equal(70, sheet.Cell(dataRow, 6).GetValue<int>());
+            Assert.Equal("Approved", sheet.Cell(dataRow, 8).GetString());
+        }
+
+        // SECTION: Helpers
+        private static string FindFilterValue(IXLWorksheet sheet, string key)
+        {
+            for (var r = 4; r <= 50; r++)
+            {
+                if (sheet.Cell(r, 1).GetString().Equals(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    return sheet.Cell(r, 2).GetString();
+                }
+            }
+            return string.Empty;
+        }
+
+        private static int FindHeaderRow(IXLWorksheet sheet, string col1, string col4)
+        {
+            for (var r = 1; r <= 80; r++)
+            {
+                if (sheet.Cell(r, 1).GetString() == col1 && sheet.Cell(r, 4).GetString() == col4)
+                {
+                    return r;
+                }
+            }
+            return 0;
+        }
+
+        private static ApplicationDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            return new ApplicationDbContext(options);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Fix UX and correctness issues where project suggestions ignored selected category filters and report exports could become stale or mismatched. 
- Prevent LIKE-wildcard injection from user input and make unit filtering behave consistently with suggestions. 
- Validate date ranges to avoid confusing empty results and improve exported workbook usability by preserving typed dates and numbers. 

### Description

- Client-side: add `invalidateResults()` and wire filter change handlers to clear results, reset paging, disable export until rerun, clear selected project when categories change, send `projectCategoryId` and `technicalCategoryId` to project suggestions, and validate `From`/`To` before running the report in `wwwroot/js/pages/proliferation-reports.js`. 
- API/controller: add `EscapeLikePattern` helper and use `EF.Functions.ILike(..., "\\")` with escaped patterns for project lookups in `Areas/ProjectOfficeReports/Api/ProliferationController.cs`. 
- Service: add `EscapeLikePattern`, switch unit suggestions and unit filter to escaped case-insensitive "contains" queries, enforce server-side From/To validation (except `YearlyReconciliation`), produce friendly filter labels for export, and return typed `DateTime?`/numeric values from `RowToDictionary` in `Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs`. 
- Excel export: replace builder to write real Excel date and numeric cells, freeze header row, enable AutoFilter and performant autosizing in `Utilities/Reporting/ProliferationReportExcelWorkbookBuilder.cs`. 
- Tests: add `ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs` to assert friendly filter labels and that exported workbook contains typed date and numeric cells. 

### Testing

- Added an automated unit test `ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs` that verifies friendly filters and typed date/number cells in the exported workbook, but no tests were executed in this change. 
- No automated test runs or CI jobs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ead16e75c8329a09813645d80e11c)