### PR TITLE
Completed summary: add active filter count, clear action, completion-year column and responsive table UX

### DIFF
--- a/Pages/Projects/CompletedSummary/Index.cshtml
+++ b/Pages/Projects/CompletedSummary/Index.cshtml
@@ -22,31 +22,73 @@
     <div class="pm-card cs-card cs-filters">
         <div class="pm-card-header cs-card-header">
             <div>
-                <div class="pm-card-title">Filters</div>
+                <div class="pm-card-title">
+                    Filters
+                    @if (Model.HasActiveFilters)
+                    {
+                        <span class="cs-filter-count">@Model.ActiveFilterCount</span>
+                    }
+                </div>
                 <div class="pm-card-subtitle">Refine the list using category, status, year, and search.</div>
-            </div>
-            <div class="cs-filter-actions">
-                <button type="submit" form="csFiltersForm" class="btn btn-primary cs-btn">Filter</button>
-                <a asp-page="./Index"
-                   asp-page-handler="Export"
-                   asp-route-TechnicalCategoryId="@Model.TechnicalCategoryId"
-                   asp-route-TechStatus="@Model.TechStatus"
-                   asp-route-AvailableForProliferation="@Model.AvailableForProliferation"
-                   asp-route-TotCompleted="@Model.TotCompleted"
-                   asp-route-CompletedYear="@Model.CompletedYear"
-                   asp-route-Search="@Model.Search"
-                   asp-route-Build="@Model.Build"
-                   asp-route-Sort="@Model.Sort"
-                   asp-route-Dir="@Model.Dir"
-                   class="btn btn-outline-secondary cs-btn">
-                    Export
-                </a>
             </div>
         </div>
 
         <div class="pm-card-body cs-card-body">
+            @* SECTION: Filter toolbar *@
+            <div class="cs-filter-toolbar">
+                <div class="cs-filter-summary">
+                    @if (Model.HasActiveFilters)
+                    {
+                        <span class="cs-muted">Active filters: <strong>@Model.ActiveFilterCount</strong></span>
+                    }
+                    else
+                    {
+                        <span class="cs-muted">No filters applied.</span>
+                    }
+                </div>
+
+                <div class="cs-filter-actions">
+                    <button type="submit" form="csFiltersForm" class="btn btn-primary cs-btn">Filter</button>
+                    @if (Model.HasActiveFilters)
+                    {
+                        <a asp-page="./Index"
+                           asp-route-TechnicalCategoryId=""
+                           asp-route-TechStatus=""
+                           asp-route-Build=""
+                           asp-route-AvailableForProliferation=""
+                           asp-route-TotCompleted=""
+                           asp-route-CompletedYear=""
+                           asp-route-Search=""
+                           asp-route-Sort="@Model.Sort"
+                           asp-route-Dir="@Model.Dir"
+                           class="btn btn-outline-secondary cs-btn cs-btn-clear">
+                            Clear
+                        </a>
+                    }
+                    <a asp-page="./Index"
+                       asp-page-handler="Export"
+                       asp-route-TechnicalCategoryId="@Model.TechnicalCategoryId"
+                       asp-route-TechStatus="@Model.TechStatus"
+                       asp-route-AvailableForProliferation="@Model.AvailableForProliferation"
+                       asp-route-TotCompleted="@Model.TotCompleted"
+                       asp-route-CompletedYear="@Model.CompletedYear"
+                       asp-route-Search="@Model.Search"
+                       asp-route-Build="@Model.Build"
+                       asp-route-Sort="@Model.Sort"
+                       asp-route-Dir="@Model.Dir"
+                       class="btn btn-outline-secondary cs-btn">
+                        Export
+                    </a>
+                </div>
+            </div>
+
             <form method="get" id="csFiltersForm" class="cs-filter-form" novalidate>
                 <div class="cs-grid">
+                    <div class="cs-field cs-field--full">
+                        <label asp-for="Search">Search by project name</label>
+                        <input asp-for="Search"
+                               class="form-control" />
+                    </div>
                     <div class="cs-field">
                         <label asp-for="TechnicalCategoryId">Technical category</label>
                         <select asp-for="TechnicalCategoryId"
@@ -116,11 +158,6 @@
                                class="form-control"
                                inputmode="numeric" />
                     </div>
-                    <div class="cs-field cs-field--wide">
-                        <label asp-for="Search">Search by project name</label>
-                        <input asp-for="Search"
-                               class="form-control" />
-                    </div>
                 </div>
 
                 @* SECTION: Persist sorting while applying filters *@
@@ -134,7 +171,7 @@
     <div class="pm-card cs-card cs-results">
         <div class="pm-card-header cs-card-header">
             <div>
-                <div class="pm-card-title">Results</div>
+                <div class="pm-card-title">Results <span class="cs-results-count">(@Model.Items.Count)</span></div>
                 <div class="pm-card-subtitle">Completed projects matching the applied filters.</div>
             </div>
         </div>
@@ -151,6 +188,7 @@
                         @* SECTION: Column sizing *@
                         <colgroup>
                             <col class="cs-col-project" />
+                            <col class="cs-col-year" />
                             <col class="cs-col-rd" />
                             <col class="cs-col-prod" />
                             <col class="cs-col-lpp" />
@@ -188,6 +226,20 @@
                                        asp-route-CompletedYear="@Model.CompletedYear"
                                        asp-route-Search="@Model.Search"
                                        asp-route-Build="@Model.Build"
+                                       asp-route-Sort="year"
+                                       asp-route-Dir="@(Model.NextSortDirection("year"))">
+                                        Completion year @Model.GetSortIndicator("year")
+                                    </a>
+                                </th>
+                                <th scope="col" class="cs-num text-end">
+                                    <a asp-page="./Index"
+                                       asp-route-TechnicalCategoryId="@Model.TechnicalCategoryId"
+                                       asp-route-TechStatus="@Model.TechStatus"
+                                       asp-route-AvailableForProliferation="@Model.AvailableForProliferation"
+                                       asp-route-TotCompleted="@Model.TotCompleted"
+                                       asp-route-CompletedYear="@Model.CompletedYear"
+                                       asp-route-Search="@Model.Search"
+                                       asp-route-Build="@Model.Build"
                                        asp-route-Sort="rd"
                                        asp-route-Dir="@(Model.NextSortDirection("rd"))">
                                         R&amp;D / L1 cost @Model.GetSortIndicator("rd")
@@ -209,7 +261,7 @@
                                         <span class="cs-th-sub">(lakh)</span>
                                     </a>
                                 </th>
-                                <th scope="col">
+                                <th scope="col" class="cs-th-lpp">
                                     <a asp-page="./Index"
                                        asp-route-TechnicalCategoryId="@Model.TechnicalCategoryId"
                                        asp-route-TechStatus="@Model.TechStatus"
@@ -265,7 +317,7 @@
                                         ToT status @Model.GetSortIndicator("tot")
                                     </a>
                                 </th>
-                                <th scope="col">Remarks</th>
+                                <th scope="col" class="cs-th-remarks">Remarks</th>
                                 @if (Model.CanEdit)
                                 {
                                     <th scope="col" class="cs-actions-col">Actions</th>
@@ -280,10 +332,11 @@
                                         <a asp-page="/Projects/Overview"
                                            asp-route-id="@item.ProjectId"
                                            class="cs-link pm-cell-clamp-2 cs-project-cell"
-                                           title="@item.Name">
+                                           title="@(string.IsNullOrWhiteSpace(item.Remarks) ? item.Name : $"{item.Name} | {item.Remarks}")">
                                             @item.Name
                                         </a>
                                     </td>
+                                    <td class="cs-num">@(item.CompletedYear?.ToString() ?? "—")</td>
                                     <td class="cs-num text-end">@(item.RdCostLakhs?.ToString("0.##"))</td>
                                     <td class="cs-num text-end">@(item.ApproxProductionCost?.ToString("0.##"))</td>
                                     <td class="cs-muted cs-td-lpp">

--- a/Pages/Projects/CompletedSummary/Index.cshtml.cs
+++ b/Pages/Projects/CompletedSummary/Index.cshtml.cs
@@ -79,6 +79,10 @@ public sealed class IndexModel : PageModel
 
     public IReadOnlyList<CompletedProjectSummaryDto> Items { get; private set; } = Array.Empty<CompletedProjectSummaryDto>();
 
+    // SECTION: Filter state metadata
+    public int ActiveFilterCount { get; private set; }
+    public bool HasActiveFilters => ActiveFilterCount > 0;
+
     // expose to the view
     public bool CanEdit { get; private set; }
 
@@ -93,6 +97,7 @@ public sealed class IndexModel : PageModel
     {
         await LoadTechnicalCategoriesAsync(cancellationToken);
         NormaliseFilters();
+        UpdateActiveFilterCount();
         NormaliseSorting();
 
         TechStatusOptions = BuildTechStatusOptions(TechStatus);
@@ -171,6 +176,20 @@ public sealed class IndexModel : PageModel
         }
 
         Search = string.IsNullOrWhiteSpace(Search) ? null : Search.Trim();
+    }
+
+    private void UpdateActiveFilterCount()
+    {
+        // SECTION: Count active user-applied filters
+        ActiveFilterCount = 0;
+
+        if (TechnicalCategoryId.HasValue) ActiveFilterCount++;
+        if (!string.IsNullOrWhiteSpace(TechStatus)) ActiveFilterCount++;
+        if (!string.IsNullOrWhiteSpace(Build)) ActiveFilterCount++;
+        if (AvailableForProliferation.HasValue) ActiveFilterCount++;
+        if (TotCompleted.HasValue) ActiveFilterCount++;
+        if (CompletedYear.HasValue) ActiveFilterCount++;
+        if (!string.IsNullOrWhiteSpace(Search)) ActiveFilterCount++;
     }
 
     private static BuildFilter? ParseBuildFilter(string? buildValue)

--- a/wwwroot/css/pages/projects-completed-summary.css
+++ b/wwwroot/css/pages/projects-completed-summary.css
@@ -49,6 +49,43 @@
     padding: 0;
 }
 
+/* SECTION: Filter metadata */
+.cs-filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 8px;
+    margin-left: 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 800;
+    background: rgba(45, 108, 223, 0.12);
+    color: #1d4ed8;
+    border: 1px solid rgba(45, 108, 223, 0.18);
+}
+
+.cs-results-count {
+    font-weight: 800;
+    color: #64748b;
+    margin-left: 6px;
+}
+
+/* SECTION: Filter toolbar */
+.cs-filter-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.cs-filter-summary {
+    font-size: 13px;
+}
+
 /* SECTION: Filter actions */
 .cs-filter-actions {
     display: flex;
@@ -60,6 +97,10 @@
 .cs-btn {
     border-radius: 10px;
     font-weight: 700;
+}
+
+.cs-btn-clear {
+    font-weight: 800;
 }
 
 /* SECTION: Filters grid */
@@ -85,6 +126,10 @@
     grid-column: span 2;
 }
 
+.cs-field--full {
+    grid-column: 1 / -1;
+}
+
 /* SECTION: Inputs */
 .cs-filters .form-control,
 .cs-filters .form-select {
@@ -101,7 +146,7 @@
 
 /* SECTION: Table wrapper */
 .cs-table-wrap {
-    overflow-x: auto;
+    overflow-x: hidden;
     border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
 
@@ -190,7 +235,11 @@
 
 /* SECTION: Deterministic column sizing */
 .cs-col-project {
-    width: 28%;
+    width: 26%;
+}
+
+.cs-col-year {
+    width: 8%;
 }
 
 .cs-col-rd {
@@ -198,7 +247,7 @@
 }
 
 .cs-col-prod {
-    width: 12%;
+    width: 11%;
 }
 
 .cs-col-lpp {
@@ -218,7 +267,7 @@
 }
 
 .cs-col-remarks {
-    width: 7%;
+    width: 8%;
 }
 
 .cs-col-actions {
@@ -310,8 +359,22 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .cs-col-remarks,
+    .cs-td-remarks,
+    .cs-th-remarks {
+        display: none;
+    }
+
     .cs-field--wide {
         grid-column: span 2;
+    }
+}
+
+@media (max-width: 992px) {
+    .cs-col-lpp,
+    .cs-td-lpp,
+    .cs-th-lpp {
+        display: none;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Improve usability of the Completed Projects summary by making applied filters visible, easing filter clearing, and surfacing completion year as a sortable column. 
- Prevent horizontal scrolling and make the table resilient on narrower screens by hiding low-priority columns and rebalancing column widths.

### Description

- Added filter state metadata to the page model by introducing `ActiveFilterCount` and `HasActiveFilters` and computing the count in `UpdateActiveFilterCount()` (called after `NormaliseFilters()` in `OnGetAsync`) in `Pages/Projects/CompletedSummary/Index.cshtml.cs`.
- Refactored the filters card in `Pages/Projects/CompletedSummary/Index.cshtml` to show a small badge for active filters, add a filter toolbar with a conditional `Clear` link that clears only the filter query parameters while preserving `Sort`/`Dir`, and moved `Search` to a prominent full-width position in the form.
- Added a sortable `Completion year` column to the results table (colgroup entry, header sort link with `asp-route-Sort="year"`, and a row cell rendering `item.CompletedYear`) and augmented the project link `title` to include remarks when present in `Index.cshtml`.
- Updated styling in `wwwroot/css/pages/projects-completed-summary.css` to add `.cs-filter-count`, `.cs-results-count`, `.cs-filter-toolbar`, `.cs-field--full`, `.cs-btn-clear`, introduced `.cs-col-year`, rebalanced deterministic column widths, disabled horizontal scrolling (`overflow-x: hidden`), and added responsive rules that hide `Remarks` at `max-width: 1200px` and `Latest LPP` at `max-width: 992px`.

### Testing

- Attempted to run unit/integration tests with `dotnet test ProjectManagement.sln`, but the command failed because `dotnet` is not available in the execution environment. (failed)
- Attempted to validate the UI with a Playwright script to capture `http://127.0.0.1:5000/Projects/CompletedSummary`, but the local app was not running so the navigation returned `ERR_EMPTY_RESPONSE`. (failed)
- No automated tests were executed successfully in this environment; changes are limited to UI and view-model logic and should be validated in a local/dev environment with `dotnet run` and the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e937dfea883298536e1edf5cdb586)