### PR TITLE
Align WorkflowVersion migration with 64-char EF model

### DIFF
--- a/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
+++ b/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
@@ -13,41 +13,9 @@ namespace ProjectManagement.Migrations
         // SECTION: Apply schema changes
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            // SECTION: Data remediation policy for workflow version shrink
-            // Policy: this migration does not mutate unknown legacy values. It fails fast with
-            // a clear exception when invalid data exists so operators can remediate deterministically.
-            migrationBuilder.Sql(
-                @"DO $$
-BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM ""Projects""
-        WHERE ""WorkflowVersion"" IS NULL
-           OR length(""WorkflowVersion"") > 32
-    ) THEN
-        RAISE EXCEPTION
-            'Cannot shrink Projects.WorkflowVersion to varchar(32): found NULL or values longer than 32 characters. Remediate data before applying migration.';
-    END IF;
-END $$;");
-
-            // SECTION: Enforce final schema after data is validated
-            migrationBuilder.AlterColumn<string>(
-                name: "WorkflowVersion",
-                table: "Projects",
-                type: "character varying(32)",
-                maxLength: 32,
-                nullable: false,
-                defaultValue: "SDD-1.0",
-                oldClrType: typeof(string),
-                oldType: "character varying(64)",
-                oldMaxLength: 64,
-                oldDefaultValue: "SDD-1.0");
-        }
-
-        // SECTION: Revert schema changes
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            // SECTION: Roll back schema change to previous length/constraint contract
+            // SECTION: Align persisted schema with EF model contract
+            // The model defines WorkflowVersion as MaxLength(64). Previous migration history
+            // may leave the physical column at varchar(32), so this migration expands to 64.
             migrationBuilder.AlterColumn<string>(
                 name: "WorkflowVersion",
                 table: "Projects",
@@ -58,6 +26,23 @@ END $$;");
                 oldClrType: typeof(string),
                 oldType: "character varying(32)",
                 oldMaxLength: 32,
+                oldDefaultValue: "SDD-1.0");
+        }
+
+        // SECTION: Revert schema changes
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // SECTION: Roll back schema change to previous length/constraint contract
+            migrationBuilder.AlterColumn<string>(
+                name: "WorkflowVersion",
+                table: "Projects",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "SDD-1.0",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
                 oldDefaultValue: "SDD-1.0");
         }
     }


### PR DESCRIPTION
### Motivation
- Fix a high-priority mismatch where the migration was shrinking `Projects.WorkflowVersion` to `varchar(32)` while the EF model and snapshots declare `WorkflowVersion` as `MaxLength(64)`, which would cause runtime write failures for values 33–64 chars. 
- Ensure the migration reconciles schema drift deterministically by aligning the persisted column with the current entity contract so fresh and existing environments remain compatible.

### Description
- Changed `Up` in `Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs` to alter `WorkflowVersion` to `character varying(64)` with `maxLength: 64` so the database matches the model. 
- Adjusted `Down` to revert to `character varying(32)` / `maxLength: 32` so rollbacks remain reversible against the prior physical state. 
- Removed the previous shrink precheck/fail-fast SQL block because this migration's intent is to expand/align to the model (not to shrink), and added comments documenting the purpose and rationale. 
- Updated `oldType`/`oldMaxLength` parameters to reflect the correct previous physical state for EF migration metadata.

### Testing
- Searched the repository for related references with `rg -n "WorkflowVersion|AlterColumn|character varying(32)|character varying(64)"` to locate relevant files and confirm snapshots and model usage. (succeeded)
- Inspected the edited migration file with `nl -ba Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs | sed -n '1,140p'` and verified the `AlterColumn` changes and comments. (succeeded)
- Attempted build validation with `dotnet build ProjectManagement.sln` but it could not be executed in this environment because the `dotnet` CLI is not available (`command not found`). (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862f5c64f08329bf16a97ac9b41b8d)