### PR TITLE
Remove bundled Mulish binaries and finalize CSP directive builders

### DIFF
--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -135,5 +135,18 @@
     "ContentSecurityPolicy": {
       "ConnectSources": []
     }
+  },
+  "Security": {
+    "Csp": {
+      "ConnectSrcExtra": [
+        "http://localhost:*",
+        "https://localhost:*",
+        "ws://localhost:*",
+        "wss://localhost:*"
+      ],
+      "StyleSrcExtra": [],
+      "FontSrcExtra": [],
+      "ImgSrcExtra": []
+    }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -166,5 +166,13 @@
     "ContentSecurityPolicy": {
       "ConnectSources": []
     }
+  },
+  "Security": {
+    "Csp": {
+      "ConnectSrcExtra": [],
+      "StyleSrcExtra": [],
+      "FontSrcExtra": [],
+      "ImgSrcExtra": []
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Remove committed binary font files from the change set and avoid introducing local 404 font requests while preserving the previously-introduced CSP hardening work.
- Provide a cleaner, configuration-driven way to build CSP directives so environment-specific extras (e.g. dev loopback/ws) can be added without weakening production defaults.

### Description
- Removed the four `*.woff2` files from `wwwroot/fonts/mulish` and removed the temporary self-hosted `@font-face` block from `wwwroot/css/site.css`, restoring the system font stack in CSS.
- Introduced new CSP builder helpers in `Program.cs`: `BuildImgSrcDirective`, `BuildStyleSrcDirective`, `BuildFontSrcDirective`, and a reusable `BuildDirectiveWithExtras` that merges baseline sources with `Security:Csp:*` arrays from configuration.
- Rewired CSP header assembly in `Program.cs` to use the new directive builders (`imgSrcDirective`, `styleSrcDirective`, `fontSrcDirective`) and kept a development-aware `connect-src` merge path via `BuildConnectSrcDirective` + config extras.
- Added empty defaults for `Security:Csp:ConnectSrcExtra`, `StyleSrcExtra`, `FontSrcExtra`, and `ImgSrcExtra` to `appsettings.json` and populated development loopback/ws entries in `appsettings.Development.json` only.

### Testing
- Ran `git status --short` and file inspections to confirm the font binaries were removed and only the intended CSS change remained (pass).
- Searched `wwwroot/css/site.css` with ripgrep for `Mulish`, `/fonts/mulish`, and `@font-face` to confirm no lingering references (pass).
- Verified the restored CSS font stack lines are present by inspecting `wwwroot/css/site.css` (pass).
- Attempted a Playwright navigation to `http://127.0.0.1:5000/` to capture a runtime screenshot, but the local web server was not running and navigation failed with `ERR_EMPTY_RESPONSE` (automated runtime check failed; manual runtime verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b34d8d508329890a7c0012654cd6)