### PR TITLE
Handle nullable ProjectTots.Status in compendium query and add regression test

### DIFF
--- a/Areas/Compendiums/Application/CompendiumReadService.cs
+++ b/Areas/Compendiums/Application/CompendiumReadService.cs
@@ -131,7 +131,9 @@ public sealed class CompendiumReadService : ICompendiumReadService
                    project.CoverPhotoId,
                    EF.Property<int?>(project, nameof(Project.CoverPhotoVersion)),
                    project.CostLakhs,
-                   tot != null ? (ProjectTotStatus?)tot.Status : null,
+                   tot != null
+                       ? EF.Property<ProjectTotStatus?>(tot, nameof(ProjectTot.Status))
+                       : null,
                    tot != null ? tot.CompletedOn : null);
     }
 

--- a/ProjectManagement.Tests/CompendiumReadServiceTests.cs
+++ b/ProjectManagement.Tests/CompendiumReadServiceTests.cs
@@ -108,6 +108,104 @@ public sealed class CompendiumReadServiceTests
         Assert.Null(project.CoverPhotoVersion);
     }
 
+    [Fact]
+    public async Task GetEligibleProjectsAsync_AllowsLegacyNullTotStatusFromDatabase()
+    {
+        // SECTION: Arrange sqlite schema with nullable TOT status column and legacy null value
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        await using (var schemaContext = CreateSqliteContext(connection))
+        {
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE Projects (
+                    Id INTEGER NOT NULL CONSTRAINT PK_Projects PRIMARY KEY,
+                    Name TEXT NOT NULL,
+                    Description TEXT NULL,
+                    CompletedYear INTEGER NULL,
+                    CompletedOn TEXT NULL,
+                    SponsoringLineDirectorateId INTEGER NULL,
+                    ArmService TEXT NULL,
+                    CoverPhotoId INTEGER NULL,
+                    CoverPhotoVersion INTEGER NULL,
+                    CostLakhs TEXT NULL,
+                    IsDeleted INTEGER NOT NULL,
+                    IsArchived INTEGER NOT NULL,
+                    LifecycleStatus INTEGER NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectTechStatuses (
+                    ProjectId INTEGER NOT NULL CONSTRAINT PK_ProjectTechStatuses PRIMARY KEY,
+                    TechStatus TEXT NOT NULL,
+                    AvailableForProliferation INTEGER NOT NULL,
+                    NotAvailableReason TEXT NULL,
+                    Remarks TEXT NULL,
+                    MarkedAtUtc TEXT NOT NULL,
+                    MarkedByUserId TEXT NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectProductionCostFacts (
+                    ProjectId INTEGER NOT NULL CONSTRAINT PK_ProjectProductionCostFacts PRIMARY KEY,
+                    ApproxProductionCost TEXT NULL,
+                    Remarks TEXT NULL,
+                    UpdatedAtUtc TEXT NOT NULL,
+                    UpdatedByUserId TEXT NOT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TABLE ProjectTots (
+                    Id INTEGER NOT NULL CONSTRAINT PK_ProjectTots PRIMARY KEY,
+                    ProjectId INTEGER NOT NULL,
+                    Status INTEGER NULL,
+                    CompletedOn TEXT NULL
+                );
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO Projects (
+                    Id, Name, Description, CompletedYear, CompletedOn, SponsoringLineDirectorateId,
+                    ArmService, CoverPhotoId, CoverPhotoVersion, CostLakhs, IsDeleted, IsArchived, LifecycleStatus)
+                VALUES (201, 'Project Null TOT Status', NULL, 2024, NULL, NULL, 'Army', NULL, NULL, 75, 0, 0, 2);
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ProjectTechStatuses (
+                    ProjectId, TechStatus, AvailableForProliferation, NotAvailableReason, Remarks, MarkedAtUtc, MarkedByUserId)
+                VALUES (201, 'Current', 1, NULL, NULL, '2026-01-01T00:00:00Z', 'seed-user');
+                """);
+
+            await schemaContext.Database.ExecuteSqlRawAsync(
+                """
+                INSERT INTO ProjectTots (Id, ProjectId, Status, CompletedOn)
+                VALUES (1, 201, NULL, NULL);
+                """);
+        }
+
+        await using var assertionContext = CreateSqliteContext(connection);
+        var service = new CompendiumReadService(
+            assertionContext,
+            new NoOpProjectPhotoService(),
+            new ZeroProliferationMetricsService());
+
+        // SECTION: Act
+        var projects = await service.GetEligibleProjectsAsync(CancellationToken.None);
+
+        // SECTION: Assert
+        var project = Assert.Single(projects);
+        Assert.Equal(201, project.ProjectId);
+    }
+
     // SECTION: Shared sqlite context helper
     private static ApplicationDbContext CreateSqliteContext(SqliteConnection connection)
     {


### PR DESCRIPTION
### Motivation
- A left-joined `ProjectTots` row containing a NULL `Status` can cause EF materialization to throw when projecting the non-nullable `tot.Status`, resulting in an internal error when loading compendium project lists.
- The change prevents crashes on legacy databases that have `NULL` in `ProjectTots.Status` without changing outward DTO behavior.

### Description
- Use `EF.Property<ProjectTotStatus?>(tot, nameof(ProjectTot.Status))` in the compendium projection so the TOT status is read as a nullable enum and null DB values are handled safely in the query.
- Added a regression test `GetEligibleProjectsAsync_AllowsLegacyNullTotStatusFromDatabase` that creates a SQLite schema with a nullable `ProjectTots.Status`, inserts a NULL status row, and verifies `GetEligibleProjectsAsync` returns projects instead of crashing.
- Files changed: `Areas/Compendiums/Application/CompendiumReadService.cs` and `ProjectManagement.Tests/CompendiumReadServiceTests.cs`.

### Testing
- Added automated test `GetEligibleProjectsAsync_AllowsLegacyNullTotStatusFromDatabase` in `ProjectManagement.Tests/CompendiumReadServiceTests.cs` which reproduces the legacy-null `ProjectTots.Status` scenario.
- Existing test `GetEligibleProjectsAsync_AllowsNullCoverPhotoVersionFromDatabase` remains in place and is unchanged.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter CompendiumReadServiceTests`, but the `dotnet` runtime/SDK is not available in this environment so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918e10ccc08329a349276a31a6ee64)