### PR TITLE
Fix MarkdownPdfRenderer CS0023 compile errors

### DIFF
--- a/Utilities/Reporting/MarkdownPdfRenderer.cs
+++ b/Utilities/Reporting/MarkdownPdfRenderer.cs
@@ -34,17 +34,25 @@ internal static class MarkdownPdfRenderer
                 switch (block)
                 {
                     case HeadingBlock heading:
-                        col.Item().Text(text => RenderInlines(text, heading.Inline))
-                            .FontSize(HeadingSize(heading.Level))
-                            .SemiBold()
-                            .FontColor("#0F172A");
+                        col.Item().Text(text =>
+                        {
+                            text.DefaultTextStyle(TextStyle.Default
+                                .FontSize(HeadingSize(heading.Level))
+                                .SemiBold()
+                                .FontColor("#0F172A"));
+                            RenderInlines(text, heading.Inline);
+                        });
                         break;
 
                     case ParagraphBlock paragraph:
-                        col.Item().Text(text => RenderInlines(text, paragraph.Inline))
-                            .FontSize(10)
-                            .FontColor("#0F172A")
-                            .LineHeight(1.25f);
+                        col.Item().Text(text =>
+                        {
+                            text.DefaultTextStyle(TextStyle.Default
+                                .FontSize(10)
+                                .FontColor("#0F172A")
+                                .LineHeight(1.25f));
+                            RenderInlines(text, paragraph.Inline);
+                        });
                         break;
 
                     case ListBlock list:
@@ -84,7 +92,7 @@ internal static class MarkdownPdfRenderer
 
     private static void RenderList(ColumnDescriptor col, ListBlock list, int depth)
     {
-        var index = list.OrderedStart;
+        var index = int.TryParse(list.OrderedStart?.ToString(), out var parsedIndex) ? parsedIndex : 1;
 
         foreach (var item in list)
         {
@@ -108,10 +116,14 @@ internal static class MarkdownPdfRenderer
                         switch (block)
                         {
                             case ParagraphBlock paragraph:
-                                itemCol.Item().Text(text => RenderInlines(text, paragraph.Inline))
-                                    .FontSize(10)
-                                    .FontColor("#0F172A")
-                                    .LineHeight(1.25f);
+                                itemCol.Item().Text(text =>
+                                {
+                                    text.DefaultTextStyle(TextStyle.Default
+                                        .FontSize(10)
+                                        .FontColor("#0F172A")
+                                        .LineHeight(1.25f));
+                                    RenderInlines(text, paragraph.Inline);
+                                });
                                 break;
 
                             case ListBlock nested:


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by using QuestPDF text-style chaining on the `Text(...)` callback (resulting in `CS0023` "operator '.' cannot be applied to operand of type 'void'").
- Fix ordered list indexing where `ListBlock.OrderedStart` was used as a non-integer and `++` could not be applied to a `string`.

### Description
- Move heading and paragraph styling into the `TextDescriptor.DefaultTextStyle(...)` call inside the `Text(...)` callback and call `RenderInlines(...)` from within that callback for headings and top-level paragraphs.
- Apply the same `DefaultTextStyle(...)` pattern for paragraph blocks inside list items so list item paragraphs no longer chain void-returning methods.
- Replace direct use of `list.OrderedStart` with `int.TryParse(list.OrderedStart?.ToString(), out var parsedIndex) ? parsedIndex : 1` to safely obtain an integer index for ordered lists.
- Small refactor and formatting adjustments in `Utilities/Reporting/MarkdownPdfRenderer.cs` to match the new APIs.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln`, but the `dotnet` CLI was not available in this environment (`command not found`), so an automated build could not be executed here.
- No other automated tests were run in this environment due to tool unavailability. Please run `dotnet build` and project test suites locally or in CI to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991fae24a388329a692a5d6bff0dc05)