### PR TITLE
Fix IFileSecurityValidator API and EF Core check-constraint usage

### DIFF
--- a/Application/Security/FileSecurityValidator.cs
+++ b/Application/Security/FileSecurityValidator.cs
@@ -9,6 +9,36 @@ public class FileSecurityValidator(IVirusScanner? virusScanner = null) : IFileSe
 {
     private readonly IVirusScanner? _virusScanner = virusScanner;
 
+    // Section: Relative path validation
+    public void ValidateRelativePath(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new ArgumentException("Relative path is required.", nameof(relativePath));
+        }
+
+        var normalizedPath = relativePath.Replace('\\', '/').Trim();
+        if (Path.IsPathRooted(normalizedPath))
+        {
+            throw new ArgumentException("Relative path must not be rooted.", nameof(relativePath));
+        }
+
+        var segments = normalizedPath.Split('/', System.StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            throw new ArgumentException("Relative path must contain at least one segment.", nameof(relativePath));
+        }
+
+        foreach (var segment in segments)
+        {
+            if (segment == "." || segment == "..")
+            {
+                throw new ArgumentException("Relative path contains invalid traversal segments.", nameof(relativePath));
+            }
+        }
+    }
+
+    // Section: File content validation
     public async Task<bool> IsSafeAsync(string filePath, string contentType, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))

--- a/Application/Security/IFileSecurityValidator.cs
+++ b/Application/Security/IFileSecurityValidator.cs
@@ -5,5 +5,9 @@ namespace ProjectManagement.Application.Security;
 
 public interface IFileSecurityValidator
 {
+    // Section: Relative path validation
+    void ValidateRelativePath(string relativePath);
+
+    // Section: File content validation
     Task<bool> IsSafeAsync(string filePath, string contentType, CancellationToken cancellationToken = default);
 }

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -2828,13 +2828,16 @@ namespace ProjectManagement.Data
 
             builder.Entity<IndustryPartnerContact>(entity =>
             {
-                entity.ToTable("IndustryPartnerContacts");
+                entity.ToTable("IndustryPartnerContacts", table =>
+                {
+                    table.HasCheckConstraint(
+                        "CK_IndustryPartnerContacts_PhoneOrEmail",
+                        "(nullif(trim(coalesce(\"Phone\", '')), '') is not null) OR (nullif(trim(coalesce(\"Email\", '')), '') is not null)");
+                });
                 ConfigureRowVersion(entity);
                 entity.Property(x => x.Name).HasMaxLength(200);
                 entity.Property(x => x.Phone).HasMaxLength(64);
                 entity.Property(x => x.Email).HasMaxLength(256);
-                entity.HasCheckConstraint("CK_IndustryPartnerContacts_PhoneOrEmail",
-                    "(nullif(trim(coalesce(\"Phone\", '')), '') is not null) OR (nullif(trim(coalesce(\"Email\", '')), '') is not null)");
                 entity.HasOne(x => x.IndustryPartner)
                     .WithMany(x => x.Contacts)
                     .HasForeignKey(x => x.IndustryPartnerId)

--- a/ProjectManagement.Tests/Application/Ffc/FfcAttachmentStorageTests.cs
+++ b/ProjectManagement.Tests/Application/Ffc/FfcAttachmentStorageTests.cs
@@ -167,6 +167,13 @@ public sealed class FfcAttachmentStorageTests : IDisposable
     {
         public int CallCount { get; private set; }
 
+        // Section: Relative path validation
+        public void ValidateRelativePath(string relativePath)
+        {
+            // Test double intentionally no-op.
+        }
+
+        // Section: File content validation
         public Task<bool> IsSafeAsync(string filePath, string contentType, System.Threading.CancellationToken cancellationToken = default)
         {
             CallCount++;


### PR DESCRIPTION
### Motivation
- Repair compile errors where storage services call `ValidateRelativePath` on `IFileSecurityValidator` and address an obsolete EF Core `HasCheckConstraint` usage.

### Description
- Add `ValidateRelativePath(string relativePath)` to `IFileSecurityValidator` and implement it in `FileSecurityValidator` with checks for empty input, rooted paths, and traversal segments (`.`/`..`).
- Keep existing `IsSafeAsync` behavior in `FileSecurityValidator` unchanged while adding the new relative-path validation method.
- Update the `TestFileSecurityValidator` test double to implement `ValidateRelativePath` (no-op for tests) so tests compile against the new interface.
- Migrate `IndustryPartnerContact` check-constraint configuration to the recommended pattern via `entity.ToTable(..., table => table.HasCheckConstraint(...))` to avoid the obsolete API.

### Testing
- Attempted to run `dotnet build -nologo` in the execution environment but it failed because `dotnet` is not available (build could not be executed).
- Performed source-level verification to ensure all `IFileSecurityValidator` implementers include `ValidateRelativePath` and that the EF check-constraint call was migrated; no automated build/test succeeded due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861095d78c8329aa51252e376f3e3f)