### PR TITLE
Fix failing test build errors and upgrade HtmlSanitizer

### DIFF
--- a/ProjectManagement.Tests/ProjectDocumentUploadRequestPageTests.cs
+++ b/ProjectManagement.Tests/ProjectDocumentUploadRequestPageTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Options;
 using ProjectManagement.Configuration;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
+using ProjectManagement.Models.Execution;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Pages.Projects.Documents;
 using ProjectManagement.Services;
@@ -65,7 +66,7 @@ public sealed class ProjectDocumentUploadRequestPageTests
     {
         await using var db = CreateContext();
         await SeedProjectAsync(db, 1, leadPoUserId: "po-1");
-        await SeedStageAsync(db, 1, 10, StageCodes.Planning, sortOrder: 1);
+        await SeedStageAsync(db, 1, 10, StageCodes.FS, sortOrder: 1);
 
         var userContext = new FakeUserContext("po-1", "Project Officer");
         var documentService = new StubDocumentService();
@@ -97,7 +98,7 @@ public sealed class ProjectDocumentUploadRequestPageTests
         await using var db = CreateContext();
         await SeedProjectAsync(db, 1, leadPoUserId: "po-1");
         await SeedProjectAsync(db, 2, leadPoUserId: "po-2");
-        await SeedStageAsync(db, 2, 20, StageCodes.Execution, sortOrder: 1);
+        await SeedStageAsync(db, 2, 20, StageCodes.DEVP, sortOrder: 1);
 
         var userContext = new FakeUserContext("po-1", "Project Officer");
         var documentService = new StubDocumentService();
@@ -160,7 +161,7 @@ public sealed class ProjectDocumentUploadRequestPageTests
     {
         await using var db = CreateContext();
         await SeedProjectAsync(db, 1, leadPoUserId: "po-1");
-        await SeedStageAsync(db, 1, 10, StageCodes.Execution, sortOrder: 1);
+        await SeedStageAsync(db, 1, 10, StageCodes.DEVP, sortOrder: 1);
 
         var userContext = new FakeUserContext("po-1", "Project Officer");
         var documentService = new StubDocumentService();

--- a/ProjectManagement.Tests/ProjectOfficeReportsSocialMediaPhotoIntegrationTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReportsSocialMediaPhotoIntegrationTests.cs
@@ -90,7 +90,7 @@ public sealed class ProjectOfficeReportsSocialMediaPhotoIntegrationTests
             var photoService = new SocialMediaEventPhotoService(db, clock, photoOptions, uploadRoot, NullLogger<SocialMediaEventPhotoService>.Instance);
             var eventService = new SocialMediaEventService(db, clock, photoService);
             var userManager = CreateUserManager(db);
-            var page = new EditModel(eventService, platformService, photoService, userManager);
+            var page = new EditModel(eventService, platformService, photoService, userManager, Options.Create(new SocialMediaPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 
@@ -192,7 +192,7 @@ public sealed class ProjectOfficeReportsSocialMediaPhotoIntegrationTests
             var photoService = new SocialMediaEventPhotoService(db, clock, photoOptions, uploadRoot, NullLogger<SocialMediaEventPhotoService>.Instance);
             var eventService = new SocialMediaEventService(db, clock, photoService);
             var userManager = CreateUserManager(db);
-            var page = new EditModel(eventService, platformService, photoService, userManager);
+            var page = new EditModel(eventService, platformService, photoService, userManager, Options.Create(new SocialMediaPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 
@@ -287,7 +287,7 @@ public sealed class ProjectOfficeReportsSocialMediaPhotoIntegrationTests
             var photoService = new SocialMediaEventPhotoService(db, clock, photoOptions, uploadRoot, NullLogger<SocialMediaEventPhotoService>.Instance);
             var eventService = new SocialMediaEventService(db, clock, photoService);
             var userManager = CreateUserManager(db);
-            var page = new EditModel(eventService, platformService, photoService, userManager);
+            var page = new EditModel(eventService, platformService, photoService, userManager, Options.Create(new SocialMediaPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 

--- a/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
@@ -97,7 +97,7 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
             var photoService = new VisitPhotoService(db, clock, audit, photoOptions, uploadRoot, NullLogger<VisitPhotoService>.Instance);
 
             var userManager = CreateUserManager(db);
-            var page = new EditModel(null!, null!, photoService, userManager);
+            var page = new EditModel(null!, null!, photoService, userManager, Options.Create(new VisitPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 
@@ -203,7 +203,7 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
             var audit = new RecordingAudit();
             var photoService = new VisitPhotoService(db, clock, audit, photoOptions, uploadRoot, NullLogger<VisitPhotoService>.Instance);
             var userManager = CreateUserManager(db);
-            var page = new EditModel(null!, null!, photoService, userManager);
+            var page = new EditModel(null!, null!, photoService, userManager, Options.Create(new VisitPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 
@@ -301,7 +301,7 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
             var audit = new RecordingAudit();
             var photoService = new VisitPhotoService(db, clock, audit, photoOptions, uploadRoot, NullLogger<VisitPhotoService>.Instance);
             var userManager = CreateUserManager(db);
-            var page = new EditModel(null!, null!, photoService, userManager);
+            var page = new EditModel(null!, null!, photoService, userManager, Options.Create(new VisitPhotoOptions()));
 
             ConfigurePageContext(page, CreatePrincipal("creator", "Admin"));
 

--- a/ProjectManagement.Tests/ProjectPhotoPageTests.cs
+++ b/ProjectManagement.Tests/ProjectPhotoPageTests.cs
@@ -297,7 +297,7 @@ public sealed class ProjectPhotoPageTests
         var page = CreateUploadPage(db, userContext);
         ConfigurePageContext(page, userContext.User);
 
-        var result = await page.OnGetAsync(21, CancellationToken.None);
+        var result = await page.OnGetAsync(21, false, CancellationToken.None);
 
         Assert.IsType<ForbidResult>(result);
     }

--- a/ProjectManagement.csproj
+++ b/ProjectManagement.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Markdig" Version="0.31.0" />
-    <PackageReference Include="HtmlSanitizer" Version="8.0.795" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="Ical.Net" Version="4.3.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SixLabors.ImageSharp.Web" Version="3.2.0" />


### PR DESCRIPTION
### Motivation
- Tests and build were failing due to updated page model constructors and changed handler signatures, and a dependency with a known vulnerability needed updating.

### Description
- Updated test instantiations of `Visits.EditModel` to supply the new `IOptions<VisitPhotoOptions>` dependency via `Options.Create(new VisitPhotoOptions())`.
- Updated test instantiations of `SocialMedia.EditModel` to supply the new `IOptions<SocialMediaPhotoOptions>` dependency via `Options.Create(new SocialMediaPhotoOptions())`.
- Adjusted the `ProjectPhoto` upload test to call `UploadModel.OnGetAsync` with the required `cover` boolean argument (`OnGetAsync(..., false, ...)`).
- Fixed document stage test issues by adding `using ProjectManagement.Models.Execution;` and replacing invalid stage constants with existing `StageCodes.FS` and `StageCodes.DEVP` values, and upgraded `HtmlSanitizer` to version `9.0.886` in `ProjectManagement.csproj` to address the `NU1902` warning.

### Testing
- Performed targeted static searches with `rg` to locate and verify updated constructor call sites and handler invocations, which returned no remaining occurrences of the original failing patterns (success).
- Inspected modified files with file dumps (`sed`/`nl`) to confirm the new arguments and imports are present (success).
- Attempted to run `dotnet list ProjectManagement.csproj package --vulnerable --include-transitive` to validate package issues but the `dotnet` CLI is not available in this environment (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698616d041588329b393a2892753ed34)