### PR TITLE
Remove duplicate migration attributes from AddIndustryPartners partial class

### DIFF
--- a/Migrations/20261125120000_AddIndustryPartners.cs
+++ b/Migrations/20261125120000_AddIndustryPartners.cs
@@ -1,15 +1,11 @@
 using System;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using ProjectManagement.Data;
 
 #nullable disable
 
 namespace ProjectManagement.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20261125120000_AddIndustryPartners")]
     public partial class AddIndustryPartners : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
### Motivation
- Prevent a compilation error (`CS0579`) caused by duplicate non-multi-use attributes declared on both partial class files for the `AddIndustryPartners` migration.

### Description
- Removed the `[DbContext(typeof(ApplicationDbContext))]` and `[Migration("20261125120000_AddIndustryPartners")]` attributes and now-unused `using` directives from `Migrations/20261125120000_AddIndustryPartners.cs` so the attributes are declared only in `Migrations/20261125120000_AddIndustryPartners.Designer.cs`.

### Testing
- Validated with `rg -n "\[DbContext\(|\[Migration\(" Migrations/20261125120000_AddIndustryPartners*.cs` which confirmed the attributes exist only in the designer file; attempted `dotnet build` but `dotnet` is not installed in this environment so a full build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698630322c84832991c1a3143c86b564)