### PR TITLE
Fix Markdown rendering: allow HR/mailto/relative links, make renderer transient, and improve preview UX

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -421,7 +421,7 @@ builder.Services.AddScoped<ProliferationTrackerReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<ProjectRemarksPanelService>();
 builder.Services.AddScoped<ProjectMediaAggregator>();
-builder.Services.AddSingleton<IMarkdownRenderer, MarkdownRenderer>();
+builder.Services.AddTransient<IMarkdownRenderer, MarkdownRenderer>();
 builder.Services.AddScoped<ProjectModerationService>();
 builder.Services.AddScoped<IRemarkService, RemarkService>();
 builder.Services.AddScoped<INotificationPreferenceService, NotificationPreferenceService>();

--- a/wwwroot/js/pages/projects-meta-edit-description-preview.js
+++ b/wwwroot/js/pages/projects-meta-edit-description-preview.js
@@ -23,6 +23,16 @@
       previewError.textContent = '';
     }
 
+    if (!tokenInput?.value) {
+      previewContainer.innerHTML = '<span class="text-muted">Preview unavailable.</span>';
+      if (previewError) {
+        previewError.textContent = 'Preview unavailable (missing antiforgery token). Reload page.';
+        previewError.classList.remove('d-none');
+      }
+
+      return;
+    }
+
     previewContainer.textContent = 'Loading preview...';
 
     const body = new URLSearchParams();


### PR DESCRIPTION
### Motivation
- Single-line soft breaks and horizontal rules should survive sanitization and render as expected in previews and saved descriptions.
- Internal relative links and `mailto:` addresses must be preserved while still blocking unsafe schemes like `javascript:` to avoid broken internal links.
- The sanitizer instance must not be shared across concurrent requests to avoid potential thread-safety issues with a singleton renderer instance.

### Description
- Added `mailto` to allowed schemes and `hr` to allowed tags in `Services/Text/MarkdownRenderer.cs` to support mail links and markdown separators.
- Replaced absolute-only anchor validation with a dedicated `IsAllowedHref` helper that allows relative links and permits absolute `http`, `https`, and `mailto` schemes while stripping unsafe values. 
- Kept link hardening by setting `rel="noopener noreferrer"` and removing `target` for anchors. 
- Changed DI registration in `Program.cs` from `AddSingleton<IMarkdownRenderer, MarkdownRenderer>()` to `AddTransient<IMarkdownRenderer, MarkdownRenderer>()` to avoid sharing sanitizer state across requests. 
- Improved preview JavaScript (`wwwroot/js/pages/projects-meta-edit-description-preview.js`) to show an explicit error and return early when the antiforgery token is missing instead of issuing a broken request.

### Testing
- Attempted `dotnet build`, but the `dotnet` CLI is not available in this environment so the build could not be executed (failed: `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a843bc0483298013ad52b4fe1c24)