### PR TITLE
Fix QuestPDF compile errors and CSS IntelliSense warning

### DIFF
--- a/Utilities/Reporting/ProliferationCompendiumPdfBuilder.cs
+++ b/Utilities/Reporting/ProliferationCompendiumPdfBuilder.cs
@@ -23,18 +23,12 @@ public sealed class ProliferationCompendiumPdfBuilder : IProliferationCompendium
 
     public byte[] Build(ProliferationCompendiumPdfContext context)
     {
-        // SECTION: Two-pass rendering for accurate index page numbers
-        var projectStartPages = new Dictionary<int, int>();
-        CreateDocument(context, projectStartPages, capturePageNumbers: true).GeneratePdf();
-
-        return CreateDocument(context, projectStartPages, capturePageNumbers: false).GeneratePdf();
+        // SECTION: Single-pass rendering for deterministic offline generation
+        return CreateDocument(context).GeneratePdf();
     }
 
-    // SECTION: Shared document composition for pass-1 and pass-2
-    private static Document CreateDocument(
-        ProliferationCompendiumPdfContext context,
-        Dictionary<int, int> projectStartPages,
-        bool capturePageNumbers)
+    // SECTION: Shared document composition
+    private static Document CreateDocument(ProliferationCompendiumPdfContext context)
     {
         return Document.Create(container =>
         {
@@ -87,10 +81,7 @@ public sealed class ProliferationCompendiumPdfBuilder : IProliferationCompendium
                         table.Cell().Text(project.SponsoringLineDirectorateName);
                         table.Cell().Text(project.CompletionYearText);
 
-                        var pageText = projectStartPages.TryGetValue(project.ProjectId, out var startPage)
-                            ? startPage.ToString(CultureInfo.InvariantCulture)
-                            : "-";
-                        table.Cell().AlignRight().Text(pageText);
+                        table.Cell().AlignRight().Text("-");
                     }
                 });
                 page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));
@@ -105,14 +96,6 @@ public sealed class ProliferationCompendiumPdfBuilder : IProliferationCompendium
                     page.Margin(35);
                     page.Content().Column(column =>
                     {
-                        column.Item().CaptureContentPosition(position =>
-                        {
-                            if (capturePageNumbers && !projectStartPages.ContainsKey(project.ProjectId))
-                            {
-                                projectStartPages[project.ProjectId] = position.PageNumber;
-                            }
-                        });
-
                         column.Item().Element(c => ComposeProject(c, project));
                     });
                     page.Footer().Element(c => PrismPdfChrome.ComposeFooter(c, context.FooterLogoBytes, context.GeneratedOn));

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -99,6 +99,7 @@
     --pm-chip-bg: var(--pm-surface-contrast);
     --pm-chip-text: var(--pm-text-secondary);
     --pm-chip-border: rgba(148, 163, 184, 0.6);
+    --pm-chip-hover-bg: #e2e8f0;
     --pm-divider: rgba(148, 163, 184, 0.4);
     /* -- SECTION: Accents & category colors -- */
     --pm-accent-blue: #3b82f6;
@@ -533,7 +534,7 @@ main[role="main"] {
 }
 
 .pm-chip-link:hover {
-    background: color-mix(in srgb, var(--pm-chip-bg) 94%, var(--pm-text) 6%);
+    background: var(--pm-chip-hover-bg);
     text-decoration: none;
     color: var(--pm-text);
 }


### PR DESCRIPTION
### Motivation
- The QuestPDF API version in use does not expose `CaptureContentPosition` on `IContainer`, which caused CS1061 compile errors in both compendium PDF builders.
- The index page attempted to show runtime-captured page numbers using a two-pass flow that is incompatible with the installed QuestPDF package and offline deterministic generation.
- A CSS `color-mix(...)` expression in `.pm-chip-link:hover` triggered an IntelliSense warning because it is not recognized as a valid `background` value in the target environment.

### Description
- Removed unsupported `CaptureContentPosition` usage from `HistoricalCompendiumPdfBuilder` and `ProliferationCompendiumPdfBuilder` and simplified both builders to a single-pass `CreateDocument(...).GeneratePdf()` flow to avoid the missing API.
- Replaced runtime page-number capture logic with a stable placeholder `"-"` in the index page `Page` column to keep output deterministic when the runtime capture API is unavailable.
- Added a new CSS variable `--pm-chip-hover-bg` and replaced `color-mix(...)` in `.pm-chip-link:hover` with `background: var(--pm-chip-hover-bg);` to eliminate the IntelliSense warning while keeping a consistent hover color.
- Kept section comments and modular structure in the modified files for readability and future adjustments.

### Testing
- Ran a code search for `CaptureContentPosition` and `color-mix(` using `rg` and confirmed there are no remaining occurrences in the modified files, which succeeded.
- Performed a static whitespace/format check (`git diff --check`) which returned clean results, which succeeded.
- Attempted to run a UI smoke check with Playwright to capture a screenshot at `http://127.0.0.1:5000`, but it failed with `ERR_EMPTY_RESPONSE` because the local web endpoint was not running in this environment (test failed).
- Attempted to run `dotnet` related commands to build the project but the environment did not have the `dotnet` CLI available, so a full compilation could not be executed (test not completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699184ab787c832983369b3b413cddc9)