### PR TITLE
Fix compendium pages crash when CoverPhotoVersion is null

### DIFF
--- a/Areas/Compendiums/Application/CompendiumReadService.cs
+++ b/Areas/Compendiums/Application/CompendiumReadService.cs
@@ -129,7 +129,7 @@ public sealed class CompendiumReadService : ICompendiumReadService
                    project.ArmService,
                    costFact != null ? costFact.ApproxProductionCost : null,
                    project.CoverPhotoId,
-                   project.CoverPhotoVersion,
+                   EF.Property<int?>(project, nameof(Project.CoverPhotoVersion)),
                    project.CostLakhs,
                    tot != null ? (ProjectTotStatus?)tot.Status : null,
                    tot != null ? tot.CompletedOn : null);


### PR DESCRIPTION
## Summary
- fixed the compendium eligible-project query to safely read `Projects.CoverPhotoVersion` as nullable
- replaced direct access to `project.CoverPhotoVersion` with `EF.Property<int?>(project, nameof(Project.CoverPhotoVersion))`
- prevents EF Core materialization exceptions when legacy rows have `NULL` in `CoverPhotoVersion`

## Root cause
`Project.CoverPhotoVersion` is modeled as non-nullable `int`, but some database rows contain `NULL`. During the compendium projection query, EF attempted to read this value through the non-nullable mapping, throwing `InvalidOperationException: Nullable object must have a value`.

## Validation
- static inspection confirms stack trace path (`CompendiumReadService.GetEligibleProjectsAsync`) now reads cover photo version via nullable accessor
- existing regression test in `ProjectManagement.Tests/CompendiumReadServiceTests.cs` aligns with this scenario (`GetEligibleProjectsAsync_AllowsNullCoverPhotoVersionFromDatabase`)
- unable to execute tests in this container because `dotnet` CLI is not available

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918ccbca0c83299a29d162dbe7e906)