### PR TITLE
Fix completed projects table overflow

### DIFF
--- a/wwwroot/css/pages/projects-completed-summary.css
+++ b/wwwroot/css/pages/projects-completed-summary.css
@@ -117,6 +117,16 @@
     width: 100%;
 }
 
+/* SECTION: Table sizing normalization */
+.cs-table th,
+.cs-table td {
+    box-sizing: border-box;
+}
+
+.cs-table thead th {
+    white-space: normal;
+}
+
 .cs-table thead th {
     position: sticky;
     top: 0;


### PR DESCRIPTION
### Motivation
- Prevent horizontal scrolling in the Completed projects results table caused by cell padding and forced header nowrap which could push the table wider than its container.

### Description
- Normalize table cell sizing and allow header text to wrap by adding `box-sizing: border-box` to `.cs-table th, .cs-table td` and setting `white-space: normal` for `.cs-table thead th` in `wwwroot/css/pages/projects-completed-summary.css`, while preserving the existing sticky header styles.

### Testing
- Attempted an automated visual check using Playwright to capture a screenshot, but the page could not be reached (error `net::ERR_EMPTY_RESPONSE`) so the visual verification failed and no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ffdad0a7c832989b422ae0b19f89f)