### PR TITLE
Compendium PDF: render full-width Markdown description & remove sponsoring line directorate

### DIFF
--- a/Services/Compendiums/CompendiumDtos.cs
+++ b/Services/Compendiums/CompendiumDtos.cs
@@ -9,10 +9,10 @@ public sealed record CompendiumProjectDto(
     string TechnicalCategoryName,
     int? CompletionYearValue,
     string CompletionYearDisplay,
-    string SponsoringLineDirectorateDisplay,
     string ArmServiceDisplay,
     decimal? ProliferationCostLakhs,
-    int? CoverPhotoId);
+    int? CoverPhotoId,
+    string DescriptionMarkdown);
 
 public sealed record CompendiumCategoryGroupDto(
     string TechnicalCategoryName,

--- a/Services/Compendiums/CompendiumExportService.cs
+++ b/Services/Compendiums/CompendiumExportService.cs
@@ -52,11 +52,11 @@ public sealed class CompendiumExportService : ICompendiumExportService
                     ProjectName: p.ProjectName,
                     CategoryName: group.TechnicalCategoryName,
                     CompletionYearDisplay: p.CompletionYearDisplay,
-                    SponsoringLineDirectorateDisplay: p.SponsoringLineDirectorateDisplay,
                     ArmServiceDisplay: p.ArmServiceDisplay,
                     ProliferationCostDisplay: p.ProliferationCostLakhs.HasValue
                         ? p.ProliferationCostLakhs.Value.ToString("0.##", CultureInfo.InvariantCulture)
                         : "Not recorded",
+                    DescriptionMarkdown: p.DescriptionMarkdown,
                     CoverPhoto: photoBytes));
             }
 

--- a/Services/Compendiums/CompendiumReadService.cs
+++ b/Services/Compendiums/CompendiumReadService.cs
@@ -40,9 +40,9 @@ public sealed class CompendiumReadService : ICompendiumReadService
             {
                 p.Id,
                 p.Name,
+                p.Description,
                 p.TechnicalCategoryId,
                 TechnicalCategoryName = p.TechnicalCategory != null ? p.TechnicalCategory.Name : null,
-                SponsoringLineDirectorateName = p.SponsoringLineDirectorate != null ? p.SponsoringLineDirectorate.Name : null,
                 p.ArmService,
                 p.CompletedYear,
                 p.CompletedOn,
@@ -144,13 +144,13 @@ public sealed class CompendiumReadService : ICompendiumReadService
                 ? "Not recorded"
                 : p.TechnicalCategoryName!.Trim();
 
-            var ldDisplay = string.IsNullOrWhiteSpace(p.SponsoringLineDirectorateName)
-                ? "Not recorded"
-                : p.SponsoringLineDirectorateName!.Trim();
-
             var armDisplay = string.IsNullOrWhiteSpace(p.ArmService)
                 ? "Not recorded"
                 : p.ArmService.Trim();
+
+            var descriptionMd = string.IsNullOrWhiteSpace(p.Description)
+                ? "Not recorded"
+                : p.Description.Trim();
 
             var coverPhotoId = p.CoverPhotoId;
             if (!coverPhotoId.HasValue && coverPhotoFallbackByProjectId.TryGetValue(p.Id, out var fallbackId))
@@ -164,10 +164,10 @@ public sealed class CompendiumReadService : ICompendiumReadService
                 TechnicalCategoryName: categoryName,
                 CompletionYearValue: completionYear,
                 CompletionYearDisplay: completionYearDisplay,
-                SponsoringLineDirectorateDisplay: ldDisplay,
                 ArmServiceDisplay: armDisplay,
                 ProliferationCostLakhs: cost?.ApproxProductionCost,
-                CoverPhotoId: coverPhotoId));
+                CoverPhotoId: coverPhotoId,
+                DescriptionMarkdown: descriptionMd));
         }
 
         // SECTION: Grouping and ordering per URD.

--- a/Utilities/Reporting/MarkdownPdfRenderer.cs
+++ b/Utilities/Reporting/MarkdownPdfRenderer.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+
+namespace ProjectManagement.Utilities.Reporting;
+
+// SECTION: Render Markdown content into QuestPDF components without HTML conversion.
+internal static class MarkdownPdfRenderer
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .DisableHtml()
+        .UseEmphasisExtras()
+        .UseAutoLinks()
+        .UsePipeTables()
+        .UseTaskLists()
+        .Build();
+
+    public static void Render(IContainer container, string markdown)
+    {
+        var source = string.IsNullOrWhiteSpace(markdown) ? "Not recorded" : markdown;
+        var doc = Markdig.Markdown.Parse(source, Pipeline);
+
+        container.Column(col =>
+        {
+            col.Spacing(6);
+
+            foreach (var block in doc)
+            {
+                switch (block)
+                {
+                    case HeadingBlock heading:
+                        col.Item().Text(text => RenderInlines(text, heading.Inline))
+                            .FontSize(HeadingSize(heading.Level))
+                            .SemiBold()
+                            .FontColor("#0F172A");
+                        break;
+
+                    case ParagraphBlock paragraph:
+                        col.Item().Text(text => RenderInlines(text, paragraph.Inline))
+                            .FontSize(10)
+                            .FontColor("#0F172A")
+                            .LineHeight(1.25f);
+                        break;
+
+                    case ListBlock list:
+                        RenderList(col, list, 0);
+                        break;
+
+                    case FencedCodeBlock fenced:
+                        RenderCodeBlock(col, fenced);
+                        break;
+
+                    case CodeBlock code:
+                        RenderCodeBlock(col, code);
+                        break;
+
+                    case ThematicBreakBlock:
+                        col.Item().PaddingVertical(6).Element(e => e.Height(1).Background("#E2E8F0"));
+                        break;
+
+                    default:
+                        col.Item().Text(block.ToString() ?? string.Empty)
+                            .FontSize(10)
+                            .FontColor("#0F172A");
+                        break;
+                }
+            }
+        });
+    }
+
+    // SECTION: Block rendering helpers
+    private static float HeadingSize(int level) => level switch
+    {
+        1 => 14,
+        2 => 13,
+        3 => 12,
+        _ => 11
+    };
+
+    private static void RenderList(ColumnDescriptor col, ListBlock list, int depth)
+    {
+        var index = list.OrderedStart;
+
+        foreach (var item in list)
+        {
+            if (item is not ListItemBlock li)
+            {
+                continue;
+            }
+
+            var prefix = list.IsOrdered ? $"{index}. " : "• ";
+            index++;
+
+            col.Item().PaddingLeft(depth * 14).Row(row =>
+            {
+                row.ConstantItem(18).Text(prefix).FontSize(10).FontColor("#0F172A");
+                row.RelativeItem().Column(itemCol =>
+                {
+                    itemCol.Spacing(4);
+
+                    foreach (var block in li)
+                    {
+                        switch (block)
+                        {
+                            case ParagraphBlock paragraph:
+                                itemCol.Item().Text(text => RenderInlines(text, paragraph.Inline))
+                                    .FontSize(10)
+                                    .FontColor("#0F172A")
+                                    .LineHeight(1.25f);
+                                break;
+
+                            case ListBlock nested:
+                                RenderList(itemCol, nested, depth + 1);
+                                break;
+
+                            case FencedCodeBlock fenced:
+                                RenderCodeBlock(itemCol, fenced);
+                                break;
+
+                            case CodeBlock code:
+                                RenderCodeBlock(itemCol, code);
+                                break;
+
+                            default:
+                                itemCol.Item().Text(block.ToString() ?? string.Empty)
+                                    .FontSize(10)
+                                    .FontColor("#0F172A");
+                                break;
+                        }
+                    }
+                });
+            });
+        }
+    }
+
+    private static void RenderCodeBlock(ColumnDescriptor col, CodeBlock code)
+    {
+        var content = string.Join("\n", code.Lines.Lines.Select(line => line.ToString()));
+        RenderCodeBlockText(col, content);
+    }
+
+    private static void RenderCodeBlock(ColumnDescriptor col, FencedCodeBlock code)
+    {
+        var content = string.Join("\n", code.Lines.Lines.Select(line => line.ToString()));
+        RenderCodeBlockText(col, content);
+    }
+
+    private static void RenderCodeBlockText(ColumnDescriptor col, string content)
+    {
+        var safe = string.IsNullOrWhiteSpace(content) ? string.Empty : content.TrimEnd();
+
+        col.Item().Element(box =>
+        {
+            box.Border(1)
+                .BorderColor("#E2E8F0")
+                .Background("#F8FAFC")
+                .Padding(10)
+                .Text(safe)
+                .FontSize(9)
+                .FontColor("#0F172A");
+        });
+    }
+
+    // SECTION: Inline rendering helpers
+    private static void RenderInlines(TextDescriptor text, ContainerInline? inline)
+    {
+        if (inline is null)
+        {
+            return;
+        }
+
+        foreach (var child in inline)
+        {
+            RenderInline(text, child, isBold: false, isItalic: false);
+        }
+    }
+
+    private static void RenderInline(TextDescriptor text, Inline child, bool isBold, bool isItalic)
+    {
+        switch (child)
+        {
+            case LiteralInline literal:
+                ApplySpanStyle(text.Span(literal.Content.ToString()), isBold, isItalic);
+                break;
+
+            case LineBreakInline:
+                text.Span("\n");
+                break;
+
+            case EmphasisInline emphasis:
+                var nextBold = isBold || emphasis.DelimiterCount >= 2;
+                var nextItalic = isItalic || emphasis.DelimiterCount == 1;
+                foreach (var inner in emphasis)
+                {
+                    RenderInline(text, inner, nextBold, nextItalic);
+                }
+                break;
+
+            case CodeInline code:
+                ApplySpanStyle(text.Span(code.Content).FontSize(9), isBold, isItalic);
+                break;
+
+            case LinkInline link:
+                RenderLink(text, link, isBold, isItalic);
+                break;
+
+            default:
+                ApplySpanStyle(text.Span(child.ToString() ?? string.Empty), isBold, isItalic);
+                break;
+        }
+    }
+
+    private static void RenderLink(TextDescriptor text, LinkInline link, bool isBold, bool isItalic)
+    {
+        var label = InlineText(link);
+        var url = link.GetDynamicUrl is not null ? link.GetDynamicUrl() : link.Url;
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            label = string.IsNullOrWhiteSpace(url) ? string.Empty : url.Trim();
+        }
+
+        ApplySpanStyle(text.Span(label), isBold, isItalic);
+
+        if (!string.IsNullOrWhiteSpace(url))
+        {
+            text.Span($" ({url.Trim()})").FontSize(9).FontColor("#64748B");
+        }
+    }
+
+    private static TextSpanDescriptor ApplySpanStyle(TextSpanDescriptor span, bool isBold, bool isItalic)
+    {
+        if (isBold)
+        {
+            span = span.SemiBold();
+        }
+
+        if (isItalic)
+        {
+            span = span.Italic();
+        }
+
+        return span;
+    }
+
+    private static string InlineText(Inline inline)
+    {
+        return inline switch
+        {
+            LiteralInline literal => literal.Content.ToString(),
+            ContainerInline container => string.Concat(container.Select(InlineText)),
+            _ => inline.ToString() ?? string.Empty
+        };
+    }
+}


### PR DESCRIPTION
### Motivation

- Make project `Description` the primary, full-width content on compendium detail pages and preserve Markdown formatting for PDF exports.
- Remove the `Sponsoring line directorate` field from the compendium data pipeline and PDF because it should no longer be displayed or exported.

### Description

- Add `DescriptionMarkdown` to the compendium DTO (`CompendiumProjectDto`) and flow it through the read and export services via `Project.Description` instead of the sponsoring-line directorate field.
- Update `CompendiumReadService` to select `p.Description`, default blank values to `"Not recorded"`, and stop selecting/mapping `SponsoringLineDirectorate`.
- Update `CompendiumExportService` to pass `DescriptionMarkdown` into PDF project sections and remove references to `SponsoringLineDirectorateDisplay`.
- Update `CompendiumPdfReportBuilder` to remove the sponsoring-line field from the project record and rework `ComposeProjectDetail` so the description is rendered as a full-width, primary section and the cover photo (if any) is rendered below the description.
- Add `MarkdownPdfRenderer` to render Markdown into QuestPDF content using the Markdig AST (no HTML), supporting headings, paragraphs, bold/italic, lists and nesting, inline code, fenced code blocks, links (shown as text plus URL), line breaks, and horizontal rules.

### Testing

- Ran repository searches (`rg`) to verify the new `DescriptionMarkdown` field is present and that references to `SponsoringLineDirectorateDisplay` were removed, which returned no remaining matches for the sponsoring-line label (success).
- Attempted `dotnet build` in this environment but it failed because the `dotnet` CLI is not installed here (build could not be validated).
- Attempted an automated browser screenshot using Playwright against `http://127.0.0.1:5000` to exercise the UI, but the local web service was not running (net::ERR_EMPTY_RESPONSE), so rendered PDF/visual validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f72333048329827baf5fe344729a)