### PR TITLE
Add clickable PDF index links and simplify index header styling

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -186,6 +186,9 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
         return document.GeneratePdf();
     }
 
+    // SECTION: Stable named destinations used for in-document navigation.
+    private static string ProjectAnchorId(int projectId) => $"proj-{projectId.ToString(CultureInfo.InvariantCulture)}";
+
     private static byte[]? TryLoadFooterLogoBytes(IWebHostEnvironment env, string relativeUnderWwwroot)
     {
         try
@@ -272,7 +275,10 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
 
                 foreach (var p in category.Projects)
                 {
-                    table.Cell().Element(CellBody).Text(p.ProjectName);
+                    table.Cell().Element(CellBody).Text(t =>
+                    {
+                        t.InternalLink(ProjectAnchorId(p.ProjectId)).Span(p.ProjectName);
+                    });
                     table.Cell().Element(CellBody).AlignRight().Text(p.CompletionYearDisplay);
                 }
             });
@@ -285,7 +291,8 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
         {
             col.Spacing(14);
 
-            col.Item().AlignCenter().Text(project.ProjectName)
+            col.Item().Section(ProjectAnchorId(project.ProjectId))
+                .AlignCenter().Text(project.ProjectName)
                 .FontSize(20)
                 .SemiBold()
                 .FontColor("#0F172A");
@@ -352,11 +359,10 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
 
     private static IContainer CellHeader(IContainer container)
         => container.DefaultTextStyle(x => x.SemiBold().FontColor("#334155").FontSize(10))
-            .Background("#F1F5F9")
             .PaddingVertical(6)
             .PaddingHorizontal(8)
-            .Border(1)
-            .BorderColor("#E2E8F0");
+            .BorderBottom(1)
+            .BorderColor("#CBD5E1");
 
     private static IContainer CellBody(IContainer container)
         => container.DefaultTextStyle(x => x.FontSize(10).FontColor("#0F172A"))


### PR DESCRIPTION
### Motivation
- Make the generated PDF index entries navigable so readers can click a project in the index and jump to its detail page. 
- Remove the boxed header visual (perceived shadow) in the index table to produce a cleaner, less “raised” table header.

### Description
- Added a stable helper `ProjectAnchorId(int)` to produce consistent named destinations for in-document navigation in `Utilities/Reporting/CompendiumPdfReportBuilder.cs`.
- Turned index project name cells into QuestPDF internal links using `InternalLink(ProjectAnchorId(...))` so index rows jump to project detail pages.
- Added a named destination on each project detail heading by wrapping the title with `.Section(ProjectAnchorId(...))` to target the internal links.
- Simplified header styling in `CellHeader` by removing the background and full border and switching to a subtle bottom border (`BorderBottom(1)` and updated `BorderColor`).

### Testing
- Attempted to run `dotnet build ProjectManagement.sln` to validate compilation, but the environment lacks the `dotnet` CLI so the build failed with `bash: command not found: dotnet`.
- No other automated tests were run in this environment due to the missing .NET toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699328d735988329b8618ee034cfc0be)