### PR TITLE
Keep file input enabled on submit for industry partner attachments; add regression test

### DIFF
--- a/ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs
+++ b/ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using ProjectManagement.Pages.IndustryPartners;
+using ProjectManagement.Services.IndustryPartners;
+using Xunit;
+
+namespace ProjectManagement.Tests.IndustryPartners;
+
+public sealed class IndustryPartnersIndexPageAttachmentUploadTests
+{
+    [Fact]
+    public async Task OnPostUploadAttachmentAsync_WithRequestFormFile_UsesRequestFormFileCollection()
+    {
+        // SECTION: Arrange page and dependencies
+        var attachmentManager = new RecordingAttachmentManager();
+        var page = CreatePage(attachmentManager);
+
+        // SECTION: Arrange multipart form file in HttpContext request
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("attachment-content"));
+        var formFile = new FormFile(stream, 0, stream.Length, "attachment", "partner-notes.txt")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "text/plain"
+        };
+
+        var files = new FormFileCollection { formFile };
+        var form = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), files);
+        page.HttpContext.Features.Set<IFormFeature>(new FormFeature(form));
+
+        // SECTION: Act
+        var result = await page.OnPostUploadAttachmentAsync(partnerId: 42, CancellationToken.None);
+
+        // SECTION: Assert
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal(42, redirect.RouteValues?["id"]);
+        Assert.Equal("Attachment uploaded.", page.TempData["Message"]);
+
+        var uploaded = Assert.Single(attachmentManager.UploadedFiles);
+        Assert.Equal("partner-notes.txt", uploaded.FileName);
+        Assert.Equal(42, uploaded.PartnerId);
+    }
+
+    private static IndexModel CreatePage(RecordingAttachmentManager attachmentManager)
+    {
+        var page = new IndexModel(new StubIndustryPartnerService(), attachmentManager, new AllowAuthorizationService());
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "manager-1"),
+            new(ClaimTypes.Role, "Admin")
+        };
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+
+        var httpContext = new DefaultHttpContext { User = user };
+        var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor());
+
+        page.PageContext = new PageContext(actionContext)
+        {
+            ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        };
+
+        page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
+        return page;
+    }
+
+    // SECTION: Test doubles
+    private sealed class RecordingAttachmentManager : IIndustryPartnerAttachmentManager
+    {
+        public List<(int PartnerId, IFormFile File)> UploadedFiles { get; } = new();
+
+        public Task<Guid> UploadAsync(int partnerId, IFormFile file, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+        {
+            UploadedFiles.Add((partnerId, file));
+            return Task.FromResult(Guid.NewGuid());
+        }
+
+        public Task<(Stream Stream, string FileName, string ContentType)> DownloadAsync(int partnerId, Guid attachmentId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task DeleteAsync(int partnerId, Guid attachmentId, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class StubIndustryPartnerService : IIndustryPartnerService
+    {
+        public Task<IndustryPartnerSearchResult> SearchAsync(string? query, int page, int pageSize, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IndustryPartnerDto?> GetAsync(int id, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<int> CreateAsync(CreateIndustryPartnerRequest req, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task UpdateFieldAsync(int id, string field, string? value, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<int> AddContactAsync(int partnerId, ContactRequest req, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task UpdateContactAsync(int partnerId, int contactId, ContactRequest req, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task DeleteContactAsync(int partnerId, int contactId, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task LinkProjectAsync(int partnerId, int projectId, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task UnlinkProjectAsync(int partnerId, int projectId, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task DeletePartnerAsync(int partnerId, ClaimsPrincipal user, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class AllowAuthorizationService : IAuthorizationService
+    {
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+            => Task.FromResult(AuthorizationResult.Success());
+
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, string policyName)
+            => Task.FromResult(AuthorizationResult.Success());
+    }
+
+    private sealed class DictionaryTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => new Dictionary<string, object?>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+        }
+    }
+}

--- a/wwwroot/js/pages/industry-partners.js
+++ b/wwwroot/js/pages/industry-partners.js
@@ -479,9 +479,6 @@
     uploadForm.addEventListener('submit', () => {
       submitButton.disabled = true;
       submitButton.textContent = 'Uploading...';
-      if (fileInput) {
-        fileInput.disabled = true;
-      }
     });
 
     syncUploadState();


### PR DESCRIPTION
### Motivation

- Prevent the browser from dropping the selected file from multipart submissions by avoiding disabling the file input before the form is sent. 
- Preserve UX that prevents duplicate submissions while upload is in progress. 
- Add a regression test to ensure the server-side handler still receives the posted file via `Request.Form.Files`.

### Description

- Removed the code that disabled the file input in `initAttachmentUpload()` so the file input remains enabled until the request is actually sent (`wwwroot/js/pages/industry-partners.js`).
- Kept UX feedback by still disabling the submit button and updating its label to `Uploading...` in the form submit handler. 
- Confirmed server-side handler `OnPostUploadAttachmentAsync` continues to read `Request.Form.Files.FirstOrDefault()` and upload the file (`Pages/IndustryPartners/Index.cshtml.cs`).
- Added a regression page-model test `IndustryPartnersIndexPageAttachmentUploadTests` that populates `Request.Form.Files` via an `IFormFeature` and asserts the page handler receives and passes the uploaded `FormFile` to the attachment manager (`ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs`).

### Testing

- Added the test `IndustryPartnersIndexPageAttachmentUploadTests.OnPostUploadAttachmentAsync_WithRequestFormFile_UsesRequestFormFileCollection` to validate the server receives the selected file and the attachment manager is invoked. 
- Attempted to run the test locally with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~IndustryPartnersIndexPageAttachmentUploadTests"`, but the command failed in this environment because `dotnet` is not installed (`command not found`).
- No other automated test runs were performed in this environment; the new test is self-contained and should pass in CI where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987983b05e083298f7d1208da0c1458)