### PR TITLE
Proliferation reports: remove Code column, make ProjectToUnits optional, add Manage actions

### DIFF
--- a/Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs
+++ b/Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs
@@ -128,7 +128,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
             return new Dictionary<string, object?>
             {
                 ["projectName"] = r.ProjectName,
-                ["projectCode"] = r.ProjectCode,
                 ["sourceLabel"] = r.SourceLabel,
                 ["unitName"] = r.UnitName,
                 ["proliferationDate"] = r.ProliferationDateUtc?.Date,
@@ -276,11 +275,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
             int pageSize,
             CancellationToken ct)
         {
-            if (!q.ProjectId.HasValue)
-            {
-                return Empty(q.Report, ProjectToUnitsColumns(), page, pageSize);
-            }
-
             var projects = EligibleProjectsQuery(q.ProjectCategoryId, q.TechnicalCategoryId);
 
             var baseQuery = from g in GranularBase(q, fromDate, toDate, statusFilter)
@@ -672,7 +666,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
         private static IReadOnlyList<ProliferationReportColumnDto> ProjectToUnitsColumns() => new[]
         {
             Col("projectName", "Project"),
-            Col("projectCode", "Code"),
             Col("sourceLabel", "Source"),
             Col("unitName", "Unit"),
             Col("proliferationDate", "Proliferation date"),
@@ -686,7 +679,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
         {
             Col("unitName", "Unit"),
             Col("projectName", "Project"),
-            Col("projectCode", "Code"),
             Col("sourceLabel", "Source"),
             Col("proliferationDate", "Proliferation date"),
             Col("year", "Year"),
@@ -698,7 +690,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
         private static IReadOnlyList<ProliferationReportColumnDto> ProjectCoverageColumns() => new[]
         {
             Col("projectName", "Project"),
-            Col("projectCode", "Code"),
             Col("sourceLabel", "Source"),
             Col("totalQuantity", "Total quantity"),
             Col("uniqueUnits", "Unique units"),
@@ -709,7 +700,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
         private static IReadOnlyList<ProliferationReportColumnDto> GranularLedgerColumns() => new[]
         {
             Col("projectName", "Project"),
-            Col("projectCode", "Code"),
             Col("sourceLabel", "Source"),
             Col("proliferationDate", "Proliferation date"),
             Col("unitName", "Unit"),
@@ -721,7 +711,6 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
         private static IReadOnlyList<ProliferationReportColumnDto> YearlyReconciliationColumns() => new[]
         {
             Col("projectName", "Project"),
-            Col("projectCode", "Code"),
             Col("sourceLabel", "Source"),
             Col("year", "Year"),
             Col("yearlyApprovedTotal", "Yearly approved total"),

--- a/Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml
@@ -4,7 +4,9 @@
     ViewData["Title"] = "Proliferation reports";
 }
 
-<div class="container-fluid mt-3" data-page="proliferation-reports">
+<div class="container-fluid mt-3"
+     data-page="proliferation-reports"
+     data-can-manage-records="@(Model.CanManageRecords ? "true" : "false")">
     <!-- SECTION: Header -->
     <div class="d-flex align-items-center justify-content-between mb-3">
         <div>
@@ -17,6 +19,11 @@
             <div class="text-muted">Generate unit-wise and project-wise reports from granular proliferation data.</div>
         </div>
         <div class="d-flex gap-2">
+            @if (Model.CanManageRecords)
+            {
+                <!-- SECTION: Manage -->
+                <a class="btn btn-outline-primary" asp-area="ProjectOfficeReports" asp-page="/Proliferation/Manage">Manage proliferation</a>
+            }
             <a class="btn btn-outline-secondary" asp-area="ProjectOfficeReports" asp-page="/Proliferation/Summary">Back to summary</a>
         </div>
     </div>

--- a/Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Areas.ProjectOfficeReports.Application;
@@ -8,8 +11,22 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Pages.Proliferation
     [Authorize(Policy = ProjectOfficeReportsPolicies.ViewProliferationTracker)]
     public sealed class ReportsModel : PageModel
     {
-        public void OnGet()
+        private readonly IAuthorizationService _authorizationService;
+
+        public ReportsModel(IAuthorizationService authorizationService)
         {
+            _authorizationService = authorizationService ?? throw new ArgumentNullException(nameof(authorizationService));
+        }
+
+        public bool CanManageRecords { get; private set; }
+
+        public async Task OnGetAsync(CancellationToken cancellationToken)
+        {
+            var submitResult = await _authorizationService.AuthorizeAsync(
+                User,
+                resource: null,
+                ProjectOfficeReportsPolicies.SubmitProliferationTracker);
+            CanManageRecords = submitResult.Succeeded;
         }
     }
 }

--- a/ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs
+++ b/ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs
@@ -114,13 +114,12 @@ namespace ProjectManagement.Tests
             var dataRow = headerRow + 1;
 
             Assert.Equal("Simulator Expansion", sheet.Cell(dataRow, 1).GetString());
-            Assert.Equal("SIM-042", sheet.Cell(dataRow, 2).GetString());
-            Assert.Equal("SDD", sheet.Cell(dataRow, 3).GetString());
+            Assert.Equal("SDD", sheet.Cell(dataRow, 2).GetString());
 
-            Assert.Equal(new DateTime(2024, 3, 15), sheet.Cell(dataRow, 4).GetDateTime().Date);
-            Assert.Equal("Alpha", sheet.Cell(dataRow, 5).GetString());
-            Assert.Equal(70, sheet.Cell(dataRow, 6).GetValue<int>());
-            Assert.Equal("Approved", sheet.Cell(dataRow, 8).GetString());
+            Assert.Equal(new DateTime(2024, 3, 15), sheet.Cell(dataRow, 3).GetDateTime().Date);
+            Assert.Equal("Alpha", sheet.Cell(dataRow, 4).GetString());
+            Assert.Equal(70, sheet.Cell(dataRow, 5).GetValue<int>());
+            Assert.Equal("Approved", sheet.Cell(dataRow, 7).GetString());
         }
 
         // SECTION: Helpers
@@ -136,11 +135,11 @@ namespace ProjectManagement.Tests
             return string.Empty;
         }
 
-        private static int FindHeaderRow(IXLWorksheet sheet, string col1, string col4)
+        private static int FindHeaderRow(IXLWorksheet sheet, string col1, string col3)
         {
             for (var r = 1; r <= 80; r++)
             {
-                if (sheet.Cell(r, 1).GetString() == col1 && sheet.Cell(r, 4).GetString() == col4)
+                if (sheet.Cell(r, 1).GetString() == col1 && sheet.Cell(r, 3).GetString() == col3)
                 {
                     return r;
                 }


### PR DESCRIPTION
### Motivation

- Remove the redundant “Code” column from all proliferation report tables and Excel exports to simplify reports and exports.
- Allow the `Project to units (detail)` report to run without forcing a project selection so users can view results across eligible projects.
- Provide a clear, policy-protected path for authorised users to edit/delete records by redirecting from Reports rows to the existing Manage page rather than implementing inline edits.

### Description

- Remove `projectCode`/`Code` from all report column definitions and from the row dictionary in `Areas/ProjectOfficeReports/Application/ProliferationReportsService.cs`, and remove the early return that blocked `RunProjectToUnitsAsync` when `ProjectId` was null so the report can run across all eligible projects.
- Add authorization-aware manage affordances: update `Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml.cs` to compute `CanManageRecords`, add `data-can-manage-records` and an optional "Manage proliferation" button in `Areas/ProjectOfficeReports/Pages/Proliferation/Reports.cshtml`.
- Update `wwwroot/js/pages/proliferation-reports.js` to treat the project filter as optional (split show vs require logic), only include `projectId` in queries when selected, surface a contextual hint text, and add a safe `__actions` column for authorised users that builds a managed `Manage` link using `projectId`, `source`, `year`, and `kind=Granular`.
- Adjust the export/unit test `ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs` to reflect the shifted column indices after removing the Code column.

### Testing

- Updated unit test `ProliferationReportsServiceExportTests` to match the new column layout and header positions in the Excel export (`ProjectManagement.Tests/ProliferationReportsServiceExportTests.cs`).
- Attempted to run the specific test with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter FullyQualifiedName~ProliferationReportsServiceExportTests` but `dotnet` is not available in this environment so the test could not be executed here.
- No other automated test runs were possible in this environment; changes were validated by code inspection and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb9bc2a488329844c858d95611dda)