### PR TITLE
Fix CompendiumPdfReportBuilder QuestPDF compile errors

### DIFF
--- a/Utilities/Reporting/CompendiumPdfReportBuilder.cs
+++ b/Utilities/Reporting/CompendiumPdfReportBuilder.cs
@@ -86,23 +86,15 @@ public sealed class CompendiumPdfReportBuilder : ICompendiumPdfReportBuilder
                         bg.Background("#0B1220");
 
                         // SECTION: Subtle diagonal band.
-                        bg.AlignTopLeft().TranslateX(-120).TranslateY(160).Rotate(-10).Element(band =>
+                        bg.AlignLeft().AlignTop().TranslateX(-120).TranslateY(160).Rotate(-10).Element(band =>
                         {
-                            band.Width(page.Size().Width + 300)
+                            // SECTION: A4 portrait width is ~595pt; fixed width keeps this compatible with older QuestPDF APIs.
+                            band.Width(895)
                                 .Height(120)
-                                .Background("#111C33")
-                                .Opacity(0.9f);
+                                .Background("#111C33");
                         });
 
-                        // SECTION: Watermark (very subtle): use SDD mark.
-                        if (coverSddBytes is not null && coverSddBytes.Length > 0)
-                        {
-                            bg.AlignCenter().Opacity(0.08f).Element(wm =>
-                            {
-                                wm.Width(420).Height(420).AlignCenter().AlignMiddle()
-                                  .Image(coverSddBytes).FitArea();
-                            });
-                        }
+                        // SECTION: Watermark intentionally omitted to avoid unsupported opacity APIs in this QuestPDF version.
                     });
 
                     // SECTION: Cover foreground content.


### PR DESCRIPTION
### Motivation
- The compendium PDF builder used QuestPDF container APIs (`AlignTopLeft()`, container `Opacity(...)`, and `page.Size().Width`) that are not available in the project’s QuestPDF/runtime, causing compile-time errors (CS1061, CS0023, CS1501) while generating the cover layout.

### Description
- Replaced unsupported `AlignTopLeft()` with `AlignLeft().AlignTop()` for the diagonal cover band placement in `Utilities/Reporting/CompendiumPdfReportBuilder.cs`.
- Replaced the dynamic `page.Size().Width` usage with a fixed A4-safe band width (`band.Width(895)`) to avoid the `Size()` overload error while keeping a consistent diagonal band layout.
- Removed the watermark block that relied on container `Opacity(...)` (unsupported here) and left an explicit comment documenting the omission to preserve PDF generation stability.
- Kept surrounding layout and comments intact so other features and cover foreground content remain unchanged.

### Testing
- Ran a scoped search with `rg -n "AlignTopLeft|\.Opacity\(|page\.Size\(" Utilities/Reporting/CompendiumPdfReportBuilder.cs` and confirmed the unsupported API usages were removed from the modified file.
- Attempted `dotnet build -nologo` but the environment lacks the .NET SDK (`bash: command not found: dotnet`), so a full project build could not be executed here.
- Changes were committed to the current branch after verification of the code edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699343d990ac8329bf5593e6ef983f9a)