### PR TITLE
Add Compendiums nullable-materialization guardrail comment

### DIFF
--- a/Areas/Compendiums/Application/CompendiumReadService.cs
+++ b/Areas/Compendiums/Application/CompendiumReadService.cs
@@ -101,6 +101,8 @@ public sealed class CompendiumReadService : ICompendiumReadService
     }
 
     // SECTION: Base eligibility + ordering projection
+    // Guardrail: if a model property is non-nullable but legacy database rows can store NULL,
+    // read it with EF.Property<T?> in this projection to avoid nullable materialization crashes.
     private IQueryable<CompendiumProjection> BuildEligibleProjectQuery()
     {
         return from project in _db.Projects.AsNoTracking()


### PR DESCRIPTION
### Motivation
- Prevent future regressions where EF Core attempts to materialize legacy `NULL` values into non-nullable model properties by documenting the required `EF.Property<T?>` pattern for Compendiums projections.

### Description
- Add a short guardrail comment above `BuildEligibleProjectQuery()` in `Areas/Compendiums/Application/CompendiumReadService.cs` explaining that properties which are non-nullable in the model but can be `NULL` in legacy DB rows must be read with `EF.Property<T?>` to avoid nullable-materialization crashes. 

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter CompendiumReadServiceTests`, but the command could not be executed in this environment because the `dotnet` CLI is unavailable, so no tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699194b78ee083298d8fdd58c9d75a94)