### PR TITLE
Fix QuestPDF footer API usage in compendium report

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -176,9 +176,7 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                             ComposeProjectFooter(
                                 f,
                                 footerLogoBytes,
-                                generatedAtText,
-                                pageNumberProvider: () => page.GetCurrentPageNumber(),
-                                totalPagesProvider: () => page.GetTotalPages());
+                                generatedAtText);
                         });
                     });
                 }
@@ -211,9 +209,7 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
     private static void ComposeProjectFooter(
         IContainer container,
         byte[]? logoBytes,
-        string generatedAtText,
-        Func<int> pageNumberProvider,
-        Func<int> totalPagesProvider)
+        string generatedAtText)
     {
         container
             .Background("#F8FAFC")
@@ -226,7 +222,7 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                 {
                     if (logoBytes is not null && logoBytes.Length > 0)
                     {
-                        left.ConstantItem(22).Height(22).AlignMiddle().Image(logoBytes, ImageScaling.FitArea);
+                        left.ConstantItem(22).Height(22).AlignMiddle().Element(logo => logo.Image(logoBytes).FitArea());
                         left.ConstantItem(8);
                     }
 
@@ -242,9 +238,9 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                 {
                     t.DefaultTextStyle(s => s.FontSize(9).FontColor("#64748B"));
                     t.Span($"Generated on {generatedAtText} · through PRISM ERP · Page ");
-                    t.Span(pageNumberProvider().ToString(CultureInfo.InvariantCulture)).SemiBold();
+                    t.CurrentPageNumber().SemiBold();
                     t.Span(" / ");
-                    t.Span(totalPagesProvider().ToString(CultureInfo.InvariantCulture)).SemiBold();
+                    t.TotalPages().SemiBold();
                 });
             });
     }


### PR DESCRIPTION
### Motivation
- Resolve IntelliSense errors where `PageDescriptor` methods (`GetCurrentPageNumber` / `GetTotalPages`) were referenced but unavailable in the detail-page footer.
- Remove use of an obsolete `Image` overload that raised a CS0618 warning and adapt to the newer descriptor-based API.

### Description
- Updated detail-page footer call site to stop passing page-number provider delegates and instead pass only stable footer data (`generatedAtText`, `logoBytes`) to `ComposeProjectFooter`.
- Refactored `ComposeProjectFooter` to render page numbers with QuestPDF text tokens `CurrentPageNumber()` and `TotalPages()` instead of calling provider delegates.
- Replaced the obsolete image overload with the descriptor-based usage `Element(logo => logo.Image(logoBytes).FitArea())` to address the deprecation warning.
- Changed only `Utilities/Reporting/CompendiumPdfReportBuilder.cs` to implement the above adjustments.

### Testing
- Attempted to run `dotnet build`, but the environment does not have the `dotnet` CLI installed so the build could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932539dcbc8329a618ef1868acc601)