### PR TITLE
Fix PDF quote rendering and restore two-column compendium header

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -227,14 +227,32 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                 .SemiBold()
                 .FontColor("#0F172A");
 
-            // SECTION: Metadata (compact; description is the primary section below)
-            col.Item().Column(meta =>
+            // SECTION: Header two-column layout (left metadata, right cover photo).
+            col.Item().Row(row =>
             {
-                meta.Spacing(6);
-                meta.Item().Element(c => ComposeKeyValue(c, "Technical category", project.CategoryName));
-                meta.Item().Element(c => ComposeKeyValue(c, "Year of completion", project.CompletionYearDisplay));
-                meta.Item().Element(c => ComposeKeyValue(c, "Arm/Service", project.ArmServiceDisplay));
-                meta.Item().Element(c => ComposeKeyValue(c, "Proliferation cost (lakhs)", project.ProliferationCostDisplay));
+                row.RelativeItem().Column(meta =>
+                {
+                    meta.Spacing(6);
+                    meta.Item().Element(c => ComposeKeyValue(c, "Technical category", project.CategoryName));
+                    meta.Item().Element(c => ComposeKeyValue(c, "Year of completion", project.CompletionYearDisplay));
+                    meta.Item().Element(c => ComposeKeyValue(c, "Arm/Service", project.ArmServiceDisplay));
+                    meta.Item().Element(c => ComposeKeyValue(c, "Proliferation cost (lakhs)", project.ProliferationCostDisplay));
+                });
+
+                if (project.CoverPhoto is not null && project.CoverPhoto.Length > 0)
+                {
+                    row.ConstantItem(230).Height(170).PaddingLeft(14).Element(img =>
+                    {
+                        img.Border(1)
+                            .BorderColor("#E2E8F0")
+                            .Background("#F8FAFC")
+                            .Padding(8)
+                            .AlignCenter()
+                            .AlignMiddle()
+                            .Image(project.CoverPhoto)
+                            .FitArea();
+                    });
+                }
             });
 
             // SECTION: Description (full width with markdown formatting)
@@ -255,23 +273,6 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                         desc.Item().Element(md => MarkdownPdfRenderer.Render(md, project.DescriptionMarkdown));
                     });
             });
-
-            // SECTION: Cover photo (optional and rendered below description)
-            if (project.CoverPhoto is not null && project.CoverPhoto.Length > 0)
-            {
-                col.Item().PaddingTop(8).Element(img =>
-                {
-                    img.Border(1)
-                        .BorderColor("#E2E8F0")
-                        .Background("#F8FAFC")
-                        .Padding(8)
-                        .Height(220)
-                        .AlignCenter()
-                        .AlignMiddle()
-                        .Image(project.CoverPhoto)
-                        .FitArea();
-                });
-            }
 
             col.Item().PaddingTop(4).Element(e => e.Height(1).Background("#E2E8F0"));
 


### PR DESCRIPTION
### Motivation
- Prevent block quotes from falling back to `ToString()` (which printed `Markdig.Syntax.QuoteBlock`) by explicitly rendering `QuoteBlock` nodes. 
- Restore the compendium project header layout so metadata appears in a left column and the cover photo appears as a right-side visual, with the project description remaining full-width below.

### Description
- Added explicit `QuoteBlock` handling in `Utilities/Reporting/MarkdownPdfRenderer.cs` and implemented `RenderQuoteBlock` to render quotes with a styled left border, background, padding, and support for nested paragraphs, lists, code blocks, and nested quotes.
- Updated `Utilities/Reporting/CompendiumPdfReportBuilder.cs` `ComposeProjectDetail` to use a two-column header row: left column for metadata and right column for an optional cover photo, and kept the `Project description` Markdown section as a full-width box below the header row.
- Adjusted image rendering in the header to use a fixed column (`ConstantItem(230)` / `.Height(170)`) and `FitArea()` so the cover photo remains a right-side visual instead of being rendered below the description.
- Files modified: `Utilities/Reporting/MarkdownPdfRenderer.cs` and `Utilities/Reporting/CompendiumPdfReportBuilder.cs`.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln` in this environment, but the `dotnet` SDK is not available here so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991fd729b188329b4489d9a771a0638)