### PR TITLE
Fix numeric assignments for ClosedXML cells

### DIFF
--- a/Utilities/Reporting/ProliferationReportExcelWorkbookBuilder.cs
+++ b/Utilities/Reporting/ProliferationReportExcelWorkbookBuilder.cs
@@ -89,8 +89,62 @@ namespace ProjectManagement.Utilities.Reporting
                             }
                             break;
 
-                        case int or long or short or byte or decimal or double or float:
-                            cell.Value = value;
+                        case int intValue:
+                            cell.Value = intValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case long longValue:
+                            cell.Value = longValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case short shortValue:
+                            cell.Value = shortValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case byte byteValue:
+                            cell.Value = byteValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case decimal decimalValue:
+                            cell.Value = decimalValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case double doubleValue:
+                            cell.Value = doubleValue;
+                            if (!numberFormatted[i])
+                            {
+                                sheet.Column(i + 1).Style.NumberFormat.Format = "0";
+                                numberFormatted[i] = true;
+                            }
+                            break;
+
+                        case float floatValue:
+                            cell.Value = floatValue;
                             if (!numberFormatted[i])
                             {
                                 sheet.Column(i + 1).Style.NumberFormat.Format = "0";


### PR DESCRIPTION
### Motivation
- Resolve the CS0266 implicit conversion error when assigning boxed numeric `object` values to ClosedXML cell values by providing explicit, typed assignments and maintaining column number formatting.

### Description
- Replace the combined numeric pattern `case int or long or short or byte or decimal or double or float` with individual typed `case` arms for `int`, `long`, `short`, `byte`, `decimal`, `double`, and `float` in `Utilities/Reporting/ProliferationReportExcelWorkbookBuilder.cs`.
- Assign the typed value into the cell (e.g. `cell.Value = intValue`) instead of assigning the boxed `object`, avoiding implicit conversion issues.
- Preserve per-column number-formatting behavior by applying the `"0"` number format the first time a numeric type is seen for that column.
- Keep existing handling for `DateTime`, `DateTimeOffset`, `bool`, `null`, and default `ToString()` behavior unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eaf334da88329a295d8740c189da6)