### PR TITLE
Align TrainingCounters UpdatedAtUtc mapping to snapshot to prevent EF pending changes

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -2514,18 +2514,23 @@ namespace ProjectManagement.Data
                 ConfigureRowVersion(entity);
                 entity.ToTable("TrainingCounters");
                 entity.HasKey(x => x.TrainingId);
-                entity.Property(x => x.UpdatedAtUtc).HasDefaultValueSql("now() at time zone 'utc'");
+
+                // SECTION: Training counters updated-at default aligned with model snapshot
+                var updatedAt = entity.Property(x => x.UpdatedAtUtc)
+                    .ValueGeneratedOnAdd();
+
                 if (Database.IsNpgsql())
                 {
-                    entity.Property(x => x.UpdatedAtUtc).HasColumnType("timestamp with time zone");
+                    updatedAt.HasColumnType("timestamp with time zone");
+                    updatedAt.HasDefaultValueSql("timezone('utc', now())");
                 }
                 else if (Database.IsSqlServer())
                 {
-                    entity.Property(x => x.UpdatedAtUtc).HasDefaultValueSql("GETUTCDATE()");
+                    updatedAt.HasDefaultValueSql("GETUTCDATE()");
                 }
                 else
                 {
-                    entity.Property(x => x.UpdatedAtUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+                    updatedAt.HasDefaultValueSql("CURRENT_TIMESTAMP");
                 }
 
                 entity.Property(x => x.Source)


### PR DESCRIPTION
### Motivation
- Prevent EF Core from detecting an unintended `AlterColumn` on `TrainingCounters.UpdatedAtUtc` when scaffolding migrations by making the DbContext mapping match the model snapshot exactly.
- Allow creating a clean Industry Partners migration that contains only the new Industry Partners tables and indexes.
- Ensure DI for Industry Partners attachments is correct and that no singleton depends on scoped services.

### Description
- Replaced the unconditional `HasDefaultValueSql("now() at time zone 'utc'")` for `TrainingCounters.UpdatedAtUtc` with a single property builder (`updatedAt`) and added `ValueGeneratedOnAdd()` so EF treats the value as insert-generated.
- Applied provider-specific configuration: for Npgsql set `HasColumnType("timestamp with time zone")` and `HasDefaultValueSql("timezone('utc', now())")`; for SQL Server use `GETUTCDATE()`; otherwise use `CURRENT_TIMESTAMP`.
- Confirmed Industry Partners DI registration already uses a scoped lifetime for `IIndustryPartnerAttachmentStorage` and therefore required no code change in `Program.cs`.
- Verified Industry Partners entities and fluent mappings (DbSets, table names, Restrict FK on partner projects, and the two filtered unique indexes for `NormalizedLocation`) are present and the `AddIndustryPartners` migration creates only the expected tables and indexes.

### Testing
- Inspected source and migration artifacts (`Data/ApplicationDbContext.cs`, `Migrations/ApplicationDbContextModelSnapshot.cs`, and `Migrations/20261125120000_AddIndustryPartners.cs`) using static search/print commands to confirm the snapshot and migration contain the expected `ValueGeneratedOnAdd`, `timestamp with time zone`, `timezone('utc', now())`, and only Industry Partners operations; these inspections succeeded.
- Ran an EF CLI validation attempt (`dotnet ef migrations list --context ApplicationDbContext`), which failed due to the container missing the .NET SDK/`dotnet` CLI, so runtime EF validation could not be executed in this environment.
- Performed a local code diff review to confirm only the intended lines in `Data/ApplicationDbContext.cs` were modified and no other schema-affecting changes were introduced; this review succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862456328c83299dc903a3908c1adf)