### PR TITLE
Fix Compendiums null CoverPhotoVersion crash and add regression test

### DIFF
--- a/Areas/Compendiums/Application/CompendiumReadService.cs
+++ b/Areas/Compendiums/Application/CompendiumReadService.cs
@@ -259,7 +259,7 @@ public sealed class CompendiumReadService : ICompendiumReadService
         string? ArmService,
         decimal? ApproxProductionCost,
         int? CoverPhotoId,
-        int CoverPhotoVersion,
+        int? CoverPhotoVersion,
         decimal? CostLakhs,
         ProjectTotStatus? TotStatus,
         DateOnly? TotCompletedOn);

--- a/Areas/Compendiums/Pages/_ViewStart.cshtml
+++ b/Areas/Compendiums/Pages/_ViewStart.cshtml
@@ -1,0 +1,4 @@
+@{
+    @* SECTION: Apply application layout to compendium pages *@
+    Layout = "/Pages/Shared/_Layout.cshtml";
+}

--- a/ProjectManagement.Tests/CompendiumReadServiceTests.cs
+++ b/ProjectManagement.Tests/CompendiumReadServiceTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Areas.Compendiums.Application;
+using ProjectManagement.Areas.ProjectOfficeReports.Domain;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Projects;
+using ProjectManagement.Services.Projects;
+
+namespace ProjectManagement.Tests;
+
+public sealed class CompendiumReadServiceTests
+{
+    [Fact]
+    public async Task GetEligibleProjectsAsync_AllowsNullCoverPhotoVersionFromDatabase()
+    {
+        // SECTION: Arrange sqlite schema with nullable cover photo version column
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        await using (var schemaContext = CreateSqliteContext(connection))
+        {
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE Projects (
+                    Id INTEGER NOT NULL CONSTRAINT PK_Projects PRIMARY KEY,
+                    Name TEXT NOT NULL,
+                    Description TEXT NULL,
+                    CompletedYear INTEGER NULL,
+                    CompletedOn TEXT NULL,
+                    SponsoringLineDirectorateId INTEGER NULL,
+                    ArmService TEXT NULL,
+                    CoverPhotoId INTEGER NULL,
+                    CoverPhotoVersion INTEGER NULL,
+                    CostLakhs TEXT NULL,
+                    IsDeleted INTEGER NOT NULL,
+                    IsArchived INTEGER NOT NULL,
+                    LifecycleStatus INTEGER NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectTechStatuses (
+                    ProjectId INTEGER NOT NULL CONSTRAINT PK_ProjectTechStatuses PRIMARY KEY,
+                    TechStatus TEXT NOT NULL,
+                    AvailableForProliferation INTEGER NOT NULL,
+                    NotAvailableReason TEXT NULL,
+                    Remarks TEXT NULL,
+                    MarkedAtUtc TEXT NOT NULL,
+                    MarkedByUserId TEXT NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectProductionCostFacts (
+                    ProjectId INTEGER NOT NULL CONSTRAINT PK_ProjectProductionCostFacts PRIMARY KEY,
+                    ApproxProductionCost TEXT NULL,
+                    Remarks TEXT NULL,
+                    UpdatedAtUtc TEXT NOT NULL,
+                    UpdatedByUserId TEXT NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectTots (
+                    Id INTEGER NOT NULL CONSTRAINT PK_ProjectTots PRIMARY KEY,
+                    ProjectId INTEGER NOT NULL,
+                    Status INTEGER NOT NULL,
+                    CompletedOn TEXT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO Projects (
+                    Id, Name, Description, CompletedYear, CompletedOn, SponsoringLineDirectorateId,
+                    ArmService, CoverPhotoId, CoverPhotoVersion, CostLakhs, IsDeleted, IsArchived, LifecycleStatus)
+                VALUES (101, 'Project Null Cover Version', NULL, 2025, NULL, NULL, 'Navy', NULL, NULL, 50, 0, 0, 2);
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ProjectTechStatuses (
+                    ProjectId, TechStatus, AvailableForProliferation, NotAvailableReason, Remarks, MarkedAtUtc, MarkedByUserId)
+                VALUES (101, 'Current', 1, NULL, NULL, '2026-01-01T00:00:00Z', 'seed-user');
+                """);
+        }
+
+        await using var assertionContext = CreateSqliteContext(connection);
+        var service = new CompendiumReadService(
+            assertionContext,
+            new NoOpProjectPhotoService(),
+            new ZeroProliferationMetricsService());
+
+        // SECTION: Act
+        var projects = await service.GetEligibleProjectsAsync(CancellationToken.None);
+
+        // SECTION: Assert
+        var project = Assert.Single(projects);
+        Assert.Equal(101, project.ProjectId);
+        Assert.Null(project.CoverPhotoVersion);
+    }
+
+    // SECTION: Shared sqlite context helper
+    private static ApplicationDbContext CreateSqliteContext(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    // SECTION: Test double for photo service (unused in list query path)
+    private sealed class NoOpProjectPhotoService : IProjectPhotoService
+    {
+        public Task<ProjectPhoto> AddAsync(int projectId, Stream content, string originalFileName, string? contentType, string userId, bool setAsCover, string? caption, int? totId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto> AddAsync(int projectId, Stream content, string originalFileName, string? contentType, string userId, bool setAsCover, string? caption, ProjectPhotoCrop crop, int? totId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto?> ReplaceAsync(int projectId, int photoId, Stream content, string originalFileName, string? contentType, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto?> ReplaceAsync(int projectId, int photoId, Stream content, string originalFileName, string? contentType, string userId, ProjectPhotoCrop crop, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto?> UpdateCaptionAsync(int projectId, int photoId, string? caption, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto?> UpdateCropAsync(int projectId, int photoId, ProjectPhotoCrop crop, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<ProjectPhoto?> UpdateTotAsync(int projectId, int photoId, int? totId, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<bool> RemoveAsync(int projectId, int photoId, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task ReorderAsync(int projectId, IReadOnlyList<int> orderedPhotoIds, string userId, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<(Stream Stream, string ContentType)?> OpenDerivativeAsync(int projectId, int photoId, string sizeKey, bool preferWebp, CancellationToken cancellationToken) => Task.FromResult< (Stream Stream, string ContentType)?>(null);
+        public Task<(Stream Stream, string ContentType)?> OpenDerivativeAsync(int projectId, int photoId, string sizeKey, string requestedFormat, CancellationToken cancellationToken) => Task.FromResult< (Stream Stream, string ContentType)?>(null);
+        public string GetDerivativePath(ProjectPhoto photo, string sizeKey, bool preferWebp) => string.Empty;
+    }
+
+    // SECTION: Test double for metrics service (unused in list query path)
+    private sealed class ZeroProliferationMetricsService : IProliferationMetricsService
+    {
+        public Task<int> GetAllTimeTotalAsync(int projectId, ProliferationSource source, CancellationToken cancellationToken) => Task.FromResult(0);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix an `InvalidOperationException` when EF projects a nullable DB column into a non-nullable projection field for the Proliferation compendium page. 
- Ensure compendium pages use the shared application layout to avoid an unstyled landing page.
- Prevent regression by adding an automated test that reproduces the nullable DB value scenario.

### Description
- Made `CompendiumProjection.CoverPhotoVersion` nullable (`int?`) in `Areas/Compendiums/Application/CompendiumReadService.cs` so EF can materialize rows where the database column is `NULL`.
- Added `Areas/Compendiums/Pages/_ViewStart.cshtml` to apply the shared layout (`/Pages/Shared/_Layout.cshtml`) to compendium pages.
- Added a regression test `ProjectManagement.Tests/CompendiumReadServiceTests.cs` which seeds an in-memory SQLite schema containing a `NULL` `CoverPhotoVersion` and asserts `GetEligibleProjectsAsync` returns the row with `CoverPhotoVersion == null`.
- Included small test doubles for `IProjectPhotoService` and `IProliferationMetricsService` used by the new test.

### Testing
- Added unit test `CompendiumReadServiceTests.GetEligibleProjectsAsync_AllowsNullCoverPhotoVersionFromDatabase` (present in `ProjectManagement.Tests/CompendiumReadServiceTests.cs`) which uses an in-memory SQLite connection and should pass in CI.
- Attempted to run the test locally with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter CompendiumReadServiceTests`, but the `dotnet` runtime is not available in this environment so the test could not be executed here (failed).
- No other automated tests were executed in this environment; the new test is self-contained and expected to pass when run in the project CI or a developer machine with `.NET` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918ae0bf288329b0338b8dde850b34)