### PR TITLE
Add Compendiums landing/nav; bulk export & two‑pass PDF index fixes

### DIFF
--- a/Areas/Compendiums/Application/ICompendiumReadService.cs
+++ b/Areas/Compendiums/Application/ICompendiumReadService.cs
@@ -7,4 +7,5 @@ public interface ICompendiumReadService
 {
     Task<IReadOnlyList<CompendiumProjectCardDto>> GetEligibleProjectsAsync(CancellationToken cancellationToken);
     Task<CompendiumProjectDetailDto?> GetProjectAsync(int projectId, bool includeHistoricalExtras, CancellationToken cancellationToken);
+    Task<IReadOnlyList<CompendiumProjectDetailDto>> GetEligibleProjectDetailsAsync(bool includeHistoricalExtras, CancellationToken cancellationToken);
 }

--- a/Areas/Compendiums/Pages/Historical/ExportPdf.cshtml.cs
+++ b/Areas/Compendiums/Pages/Historical/ExportPdf.cshtml.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Areas.Compendiums.Application;
-using ProjectManagement.Areas.Compendiums.Application.Dto;
 using ProjectManagement.Utilities.Reporting;
 
 namespace ProjectManagement.Areas.Compendiums.Pages.Historical;
@@ -23,17 +22,7 @@ public sealed class ExportPdfModel : PageModel
 
     public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
     {
-        var cards = await _readService.GetEligibleProjectsAsync(cancellationToken);
-        var details = new List<CompendiumProjectDetailDto>(cards.Count);
-
-        foreach (var card in cards)
-        {
-            var detail = await _readService.GetProjectAsync(card.ProjectId, includeHistoricalExtras: true, cancellationToken);
-            if (detail is not null)
-            {
-                details.Add(detail);
-            }
-        }
+        var details = await _readService.GetEligibleProjectDetailsAsync(includeHistoricalExtras: true, cancellationToken);
 
         var logoPath = Path.Combine(_environment.WebRootPath, "img", "logos", "sdd.png");
         var logoBytes = System.IO.File.Exists(logoPath) ? await System.IO.File.ReadAllBytesAsync(logoPath, cancellationToken) : null;

--- a/Areas/Compendiums/Pages/Historical/Index.cshtml
+++ b/Areas/Compendiums/Pages/Historical/Index.cshtml
@@ -32,6 +32,7 @@
                         <p class="mb-1"><strong>Sponsoring dte:</strong> @project.SponsoringLineDirectorateName</p>
                         <p class="mb-1"><strong>Completion year:</strong> @project.CompletionYearText</p>
                         <p class="mb-1"><strong>ToT status:</strong> Internal</p>
+                        <p class="mb-1"><strong>Proliferation cost:</strong> @(project.ProliferationCostLakhs.HasValue ? $"{project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</p>
                         <p class="mb-2"><strong>Total proliferation:</strong> @(Model.TotalsByProject.TryGetValue(project.ProjectId, out var total) ? total : 0)</p>
                         <a asp-page="/Historical/Project" asp-area="Compendiums" asp-route-id="@project.ProjectId" class="btn btn-outline-primary btn-sm">View</a>
                     </div>

--- a/Areas/Compendiums/Pages/Historical/Project.cshtml
+++ b/Areas/Compendiums/Pages/Historical/Project.cshtml
@@ -14,7 +14,7 @@
             <div class="col-md-4 small">
                 <div><strong>Completion year:</strong> @Model.Project.CompletionYearText</div>
                 <div><strong>Arms / Services:</strong> @Model.Project.ArmService</div>
-                <div><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs?.ToString("0.##") ?? "Not recorded") lakh INR</div>
+                <div><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs.HasValue ? $"{Model.Project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</div>
             </div>
         </div>
     </div>
@@ -34,7 +34,7 @@
     <div class="card bg-light mb-3">
         <div class="card-body">
             <h6>Historical record</h6>
-            <div><strong>R&amp;D cost (lakh INR):</strong> @(Model.Project.HistoricalExtras?.RdCostLakhs?.ToString("0.##") ?? "Not recorded")</div>
+            <div><strong>R&amp;D cost:</strong> @(Model.Project.HistoricalExtras?.RdCostLakhs.HasValue == true ? $"{Model.Project.HistoricalExtras.RdCostLakhs.Value:0.##} lakh INR" : "Not recorded")</div>
             <div><strong>ToT status:</strong> @Model.Project.HistoricalExtras?.TotStatusText</div>
             <div><strong>Completed on:</strong> @Model.Project.HistoricalExtras?.TotCompletedOnText</div>
             <div><strong>Proliferation counts (all time):</strong></div>
@@ -48,7 +48,7 @@
 
     <div class="card mb-3">
         <div class="card-body">
-            <div class="mb-2"><strong>Proliferation cost (lakh INR):</strong> @(Model.Project.ProliferationCostLakhs?.ToString("0.##") ?? "Not recorded")</div>
+            <div class="mb-2"><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs.HasValue ? $"{Model.Project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</div>
             <div class="fst-italic text-secondary">Note: Software will be provided free of cost by SDD.</div>
         </div>
     </div>

--- a/Areas/Compendiums/Pages/Index.cshtml
+++ b/Areas/Compendiums/Pages/Index.cshtml
@@ -1,0 +1,36 @@
+@page "/Compendiums"
+@model ProjectManagement.Areas.Compendiums.Pages.IndexModel
+@{
+    ViewData["Title"] = "Compendiums";
+}
+
+<div class="container py-4">
+    @* SECTION: Page header *@
+    <div class="mb-4">
+        <h2 class="mb-1">Compendiums</h2>
+        <p class="text-muted mb-0">Browse compendium outputs for eligible completed projects.</p>
+    </div>
+
+    @* SECTION: Compendium options *@
+    <div class="row g-3">
+        <div class="col-12 col-lg-6">
+            <div class="card border-primary h-100 shadow-sm">
+                <div class="card-body d-flex flex-column">
+                    <h5 class="card-title">Proliferation Compendium</h5>
+                    <p class="card-text text-muted flex-grow-1">Default compendium view with completed projects available for proliferation.</p>
+                    <a asp-area="Compendiums" asp-page="/Proliferation/Index" class="btn btn-primary align-self-start">Open Proliferation Compendium</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-lg-6">
+            <div class="card h-100 shadow-sm">
+                <div class="card-body d-flex flex-column">
+                    <h5 class="card-title">Historical Repository Compendium</h5>
+                    <p class="card-text text-muted flex-grow-1">Historical project snapshots with ToT and all-time proliferation metrics.</p>
+                    <a asp-area="Compendiums" asp-page="/Historical/Index" class="btn btn-outline-primary align-self-start">Open Historical Repository Compendium</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Areas/Compendiums/Pages/Index.cshtml.cs
+++ b/Areas/Compendiums/Pages/Index.cshtml.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ProjectManagement.Areas.Compendiums.Pages;
+
+[Authorize]
+public sealed class IndexModel : PageModel
+{
+    // SECTION: Landing page model (intentionally empty)
+    public void OnGet()
+    {
+    }
+}

--- a/Areas/Compendiums/Pages/Proliferation/ExportPdf.cshtml.cs
+++ b/Areas/Compendiums/Pages/Proliferation/ExportPdf.cshtml.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ProjectManagement.Areas.Compendiums.Application;
-using ProjectManagement.Areas.Compendiums.Application.Dto;
 using ProjectManagement.Utilities.Reporting;
 
 namespace ProjectManagement.Areas.Compendiums.Pages.Proliferation;
@@ -23,17 +22,7 @@ public sealed class ExportPdfModel : PageModel
 
     public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
     {
-        var cards = await _readService.GetEligibleProjectsAsync(cancellationToken);
-        var details = new List<CompendiumProjectDetailDto>(cards.Count);
-
-        foreach (var card in cards)
-        {
-            var detail = await _readService.GetProjectAsync(card.ProjectId, includeHistoricalExtras: false, cancellationToken);
-            if (detail is not null)
-            {
-                details.Add(detail);
-            }
-        }
+        var details = await _readService.GetEligibleProjectDetailsAsync(includeHistoricalExtras: false, cancellationToken);
 
         var logoPath = Path.Combine(_environment.WebRootPath, "img", "logos", "sdd.png");
         var logoBytes = System.IO.File.Exists(logoPath) ? await System.IO.File.ReadAllBytesAsync(logoPath, cancellationToken) : null;

--- a/Areas/Compendiums/Pages/Proliferation/Index.cshtml
+++ b/Areas/Compendiums/Pages/Proliferation/Index.cshtml
@@ -31,7 +31,7 @@
                         <h5 class="card-title">@project.Name</h5>
                         <p class="mb-1"><strong>Sponsoring dte:</strong> @project.SponsoringLineDirectorateName</p>
                         <p class="mb-1"><strong>Completion year:</strong> @project.CompletionYearText</p>
-                        <p class="mb-2"><strong>Proliferation cost:</strong> @(project.ProliferationCostLakhs?.ToString("0.##") ?? "Not recorded") lakh INR</p>
+                        <p class="mb-2"><strong>Proliferation cost:</strong> @(project.ProliferationCostLakhs.HasValue ? $"{project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</p>
                         <a asp-page="/Proliferation/Project" asp-area="Compendiums" asp-route-id="@project.ProjectId" class="btn btn-outline-primary btn-sm">View</a>
                     </div>
                 </div>

--- a/Areas/Compendiums/Pages/Proliferation/Index.cshtml.cs
+++ b/Areas/Compendiums/Pages/Proliferation/Index.cshtml.cs
@@ -30,17 +30,7 @@ public sealed class IndexModel : PageModel
 
     public async Task<IActionResult> OnGetExportPdfAsync(CancellationToken cancellationToken)
     {
-        var cards = await _readService.GetEligibleProjectsAsync(cancellationToken);
-        var details = new List<CompendiumProjectDetailDto>(cards.Count);
-
-        foreach (var card in cards)
-        {
-            var detail = await _readService.GetProjectAsync(card.ProjectId, includeHistoricalExtras: false, cancellationToken);
-            if (detail is not null)
-            {
-                details.Add(detail);
-            }
-        }
+        var details = await _readService.GetEligibleProjectDetailsAsync(includeHistoricalExtras: false, cancellationToken);
 
         var logoPath = Path.Combine(_environment.WebRootPath, "img", "logos", "sdd.png");
         var logoBytes = System.IO.File.Exists(logoPath) ? await System.IO.File.ReadAllBytesAsync(logoPath, cancellationToken) : null;

--- a/Areas/Compendiums/Pages/Proliferation/Project.cshtml
+++ b/Areas/Compendiums/Pages/Proliferation/Project.cshtml
@@ -14,7 +14,7 @@
             <div class="col-md-4 small">
                 <div><strong>Completion year:</strong> @Model.Project.CompletionYearText</div>
                 <div><strong>Arms / Services:</strong> @Model.Project.ArmService</div>
-                <div><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs?.ToString("0.##") ?? "Not recorded") lakh INR</div>
+                <div><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs.HasValue ? $"{Model.Project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</div>
             </div>
         </div>
     </div>
@@ -34,7 +34,7 @@
 
     <div class="card mb-3">
         <div class="card-body">
-            <div class="mb-2"><strong>Proliferation cost (lakh INR):</strong> @(Model.Project.ProliferationCostLakhs?.ToString("0.##") ?? "Not recorded")</div>
+            <div class="mb-2"><strong>Proliferation cost:</strong> @(Model.Project.ProliferationCostLakhs.HasValue ? $"{Model.Project.ProliferationCostLakhs.Value:0.##} lakh INR" : "Not recorded")</div>
             <div class="fst-italic text-secondary">Note: Software will be provided free of cost by SDD.</div>
         </div>
     </div>

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -69,6 +69,13 @@ public class RoleBasedNavigationProvider : INavigationProvider
                 Page = "/Activities/Index",
                 Icon = "bi-stars"
             },
+            new()
+            {
+                Text = "Compendiums",
+                Area = "Compendiums",
+                Page = "/Index",
+                Icon = "bi-book"
+            },
             // Progress review entry (drawer only).
             new()
             {

--- a/Utilities/Reporting/HistoricalCompendiumPdfBuilder.cs
+++ b/Utilities/Reporting/HistoricalCompendiumPdfBuilder.cs
@@ -23,10 +23,22 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
 
     public byte[] Build(HistoricalCompendiumPdfContext context)
     {
-        var indexEntries = BuildIndexEntries(context.Projects);
+        // SECTION: Two-pass rendering for accurate index page numbers
+        var projectStartPages = new Dictionary<int, int>();
+        CreateDocument(context, projectStartPages, capturePageNumbers: true).GeneratePdf();
 
-        var document = Document.Create(container =>
+        return CreateDocument(context, projectStartPages, capturePageNumbers: false).GeneratePdf();
+    }
+
+    // SECTION: Shared document composition for pass-1 and pass-2
+    private static Document CreateDocument(
+        HistoricalCompendiumPdfContext context,
+        Dictionary<int, int> projectStartPages,
+        bool capturePageNumbers)
+    {
+        return Document.Create(container =>
         {
+            // SECTION: Cover page
             container.Page(page =>
             {
                 page.Size(PageSizes.A4);
@@ -41,6 +53,7 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
                 page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));
             });
 
+            // SECTION: Index page
             container.Page(page =>
             {
                 page.Size(PageSizes.A4);
@@ -66,29 +79,47 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
                         h.Cell().AlignRight().Text("Page").SemiBold();
                     });
 
-                    foreach (var entry in indexEntries)
+                    for (var index = 0; index < context.Projects.Count; index++)
                     {
-                        table.Cell().Text(entry.Serial.ToString(CultureInfo.InvariantCulture));
-                        table.Cell().Text(entry.Project.Name);
-                        table.Cell().Text(entry.Project.SponsoringLineDirectorateName);
-                        table.Cell().Text(entry.Project.CompletionYearText);
-                        table.Cell().AlignRight().Text(entry.StartPage.ToString(CultureInfo.InvariantCulture));
+                        var project = context.Projects[index];
+                        table.Cell().Text((index + 1).ToString(CultureInfo.InvariantCulture));
+                        table.Cell().Text(project.Name);
+                        table.Cell().Text(project.SponsoringLineDirectorateName);
+                        table.Cell().Text(project.CompletionYearText);
+
+                        var pageText = projectStartPages.TryGetValue(project.ProjectId, out var startPage)
+                            ? startPage.ToString(CultureInfo.InvariantCulture)
+                            : "-";
+                        table.Cell().AlignRight().Text(pageText);
                     }
                 });
                 page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));
             });
 
+            // SECTION: Project sections
             foreach (var project in context.Projects)
             {
                 container.Page(page =>
                 {
                     page.Size(PageSizes.A4);
                     page.Margin(35);
-                    page.Content().Element(c => ComposeProject(c, project));
+                    page.Content().Column(column =>
+                    {
+                        column.Item().CaptureContentPosition(position =>
+                        {
+                            if (capturePageNumbers && !projectStartPages.ContainsKey(project.ProjectId))
+                            {
+                                projectStartPages[project.ProjectId] = position.PageNumber;
+                            }
+                        });
+
+                        column.Item().Element(c => ComposeProject(c, project));
+                    });
                     page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));
                 });
             }
 
+            // SECTION: Back cover
             container.Page(page =>
             {
                 page.Size(PageSizes.A4);
@@ -103,8 +134,6 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
                 page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));
             });
         });
-
-        return document.GeneratePdf();
     }
 
     private static void ComposeProject(IContainer container, CompendiumProjectDetailDto project)
@@ -125,7 +154,7 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
                 {
                     right.Item().Text($"Completion year: {project.CompletionYearText}").FontSize(10);
                     right.Item().Text($"Arms / Services: {project.ArmService}").FontSize(10);
-                    right.Item().Text($"Proliferation cost: {(project.ProliferationCostLakhs.HasValue ? project.ProliferationCostLakhs.Value.ToString("0.##", CultureInfo.InvariantCulture) + " lakh INR" : "Not recorded")}").FontSize(10);
+                    right.Item().Text($"Proliferation cost: {FormatCost(project.ProliferationCostLakhs)}").FontSize(10);
                 });
             });
 
@@ -149,7 +178,7 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
                 {
                     hist.Spacing(4);
                     hist.Item().Text("Historical record").SemiBold().FontColor("#0F172A");
-                    hist.Item().Text($"R&D cost (lakh INR): {(historical.RdCostLakhs.HasValue ? historical.RdCostLakhs.Value.ToString("0.##", CultureInfo.InvariantCulture) : "Not recorded")}");
+                    hist.Item().Text($"R&D cost: {FormatCost(historical.RdCostLakhs)}");
                     hist.Item().Text($"ToT status: {historical.TotStatusText}");
                     hist.Item().Text($"Completed on: {historical.TotCompletedOnText}");
                     hist.Item().Text($"Proliferation counts (all time): Total {historical.ProliferationTotalAllTime}, SDD {historical.ProliferationSddAllTime}, 515 ABW {historical.ProliferationAbw515AllTime}");
@@ -158,26 +187,15 @@ public sealed class HistoricalCompendiumPdfBuilder : IHistoricalCompendiumPdfBui
 
             column.Item().Border(1).BorderColor("#E2E8F0").Padding(10).Column(cost =>
             {
-                cost.Item().Text($"Proliferation cost (lakh INR): {(project.ProliferationCostLakhs.HasValue ? project.ProliferationCostLakhs.Value.ToString("0.##", CultureInfo.InvariantCulture) : "Not recorded")}");
+                cost.Item().Text($"Proliferation cost: {FormatCost(project.ProliferationCostLakhs)}");
                 cost.Item().PaddingTop(6).Text("Note: Software will be provided free of cost by SDD.").Italic().FontColor("#334155");
             });
         });
     }
 
-    private static List<IndexEntry> BuildIndexEntries(IReadOnlyList<CompendiumProjectDetailDto> projects)
-    {
-        var entries = new List<IndexEntry>(projects.Count);
-        var page = 3;
-
-        for (var i = 0; i < projects.Count; i++)
-        {
-            var project = projects[i];
-            entries.Add(new IndexEntry(i + 1, project, page));
-            page += Math.Max(1, 1 + ((project.Description?.Length ?? 0) / 2600));
-        }
-
-        return entries;
-    }
-
-    private sealed record IndexEntry(int Serial, CompendiumProjectDetailDto Project, int StartPage);
+    // SECTION: Cost formatter to avoid invalid unit suffixes on null values
+    private static string FormatCost(decimal? value)
+        => value.HasValue
+            ? $"{value.Value.ToString("0.##", CultureInfo.InvariantCulture)} lakh INR"
+            : "Not recorded";
 }


### PR DESCRIPTION
### Motivation

- Provide a discoverable Compendiums entry in the left drawer and a simple landing page so authorised users can open Proliferation or Historical compendiums.
- Ensure PDF indexes show correct project start page numbers regardless of content by replacing heuristic estimation with a true two‑pass capture approach.
- Fix export performance by removing N+1 per‑project detail fetches and loading eligible project details in bulk.

### Description

- Added a new authorized landing page at `/Compendiums` (`Areas/Compendiums/Pages/Index.cshtml` + model) and inserted a top‑level `Compendiums` navigation item below “Miscellaneous activities” in `Services/Navigation/RoleBasedNavigationProvider.cs`.
- Extended `ICompendiumReadService` with `GetEligibleProjectDetailsAsync` and implemented bulk detail loading in `CompendiumReadService` including controlled loops to resolve cover photos and historical extras, plus a shared `MapToDetail` mapper.
- Updated export handlers and index pages to use the bulk API (removed per‑project `GetProjectAsync` loops) in `Areas/Compendiums/Pages/*/ExportPdf.cshtml.cs` and list pages.
- Rewrote `Utilities/Reporting/ProliferationCompendiumPdfBuilder.cs` and `Utilities/Reporting/HistoricalCompendiumPdfBuilder.cs` to perform a two‑pass render: pass‑1 captures each project start page into a `Dictionary<int,int>` via `CaptureContentPosition`, pass‑2 renders the final PDF and builds the index from captured pages, and removed the old heuristic estimation logic; also added `FormatCost` helper and adjusted Razor views to render cost units only when a numeric value exists.

### Testing

- Attempted to run `dotnet build`, but the .NET SDK/runtime is not available in this environment (`dotnet: command not found`).
- Ran repository searches to confirm the cost/unit polish (no occurrences of the problematic `"Not recorded lakh INR"` pattern were found). 
- Performed static code inspection to verify export endpoints now call `GetEligibleProjectDetailsAsync` and that both PDF builders implement the two‑pass capture map for index page numbers. 
- Attempted an automated UI screenshot with Playwright, but Chromium crashed in this environment (SIGSEGV) so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991822dd7d08329a936ccd857783951)