### PR TITLE
Add full-bleed branded footer to compendium index pages

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -145,12 +145,12 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                     }
                 });
 
-                page.Footer().AlignCenter().Text(text =>
+                // SECTION: Index footer (full-bleed, no page numbers).
+                page.Footer().Element(f =>
                 {
-                    text.DefaultTextStyle(style => style.FontSize(9).FontColor("#94A3B8"));
-                    text.CurrentPageNumber();
-                    text.Span(" / ");
-                    text.TotalPages();
+                    ComposeIndexFooter(
+                        f.PaddingLeft(-35).PaddingRight(-35),
+                        footerLogoBytes);
                 });
             });
 
@@ -245,6 +245,41 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                     t.CurrentPageNumber().SemiBold();
                     t.Span(" / ");
                     t.TotalPages().SemiBold();
+                });
+            });
+    }
+
+    private static void ComposeIndexFooter(
+        IContainer container,
+        byte[]? logoBytes)
+    {
+        container
+            .Background("#F8FAFC")
+            .PaddingVertical(8)
+            .PaddingHorizontal(35)
+            .Row(row =>
+            {
+                // SECTION: Left footer content (logo and organization label).
+                row.RelativeItem().Row(left =>
+                {
+                    if (logoBytes is not null && logoBytes.Length > 0)
+                    {
+                        left.ConstantItem(22).Height(22).AlignMiddle().Element(logo => logo.Image(logoBytes).FitArea());
+                        left.ConstantItem(8);
+                    }
+
+                    left.RelativeItem().AlignMiddle().Text(t =>
+                    {
+                        t.DefaultTextStyle(s => s.FontSize(9).FontColor("#475569").SemiBold());
+                        t.Span("Simulator Development Division");
+                    });
+                });
+
+                // SECTION: Right footer content (product label only).
+                row.RelativeItem().AlignRight().AlignMiddle().Text(t =>
+                {
+                    t.DefaultTextStyle(s => s.FontSize(9).FontColor("#64748B"));
+                    t.Span("PRISM ERP");
                 });
             });
     }


### PR DESCRIPTION
### Motivation
- Ensure the index pages share the same polished full-bleed footer strip as detail pages while keeping the index clean of page numbers.
- Preserve existing detail-page behavior (`PRISM ERP · Page X / Y`) and reuse existing branding/layout to keep visuals consistent.

### Description
- Replaced the centered page-number footer on index pages with a full-bleed footer element that negates the page horizontal margin via `f.PaddingLeft(-35).PaddingRight(-35)` in `Utilities/Reporting/CompendiumPdfReportBuilder.cs`.
- Added a new helper `ComposeIndexFooter(IContainer, byte[]?)` placed near `ComposeProjectFooter` that renders the left branding (logo + `Simulator Development Division`) and a right-aligned `PRISM ERP` label without page numbers.
- Kept the existing `ComposeProjectFooter` implementation unchanged so detail pages still show `PRISM ERP · Page X / Y`.

### Testing
- Attempted to run `dotnet build ProjectManagement.csproj -nologo`, but the build could not be executed because the `dotnet` CLI is not installed in this environment (build not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699334af13d88329b5866ed7c6c5ea37)