### PR TITLE
Make Markdown sanitizer per-call and register renderer as singleton

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -421,7 +421,7 @@ builder.Services.AddScoped<ProliferationTrackerReadService>();
 builder.Services.AddScoped<ProjectCommentService>();
 builder.Services.AddScoped<ProjectRemarksPanelService>();
 builder.Services.AddScoped<ProjectMediaAggregator>();
-builder.Services.AddTransient<IMarkdownRenderer, MarkdownRenderer>();
+builder.Services.AddSingleton<IMarkdownRenderer, MarkdownRenderer>();
 builder.Services.AddScoped<ProjectModerationService>();
 builder.Services.AddScoped<IRemarkService, RemarkService>();
 builder.Services.AddScoped<INotificationPreferenceService, NotificationPreferenceService>();

--- a/Services/Text/MarkdownRenderer.cs
+++ b/Services/Text/MarkdownRenderer.cs
@@ -13,8 +13,6 @@ public sealed class MarkdownRenderer : IMarkdownRenderer
         .UseSoftlineBreakAsHardlineBreak()
         .Build();
 
-    private static readonly HtmlSanitizer Sanitizer = CreateSanitizer();
-
     public string ToSafeHtml(string? markdown)
     {
         var trimmed = markdown?.Trim();
@@ -24,7 +22,9 @@ public sealed class MarkdownRenderer : IMarkdownRenderer
         }
 
         var unsafeHtml = Markdig.Markdown.ToHtml(trimmed, Pipeline);
-        var safeHtml = Sanitizer.Sanitize(unsafeHtml).Trim();
+        // SECTION: Per-call sanitizer instance (thread-safe by construction)
+        var sanitizer = CreateSanitizer();
+        var safeHtml = sanitizer.Sanitize(unsafeHtml).Trim();
         return safeHtml;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent shared mutable `HtmlSanitizer` state from causing concurrency issues during Markdown rendering by ensuring sanitizer state is not shared across threads. 
- Avoid unnecessary transient allocation churn while keeping a thread-safe renderer by adjusting the DI lifetime for `IMarkdownRenderer`.

### Description
- Replaced the process-wide static sanitizer with a per-call sanitizer by removing `private static readonly HtmlSanitizer Sanitizer` and calling `CreateSanitizer()` inside `ToSafeHtml` in `Services/Text/MarkdownRenderer.cs`. 
- Preserved the existing allowlist and link-hardening logic inside `CreateSanitizer()` so behavior remains consistent. 
- Changed DI registration from `AddTransient<IMarkdownRenderer, MarkdownRenderer>()` to `AddSingleton<IMarkdownRenderer, MarkdownRenderer>()` in `Program.cs` to reduce transient churn while the sanitizer is created per call.

### Testing
- Attempted to run unit tests filtered for markdown via `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter Markdown`, but the command failed because `dotnet` is not available in this environment (`bash: command not found: dotnet`).
- Verified code changes and usage via repository searches (`rg`) to confirm the new per-call sanitizer usage and the updated DI registration succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a9d0280c8329b19c9bcdece98aef)