### PR TITLE
Upgrade Industry Partners UI and add searchable project linking

### DIFF
--- a/Controllers/IndustryPartnersProjectLookupController.cs
+++ b/Controllers/IndustryPartnersProjectLookupController.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Controllers;
+
+[Authorize(Policy = Policies.IndustryPartners.View)]
+[ApiController]
+[Route("api/industry-partners/projects")]
+public sealed class IndustryPartnersProjectLookupController : ControllerBase
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public IndustryPartnersProjectLookupController(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAsync([FromQuery] string? q, [FromQuery] int take = 20, CancellationToken cancellationToken = default)
+    {
+        // SECTION: Input normalization
+        var trimmedQuery = q?.Trim();
+        var normalizedTake = Math.Clamp(take, 1, 50);
+
+        // SECTION: Base project filters
+        var projectsQuery = _dbContext.Projects
+            .AsNoTracking()
+            .Where(project => !project.IsDeleted && !project.IsArchived);
+
+        // SECTION: Query-based search filters
+        if (!string.IsNullOrWhiteSpace(trimmedQuery))
+        {
+            var pattern = $"%{trimmedQuery}%";
+            projectsQuery = projectsQuery.Where(project =>
+                EF.Functions.ILike(project.Name, pattern) ||
+                (!string.IsNullOrWhiteSpace(project.CaseFileNumber) && EF.Functions.ILike(project.CaseFileNumber!, pattern)));
+        }
+
+        // SECTION: Lightweight response projection
+        var items = await projectsQuery
+            .OrderBy(project => project.Name)
+            .ThenBy(project => project.Id)
+            .Take(normalizedTake)
+            .Select(project => new
+            {
+                id = project.Id,
+                name = string.IsNullOrWhiteSpace(project.CaseFileNumber)
+                    ? $"{project.Name} (ID: {project.Id})"
+                    : $"{project.Name} | {project.CaseFileNumber}"
+            })
+            .ToListAsync(cancellationToken);
+
+        return Ok(new { items });
+    }
+}

--- a/Pages/IndustryPartners/Index.cshtml
+++ b/Pages/IndustryPartners/Index.cshtml
@@ -4,8 +4,12 @@
     ViewData["Title"] = "Industry partners";
 }
 
-<div class="container-fluid py-3" data-industry-partners-root>
-    <div class="d-flex justify-content-between align-items-center mb-3">
+@section Styles {
+    <link rel="stylesheet" href="~/css/pages/industry-partners.css" asp-append-version="true" />
+}
+
+<div class="container-fluid py-3 industry-partners-page" data-industry-partners-root>
+    <div class="d-flex justify-content-between align-items-center mb-3 industry-page-header">
         <h1 class="h4 mb-0">Industry partners</h1>
         @if (Model.CanManage)
         {
@@ -30,17 +34,20 @@
 
     <div class="row g-3">
         <div class="col-lg-4">
-            <div class="card">
+            <div class="card industry-list-panel">
                 <div class="card-body">
                     <form method="get" class="mb-3">
-                        <input class="form-control" name="q" value="@Model.Q" placeholder="Search partner name or location" />
+                        <input class="form-control form-control-sm" name="q" value="@Model.Q" placeholder="Search partner name or location" />
                     </form>
-                    <div class="list-group">
+                    <div class="list-group industry-list-group">
                         @foreach (var item in Model.SearchResult.Items)
                         {
-                            <a asp-page="./Index" asp-route-id="@item.Id" asp-route-q="@Model.Q" class="list-group-item list-group-item-action @(Model.Id == item.Id ? "active" : string.Empty)">
+                            <a asp-page="./Index" asp-route-id="@item.Id" asp-route-q="@Model.Q" class="list-group-item list-group-item-action industry-list-item @(Model.Id == item.Id ? "active" : string.Empty)">
                                 <div class="fw-semibold">@item.Name</div>
-                                <div class="small text-muted">@item.Location</div>
+                                @if (!string.IsNullOrWhiteSpace(item.Location))
+                                {
+                                    <div class="small text-muted">@item.Location</div>
+                                }
                             </a>
                         }
                     </div>

--- a/Pages/IndustryPartners/_Attachments.cshtml
+++ b/Pages/IndustryPartners/_Attachments.cshtml
@@ -1,16 +1,20 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card">
+<div class="card industry-section-card">
     <div class="card-body">
-        <h3 class="h6">Attachments</h3>
+        <div class="industry-section-heading-row mb-2">
+            <h3 class="h6 mb-0">Attachments</h3>
+            <small class="text-muted">Supporting documents and media files.</small>
+        </div>
+
         @if (Model.CanManage)
         {
             <form method="post" asp-page-handler="UploadAttachment" enctype="multipart/form-data" class="mb-3">
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="partnerId" value="@p.Id" />
-                <div class="input-group input-group-sm">
-                    <input type="file" name="file" class="form-control" required />
-                    <button class="btn btn-primary">Upload</button>
+                <div class="d-flex flex-wrap align-items-center gap-2 industry-upload-row">
+                    <input type="file" name="file" class="form-control form-control-sm" required />
+                    <button class="btn btn-sm btn-primary">Upload</button>
                 </div>
             </form>
         }
@@ -18,17 +22,22 @@
         <ul class="list-group list-group-flush">
             @foreach (var a in p.Attachments)
             {
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <a asp-page="./Index" asp-page-handler="DownloadAttachment" asp-route-partnerId="@p.Id" asp-route-attachmentId="@a.Id">@a.OriginalFileName</a>
-                    @if (Model.CanManage)
-                    {
-                        <form method="post" asp-page-handler="DeleteAttachment" class="d-inline">
-                            @Html.AntiForgeryToken()
-                            <input type="hidden" name="partnerId" value="@p.Id" />
-                            <input type="hidden" name="attachmentId" value="@a.Id" />
-                            <button class="btn btn-sm btn-outline-danger">Delete</button>
-                        </form>
-                    }
+                <li class="list-group-item px-0">
+                    <div class="d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                        <div>
+                            <a asp-page="./Index" asp-page-handler="DownloadAttachment" asp-route-partnerId="@p.Id" asp-route-attachmentId="@a.Id" class="fw-semibold text-decoration-none">@a.OriginalFileName</a>
+                            <span class="text-muted small ms-2">@($"{a.SizeBytes / 1024.0:F1} KB")</span>
+                        </div>
+                        @if (Model.CanManage)
+                        {
+                            <form method="post" asp-page-handler="DeleteAttachment" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="partnerId" value="@p.Id" />
+                                <input type="hidden" name="attachmentId" value="@a.Id" />
+                                <button class="btn btn-sm btn-outline-danger">Delete</button>
+                            </form>
+                        }
+                    </div>
                 </li>
             }
         </ul>

--- a/Pages/IndustryPartners/_Contacts.cshtml
+++ b/Pages/IndustryPartners/_Contacts.cshtml
@@ -1,10 +1,14 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card">
+<div class="card industry-section-card">
     <div class="card-body">
-        <h3 class="h6">Contacts</h3>
+        <div class="industry-section-heading-row mb-2">
+            <h3 class="h6 mb-0">Contacts</h3>
+            <small class="text-muted">People and communication details.</small>
+        </div>
+
         <div class="table-responsive">
-            <table class="table table-sm align-middle">
+            <table class="table table-sm align-middle industry-compact-table">
                 <thead><tr><th>Name</th><th>Phone</th><th>Email</th><th></th></tr></thead>
                 <tbody>
                 @foreach (var c in p.Contacts)

--- a/Pages/IndustryPartners/_LinkedProjects.cshtml
+++ b/Pages/IndustryPartners/_LinkedProjects.cshtml
@@ -1,12 +1,16 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card">
+<div class="card industry-section-card">
     <div class="card-body">
-        <h3 class="h6">Linked projects</h3>
+        <div class="industry-section-heading-row mb-2">
+            <h3 class="h6 mb-0">Linked projects</h3>
+            <small class="text-muted">Connect project records to this partner.</small>
+        </div>
+
         <div class="d-flex flex-wrap gap-2 mb-3">
             @foreach (var link in p.LinkedProjects)
             {
-                <span class="badge text-bg-light">
+                <span class="badge text-bg-light industry-link-badge">
                     @link.ProjectName
                     @if (Model.CanManage)
                     {
@@ -23,11 +27,26 @@
 
         @if (Model.CanManage)
         {
-            <form method="post" asp-page-handler="LinkProject" class="row g-2">
+            <form method="post" asp-page-handler="LinkProject" class="row g-2" data-link-project-form>
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="partnerId" value="@p.Id" />
-                <div class="col-sm-8"><input class="form-control form-control-sm" name="projectId" placeholder="Project ID" type="number" min="1" required /></div>
-                <div class="col-sm-4"><button class="btn btn-sm btn-outline-primary w-100">Link project</button></div>
+                <div class="col-sm-8 position-relative">
+                    <input class="form-control form-control-sm"
+                           name="projectSearch"
+                           placeholder="Search project by name or file number"
+                           autocomplete="off"
+                           data-project-search />
+
+                    <input type="hidden" name="projectId" data-project-id required />
+
+                    <div class="list-group position-absolute w-100 shadow-sm d-none industry-project-results"
+                         data-project-results></div>
+
+                    <div class="form-text text-danger d-none" data-project-error>
+                        Select a project from the list.
+                    </div>
+                </div>
+                <div class="col-sm-4"><button class="btn btn-sm btn-outline-primary w-100" type="submit" data-link-project-submit disabled>Link project</button></div>
             </form>
         }
     </div>

--- a/Pages/IndustryPartners/_PartnerPanel.cshtml
+++ b/Pages/IndustryPartners/_PartnerPanel.cshtml
@@ -1,29 +1,41 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card">
+<div class="card industry-section-card industry-workspace-card">
     <div class="card-body">
-        <h2 class="h5">Partner workspace</h2>
-        <div class="mb-3">
-            <label class="form-label">Name</label>
-            <input class="form-control" value="@p.Name" data-inline-field="name" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled") />
+        <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+            <div>
+                <h2 class="h5 mb-1">@p.Name</h2>
+                <div class="text-muted small" data-save-status aria-live="polite">Saved</div>
+            </div>
+            @if (Model.CanDelete)
+            {
+                <form method="post" asp-page-handler="DeletePartner">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="partnerId" value="@p.Id" />
+                    <button type="submit" class="btn btn-outline-danger btn-sm">Delete partner</button>
+                </form>
+            }
         </div>
-        <div class="mb-3">
-            <label class="form-label">Location</label>
-            <textarea class="form-control" rows="3" data-inline-field="location" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Location</textarea>
-        </div>
-        <div class="mb-3">
-            <label class="form-label">Remarks</label>
-            <textarea class="form-control" rows="4" data-inline-field="remarks" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Remarks</textarea>
-        </div>
-        <div class="text-muted small" data-save-status aria-live="polite"></div>
 
-        @if (Model.CanDelete)
-        {
-            <form method="post" asp-page-handler="DeletePartner" class="mt-3">
-                @Html.AntiForgeryToken()
-                <input type="hidden" name="partnerId" value="@p.Id" />
-                <button type="submit" class="btn btn-outline-danger btn-sm">Delete partner</button>
-            </form>
-        }
+        <div class="industry-section-heading-row">
+            <label class="form-label mb-1">Name</label>
+        </div>
+        <div class="mb-3">
+            <input class="form-control form-control-sm" value="@p.Name" data-inline-field="name" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled") />
+        </div>
+
+        <div class="industry-section-heading-row">
+            <label class="form-label mb-1">Location</label>
+        </div>
+        <div class="mb-3">
+            <textarea class="form-control form-control-sm" rows="3" data-inline-field="location" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Location</textarea>
+        </div>
+
+        <div class="industry-section-heading-row">
+            <label class="form-label mb-1">Remarks</label>
+        </div>
+        <div>
+            <textarea class="form-control form-control-sm" rows="4" data-inline-field="remarks" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Remarks</textarea>
+        </div>
     </div>
 </div>

--- a/wwwroot/css/pages/industry-partners.css
+++ b/wwwroot/css/pages/industry-partners.css
@@ -1,0 +1,93 @@
+/* SECTION: Page-level layout and surfaces */
+.industry-partners-page {
+  --industry-border: #dde3ee;
+  --industry-surface: #fbfcff;
+  --industry-surface-strong: #f3f6fb;
+  --industry-accent: #204b95;
+}
+
+.industry-partners-page .card {
+  border-color: var(--industry-border);
+  box-shadow: 0 8px 24px rgba(15, 26, 56, 0.04);
+}
+
+.industry-page-header {
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--industry-border);
+}
+
+/* SECTION: Left panel and list interaction */
+.industry-list-panel {
+  position: sticky;
+  top: 1rem;
+  background: var(--industry-surface);
+}
+
+.industry-list-group {
+  border: 1px solid var(--industry-border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.industry-list-item {
+  border: 0;
+  border-bottom: 1px solid #edf1f7;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.industry-list-item:last-child {
+  border-bottom: 0;
+}
+
+.industry-list-item:hover {
+  background: #f6f9ff;
+}
+
+.industry-list-item.active {
+  background: var(--industry-surface-strong);
+  color: inherit;
+  border-left: 3px solid var(--industry-accent);
+  padding-left: calc(1rem - 3px);
+}
+
+.industry-list-item.active .text-muted {
+  color: #5e6d86 !important;
+}
+
+/* SECTION: Right workspace sections */
+.industry-section-card .card-body {
+  background: var(--industry-surface);
+}
+
+.industry-section-heading-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.industry-compact-table > :not(caption) > * > * {
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+}
+
+.industry-upload-row input[type="file"] {
+  max-width: 360px;
+}
+
+.industry-link-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid var(--industry-border);
+}
+
+.industry-partners-page .form-control-sm,
+.industry-partners-page .btn-sm {
+  border-radius: 0.35rem;
+}
+
+
+.industry-project-results {
+  z-index: 1000;
+}

--- a/wwwroot/js/pages/industry-partners.js
+++ b/wwwroot/js/pages/industry-partners.js
@@ -2,7 +2,17 @@
   const root = document.querySelector('[data-industry-partners-root]');
   if (!root) return;
 
-  // SECTION: Anti-forgery token retrieval
+  // SECTION: Shared helpers
+  function debounce(fn, wait) {
+    let timer;
+    return function () {
+      const args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(null, args), wait);
+    };
+  }
+
+  // SECTION: Inline field autosave
   const token = document.querySelector('#industryPartnerToken input[name="__RequestVerificationToken"]')?.value;
   const statusEl = root.querySelector('[data-save-status]');
   const fields = root.querySelectorAll('[data-inline-field]');
@@ -12,15 +22,6 @@
     statusEl.textContent = message;
     statusEl.classList.toggle('text-danger', !!isError);
     statusEl.classList.toggle('text-success', !isError);
-  }
-
-  function debounce(fn, wait) {
-    let timer;
-    return function () {
-      const args = arguments;
-      clearTimeout(timer);
-      timer = setTimeout(() => fn.apply(null, args), wait);
-    };
   }
 
   const saveField = debounce(async (fieldEl) => {
@@ -62,4 +63,130 @@
       saveField(field);
     });
   });
+
+  // SECTION: Linked project typeahead
+  const linkForm = root.querySelector('[data-link-project-form]');
+  if (!linkForm) return;
+
+  const searchInput = linkForm.querySelector('[data-project-search]');
+  const projectIdInput = linkForm.querySelector('[data-project-id]');
+  const resultsContainer = linkForm.querySelector('[data-project-results]');
+  const errorMessage = linkForm.querySelector('[data-project-error]');
+  const submitButton = linkForm.querySelector('[data-link-project-submit]');
+  let lastSelectedLabel = '';
+
+  function setSubmitEnabled() {
+    if (!submitButton || !projectIdInput) return;
+    submitButton.disabled = !projectIdInput.value;
+  }
+
+  function clearSelection() {
+    if (!projectIdInput) return;
+    projectIdInput.value = '';
+    lastSelectedLabel = '';
+    setSubmitEnabled();
+  }
+
+  function hideResults() {
+    if (!resultsContainer) return;
+    resultsContainer.classList.add('d-none');
+    resultsContainer.innerHTML = '';
+  }
+
+  function showError(show) {
+    if (!errorMessage) return;
+    errorMessage.classList.toggle('d-none', !show);
+  }
+
+  function selectProject(item) {
+    if (!searchInput || !projectIdInput) return;
+    searchInput.value = item.name;
+    projectIdInput.value = String(item.id);
+    lastSelectedLabel = item.name;
+    hideResults();
+    showError(false);
+    setSubmitEnabled();
+  }
+
+  function renderResults(items) {
+    if (!resultsContainer) return;
+    resultsContainer.innerHTML = '';
+
+    if (!items || !items.length) {
+      hideResults();
+      return;
+    }
+
+    items.forEach((item) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'list-group-item list-group-item-action';
+      button.textContent = item.name;
+      button.addEventListener('click', () => selectProject(item));
+      resultsContainer.appendChild(button);
+    });
+
+    resultsContainer.classList.remove('d-none');
+  }
+
+  const searchProjects = debounce(async () => {
+    if (!searchInput) return;
+    const query = searchInput.value.trim();
+
+    if (query.length < 2) {
+      hideResults();
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/industry-partners/projects?q=${encodeURIComponent(query)}&take=20`, {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      if (!response.ok) {
+        hideResults();
+        return;
+      }
+
+      const payload = await response.json();
+      renderResults(payload.items || []);
+    } catch (err) {
+      hideResults();
+    }
+  }, 250);
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      if (searchInput.value.trim() !== lastSelectedLabel) {
+        clearSelection();
+      }
+      showError(false);
+      searchProjects();
+    });
+
+    searchInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        hideResults();
+      }
+    });
+  }
+
+  linkForm.addEventListener('submit', (event) => {
+    if (!projectIdInput || !projectIdInput.value) {
+      event.preventDefault();
+      showError(true);
+      setSubmitEnabled();
+      return;
+    }
+
+    showError(false);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!linkForm.contains(event.target)) {
+      hideResults();
+    }
+  });
+
+  setSubmitEnabled();
 })();


### PR DESCRIPTION
### Motivation

- Replace the awkward numeric Project ID input with a user-friendly searchable picker so users can find projects by name or case file number without knowing an ID. 
- Provide a lightweight, secure API endpoint to support the typeahead lookup while excluding deleted/archived projects. 
- Improve the Industry Partners page visual hierarchy and usability (sticky list, clearer workspace, compact contacts/attachments) while preserving the single-page workflow and inline autosave. 
- Prevent accidental linking by blocking form submission unless a project from the suggestion list is explicitly selected.

### Description

- Added controller `Controllers/IndustryPartnersProjectLookupController.cs` implementing `GET /api/industry-partners/projects` with query params `q` and `take` (bounded 1..50) and a lightweight JSON response shape `{ items: [{ id, name }] }` where `name` includes `CaseFileNumber` when present. 
- Replaced numeric `projectId` input with a typeahead UI in `Pages/IndustryPartners/_LinkedProjects.cshtml` (text input `name="projectSearch"`, hidden `name="projectId"`, suggestions container, inline error text, and disabled submit until selection). 
- Implemented client-side typeahead and selection logic in `wwwroot/js/pages/industry-partners.js` with debounced search (250ms), minimum 2 characters, fetch to `/api/industry-partners/projects`, rendering selectable results, clearing hidden `projectId` when user edits after selection, blocking submit when no selection, outside-click and Escape handling, and preserving existing inline autosave behavior. 
- Added page-specific stylesheet `wwwroot/css/pages/industry-partners.css` and wired it via `@section Styles` in `Pages/IndustryPartners/Index.cshtml` to provide sticky left list, refined active/hover states, softer surfaces, consistent input sizing, and layering for the suggestion list. 
- Polished partials: `Pages/IndustryPartners/_PartnerPanel.cshtml` (workspace header with save status and delete action), `Pages/IndustryPartners/_Contacts.cshtml` (compact table and subtitle), and `Pages/IndustryPartners/_Attachments.cshtml` (inline upload row and attachment rows showing filename + size + action). 

### Testing

- Ran a local build attempt with `dotnet build`, which failed because `dotnet` is not available in the execution environment. 
- Attempted an automated browser check to open `/IndustryPartners` via Playwright, which failed with `ERR_EMPTY_RESPONSE` because no local app server was running. 
- No unit or integration tests were added; manual UI behavior is covered by the implemented client-side guards (debounce, min-length, disabled submit, selection clearing) and the lightweight controller projection to ensure minimal payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b56002088329aff59ab5986b4eba)