### PR TITLE
Restrict linked training projects to non-build while preserving legacy links

### DIFF
--- a/Areas/ProjectOfficeReports/Application/TrainingTrackerReadService.cs
+++ b/Areas/ProjectOfficeReports/Application/TrainingTrackerReadService.cs
@@ -45,11 +45,21 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application
             return types;
         }
 
-        public async Task<IReadOnlyList<ProjectOption>> GetProjectOptionsAsync(CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ProjectOption>> GetProjectOptionsAsync(
+            IEnumerable<int>? includeProjectIds,
+            CancellationToken cancellationToken)
         {
+            // ------------------------------------------------------------
+            // SECTION: Include selected legacy Build projects for edit labels
+            // ------------------------------------------------------------
+            var includeProjectIdSet = includeProjectIds?
+                .Distinct()
+                .ToHashSet() ?? new HashSet<int>();
+
             var projects = await _db.Projects
                 .AsNoTracking()
                 .Where(x => !x.IsDeleted && !x.IsArchived)
+                .Where(x => !x.IsBuild || includeProjectIdSet.Contains(x.Id))
                 .OrderBy(x => x.Name)
                 .Select(x => new ProjectOption(x.Id, x.Name))
                 .ToListAsync(cancellationToken);

--- a/Program.cs
+++ b/Program.cs
@@ -1850,7 +1850,7 @@ lookupApi.MapGet("/projects", async (
 
     var projects = db.Projects
         .AsNoTracking()
-        .Where(p => !p.IsDeleted && !p.IsArchived);
+        .Where(p => !p.IsDeleted && !p.IsArchived && !p.IsBuild);
 
     if (!string.IsNullOrEmpty(term))
     {


### PR DESCRIPTION
### Motivation

- Prevent users from discovering or selecting Build projects (`IsBuild == true`) from the Linked projects lookup while preserving display names for any Build projects already linked to an existing training record, and enforce the rule server-side to block crafted requests.

### Description

- Filtered the async projects lookup endpoint so it only returns non-build projects by adding `!p.IsBuild` to the minimal API query in `Program.cs` (`/api/lookups/projects`).
- Extended `TrainingTrackerReadService.GetProjectOptionsAsync` to accept an optional `includeProjectIds` parameter and to return all non-build projects plus any explicitly included project IDs so legacy Build-linked projects show correct names on edit.
- Updated `ManageModel` (`Areas/ProjectOfficeReports/Pages/Training/Manage.cshtml.cs`) to inject `ApplicationDbContext`, pass `Input?.ProjectIds` into `GetProjectOptionsAsync`, load options after editor data is hydrated on GET, and add `ValidateBuildProjectSelectionAsync` to enforce server-side rules that block Build IDs on create and block newly added Build IDs on edit while allowing previously linked Build IDs to remain.

### Testing

- Attempted to build the solution with `dotnet build`, but the environment does not have the `dotnet` CLI installed so the build could not be run (`command not found`).
- Attempted an automated browser check (Playwright) to load `/ProjectOfficeReports/Training/Manage`, but the local app endpoint was not reachable in this environment and returned `ERR_EMPTY_RESPONSE` so UI verification could not be performed.
- Verified diffs and ran local code edits and grep/inspection to confirm the new filters, method signature change, and validation method were applied as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699140193be88329bce117cde109eebb)