### PR TITLE
Exclude build projects from Proliferation Manager dropdown

### DIFF
--- a/Areas/ProjectOfficeReports/Application/ProliferationManageService.cs
+++ b/Areas/ProjectOfficeReports/Application/ProliferationManageService.cs
@@ -277,9 +277,14 @@ public sealed class ProliferationManageService
 
     private async Task<IReadOnlyList<ProliferationCompletedProjectOption>> GetCompletedProjectsAsync(CancellationToken ct)
     {
+        // SECTION: Completed non-build projects for Proliferation manager dropdown
         var projects = await _db.Projects
             .AsNoTracking()
-            .Where(p => !p.IsDeleted && !p.IsArchived && p.LifecycleStatus == ProjectLifecycleStatus.Completed)
+            .Where(p =>
+                !p.IsDeleted &&
+                !p.IsArchived &&
+                p.LifecycleStatus == ProjectLifecycleStatus.Completed &&
+                !p.IsBuild)
             .OrderBy(p => p.Name)
             .ToListAsync(ct);
 


### PR DESCRIPTION
### Motivation
- Ensure the Proliferation Manager "Project name / simulator name" dropdown lists only new projects (`IsBuild == false`) so build/re-manufacture projects are not selectable and the server-side list remains correct even if client-side JS fails.

### Description
- Update `GetCompletedProjectsAsync()` in `Areas/ProjectOfficeReports/Application/ProliferationManageService.cs` to add `!p.IsBuild` to the EF Core `.Where(...)` filter while preserving existing `LifecycleStatus == ProjectLifecycleStatus.Completed`, `!p.IsDeleted`, `!p.IsArchived`, alphabetical ordering by `Name`, and use of `p.BuildDisplayName()` for display; also add a short section comment clarifying the query intent.

### Testing
- Attempted to run `dotnet build`, which failed because the `dotnet` CLI is not available in the execution environment, so no automated build or test run could be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699139e17f2483299325c3e30092e723)