### PR TITLE
Add per-user unread AOTS badges to Documents navigation

### DIFF
--- a/Areas/DocumentRepository/Pages/Documents/Index.cshtml
+++ b/Areas/DocumentRepository/Pages/Documents/Index.cshtml
@@ -85,6 +85,7 @@ else
                        aria-label="AOTS">
                         <i class="bi bi-broadcast"></i>
                         <span class="docrepo-rail__label">AOTS</span>
+                        @await Component.InvokeAsync("AotsUnreadBadge", new { variant = "rail" })
                     </a>
                 </nav>
 

--- a/Pages/Shared/Components/AotsUnreadBadge/Default.cshtml
+++ b/Pages/Shared/Components/AotsUnreadBadge/Default.cshtml
@@ -1,0 +1,11 @@
+@model ProjectManagement.ViewModels.Navigation.AotsUnreadBadgeViewModel
+
+@* SECTION: AOTS unread badge *@
+@if (Model.ShowBadge)
+{
+    <span class="pm-aots-unread-badge pm-aots-unread-badge--@Model.Variant"
+          title="Unread AOTS documents"
+          aria-label="@Model.AriaLabel">
+        @Model.DisplayText
+    </span>
+}

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -71,7 +71,8 @@
                     <a asp-area="DocumentRepository"
                        asp-page="/Documents/Index"
                        class="pm-top-tabs__item @(isDocumentRepositoryPage ? "is-active" : string.Empty)">
-                        Documents
+                        <span>Documents</span>
+                        @await Component.InvokeAsync("AotsUnreadBadge", new { variant = "topnav" })
                     </a>
                 </nav>
             </div>

--- a/Program.cs
+++ b/Program.cs
@@ -291,6 +291,7 @@ builder.Services.AddScoped<IDocRepoAuditService, DocRepoAuditService>();
 builder.Services.AddScoped<IFileScanner, NoopFileScanner>();
 builder.Services.AddScoped<IDocumentOcrRunner, OcrmypdfDocumentOcrRunner>();
 builder.Services.AddScoped<IDocumentSearchService, DocumentSearchService>();
+builder.Services.AddScoped<IAotsUnreadService, AotsUnreadService>();
 builder.Services.AddScoped<IDocRepoIngestionService, DocRepoIngestionService>();
 builder.Services.AddScoped<IGlobalDocRepoSearchService, GlobalDocRepoSearchService>();
 builder.Services.AddScoped<IGlobalFfcSearchService, GlobalFfcSearchService>();

--- a/Services/DocRepo/AotsUnreadBadgeFormatter.cs
+++ b/Services/DocRepo/AotsUnreadBadgeFormatter.cs
@@ -1,0 +1,15 @@
+namespace ProjectManagement.Services.DocRepo;
+
+public static class AotsUnreadBadgeFormatter
+{
+    // SECTION: Compact badge text formatter
+    public static string Format(int count)
+    {
+        if (count <= 0)
+        {
+            return string.Empty;
+        }
+
+        return count > 9 ? "9+" : count.ToString();
+    }
+}

--- a/Services/DocRepo/AotsUnreadService.cs
+++ b/Services/DocRepo/AotsUnreadService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+
+namespace ProjectManagement.Services.DocRepo;
+
+public sealed class AotsUnreadService : IAotsUnreadService
+{
+    // SECTION: Dependencies
+    private readonly ApplicationDbContext _db;
+
+    // SECTION: Request-level cache (scoped lifetime)
+    private readonly Dictionary<string, int> _countByUserId = new(StringComparer.Ordinal);
+
+    public AotsUnreadService(ApplicationDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    // SECTION: Unread AOTS aggregate count
+    public async Task<int> GetUnreadCountAsync(string? userId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return 0;
+        }
+
+        if (_countByUserId.TryGetValue(userId, out var cachedCount))
+        {
+            return cachedCount;
+        }
+
+        var unreadCount = await _db.Documents
+            .AsNoTracking()
+            .Where(document =>
+                document.IsAots &&
+                !document.IsDeleted &&
+                !document.IsExternal &&
+                document.IsActive &&
+                !_db.DocRepoAotsViews.Any(view => view.DocumentId == document.Id && view.UserId == userId))
+            .CountAsync(cancellationToken);
+
+        _countByUserId[userId] = unreadCount;
+
+        return unreadCount;
+    }
+}

--- a/Services/DocRepo/IAotsUnreadService.cs
+++ b/Services/DocRepo/IAotsUnreadService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProjectManagement.Services.DocRepo;
+
+public interface IAotsUnreadService
+{
+    // SECTION: Unread AOTS aggregate count
+    Task<int> GetUnreadCountAsync(string? userId, CancellationToken cancellationToken = default);
+}

--- a/ViewComponents/AotsUnreadBadgeViewComponent.cs
+++ b/ViewComponents/AotsUnreadBadgeViewComponent.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using ProjectManagement.Services.DocRepo;
+using ProjectManagement.ViewModels.Navigation;
+
+namespace ProjectManagement.ViewComponents;
+
+public sealed class AotsUnreadBadgeViewComponent : ViewComponent
+{
+    // SECTION: Dependencies
+    private readonly IAotsUnreadService _aotsUnreadService;
+
+    public AotsUnreadBadgeViewComponent(IAotsUnreadService aotsUnreadService)
+    {
+        _aotsUnreadService = aotsUnreadService ?? throw new ArgumentNullException(nameof(aotsUnreadService));
+    }
+
+    // SECTION: View component entry point
+    public async Task<IViewComponentResult> InvokeAsync(string variant = "default", CancellationToken cancellationToken = default)
+    {
+        var userId = HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var count = await _aotsUnreadService.GetUnreadCountAsync(userId, cancellationToken);
+
+        if (count <= 0)
+        {
+            return View(new AotsUnreadBadgeViewModel
+            {
+                ShowBadge = false,
+                Variant = variant
+            });
+        }
+
+        return View(new AotsUnreadBadgeViewModel
+        {
+            ShowBadge = true,
+            DisplayText = AotsUnreadBadgeFormatter.Format(count),
+            AriaLabel = $"Unread AOTS documents: {count}",
+            Variant = variant
+        });
+    }
+}

--- a/ViewModels/Navigation/AotsUnreadBadgeViewModel.cs
+++ b/ViewModels/Navigation/AotsUnreadBadgeViewModel.cs
@@ -1,0 +1,16 @@
+namespace ProjectManagement.ViewModels.Navigation;
+
+public sealed class AotsUnreadBadgeViewModel
+{
+    // SECTION: Visibility
+    public bool ShowBadge { get; init; }
+
+    // SECTION: Render text
+    public string DisplayText { get; init; } = string.Empty;
+
+    // SECTION: Accessibility
+    public string AriaLabel { get; init; } = "Unread AOTS documents";
+
+    // SECTION: Visual variant selector
+    public string Variant { get; init; } = "default";
+}

--- a/wwwroot/css/docrepo-ui.css
+++ b/wwwroot/css/docrepo-ui.css
@@ -363,6 +363,15 @@
     text-align: center;
 }
 
+/* SECTION: AOTS unread badge in left rail */
+.pm-aots-unread-badge--rail {
+    margin-top: 0.1rem;
+    min-width: 1.05rem;
+    height: 1.05rem;
+    padding: 0 .28rem;
+    font-size: .6rem;
+}
+
 .docrepo-filters {
     width: 300px;
     flex: 0 0 300px;

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -6934,11 +6934,33 @@ body.has-project-photo-preview-dialog {
         color: #0f172a;
     }
 
-    .pm-top-tabs__item.is-active {
+.pm-top-tabs__item.is-active {
         color: #0f172a;
         border-bottom-color: #3b82f6; /* active underline like GitHub repo tabs */
         background: rgba(255,255,255,0.15);
     }
+
+/* SECTION: AOTS unread badges */
+.pm-aots-unread-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1rem;
+    height: 1rem;
+    padding: 0 .3rem;
+    border-radius: 9999px;
+    font-size: .62rem;
+    line-height: 1;
+    font-weight: 700;
+    background: var(--pm-danger-accent);
+    color: #fff;
+    vertical-align: middle;
+}
+
+.pm-aots-unread-badge--topnav,
+.pm-aots-unread-badge--default {
+    margin-left: .35rem;
+}
 
 .pm-topbar__right {
     display: flex;


### PR DESCRIPTION
### Motivation

- Provide a per-user unread count for AOTS documents to gently surface outstanding AOTS items in the main Documents navigation and the Documents left rail.  
- Count must be authoritative (database-driven) and use existing AOTS view-tracking in `DocRepoAotsViews`.  
- Keep the UX unobtrusive (badge only), do not alter existing Documents navigation targets or redirect behavior.

### Description

- Added a dedicated unread-count service interface and implementation (`Services/DocRepo/IAotsUnreadService.cs`, `AotsUnreadService.cs`) that returns the number of active, non-deleted, non-external `Document.IsAots` documents not yet present in `DocRepoAotsViews` for the current user, with a scoped in-memory request cache.  
- Added a small badge formatter (`AotsUnreadBadgeFormatter`) and a View Component with view model and Razor partial (`AotsUnreadBadgeViewComponent`, `AotsUnreadBadgeViewModel`, `Pages/Shared/Components/AotsUnreadBadge/Default.cshtml`) to centralize retrieval, formatting (`9+` cap), tooltip/title and ARIA text.  
- Registered the service in DI (`Program.cs`) and integrated the View Component into the top navigation Documents tab (`Pages/Shared/_Layout.cshtml`) and the Documents left rail AOTS item (`Areas/DocumentRepository/Pages/Documents/Index.cshtml`), preserving existing click targets.  
- Added lightweight CSS for the top-nav and rail badge variants (`wwwroot/css/site.css`, `wwwroot/css/docrepo-ui.css`).

### Testing

- Attempted an automated build (`dotnet build`) but it could not run in this environment due to missing SDK (`/bin/bash: dotnet: command not found`).  
- No other automated tests (unit/integration) were executed in this rollout; changes were compiled into the working tree and committed locally (`git` operations succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83bfa7e28832986aebd076054cd93)