### PR TITLE
Upgrade HtmlSanitizer to 9.0.892

### DIFF
--- a/ProjectManagement.csproj
+++ b/ProjectManagement.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Markdig" Version="0.31.0" />
-    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Ical.Net" Version="4.3.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SixLabors.ImageSharp.Web" Version="3.2.0" />


### PR DESCRIPTION
### Motivation
- Bump `HtmlSanitizer` to a patched stable release to address sanitizer vulnerabilities and reduce risk from new tags/attributes such as `template` and `shadowrootmode`.

### Description
- Updated the `HtmlSanitizer` package reference in `ProjectManagement.csproj` from `9.0.886` to `9.0.892` and reviewed the `new HtmlSanitizer()` usage in `Program.cs`, confirming there is no explicit code allowing the `template` tag or `shadowrootmode` attribute; if environments must remain on the older package, explicitly keep `template` disallowed as a short-term mitigation and track the upgrade as a priority security task.

### Testing
- Performed code searches (`rg`) for `HtmlSanitizer`, `new HtmlSanitizer`, `template`, and `shadowrootmode` which located the sanitizer instantiation and found no explicit allowlisting, and attempted `dotnet restore && dotnet build -c Release` which could not run in this environment because the `.NET SDK` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986245cd3e88329921777c2886e7f80)