### PR TITLE
Refactor compendium card query to remove TOT dependency

### DIFF
--- a/ProjectManagement.Tests/CompendiumReadServiceTests.cs
+++ b/ProjectManagement.Tests/CompendiumReadServiceTests.cs
@@ -109,9 +109,9 @@ public sealed class CompendiumReadServiceTests
     }
 
     [Fact]
-    public async Task GetEligibleProjectsAsync_AllowsLegacyNullTotStatusFromDatabase()
+    public async Task GetEligibleProjectsAsync_LoadsIndexListWhenLegacyProjectTotStatusIsNull()
     {
-        // SECTION: Arrange sqlite schema with nullable TOT status column and legacy null value
+        // SECTION: Arrange sqlite schema with legacy null TOT status value in ProjectTots
         await using var connection = new SqliteConnection("Data Source=:memory:");
         await connection.OpenAsync();
 
@@ -204,6 +204,7 @@ public sealed class CompendiumReadServiceTests
         // SECTION: Assert
         var project = Assert.Single(projects);
         Assert.Equal(201, project.ProjectId);
+        Assert.Equal("Project Null TOT Status", project.Name);
     }
 
     // SECTION: Shared sqlite context helper


### PR DESCRIPTION
### Motivation
- Avoid materialization issues and unnecessary joins when loading the compendium index by restricting the list query to only the columns needed for project cards.
- Keep `ProjectTots` joined only where TOT values are required (detail/historical paths) to prevent legacy `NULL` TOT values from affecting the index list.
- Preserve existing user-visible ordering and behavior while simplifying the list projection shape.

### Description
- Introduced `BuildEligibleProjectCardQuery()` that returns a new `CompendiumProjectCardProjection` containing only card-needed fields (`Id`, `Name`, completion fields, sponsoring directorate name, `ArmService`, `ApproxProductionCost`, `CoverPhotoId`, `CoverPhotoVersion`).
- Routed `GetEligibleProjectsAsync` to use `BuildEligibleProjectCardQuery()` and kept the `GetProjectAsync` / `GetEligibleProjectDetailsAsync` paths using `BuildEligibleProjectDetailQuery()` which still includes the `ProjectTots` join and TOT-related fields.
- Removed the `ProjectTots` join from the card/index query while keeping the ordering logic identical between card and detail queries.
- Added the `CompendiumProjectCardProjection` record and adjusted test coverage by renaming/updating the test to `GetEligibleProjectsAsync_LoadsIndexListWhenLegacyProjectTotStatusIsNull` to assert index list loading succeeds when `ProjectTots.Status` is `NULL`.

### Testing
- Updated unit tests in `ProjectManagement.Tests/CompendiumReadServiceTests.cs` to cover legacy `NULL` TOT values and nullable `CoverPhotoVersion` handling; the test method `GetEligibleProjectsAsync_LoadsIndexListWhenLegacyProjectTotStatusIsNull` now asserts the index list loads and project `Name` is present.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter CompendiumReadServiceTests` in this environment but it failed because `dotnet` is not installed here, so tests were not executed here; run the command in CI or a local dev environment to verify success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699197247d008329a116639e931427b8)