### PR TITLE
Add dedicated migration to increase Project.WorkflowVersion to 64 chars

### DIFF
--- a/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.Designer.cs
+++ b/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,10 @@ using ProjectManagement.Data;
 namespace ProjectManagement.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20261125123000_AdjustProjectWorkflowVersionLength")]
+    partial class AdjustProjectWorkflowVersionLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
+++ b/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125123000_AdjustProjectWorkflowVersionLength")]
+    public partial class AdjustProjectWorkflowVersionLength : Migration
+    {
+        // SECTION: Apply schema changes
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "WorkflowVersion",
+                table: "Projects",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "SDD-1.0",
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32,
+                oldDefaultValue: "SDD-1.0");
+        }
+
+        // SECTION: Revert schema changes
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "WorkflowVersion",
+                table: "Projects",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "SDD-1.0",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldDefaultValue: "SDD-1.0");
+        }
+    }
+}

--- a/Models/Project.cs
+++ b/Models/Project.cs
@@ -56,7 +56,7 @@ namespace ProjectManagement.Models
 
         // SECTION: Workflow Versioning
         [Required]
-        [MaxLength(32)]
+        [MaxLength(64)]
         public string WorkflowVersion { get; set; } = PlanConstants.DefaultStageTemplateVersion;
 
         public int? CategoryId { get; set; }


### PR DESCRIPTION
### Motivation
- The `Project.WorkflowVersion` property needs a larger max length (64) and this schema change must be isolated from the `AddIndustryPartners` scaffolding so that the IndustryPartner migration only contains partner table creation and related FKs/indexes.

### Description
- Updated the model annotation for `Project.WorkflowVersion` from `MaxLength(32)` to `MaxLength(64)` in `Models/Project.cs`.
- Added a dedicated migration `AdjustProjectWorkflowVersionLength` (migration + designer) that performs a single `AlterColumn` on `Projects.WorkflowVersion` (32 → 64) with a matching `Down` to revert to 32.
- Updated `Migrations/ApplicationDbContextModelSnapshot.cs` to reflect the new `character varying(64)` snapshot for `WorkflowVersion`.
- Left `Migrations/20261125120000_AddIndustryPartners.*` untouched and confirmed it only creates IndustryPartner tables, indexes, constraints and contains no `AlterColumn` for `Projects`.

### Testing
- Ran workspace checks: `git status --short` and `git diff --name-only` to confirm changed files were limited to `Models/Project.cs`, the new `AdjustProjectWorkflowVersionLength` migration files, and the updated snapshot, and the commit was created successfully (succeeded).
- Searched migrations for unintended alterations using `rg` to assert there is no `AlterColumn` in `Migrations/20261125120000_AddIndustryPartners.cs` (succeeded).
- Verified the dedicated migration contains `AlterColumn` lines for `table: "Projects"` and `WorkflowVersion` via `rg` (succeeded).
- Attempted `dotnet ef migrations has-pending-model-changes --no-build` but the `dotnet` CLI is not available in this environment, so EF CLI validation could not be executed (failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862cf53aec8329ad8f99122edc0ae3)