### PR TITLE
Polish Industry Partners UI and workflow interactions

### DIFF
--- a/Pages/IndustryPartners/Index.cshtml
+++ b/Pages/IndustryPartners/Index.cshtml
@@ -8,14 +8,14 @@
     <link rel="stylesheet" href="~/css/pages/industry-partners.css" asp-append-version="true" />
 }
 
-<div class="container-fluid py-3 industry-partners-page" data-industry-partners-root>
-    <div class="d-flex justify-content-between align-items-center mb-3 industry-page-header">
+<div class="container-fluid py-3 ip-page" data-industry-partners-root>
+    <div class="d-flex justify-content-between align-items-center ip-page-header">
         <h1 class="h4 mb-0">Industry partners</h1>
         @if (Model.CanManage)
         {
             <form method="post" asp-page-handler="CreatePartner" class="d-flex gap-2">
                 @Html.AntiForgeryToken()
-                <input name="name" class="form-control form-control-sm" placeholder="New partner name" required />
+                <input name="name" class="form-control form-control-sm ip-input" placeholder="New partner name" required />
                 <button type="submit" class="btn btn-sm btn-primary">Create</button>
             </form>
         }
@@ -32,22 +32,30 @@
 
     <div id="industryPartnerToken" class="d-none">@Html.AntiForgeryToken()</div>
 
-    <div class="row g-3">
-        <div class="col-lg-4">
-            <div class="card industry-list-panel">
-                <div class="card-body">
-                    <form method="get" class="mb-3">
-                        <input class="form-control form-control-sm" name="q" value="@Model.Q" placeholder="Search partner name or location" />
+    <div class="ip-grid">
+        <div>
+            <div class="ip-panel ip-sticky">
+                <div class="ip-panel-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h2 class="h6 mb-0">Partners</h2>
+                        <span class="ip-count-badge" title="Visible vs total partners">
+                            <span>@Model.SearchResult.Items.Count</span>/<span>@Model.SearchResult.Total</span>
+                        </span>
+                    </div>
+                    <form method="get" class="ip-list-search">
+                        <input class="form-control form-control-sm ip-input" name="q" value="@Model.Q" placeholder="Search partner name or location" />
                     </form>
-                    <div class="list-group industry-list-group">
+                    <div class="ip-list">
                         @foreach (var item in Model.SearchResult.Items)
                         {
-                            <a asp-page="./Index" asp-route-id="@item.Id" asp-route-q="@Model.Q" class="list-group-item list-group-item-action industry-list-item @(Model.Id == item.Id ? "active" : string.Empty)">
-                                <div class="fw-semibold">@item.Name</div>
-                                @if (!string.IsNullOrWhiteSpace(item.Location))
-                                {
-                                    <div class="small text-muted">@item.Location</div>
-                                }
+                            var isActive = Model.Id == item.Id;
+                            <a asp-page="./Index"
+                               asp-route-id="@item.Id"
+                               asp-route-q="@Model.Q"
+                               class="ip-list-item @(isActive ? "is-active" : string.Empty)"
+                               aria-current="@(isActive ? "true" : "false")">
+                                <div class="ip-list-item-title">@item.Name</div>
+                                <div class="ip-list-item-sub">@(string.IsNullOrWhiteSpace(item.Location) ? "Location not set" : item.Location)</div>
                             </a>
                         }
                     </div>
@@ -55,17 +63,17 @@
             </div>
         </div>
 
-        <div class="col-lg-8">
+        <div class="min-w-0">
             @if (Model.SelectedPartner is null)
             {
-                <div class="card"><div class="card-body text-muted">Select a partner to begin.</div></div>
+                <div class="ip-panel"><div class="ip-panel-body text-muted">Select a partner to begin.</div></div>
             }
             else
             {
                 <partial name="_PartnerPanel" model="Model" />
-                <div class="mt-3"><partial name="_Contacts" model="Model" /></div>
-                <div class="mt-3"><partial name="_Attachments" model="Model" /></div>
-                <div class="mt-3"><partial name="_LinkedProjects" model="Model" /></div>
+                <partial name="_Contacts" model="Model" />
+                <partial name="_Attachments" model="Model" />
+                <partial name="_LinkedProjects" model="Model" />
             }
         </div>
     </div>

--- a/Pages/IndustryPartners/_Attachments.cshtml
+++ b/Pages/IndustryPartners/_Attachments.cshtml
@@ -1,45 +1,58 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card industry-section-card">
-    <div class="card-body">
-        <div class="industry-section-heading-row mb-2">
-            <h3 class="h6 mb-0">Attachments</h3>
-            <small class="text-muted">Supporting documents and media files.</small>
-        </div>
-
+<div class="ip-section">
+    <div class="ip-section-header">
+        <h3 class="ip-section-title">Attachments</h3>
+        <small class="ip-section-note">Supporting documents and media files.</small>
+    </div>
+    <div class="ip-section-body">
         @if (Model.CanManage)
         {
-            <form method="post" asp-page-handler="UploadAttachment" enctype="multipart/form-data" class="mb-3">
+            <form method="post" asp-page-handler="UploadAttachment" enctype="multipart/form-data" class="mb-3" data-attachment-upload-form>
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="partnerId" value="@p.Id" />
-                <div class="d-flex flex-wrap align-items-center gap-2 industry-upload-row">
-                    <input type="file" name="file" class="form-control form-control-sm" required />
-                    <button class="btn btn-sm btn-primary">Upload</button>
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                    <input type="file" name="file" class="form-control form-control-sm ip-input" required data-attachment-file />
+                    <span class="ip-upload-file-name" data-attachment-file-name>No file selected</span>
+                    <button class="btn btn-sm btn-primary" type="submit" data-attachment-upload-submit disabled>Upload</button>
                 </div>
             </form>
         }
 
-        <ul class="list-group list-group-flush">
+        @if (!p.Attachments.Any())
+        {
+            <div class="ip-empty-text">No attachments uploaded yet.</div>
+        }
+        else
+        {
             @foreach (var a in p.Attachments)
             {
-                <li class="list-group-item px-0">
-                    <div class="d-flex justify-content-between align-items-center gap-2 flex-wrap">
-                        <div>
-                            <a asp-page="./Index" asp-page-handler="DownloadAttachment" asp-route-partnerId="@p.Id" asp-route-attachmentId="@a.Id" class="fw-semibold text-decoration-none">@a.OriginalFileName</a>
-                            <span class="text-muted small ms-2">@($"{a.SizeBytes / 1024.0:F1} KB")</span>
-                        </div>
+                var ext = System.IO.Path.GetExtension(a.OriginalFileName)?.Trim('.').ToUpperInvariant();
+                if (string.IsNullOrWhiteSpace(ext))
+                {
+                    ext = "FILE";
+                }
+
+                <div class="ip-attachment-item">
+                    <div>
+                        <span class="ip-file-icon">@ext</span>
+                        <a asp-page="./Index" asp-page-handler="DownloadAttachment" asp-route-partnerId="@p.Id" asp-route-attachmentId="@a.Id" class="fw-semibold text-decoration-none ip-file-name">@a.OriginalFileName</a>
+                        <div class="ip-attachment-meta">@($"{a.SizeBytes / 1024.0:F1} KB") • Uploaded @a.UploadedUtc.LocalDateTime.ToString("dd MMM yyyy")</div>
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                        <a asp-page="./Index" asp-page-handler="DownloadAttachment" asp-route-partnerId="@p.Id" asp-route-attachmentId="@a.Id" class="btn btn-sm btn-outline-secondary">Download</a>
                         @if (Model.CanManage)
                         {
                             <form method="post" asp-page-handler="DeleteAttachment" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="partnerId" value="@p.Id" />
                                 <input type="hidden" name="attachmentId" value="@a.Id" />
-                                <button class="btn btn-sm btn-outline-danger">Delete</button>
+                                <button class="btn btn-sm ip-btn-outline-danger" type="submit">Delete</button>
                             </form>
                         }
                     </div>
-                </li>
+                </div>
             }
-        </ul>
+        }
     </div>
 </div>

--- a/Pages/IndustryPartners/_Contacts.cshtml
+++ b/Pages/IndustryPartners/_Contacts.cshtml
@@ -1,31 +1,37 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card industry-section-card">
-    <div class="card-body">
-        <div class="industry-section-heading-row mb-2">
-            <h3 class="h6 mb-0">Contacts</h3>
-            <small class="text-muted">People and communication details.</small>
-        </div>
-
+<div class="ip-section">
+    <div class="ip-section-header">
+        <h3 class="ip-section-title">Contacts</h3>
+        <small class="ip-section-note">People and communication details.</small>
+    </div>
+    <div class="ip-section-body">
         <div class="table-responsive">
-            <table class="table table-sm align-middle industry-compact-table">
+            <table class="table table-sm align-middle ip-table">
                 <thead><tr><th>Name</th><th>Phone</th><th>Email</th><th></th></tr></thead>
                 <tbody>
                 @foreach (var c in p.Contacts)
                 {
+                    var hasSignificantInfo = !string.IsNullOrWhiteSpace(c.Email) || (!string.IsNullOrWhiteSpace(c.Phone) && c.Phone!.Trim().Length > 5);
                     <tr>
                         <td>@c.Name</td><td>@c.Phone</td><td>@c.Email</td>
                         <td class="text-end">
                             @if (Model.CanManage)
                             {
-                                <form method="post" asp-page-handler="DeleteContact" class="d-inline">
+                                <form method="post" asp-page-handler="DeleteContact" class="d-inline" data-contact-delete-form>
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="partnerId" value="@p.Id" />
                                     <input type="hidden" name="contactId" value="@c.Id" />
-                                    <button class="btn btn-sm btn-outline-danger">Delete</button>
+                                    <button class="ip-btn-compact-danger" type="submit" data-confirm="@(hasSignificantInfo ? "true" : "false")">Delete</button>
                                 </form>
                             }
                         </td>
+                    </tr>
+                }
+                @if (!p.Contacts.Any())
+                {
+                    <tr>
+                        <td colspan="4" class="ip-empty-text">No contacts added yet.</td>
                     </tr>
                 }
                 </tbody>
@@ -33,13 +39,16 @@
         </div>
         @if (Model.CanManage)
         {
-            <form method="post" asp-page-handler="AddContact" class="row g-2">
+            <form method="post" asp-page-handler="AddContact" class="row g-2" data-add-contact-form>
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="partnerId" value="@p.Id" />
-                <div class="col-md-4"><input class="form-control form-control-sm" name="name" placeholder="Name" /></div>
-                <div class="col-md-3"><input class="form-control form-control-sm" name="phone" placeholder="Phone" /></div>
-                <div class="col-md-4"><input class="form-control form-control-sm" name="email" placeholder="Email" /></div>
-                <div class="col-md-1"><button class="btn btn-sm btn-primary w-100">Add</button></div>
+                <div class="col-md-4"><input class="form-control form-control-sm ip-input" name="name" placeholder="Name" data-contact-name /></div>
+                <div class="col-md-3"><input class="form-control form-control-sm ip-input" name="phone" placeholder="Phone" data-contact-phone /></div>
+                <div class="col-md-4"><input class="form-control form-control-sm ip-input" name="email" placeholder="Email" data-contact-email /></div>
+                <div class="col-md-1"><button class="btn btn-sm btn-primary w-100" type="submit">Add</button></div>
+                <div class="col-12">
+                    <div class="form-text text-danger d-none" data-contact-error>Provide at least a phone number or an email address.</div>
+                </div>
             </form>
         }
     </div>

--- a/Pages/IndustryPartners/_LinkedProjects.cshtml
+++ b/Pages/IndustryPartners/_LinkedProjects.cshtml
@@ -1,27 +1,30 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card industry-section-card">
-    <div class="card-body">
-        <div class="industry-section-heading-row mb-2">
-            <h3 class="h6 mb-0">Linked projects</h3>
-            <small class="text-muted">Connect project records to this partner.</small>
-        </div>
-
-        <div class="d-flex flex-wrap gap-2 mb-3">
+<div class="ip-section" data-linked-project-section>
+    <div class="ip-section-header">
+        <h3 class="ip-section-title">Linked projects</h3>
+        <small class="ip-section-note">Connect project records to this partner.</small>
+    </div>
+    <div class="ip-section-body">
+        <div class="d-flex flex-wrap gap-2 mb-3" data-existing-links>
             @foreach (var link in p.LinkedProjects)
             {
-                <span class="badge text-bg-light industry-link-badge">
-                    @link.ProjectName
+                <span class="ip-chip" data-project-id="@link.ProjectId">
+                    <span class="ip-chip-text">@link.ProjectName</span>
                     @if (Model.CanManage)
                     {
                         <form method="post" asp-page-handler="UnlinkProject" class="d-inline">
                             @Html.AntiForgeryToken()
                             <input type="hidden" name="partnerId" value="@p.Id" />
                             <input type="hidden" name="projectId" value="@link.ProjectId" />
-                            <button type="submit" class="btn btn-link btn-sm p-0 ms-1 text-danger text-decoration-none">×</button>
+                            <button type="submit" class="ip-chip-action" aria-label="Unlink @link.ProjectName">×</button>
                         </form>
                     }
                 </span>
+            }
+            @if (!p.LinkedProjects.Any())
+            {
+                <div class="ip-empty-text">No linked projects yet.</div>
             }
         </div>
 
@@ -30,23 +33,26 @@
             <form method="post" asp-page-handler="LinkProject" class="row g-2" data-link-project-form>
                 @Html.AntiForgeryToken()
                 <input type="hidden" name="partnerId" value="@p.Id" />
-                <div class="col-sm-8 position-relative">
-                    <input class="form-control form-control-sm"
+                <div class="col-sm-8 ip-typeahead">
+                    <input class="form-control form-control-sm ip-input"
                            name="projectSearch"
                            placeholder="Search project by name or file number"
                            autocomplete="off"
-                           data-project-search />
+                           data-project-search
+                           aria-expanded="false"
+                           aria-autocomplete="list" />
 
                     <input type="hidden" name="projectId" data-project-id required />
 
-                    <div class="list-group position-absolute w-100 shadow-sm d-none industry-project-results"
-                         data-project-results></div>
+                    <div class="ip-typeahead-results d-none" data-project-results role="listbox"></div>
 
                     <div class="form-text text-danger d-none" data-project-error>
                         Select a project from the list.
                     </div>
                 </div>
-                <div class="col-sm-4"><button class="btn btn-sm btn-outline-primary w-100" type="submit" data-link-project-submit disabled>Link project</button></div>
+                <div class="col-sm-4">
+                    <button class="btn btn-sm btn-outline-primary w-100" type="submit" data-link-project-submit disabled>Link project</button>
+                </div>
             </form>
         }
     </div>

--- a/Pages/IndustryPartners/_PartnerPanel.cshtml
+++ b/Pages/IndustryPartners/_PartnerPanel.cshtml
@@ -1,41 +1,75 @@
 @model ProjectManagement.Pages.IndustryPartners.IndexModel
 @{ var p = Model.SelectedPartner!; }
-<div class="card industry-section-card industry-workspace-card">
-    <div class="card-body">
+<div class="ip-panel">
+    <div class="ip-panel-body">
         <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
             <div>
                 <h2 class="h5 mb-1">@p.Name</h2>
-                <div class="text-muted small" data-save-status aria-live="polite">Saved</div>
+                <div class="small ip-status-text">@(string.IsNullOrWhiteSpace(p.Location) ? "Location not set" : p.Location)</div>
             </div>
-            @if (Model.CanDelete)
-            {
-                <form method="post" asp-page-handler="DeletePartner">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="partnerId" value="@p.Id" />
-                    <button type="submit" class="btn btn-outline-danger btn-sm">Delete partner</button>
-                </form>
-            }
+            <div class="d-flex flex-column align-items-end gap-2">
+                <div class="ip-status-text" data-save-status aria-live="polite">Saved</div>
+                @if (Model.CanDelete)
+                {
+                    <button type="button"
+                            class="btn btn-sm ip-btn-outline-danger"
+                            data-bs-toggle="modal"
+                            data-bs-target="#deletePartnerModal"
+                            data-delete-partner-trigger
+                            data-linked-project-count="@p.LinkedProjects.Count"
+                            data-partner-name="@p.Name">
+                        Delete partner
+                    </button>
+                }
+            </div>
         </div>
 
-        <div class="industry-section-heading-row">
-            <label class="form-label mb-1">Name</label>
-        </div>
-        <div class="mb-3">
-            <input class="form-control form-control-sm" value="@p.Name" data-inline-field="name" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled") />
-        </div>
+        <div class="ip-section mt-0">
+            <div class="ip-section-header">
+                <h3 class="ip-section-title">Partner details</h3>
+                <span class="ip-section-note">Inline edits are saved automatically.</span>
+            </div>
+            <div class="ip-section-body">
+                <div class="ip-field mb-3">
+                    <label class="form-label">Name</label>
+                    <input class="form-control form-control-sm ip-input" value="@p.Name" data-inline-field="name" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled") />
+                </div>
 
-        <div class="industry-section-heading-row">
-            <label class="form-label mb-1">Location</label>
-        </div>
-        <div class="mb-3">
-            <textarea class="form-control form-control-sm" rows="3" data-inline-field="location" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Location</textarea>
-        </div>
+                <div class="ip-field mb-3">
+                    <label class="form-label">Location</label>
+                    <textarea class="form-control form-control-sm ip-textarea" rows="3" data-inline-field="location" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Location</textarea>
+                </div>
 
-        <div class="industry-section-heading-row">
-            <label class="form-label mb-1">Remarks</label>
-        </div>
-        <div>
-            <textarea class="form-control form-control-sm" rows="4" data-inline-field="remarks" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Remarks</textarea>
+                <div class="ip-field">
+                    <label class="form-label">Remarks</label>
+                    <textarea class="form-control form-control-sm ip-textarea" rows="4" data-inline-field="remarks" data-partner-id="@p.Id" @(Model.CanManage ? "" : "disabled")>@p.Remarks</textarea>
+                </div>
+            </div>
         </div>
     </div>
 </div>
+
+@if (Model.CanDelete)
+{
+    <div class="modal fade" id="deletePartnerModal" tabindex="-1" aria-labelledby="deletePartnerModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title fs-6" id="deletePartnerModalLabel">Delete partner</h3>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-0" data-delete-partner-message></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <form method="post" asp-page-handler="DeletePartner" data-delete-partner-form>
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="partnerId" value="@p.Id" />
+                        <button type="submit" class="btn btn-sm btn-danger" data-delete-partner-submit>Delete partner</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/wwwroot/css/pages/industry-partners.css
+++ b/wwwroot/css/pages/industry-partners.css
@@ -1,93 +1,350 @@
-/* SECTION: Page-level layout and surfaces */
-.industry-partners-page {
-  --industry-border: #dde3ee;
-  --industry-surface: #fbfcff;
-  --industry-surface-strong: #f3f6fb;
-  --industry-accent: #204b95;
+/* =========================================================
+   Industry Partners (IP) Local Theme Tokens
+   ========================================================= */
+:root {
+  --ip-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  --ip-text: #0f172a;
+  --ip-muted: #64748b;
+  --ip-bg: #f6f7fb;
+  --ip-surface: #ffffff;
+  --ip-surface-2: #f8fafc;
+  --ip-accent: #2563eb;
+  --ip-accent-soft: #dbeafe;
+  --ip-danger: #dc2626;
+  --ip-danger-soft: rgba(220, 38, 38, 0.08);
+  --ip-success: #16a34a;
+  --ip-border: #e2e8f0;
+  --ip-danger-border: rgba(220, 38, 38, 0.4);
+  --ip-danger-border-soft: rgba(220, 38, 38, 0.35);
+  --ip-focus: 0 0 0 0.2rem rgba(37, 99, 235, 0.25);
+  --ip-space-1: 6px;
+  --ip-space-2: 10px;
+  --ip-space-3: 14px;
+  --ip-space-4: 18px;
+  --ip-space-5: 24px;
+  --ip-space-6: 32px;
+  --ip-radius-1: 8px;
+  --ip-radius-2: 12px;
+  --ip-radius-3: 16px;
+  --ip-shadow-1: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --ip-shadow-2: 0 8px 24px rgba(15, 23, 42, 0.1);
 }
 
-.industry-partners-page .card {
-  border-color: var(--industry-border);
-  box-shadow: 0 8px 24px rgba(15, 26, 56, 0.04);
+/* SECTION: Page shell and panel system */
+.ip-page {
+  background: var(--ip-bg);
+  color: var(--ip-text);
+  font-family: var(--ip-font-sans);
 }
 
-.industry-page-header {
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--industry-border);
+.ip-grid {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: var(--ip-space-5);
+  align-items: start;
 }
 
-/* SECTION: Left panel and list interaction */
-.industry-list-panel {
+.ip-panel {
+  background: var(--ip-surface);
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-2);
+  box-shadow: var(--ip-shadow-1);
+}
+
+.ip-panel-body {
+  padding: var(--ip-space-4);
+}
+
+.ip-sticky {
   position: sticky;
-  top: 1rem;
-  background: var(--industry-surface);
+  top: var(--ip-space-4);
 }
 
-.industry-list-group {
-  border: 1px solid var(--industry-border);
-  border-radius: 0.5rem;
-  overflow: hidden;
+@media (max-width: 1100px) {
+  .ip-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ip-sticky {
+    position: static;
+  }
 }
 
-.industry-list-item {
+/* SECTION: Header and utility components */
+.ip-page-header {
+  border-bottom: 1px solid var(--ip-border);
+  margin-bottom: var(--ip-space-4);
+  padding-bottom: var(--ip-space-2);
+}
+
+.ip-status-text {
+  color: var(--ip-muted);
+  font-size: 12px;
+}
+
+.ip-count-badge {
+  background: var(--ip-surface-2);
+  border: 1px solid var(--ip-border);
+  border-radius: 999px;
+  color: var(--ip-muted);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: var(--ip-space-1);
+  padding: 2px var(--ip-space-2);
+}
+
+/* SECTION: Form controls */
+.ip-field label {
+  color: var(--ip-muted);
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: var(--ip-space-1);
+}
+
+.ip-input,
+.ip-textarea {
+  background: var(--ip-surface);
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-1);
+  color: var(--ip-text);
+}
+
+.ip-input:focus,
+.ip-textarea:focus,
+.ip-btn-outline-danger:focus,
+.ip-btn-compact-danger:focus {
+  border-color: var(--ip-accent);
+  box-shadow: var(--ip-focus);
+  outline: none;
+}
+
+.ip-input.is-invalid,
+.ip-textarea.is-invalid,
+.ip-invalid {
+  border-color: var(--ip-danger) !important;
+  box-shadow: 0 0 0 0.2rem var(--ip-danger-soft);
+}
+
+/* SECTION: Left list */
+.ip-list-search {
+  margin-bottom: var(--ip-space-3);
+}
+
+.ip-list {
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-2);
+  max-height: calc(100vh - 240px);
+  overflow: auto;
+}
+
+.ip-list-item {
+  background: var(--ip-surface);
   border: 0;
-  border-bottom: 1px solid #edf1f7;
+  border-left: 3px solid transparent;
+  border-bottom: 1px solid var(--ip-border);
+  display: block;
+  padding: var(--ip-space-2) var(--ip-space-3);
+  text-decoration: none;
   transition: background-color 120ms ease, border-color 120ms ease;
 }
 
-.industry-list-item:last-child {
+.ip-list-item:last-child {
   border-bottom: 0;
 }
 
-.industry-list-item:hover {
-  background: #f6f9ff;
+.ip-list-item:hover {
+  background: var(--ip-surface-2);
 }
 
-.industry-list-item.active {
-  background: var(--industry-surface-strong);
-  color: inherit;
-  border-left: 3px solid var(--industry-accent);
-  padding-left: calc(1rem - 3px);
+.ip-list-item.is-active {
+  background: var(--ip-accent-soft);
+  border-left-color: var(--ip-accent);
 }
 
-.industry-list-item.active .text-muted {
-  color: #5e6d86 !important;
+.ip-list-item-title {
+  color: var(--ip-text);
+  font-size: 14px;
+  font-weight: 700;
 }
 
-/* SECTION: Right workspace sections */
-.industry-section-card .card-body {
-  background: var(--industry-surface);
+.ip-list-item-sub {
+  color: var(--ip-muted);
+  font-size: 12px;
+  margin-top: 2px;
 }
 
-.industry-section-heading-row {
+/* SECTION: Sections and content blocks */
+.ip-section {
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-2);
+  margin-top: var(--ip-space-3);
+  overflow: hidden;
+}
+
+.ip-section-header {
+  background: var(--ip-surface-2);
+  border-bottom: 1px solid var(--ip-border);
   display: flex;
-  align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
+  padding: var(--ip-space-3) var(--ip-space-4);
 }
 
-.industry-compact-table > :not(caption) > * > * {
-  padding-top: 0.4rem;
-  padding-bottom: 0.4rem;
+.ip-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  margin: 0;
 }
 
-.industry-upload-row input[type="file"] {
-  max-width: 360px;
+.ip-section-note {
+  color: var(--ip-muted);
+  font-size: 12px;
 }
 
-.industry-link-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  border: 1px solid var(--industry-border);
+.ip-section-body {
+  background: var(--ip-surface);
+  padding: var(--ip-space-4);
 }
 
-.industry-partners-page .form-control-sm,
-.industry-partners-page .btn-sm {
-  border-radius: 0.35rem;
+.ip-table > :not(caption) > * > * {
+  padding-bottom: var(--ip-space-2);
+  padding-top: var(--ip-space-2);
 }
 
+.ip-empty-text {
+  color: var(--ip-muted);
+  font-size: 12px;
+}
 
-.industry-project-results {
+/* SECTION: Typeahead and chips */
+.ip-typeahead {
+  position: relative;
+}
+
+.ip-typeahead-results {
+  background: var(--ip-surface);
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-2);
+  box-shadow: var(--ip-shadow-2);
+  left: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--ip-space-1));
   z-index: 1000;
+}
+
+.ip-typeahead-item {
+  background: var(--ip-surface);
+  border: 0;
+  border-bottom: 1px solid var(--ip-border);
+  color: var(--ip-text);
+  cursor: pointer;
+  display: block;
+  font-size: 13px;
+  padding: var(--ip-space-2) var(--ip-space-3);
+  text-align: left;
+  width: 100%;
+}
+
+.ip-typeahead-item:last-child {
+  border-bottom: 0;
+}
+
+.ip-typeahead-item:hover,
+.ip-typeahead-item.is-active {
+  background: var(--ip-surface-2);
+}
+
+.ip-chip {
+  align-items: center;
+  background: var(--ip-surface-2);
+  border: 1px solid var(--ip-border);
+  border-radius: 999px;
+  color: var(--ip-text);
+  display: inline-flex;
+  gap: var(--ip-space-1);
+  max-width: 100%;
+  padding: var(--ip-space-1) var(--ip-space-2);
+}
+
+.ip-chip-text {
+  max-width: 440px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ip-chip-action {
+  background: transparent;
+  border: 0;
+  color: var(--ip-muted);
+  line-height: 1;
+}
+
+.ip-chip-action:hover {
+  color: var(--ip-danger);
+}
+
+/* SECTION: Buttons and action controls */
+.ip-btn-outline-danger {
+  background: transparent;
+  border: 1px solid var(--ip-danger-border);
+  color: var(--ip-danger);
+}
+
+.ip-btn-outline-danger:hover,
+.ip-btn-compact-danger:hover {
+  background: var(--ip-danger-soft);
+  color: var(--ip-danger);
+}
+
+.ip-btn-compact-danger {
+  background: transparent;
+  border: 1px solid var(--ip-danger-border-soft);
+  border-radius: var(--ip-radius-1);
+  color: var(--ip-danger);
+  font-size: 12px;
+  line-height: 1;
+  min-width: 2rem;
+  padding: 3px 8px;
+}
+
+/* SECTION: Attachments */
+.ip-upload-file-name {
+  color: var(--ip-muted);
+  font-size: 12px;
+}
+
+.ip-attachment-item {
+  align-items: center;
+  border: 1px solid var(--ip-border);
+  border-radius: var(--ip-radius-1);
+  display: grid;
+  gap: var(--ip-space-2);
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-bottom: var(--ip-space-2);
+  padding: var(--ip-space-2) var(--ip-space-3);
+}
+
+.ip-attachment-meta {
+  color: var(--ip-muted);
+  font-size: 12px;
+}
+
+.ip-file-icon {
+  color: var(--ip-muted);
+  font-weight: 600;
+  margin-right: var(--ip-space-2);
+}
+
+.ip-file-name {
+  color: var(--ip-text);
+  display: inline-block;
+  max-width: min(460px, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
 }


### PR DESCRIPTION
### Motivation

- Provide a cohesive, local design system and visual hierarchy for the Industry Partners module so the page reads as an intentional single-page workspace rather than many equal-weight cards.
- Improve accessibility and keyboard usability for project linking and reduce user errors via inline validation and safer destructive actions.
- Keep server-side handlers and validation unchanged while enhancing client-side UX and appearance.

### Description

- Introduced an `ip-*` local design system and CSS tokens at the top of `wwwroot/css/pages/industry-partners.css` (spacing, radii, borders, shadows, text/surface/accent/focus tokens) and refactored component styles to use these tokens.  
- Refactored page markup to `ip-*` classes and a 2-column `ip-grid` layout in `Pages/IndustryPartners/Index.cshtml`, added partner count badge and improved left-list active/hover behaviour and location fallback.  
- Reworked workspace into a single `Partner details` section in `Pages/IndustryPartners/_PartnerPanel.cshtml`, aligned title/status, and added a Bootstrap delete confirmation modal with linked-project-aware messaging.  
- Enhanced linked-projects partial `Pages/IndustryPartners/_LinkedProjects.cshtml` (typeahead container, ARIA attributes, chip UI) and upgraded client interaction in `wwwroot/js/pages/industry-partners.js` with keyboard navigation (ArrowUp/ArrowDown/Enter/Escape), loading and empty states, match-highlighting, out-of-order response guarding via `AbortController`, and duplicate-link prevention.  
- Improved contacts UX in `Pages/IndustryPartners/_Contacts.cshtml` and JS with inline validation requiring phone or email, phone sanitization, inline error display, and conditional delete confirmation.  
- Upgraded attachments UI in `Pages/IndustryPartners/_Attachments.cshtml` and JS to show selected filename, disable upload until a file is chosen, show uploading state, and present richer attachment metadata and actions.  
- Reworked and modularised `wwwroot/js/pages/industry-partners.js` (section comments, helpers, and isolated init functions) while preserving server flows for create/update/link/unlink/upload/delete.

### Testing

- Ran `node --check wwwroot/js/pages/industry-partners.js` to validate the client script syntax and it succeeded.  
- Attempted `dotnet build` for a full compile but it could not run in this environment because `dotnet` is not available, so server-side compilation was not validated here.  
- Attempted an automated UI snapshot via Playwright against `http://127.0.0.1:5000/IndustryPartners` but the endpoint returned `ERR_EMPTY_RESPONSE` because no local server was running, so visual verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698787ca274c8329977bbb81c6392393)