### PR TITLE
Add Proliferation Compendium PDF export under Projects

### DIFF
--- a/Configuration/CompendiumPdfOptions.cs
+++ b/Configuration/CompendiumPdfOptions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace ProjectManagement.Configuration;
+
+// SECTION: Configuration options for the Proliferation Compendium PDF.
+public sealed class CompendiumPdfOptions
+{
+    // SECTION: Cover page title text.
+    public string Title { get; set; } = "Proliferation Compendium";
+
+    // SECTION: Organisation/unit text displayed on the cover page.
+    public string UnitDisplayName { get; set; } = "";
+
+    // SECTION: Category names that should be forced to the end of the index ordering.
+    // Keep this list short and configurable to avoid hard-coding.
+    public List<string> MiscCategoryNames { get; set; } = new() { "Misc", "Miscellaneous" };
+
+    // SECTION: Which derivative size to fetch for cover photos.
+    // Must match keys in ProjectPhotos:Derivatives (xl/md/sm/xs).
+    public string CoverPhotoDerivativeKey { get; set; } = "md";
+
+    // SECTION: If true, prefer WebP when available.
+    public bool PreferWebp { get; set; }
+}

--- a/Pages/Projects/Compendium/Index.cshtml
+++ b/Pages/Projects/Compendium/Index.cshtml
@@ -1,0 +1,37 @@
+@page
+@model ProjectManagement.Pages.Projects.Compendium.IndexModel
+
+@{
+    ViewData["Title"] = "Proliferation Compendium";
+}
+
+<div class="container-fluid px-0">
+    <div class="d-flex align-items-start justify-content-between flex-wrap gap-3 mb-4">
+        <div>
+            <h1 class="h3 mb-1">Proliferation Compendium</h1>
+            <div class="text-muted">Generate a print-ready PDF of completed projects available for proliferation.</div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
+                <div>
+                    <div class="fw-semibold">Proliferation Compendium PDF</div>
+                    <div class="text-muted small">Includes cover page, category index, and per-project detail pages.</div>
+                </div>
+
+                <form method="post" asp-page-handler="Generate">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-file-earmark-pdf me-1"></i>
+                        Generate PDF
+                    </button>
+                </form>
+            </div>
+
+            <div class="mt-3 text-muted small">
+                Eligibility: Completed, not archived, not deleted, and available for proliferation.
+            </div>
+        </div>
+    </div>
+</div>

--- a/Pages/Projects/Compendium/Index.cshtml.cs
+++ b/Pages/Projects/Compendium/Index.cshtml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Services.Compendiums;
+
+namespace ProjectManagement.Pages.Projects.Compendium;
+
+[Authorize]
+public sealed class IndexModel : PageModel
+{
+    private readonly ICompendiumExportService _exportService;
+
+    public IndexModel(ICompendiumExportService exportService)
+    {
+        _exportService = exportService ?? throw new ArgumentNullException(nameof(exportService));
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostGenerateAsync(CancellationToken cancellationToken)
+    {
+        var result = await _exportService.GenerateAsync(cancellationToken);
+        return File(result.Bytes, "application/pdf", result.FileName);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -38,6 +38,7 @@ using ProjectManagement.Features.Analytics;
 using ProjectManagement.Features.Remarks;
 using ProjectManagement.Features.Users;
 using ProjectManagement.Helpers;
+using ProjectManagement.Services.Compendiums;
 using ProjectManagement.Hosted;
 using ProjectManagement.Hubs;
 using ProjectManagement.Services.Approvals;
@@ -365,6 +366,8 @@ builder.Services.Configure<FfcAttachmentOptions>(
     builder.Configuration.GetSection("FfcAttachments"));
 builder.Services.Configure<FileDownloadOptions>(
     builder.Configuration.GetSection("FileDownload"));
+builder.Services.Configure<CompendiumPdfOptions>(
+    builder.Configuration.GetSection("CompendiumPdf"));
 builder.Services.AddSingleton<IprAttachmentStorage>();
 builder.Services.AddScoped<IFileSecurityValidator, FileSecurityValidator>();
 builder.Services.AddScoped<IFfcAttachmentStorage, FfcAttachmentStorage>();
@@ -388,6 +391,11 @@ builder.Services.AddScoped<PlanApprovalService>();
 builder.Services.AddScoped<INavigationProvider, RoleBasedNavigationProvider>();
 builder.Services.AddScoped<ProliferationOverviewService>();
 builder.Services.AddScoped<IProliferationSummaryReadService, ProliferationSummaryReadService>();
+
+// SECTION: Proliferation Compendium (Projects module)
+builder.Services.AddScoped<ICompendiumReadService, CompendiumReadService>();
+builder.Services.AddScoped<ICompendiumExportService, CompendiumExportService>();
+builder.Services.AddScoped<ICompendiumPdfReportBuilder, CompendiumPdfReportBuilder>();
 builder.Services.AddScoped<ProliferationSubmissionService>();
 builder.Services.AddScoped<ProliferationManageService>();
 // SECTION: Proliferation reports services

--- a/Services/Compendiums/CompendiumDtos.cs
+++ b/Services/Compendiums/CompendiumDtos.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProjectManagement.Services.Compendiums;
+
+public sealed record CompendiumProjectDto(
+    int ProjectId,
+    string ProjectName,
+    string TechnicalCategoryName,
+    int? CompletionYearValue,
+    string CompletionYearDisplay,
+    string SponsoringLineDirectorateDisplay,
+    string ArmServiceDisplay,
+    decimal? ProliferationCostLakhs,
+    int? CoverPhotoId);
+
+public sealed record CompendiumCategoryGroupDto(
+    string TechnicalCategoryName,
+    IReadOnlyList<CompendiumProjectDto> Projects);
+
+public sealed record CompendiumPdfDataDto(
+    string Title,
+    string UnitDisplayName,
+    DateTimeOffset GeneratedAtUtc,
+    IReadOnlyList<CompendiumCategoryGroupDto> Groups);

--- a/Services/Compendiums/CompendiumExportService.cs
+++ b/Services/Compendiums/CompendiumExportService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
+using ProjectManagement.Services.Projects;
+using ProjectManagement.Utilities;
+using ProjectManagement.Utilities.Reporting;
+
+namespace ProjectManagement.Services.Compendiums;
+
+// SECTION: PDF export orchestration for the Proliferation Compendium.
+public sealed class CompendiumExportService : ICompendiumExportService
+{
+    private readonly ICompendiumReadService _readService;
+    private readonly IProjectPhotoService _projectPhotoService;
+    private readonly ICompendiumPdfReportBuilder _pdfBuilder;
+    private readonly CompendiumPdfOptions _options;
+
+    public CompendiumExportService(
+        ICompendiumReadService readService,
+        IProjectPhotoService projectPhotoService,
+        ICompendiumPdfReportBuilder pdfBuilder,
+        IOptions<CompendiumPdfOptions> options)
+    {
+        _readService = readService ?? throw new ArgumentNullException(nameof(readService));
+        _projectPhotoService = projectPhotoService ?? throw new ArgumentNullException(nameof(projectPhotoService));
+        _pdfBuilder = pdfBuilder ?? throw new ArgumentNullException(nameof(pdfBuilder));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task<CompendiumExportResult> GenerateAsync(CancellationToken cancellationToken = default)
+    {
+        var data = await _readService.GetProliferationCompendiumAsync(cancellationToken);
+
+        // SECTION: Attach photos in a fail-safe way.
+        var categories = new List<CompendiumPdfCategorySection>(data.Groups.Count);
+
+        foreach (var group in data.Groups)
+        {
+            var projects = new List<CompendiumPdfProjectSection>(group.Projects.Count);
+
+            foreach (var p in group.Projects)
+            {
+                var photoBytes = await TryLoadCoverPhotoAsync(p.ProjectId, p.CoverPhotoId, cancellationToken);
+
+                projects.Add(new CompendiumPdfProjectSection(
+                    ProjectId: p.ProjectId,
+                    ProjectName: p.ProjectName,
+                    CategoryName: group.TechnicalCategoryName,
+                    CompletionYearDisplay: p.CompletionYearDisplay,
+                    SponsoringLineDirectorateDisplay: p.SponsoringLineDirectorateDisplay,
+                    ArmServiceDisplay: p.ArmServiceDisplay,
+                    ProliferationCostDisplay: p.ProliferationCostLakhs.HasValue
+                        ? p.ProliferationCostLakhs.Value.ToString("0.##", CultureInfo.InvariantCulture)
+                        : "Not recorded",
+                    CoverPhoto: photoBytes));
+            }
+
+            categories.Add(new CompendiumPdfCategorySection(
+                CategoryName: group.TechnicalCategoryName,
+                Projects: projects));
+        }
+
+        var context = new CompendiumPdfReportContext(
+            Title: data.Title,
+            UnitDisplayName: data.UnitDisplayName,
+            GeneratedAtUtc: data.GeneratedAtUtc,
+            Categories: categories);
+
+        var bytes = _pdfBuilder.Build(context);
+
+        var generatedAtIst = TimeZoneInfo.ConvertTime(data.GeneratedAtUtc, TimeZoneHelper.GetIst());
+        var safeDate = generatedAtIst.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        var fileName = $"Proliferation_Compendium_{safeDate}.pdf";
+
+        return new CompendiumExportResult(bytes, fileName);
+    }
+
+    private async Task<byte[]?> TryLoadCoverPhotoAsync(int projectId, int? photoId, CancellationToken cancellationToken)
+    {
+        if (!photoId.HasValue)
+        {
+            return null;
+        }
+
+        try
+        {
+            var derivativeKey = string.IsNullOrWhiteSpace(_options.CoverPhotoDerivativeKey)
+                ? "md"
+                : _options.CoverPhotoDerivativeKey.Trim();
+
+            var opened = await _projectPhotoService.OpenDerivativeAsync(
+                projectId,
+                photoId.Value,
+                derivativeKey,
+                preferWebp: _options.PreferWebp,
+                cancellationToken);
+
+            if (opened is null)
+            {
+                return null;
+            }
+
+            await using var stream = opened.Value.Stream;
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms, cancellationToken);
+            return ms.ToArray();
+        }
+        catch
+        {
+            // SECTION: URD requirement: cover photo failures must never fail PDF generation.
+            return null;
+        }
+    }
+}

--- a/Services/Compendiums/CompendiumReadService.cs
+++ b/Services/Compendiums/CompendiumReadService.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Models.Projects;
+
+namespace ProjectManagement.Services.Compendiums;
+
+// SECTION: Read service for Proliferation Compendium export.
+public sealed class CompendiumReadService : ICompendiumReadService
+{
+    public const string BuildStamp = "CompendiumPdf_2026-02-15_zip";
+
+    private readonly ApplicationDbContext _db;
+    private readonly CompendiumPdfOptions _options;
+
+    public CompendiumReadService(ApplicationDbContext db, IOptions<CompendiumPdfOptions> options)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task<CompendiumPdfDataDto> GetProliferationCompendiumAsync(CancellationToken cancellationToken = default)
+    {
+        // SECTION: Base project selection (URD eligibility: completed + not deleted + not archived)
+        var baseProjects = await _db.Projects
+            .AsNoTracking()
+            .Where(p =>
+                p.LifecycleStatus == ProjectLifecycleStatus.Completed
+                && !p.IsDeleted
+                && !p.IsArchived)
+            .Select(p => new
+            {
+                p.Id,
+                p.Name,
+                p.TechnicalCategoryId,
+                TechnicalCategoryName = p.TechnicalCategory != null ? p.TechnicalCategory.Name : null,
+                SponsoringLineDirectorateName = p.SponsoringLineDirectorate != null ? p.SponsoringLineDirectorate.Name : null,
+                p.ArmService,
+                p.CompletedYear,
+                p.CompletedOn,
+                p.CoverPhotoId
+            })
+            .ToListAsync(cancellationToken);
+
+        if (baseProjects.Count == 0)
+        {
+            return new CompendiumPdfDataDto(
+                Title: string.IsNullOrWhiteSpace(_options.Title) ? "Proliferation Compendium" : _options.Title,
+                UnitDisplayName: _options.UnitDisplayName ?? string.Empty,
+                GeneratedAtUtc: DateTimeOffset.UtcNow,
+                Groups: Array.Empty<CompendiumCategoryGroupDto>());
+        }
+
+        var projectIds = baseProjects.Select(p => p.Id).ToList();
+
+        // SECTION: Latest tech status per project (deterministic)
+        var techRows = await _db.ProjectTechStatuses
+            .AsNoTracking()
+            .Where(t => projectIds.Contains(t.ProjectId))
+            .ToListAsync(cancellationToken);
+
+        var latestTechByProjectId = techRows
+            .GroupBy(t => t.ProjectId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(x => x.MarkedAtUtc).First());
+
+        // SECTION: URD eligibility requires AvailableForProliferation = true on latest tech status.
+        var eligibleProjectIds = new HashSet<int>(
+            latestTechByProjectId
+                .Where(kvp => kvp.Value.AvailableForProliferation)
+                .Select(kvp => kvp.Key));
+
+        if (eligibleProjectIds.Count == 0)
+        {
+            return new CompendiumPdfDataDto(
+                Title: string.IsNullOrWhiteSpace(_options.Title) ? "Proliferation Compendium" : _options.Title,
+                UnitDisplayName: _options.UnitDisplayName ?? string.Empty,
+                GeneratedAtUtc: DateTimeOffset.UtcNow,
+                Groups: Array.Empty<CompendiumCategoryGroupDto>());
+        }
+
+        // SECTION: Latest production cost fact per project (optional)
+        var costRows = await _db.ProjectProductionCostFacts
+            .AsNoTracking()
+            .Where(c => eligibleProjectIds.Contains(c.ProjectId))
+            .ToListAsync(cancellationToken);
+
+        var latestCostByProjectId = costRows
+            .GroupBy(c => c.ProjectId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(x => x.UpdatedAtUtc).First());
+
+        // SECTION: Cover photo fallback.
+        // Rule: if Project.CoverPhotoId is null, try latest ProjectPhoto with IsCover == true.
+        var missingCoverIds = baseProjects
+            .Where(p => eligibleProjectIds.Contains(p.Id) && !p.CoverPhotoId.HasValue)
+            .Select(p => p.Id)
+            .ToList();
+
+        Dictionary<int, int> coverPhotoFallbackByProjectId = new();
+        if (missingCoverIds.Count > 0)
+        {
+            var coverCandidates = await _db.ProjectPhotos
+                .AsNoTracking()
+                .Where(ph => missingCoverIds.Contains(ph.ProjectId) && ph.IsCover)
+                .Select(ph => new { ph.ProjectId, ph.Id, ph.UpdatedUtc })
+                .ToListAsync(cancellationToken);
+
+            coverPhotoFallbackByProjectId = coverCandidates
+                .GroupBy(x => x.ProjectId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(x => x.UpdatedUtc).ThenByDescending(x => x.Id).First().Id);
+        }
+
+        // SECTION: Materialise DTOs for eligible projects.
+        var projects = new List<CompendiumProjectDto>(eligibleProjectIds.Count);
+
+        foreach (var p in baseProjects)
+        {
+            if (!eligibleProjectIds.Contains(p.Id))
+            {
+                continue;
+            }
+
+            latestCostByProjectId.TryGetValue(p.Id, out var cost);
+
+            var completionYear = ResolveCompletionYear(p.CompletedYear, p.CompletedOn);
+            var completionYearDisplay = completionYear.HasValue
+                ? completionYear.Value.ToString(CultureInfo.InvariantCulture)
+                : "Not recorded";
+
+            var categoryName = string.IsNullOrWhiteSpace(p.TechnicalCategoryName)
+                ? "Not recorded"
+                : p.TechnicalCategoryName!.Trim();
+
+            var ldDisplay = string.IsNullOrWhiteSpace(p.SponsoringLineDirectorateName)
+                ? "Not recorded"
+                : p.SponsoringLineDirectorateName!.Trim();
+
+            var armDisplay = string.IsNullOrWhiteSpace(p.ArmService)
+                ? "Not recorded"
+                : p.ArmService.Trim();
+
+            var coverPhotoId = p.CoverPhotoId;
+            if (!coverPhotoId.HasValue && coverPhotoFallbackByProjectId.TryGetValue(p.Id, out var fallbackId))
+            {
+                coverPhotoId = fallbackId;
+            }
+
+            projects.Add(new CompendiumProjectDto(
+                ProjectId: p.Id,
+                ProjectName: p.Name,
+                TechnicalCategoryName: categoryName,
+                CompletionYearValue: completionYear,
+                CompletionYearDisplay: completionYearDisplay,
+                SponsoringLineDirectorateDisplay: ldDisplay,
+                ArmServiceDisplay: armDisplay,
+                ProliferationCostLakhs: cost?.ApproxProductionCost,
+                CoverPhotoId: coverPhotoId));
+        }
+
+        // SECTION: Grouping and ordering per URD.
+        var groups = GroupAndSort(projects, _options);
+
+        return new CompendiumPdfDataDto(
+            Title: string.IsNullOrWhiteSpace(_options.Title) ? "Proliferation Compendium" : _options.Title,
+            UnitDisplayName: _options.UnitDisplayName ?? string.Empty,
+            GeneratedAtUtc: DateTimeOffset.UtcNow,
+            Groups: groups);
+    }
+
+    private static int? ResolveCompletionYear(int? completedYear, DateOnly? completedOn)
+    {
+        if (completedYear.HasValue)
+        {
+            return completedYear.Value;
+        }
+
+        if (completedOn.HasValue)
+        {
+            return completedOn.Value.Year;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<CompendiumCategoryGroupDto> GroupAndSort(
+        IReadOnlyList<CompendiumProjectDto> projects,
+        CompendiumPdfOptions options)
+    {
+        var miscNames = (options.MiscCategoryNames ?? new List<string>())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .ToList();
+
+        bool IsMisc(string categoryName)
+            => miscNames.Any(x => string.Equals(x, categoryName, StringComparison.OrdinalIgnoreCase));
+
+        var groups = projects
+            .GroupBy(p => p.TechnicalCategoryName)
+            .Select(g => new
+            {
+                CategoryName = g.Key,
+                IsMisc = IsMisc(g.Key),
+                Projects = g.ToList()
+            })
+            .OrderBy(x => x.IsMisc ? 1 : 0)
+            .ThenBy(x => x.CategoryName, StringComparer.OrdinalIgnoreCase)
+            .Select(x => new CompendiumCategoryGroupDto(
+                TechnicalCategoryName: x.CategoryName,
+                Projects: x.Projects
+                    .OrderByDescending(p => p.CompletionYearValue.HasValue)
+                    .ThenByDescending(p => p.CompletionYearValue)
+                    .ThenBy(p => p.ProjectName, StringComparer.OrdinalIgnoreCase)
+                    .ToList()))
+            .ToList();
+
+        return groups;
+    }
+}

--- a/Services/Compendiums/ICompendiumExportService.cs
+++ b/Services/Compendiums/ICompendiumExportService.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services.Compendiums;
+
+public interface ICompendiumExportService
+{
+    Task<CompendiumExportResult> GenerateAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record CompendiumExportResult(byte[] Bytes, string FileName);

--- a/Services/Compendiums/ICompendiumReadService.cs
+++ b/Services/Compendiums/ICompendiumReadService.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services.Compendiums;
+
+public interface ICompendiumReadService
+{
+    Task<CompendiumPdfDataDto> GetProliferationCompendiumAsync(CancellationToken cancellationToken = default);
+}

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -69,6 +69,12 @@ public class RoleBasedNavigationProvider : INavigationProvider
                 Page = "/Activities/Index",
                 Icon = "bi-stars"
             },
+            new()
+            {
+                Text = "Proliferation compendium",
+                Page = "/Projects/Compendium/Index",
+                Icon = "bi-file-earmark-pdf"
+            },
             // Progress review entry (drawer only).
             new()
             {

--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using QuestPDF.Drawing;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+using ProjectManagement.Utilities;
+
+namespace ProjectManagement.Utilities.Reporting;
+
+public interface ICompendiumPdfReportBuilder
+{
+    byte[] Build(CompendiumPdfReportContext context);
+}
+
+public sealed record CompendiumPdfReportContext(
+    string Title,
+    string UnitDisplayName,
+    DateTimeOffset GeneratedAtUtc,
+    IReadOnlyList<CompendiumPdfCategorySection> Categories);
+
+public sealed record CompendiumPdfCategorySection(
+    string CategoryName,
+    IReadOnlyList<CompendiumPdfProjectSection> Projects);
+
+public sealed record CompendiumPdfProjectSection(
+    int ProjectId,
+    string ProjectName,
+    string CategoryName,
+    string CompletionYearDisplay,
+    string SponsoringLineDirectorateDisplay,
+    string ArmServiceDisplay,
+    string ProliferationCostDisplay,
+    byte[]? CoverPhoto);
+
+public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
+{
+    static CompendiumPdfReportBuilder()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    public byte[] Build(CompendiumPdfReportContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var generatedAtIst = TimeZoneInfo.ConvertTime(context.GeneratedAtUtc, TimeZoneHelper.GetIst());
+        var generatedAtText = generatedAtIst.ToString("dd MMMM yyyy", CultureInfo.InvariantCulture);
+        var unitText = string.IsNullOrWhiteSpace(context.UnitDisplayName) ? string.Empty : context.UnitDisplayName.Trim();
+        var titleText = string.IsNullOrWhiteSpace(context.Title) ? "Proliferation Compendium" : context.Title.Trim();
+
+        var document = Document.Create(container =>
+        {
+            // SECTION: Cover page
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(50);
+                page.PageColor("#FFFFFF");
+
+                page.Content().AlignCenter().Column(col =>
+                {
+                    col.Spacing(18);
+
+                    col.Item().PaddingTop(120).AlignCenter().Text(titleText)
+                        .FontSize(34)
+                        .SemiBold()
+                        .FontColor("#0F172A");
+
+                    if (!string.IsNullOrWhiteSpace(unitText))
+                    {
+                        col.Item().AlignCenter().Text(unitText)
+                            .FontSize(14)
+                            .FontColor("#334155");
+                    }
+
+                    col.Item().AlignCenter().Text($"Generated on {generatedAtText}")
+                        .FontSize(12)
+                        .FontColor("#64748B");
+
+                    col.Item().PaddingTop(40).AlignCenter().Element(e =>
+                    {
+                        e.Height(2).Background("#E2E8F0");
+                    });
+
+                    col.Item().PaddingTop(16).AlignCenter().Text("Official Use")
+                        .FontSize(10)
+                        .LetterSpacing(1)
+                        .FontColor("#94A3B8");
+                });
+            });
+
+            // SECTION: Index pages
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(35);
+                page.PageColor("#FFFFFF");
+                page.DefaultTextStyle(x => x.FontSize(11).FontColor("#1F2933"));
+
+                page.Header().Column(header =>
+                {
+                    header.Item().Text("Index")
+                        .FontSize(20)
+                        .SemiBold()
+                        .FontColor("#0F172A");
+
+                    header.Item().Text($"{titleText}{(string.IsNullOrWhiteSpace(unitText) ? string.Empty : " · " + unitText)}")
+                        .FontSize(10)
+                        .FontColor("#64748B");
+                });
+
+                page.Content().PaddingTop(15).Column(content =>
+                {
+                    if (context.Categories.Count == 0)
+                    {
+                        content.Item().PaddingTop(50).AlignCenter().Text("No eligible projects found.")
+                            .FontSize(14)
+                            .FontColor("#64748B");
+                        return;
+                    }
+
+                    content.Spacing(18);
+
+                    foreach (var cat in context.Categories)
+                    {
+                        var catCopy = cat;
+                        content.Item().Element(c => ComposeIndexCategory(c, catCopy));
+                    }
+                });
+
+                page.Footer().AlignCenter().Text(text =>
+                {
+                    text.DefaultTextStyle(style => style.FontSize(9).FontColor("#94A3B8"));
+                    text.CurrentPageNumber();
+                    text.Span(" / ");
+                    text.TotalPages();
+                });
+            });
+
+            // SECTION: Detail pages
+            foreach (var cat in context.Categories)
+            {
+                foreach (var proj in cat.Projects)
+                {
+                    var projCopy = proj;
+                    container.Page(page =>
+                    {
+                        page.Size(PageSizes.A4);
+                        page.Margin(35);
+                        page.PageColor("#FFFFFF");
+                        page.DefaultTextStyle(x => x.FontSize(11).FontColor("#1F2933"));
+
+                        page.Header().Column(header =>
+                        {
+                            header.Item().Text(titleText)
+                                .FontSize(14)
+                                .SemiBold()
+                                .FontColor("#0F172A");
+                            header.Item().Text(projCopy.CategoryName)
+                                .FontSize(10)
+                                .FontColor("#64748B");
+                        });
+
+                        page.Content().PaddingTop(14).Element(c => ComposeProjectDetail(c, projCopy));
+
+                        page.Footer().AlignCenter().Text(text =>
+                        {
+                            text.DefaultTextStyle(style => style.FontSize(9).FontColor("#94A3B8"));
+                            text.CurrentPageNumber();
+                            text.Span(" / ");
+                            text.TotalPages();
+                        });
+                    });
+                }
+            }
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static void ComposeIndexCategory(IContainer container, CompendiumPdfCategorySection category)
+    {
+        container.Column(col =>
+        {
+            col.Spacing(10);
+
+            col.Item().Text(category.CategoryName)
+                .FontSize(14)
+                .SemiBold()
+                .FontColor("#1E3A8A");
+
+            col.Item().Table(table =>
+            {
+                table.ColumnsDefinition(columns =>
+                {
+                    columns.RelativeColumn(4);
+                    columns.ConstantColumn(90);
+                });
+
+                table.Header(header =>
+                {
+                    header.Cell().Element(CellHeader).Text("Project");
+                    header.Cell().Element(CellHeader).AlignRight().Text("Completed");
+                });
+
+                foreach (var p in category.Projects)
+                {
+                    table.Cell().Element(CellBody).Text(p.ProjectName);
+                    table.Cell().Element(CellBody).AlignRight().Text(p.CompletionYearDisplay);
+                }
+            });
+        });
+    }
+
+    private static void ComposeProjectDetail(IContainer container, CompendiumPdfProjectSection project)
+    {
+        container.Column(col =>
+        {
+            col.Spacing(14);
+
+            col.Item().Text(project.ProjectName)
+                .FontSize(20)
+                .SemiBold()
+                .FontColor("#0F172A");
+
+            col.Item().Row(row =>
+            {
+                row.RelativeItem().Column(left =>
+                {
+                    left.Spacing(8);
+                    left.Item().Element(c => ComposeKeyValue(c, "Technical category", project.CategoryName));
+                    left.Item().Element(c => ComposeKeyValue(c, "Year of completion", project.CompletionYearDisplay));
+                    left.Item().Element(c => ComposeKeyValue(c, "Sponsoring line directorate", project.SponsoringLineDirectorateDisplay));
+                    left.Item().Element(c => ComposeKeyValue(c, "Arm/Service", project.ArmServiceDisplay));
+                    left.Item().Element(c => ComposeKeyValue(c, "Proliferation cost (lakhs)", project.ProliferationCostDisplay));
+                });
+
+                if (project.CoverPhoto is not null && project.CoverPhoto.Length > 0)
+                {
+                    row.ConstantItem(210).Height(160).PaddingLeft(14).Element(img =>
+                    {
+                        img.Border(1)
+                            .BorderColor("#CBD5F5")
+                            .Background("#F8FAFC")
+                            .Padding(6)
+                            .Image(project.CoverPhoto, ImageScaling.FitArea);
+                    });
+                }
+            });
+
+            col.Item().PaddingTop(4).Element(e => e.Height(1).Background("#E2E8F0"));
+
+            col.Item().Text(text =>
+            {
+                text.DefaultTextStyle(style => style.FontSize(9).FontColor("#64748B"));
+                text.Span("Project ID: ");
+                text.Span(project.ProjectId.ToString(CultureInfo.InvariantCulture)).SemiBold();
+            });
+        });
+    }
+
+    private static void ComposeKeyValue(IContainer container, string key, string value)
+    {
+        container.Row(row =>
+        {
+            row.ConstantItem(170).Text(key).FontSize(10).FontColor("#475569");
+            row.RelativeItem().Text(value).FontSize(10).FontColor("#0F172A");
+        });
+    }
+
+    private static IContainer CellHeader(IContainer container)
+        => container.DefaultTextStyle(x => x.SemiBold().FontColor("#334155").FontSize(10))
+            .Background("#F1F5F9")
+            .PaddingVertical(6)
+            .PaddingHorizontal(8)
+            .Border(1)
+            .BorderColor("#E2E8F0");
+
+    private static IContainer CellBody(IContainer container)
+        => container.DefaultTextStyle(x => x.FontSize(10).FontColor("#0F172A"))
+            .PaddingVertical(5)
+            .PaddingHorizontal(8)
+            .BorderBottom(1)
+            .BorderColor("#E2E8F0");
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -52,6 +52,13 @@
     "TokenLifetimeMinutes": 30,
     "BindTokensToUser": true
   },
+  "CompendiumPdf": {
+    "Title": "Proliferation Compendium",
+    "UnitDisplayName": "",
+    "MiscCategoryNames": [ "Misc", "Miscellaneous" ],
+    "CoverPhotoDerivativeKey": "md",
+    "PreferWebp": true
+  },
   "ProjectPhotos": {
     "MaxFileSizeBytes": 10485760,
     "MinWidth": 720,


### PR DESCRIPTION
### Motivation

- Provide a print-ready A4 PDF export (cover, category index, per-project detail pages) for completed projects that are `AvailableForProliferation`.
- Make ordering and photo behaviour configurable (misc category ordering, derivative key, WebP preference) and ensure missing/optional data cannot break generation.
- Integrate the export into the Projects UI with a simple page and left-nav link so users can generate/download the PDF.

### Description

- Add configuration: new `CompendiumPdf` section in `appsettings.json` and `CompendiumPdfOptions` in `Configuration/CompendiumPdfOptions.cs` to expose `Title`, `UnitDisplayName`, `MiscCategoryNames`, `CoverPhotoDerivativeKey`, and `PreferWebp`.
- Register options and services in DI (`Program.cs`) and add a left-nav item by updating `Services/Navigation/RoleBasedNavigationProvider.cs` pointing to `/Projects/Compendium/Index`.
- Implement read layer: `ICompendiumReadService` and `CompendiumReadService` which selects projects that are completed, not deleted/archived, verifies latest `ProjectTechStatus.AvailableForProliferation`, resolves completion year (`CompletedYear` -> `CompletedOn.Year` -> "Not recorded"), loads latest production cost, and chooses a cover photo with fallback to latest `ProjectPhoto.IsCover`.
- Implement export orchestration: `ICompendiumExportService` and `CompendiumExportService` that loads safe cover photo derivatives via `IProjectPhotoService.OpenDerivativeAsync(...)`, wraps retrieval in `try/catch` so failures don't abort export, builds a `CompendiumPdfReportContext`, and returns bytes + deterministic filename.
- Implement PDF builder: `ICompendiumPdfReportBuilder` and `CompendiumPdfReportBuilder` (QuestPDF) to render A4 cover page, index pages (project name + completion year), detail pages, and page numbers on non-cover pages.
- Add lightweight UI: Razor Page `Pages/Projects/Compendium/Index.cshtml` and page model to POST to the export service and return the generated PDF.

### Testing

- Ran `git diff --check` to ensure no whitespace/patch errors, which passed.
- Attempted `dotnet build ProjectManagement.sln` but the environment lacks the `dotnet` CLI so compilation could not be validated (`dotnet` not available here).
- Attempted to capture the new page with a browser script (`http://localhost:5000/Projects/Compendium/Index`) but the app server was not running, resulting in `ERR_EMPTY_RESPONSE` from the local request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f14104c4832996045618d32019db)