### PR TITLE
Fix DI lifetime mismatch for Industry Partner attachment storage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -349,7 +349,7 @@ builder.Services.AddScoped<IActivityService, ActivityService>();
 // SECTION: Industry partners services
 builder.Services.AddScoped<IIndustryPartnerService, IndustryPartnerService>();
 builder.Services.AddScoped<IIndustryPartnerAttachmentManager, IndustryPartnerAttachmentManager>();
-builder.Services.AddSingleton<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>();
+builder.Services.AddScoped<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>();
 builder.Services.AddSingleton<IndustryPartnerAttachmentValidator>();
 builder.Services.AddScoped<IActivityDeleteRequestService, ActivityDeleteRequestService>();
 builder.Services.AddScoped<IActivityNotificationService, ActivityNotificationService>();


### PR DESCRIPTION
### Motivation
- Resolve a startup DI validation error where the Industry Partner attachment storage was registered as a singleton while depending on a scoped `IFileSecurityValidator`.

### Description
- Change the registration in `Program.cs` from `AddSingleton<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>()` to `AddScoped<IIndustryPartnerAttachmentStorage, FileSystemIndustryPartnerAttachmentStorage>()` to align lifetimes and allow proper service construction.

### Testing
- Attempted to run `dotnet build` in the environment, but the command failed because `dotnet` is not installed, so no automated build tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69861477f0d08329babfecbc9ff01bce)