### PR TITLE
Fix QuestPDF InternalLink usage in compendium index

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -278,10 +278,9 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
 
                 foreach (var p in category.Projects)
                 {
-                    table.Cell().Element(CellBody).Text(t =>
-                    {
-                        t.InternalLink(ProjectAnchorId(p.ProjectId)).Span(p.ProjectName);
-                    });
+                    table.Cell().Element(CellBody)
+                        .InternalLink(ProjectAnchorId(p.ProjectId))
+                        .Text(p.ProjectName);
                     table.Cell().Element(CellBody).AlignRight().Text(p.CompletionYearDisplay);
                 }
             });


### PR DESCRIPTION
### Motivation
- Resolve a compilation error (CS1929) caused by calling `InternalLink` on a `TextDescriptor` and unblock downstream test project failure (CS0006) by ensuring the main project builds successfully.

### Description
- Replace the usage `table.Cell().Element(CellBody).Text(t => t.InternalLink(ProjectAnchorId(...)).Span(...))` with `table.Cell().Element(CellBody).InternalLink(ProjectAnchorId(...)).Text(...)` so `InternalLink` is invoked on the container element (supported QuestPDF API) while preserving anchor IDs and navigation behavior.

### Testing
- Attempted to run `dotnet build`, but the environment lacks the `dotnet` CLI (`bash: command not found: dotnet`), so no automated build/tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932a22cecc83298b28825ba2ded134)