### PR TITLE
Remove duplicate EF migration attributes from migration classes

### DIFF
--- a/Migrations/20261125120000_AddIndustryPartners.cs
+++ b/Migrations/20261125120000_AddIndustryPartners.cs
@@ -1,15 +1,11 @@
 using System;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using ProjectManagement.Data;
 
 #nullable disable
 
 namespace ProjectManagement.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20261125120000_AddIndustryPartners")]
     public partial class AddIndustryPartners : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
+++ b/Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs
@@ -1,13 +1,9 @@
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
-using ProjectManagement.Data;
 
 #nullable disable
 
 namespace ProjectManagement.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20261125123000_AdjustProjectWorkflowVersionLength")]
     public partial class AdjustProjectWorkflowVersionLength : Migration
     {
         // SECTION: Apply schema changes


### PR DESCRIPTION
### Motivation
- Duplicate EF attributes were emitted in both the migration implementation and the designer partial which produced CS0579 duplicate attribute compile errors during build.

### Description
- Removed the `[DbContext]` and `[Migration]` attributes and unnecessary `using` directives from `Migrations/20261125120000_AddIndustryPartners.cs` and `Migrations/20261125123000_AdjustProjectWorkflowVersionLength.cs` so the `.Designer.cs` partial remains the single source of migration metadata.

### Testing
- Verified the working tree diff to ensure only attribute/usings cleanup was applied to the two migration files (succeeded).
- Attempted `dotnet build ProjectManagement.sln` but it could not be run in this environment because `dotnet` is not installed (could not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986310f62788329a10569056ed93822)