### PR TITLE
Pin test project output paths and exclude bin/obj to stop recursive MSBuild copies

### DIFF
--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -1,12 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- SECTION: Target framework and compiler defaults -->
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <!-- SECTION: Test project behavior -->
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!--
+      SECTION: Stable build output paths
+      Pin output/intermediate paths to the project directory to avoid recursive
+      "bin/.../ProjectManagement.Tests/bin/..." copy chains on Windows builds.
+    -->
+    <BaseOutputPath>$(MSBuildProjectDirectory)\bin\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+
+    <!-- SECTION: Exclude generated artifacts from default item globs -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +47,14 @@
   <ItemGroup>
     <ProjectReference Include="..\ProjectManagement.csproj" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- SECTION: Defensive cleanup for generated artifacts -->
+    <Content Remove="bin\**" />
+    <Content Remove="obj\**" />
+    <None Remove="bin\**" />
+    <None Remove="obj\**" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation
- MSBuild was repeatedly failing to copy generated test assets (e.g. `MvcTestingAppManifest.json`) due to a recursive expansion of test output paths, producing `MSB3026` copy retries.
- The change prevents generated `bin`/`obj` artifacts from being re-imported as project inputs, which is the common cause of copy loops on Windows builds.

### Description
- Pinned test output and intermediate directories in `ProjectManagement.Tests.csproj` by adding `BaseOutputPath`, `BaseIntermediateOutputPath`, and `MSBuildProjectExtensionsPath` so outputs live under the test project `bin`/`obj` directories.
- Added `DefaultItemExcludes` to exclude `bin/**` and `obj/**` from default item globs so generated artifacts are not included during evaluation.
- Added an `ItemGroup` with `Content Remove` and `None Remove` entries for `bin\**` and `obj\**` to defensively remove generated artifacts from project items.
- Inserted section comments to clarify the intent and structure for future maintenance.

### Testing
- Ran `rg --files -g 'AGENTS.md'` which succeeded and confirmed repository root context for the change.
- Ran `rg -n "partial class AddIndustryPartners" Migrations` which succeeded and confirmed a single migration file for `AddIndustryPartners` was present.
- Attempted `dotnet build -c Release` to validate build behavior but it failed because the `dotnet` CLI is not available in this container, so a full compile/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698628594f0083298126b192a9f6decd)