### PR TITLE
Fix build breaks in tests after markdown renderer injection update

### DIFF
--- a/ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs
+++ b/ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs
@@ -50,7 +50,7 @@ public sealed class IndustryPartnersIndexPageAttachmentUploadTests
         Assert.Equal("Attachment uploaded.", page.TempData["Message"]);
 
         var uploaded = Assert.Single(attachmentManager.UploadedFiles);
-        Assert.Equal("partner-notes.txt", uploaded.FileName);
+        Assert.Equal("partner-notes.txt", uploaded.File.FileName);
         Assert.Equal(42, uploaded.PartnerId);
     }
 

--- a/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
+++ b/ProjectManagement.Tests/ProjectMetaEditPageTests.cs
@@ -14,6 +14,7 @@ using ProjectManagement.Models;
 using ProjectManagement.Pages.Projects.Meta;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Projects;
+using ProjectManagement.Services.Text;
 using Xunit;
 
 namespace ProjectManagement.Tests;
@@ -315,7 +316,7 @@ public sealed class ProjectMetaEditPageTests
 
     private static EditModel CreatePage(ApplicationDbContext db, IUserContext userContext)
     {
-        var page = new EditModel(db, userContext, new FakeAudit())
+        var page = new EditModel(db, userContext, new FakeAudit(), new PassThroughMarkdownRenderer())
         {
             PageContext = new PageContext
             {
@@ -353,6 +354,11 @@ public sealed class ProjectMetaEditPageTests
         {
             _data = new Dictionary<string, object?>(values);
         }
+    }
+
+    private sealed class PassThroughMarkdownRenderer : IMarkdownRenderer
+    {
+        public string ToSafeHtml(string? markdown) => markdown ?? string.Empty;
     }
 
     private sealed class FakeUserContext : IUserContext

--- a/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
+++ b/ProjectManagement.Tests/ProjectOverviewLifecycleTests.cs
@@ -25,6 +25,7 @@ using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Projects;
 using ProjectManagement.Services.Stages;
+using ProjectManagement.Services.Text;
 using ProjectManagement.ViewModels;
 using Xunit;
 using ProjectsOverviewModel = ProjectManagement.Pages.Projects.OverviewModel;
@@ -358,7 +359,12 @@ public sealed class ProjectOverviewLifecycleTests
         var remarksPanel = new ProjectRemarksPanelService(userManager, clock, workflowMetadata);
         var lifecycle = new ProjectLifecycleService(db, new NoOpAuditService(), clock);
         var mediaAggregator = new ProjectMediaAggregator();
-        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator);
+        return new ProjectsOverviewModel(db, procure, timeline, userManager, planRead, planCompare, NullLogger<ProjectsOverviewModel>.Instance, clock, remarksPanel, lifecycle, mediaAggregator, new PassThroughMarkdownRenderer());
+    }
+
+    private sealed class PassThroughMarkdownRenderer : IMarkdownRenderer
+    {
+        public string ToSafeHtml(string? markdown) => markdown ?? string.Empty;
     }
 
     private static UserManager<ApplicationUser> CreateUserManager(ApplicationDbContext db)

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -533,7 +533,7 @@ main[role="main"] {
 }
 
 .pm-chip-link:hover {
-    background: color-mix(in srgb, var(--pm-chip-bg) 94%, var(--pm-text) 6%);
+    background: var(--pm-chip-border);
     text-decoration: none;
     color: var(--pm-text);
 }


### PR DESCRIPTION
### Motivation
- Tests started failing after `IMarkdownRenderer` was made a required constructor dependency for page models, and a tuple access mismatch plus a CSS IntelliSense warning were reported.
- The change ensures tests compile against the updated constructors and removes the invalid CSS `color-mix(...)` usage flagged by IntelliSense.

### Description
- Inject a test `PassThroughMarkdownRenderer` implementing `IMarkdownRenderer` into `EditModel` in `ProjectMetaEditPageTests` and add the pass-through implementation to the test file.
- Inject a test `PassThroughMarkdownRenderer` into `ProjectsOverviewModel` construction in `ProjectOverviewLifecycleTests` and add the pass-through implementation to that test file.
- Fix the attachment test tuple access in `ProjectManagement.Tests/IndustryPartners/IndustryPartnersIndexPageAttachmentUploadTests.cs` by asserting on `uploaded.File.FileName` instead of `uploaded.FileName`.
- Replace the invalid `color-mix(...)` hover background in `wwwroot/css/site.css` with `var(--pm-chip-border)` to remove the IntelliSense warning.

### Testing
- Attempted to run unit tests with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj`, but the `dotnet` CLI is not available in this environment so the run failed. 
- Attempted an automated Playwright script to capture a screenshot of a running site, but there was no web server in the environment and the run returned `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f02b7fac8329acf9b298d9d5f558)