### PR TITLE
Fix scoped lifetime for Industry Partner attachment storage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -349,7 +349,7 @@ builder.Services.AddScoped<IActivityService, ActivityService>();
 // SECTION: Industry partners services
 builder.Services.AddScoped<IIndustryPartnerService, IndustryPartnerService>();
 builder.Services.AddScoped<IIndustryPartnerAttachmentManager, IndustryPartnerAttachmentManager>();
-builder.Services.AddSingleton<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>();
+builder.Services.AddScoped<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>();
 builder.Services.AddSingleton<IndustryPartnerAttachmentValidator>();
 builder.Services.AddScoped<IActivityDeleteRequestService, ActivityDeleteRequestService>();
 builder.Services.AddScoped<IActivityNotificationService, ActivityNotificationService>();


### PR DESCRIPTION
### Motivation

- Prevent startup/runtime scope mismatch by ensuring `FileSystemIndustryPartnerAttachmentStorage` does not capture a scoped dependency, which caused `Cannot consume scoped service from singleton` when `IFileSecurityValidator` remained scoped.

### Description

- Updated DI registration in `Program.cs` to use `AddScoped<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>()` instead of `AddSingleton(...)` so the storage implementation shares the scoped lifetime with `IFileSecurityValidator` (change located around line 352).

### Testing

- Verified the edit with `rg` and `git diff` and inspected `Program.cs` to confirm the `AddScoped` registration; no unit or runtime tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860b81690c8329b62de884dc599918)