### PR TITLE
Relax edit-actuals validation to support independent stage backfill

### DIFF
--- a/Pages/Projects/Timeline/_EditActualsForm.cshtml
+++ b/Pages/Projects/Timeline/_EditActualsForm.cshtml
@@ -17,7 +17,7 @@
 
     <!-- SECTION: Introduction -->
     <div class="small text-muted">
-        Update actual start and completion dates for your stages. Edits respect existing approvals and lock pending requests.
+        Add known actual dates for your stages. You may record start date, completion date, or both. Edits respect existing approvals and lock pending requests.
     </div>
 
     <!-- SECTION: Actuals list -->
@@ -80,7 +80,7 @@
                                    aria-describedby="@completedId-help"
                                    data-field="completed"
                                    @(disableAttr) />
-                            <div class="form-text" id="@completedId-help">Set the actual completion date.</div>
+                            <div class="form-text" id="@completedId-help">Enter the known completion date for this stage.</div>
                         </div>
                     </div>
 

--- a/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
+++ b/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
@@ -84,7 +84,189 @@ public sealed class StageActualsUpdateServiceTests
         Assert.Equal(new DateOnly(2024, 1, 25), log.ToCompletedOn);
     }
 
+    [Fact]
+    public async Task UpdateAsync_AllowsCompletionWithoutStart_ForCompletedStage()
+    {
+        var (connection, db, service) = await CreateServiceWithSingleStageAsync(
+            StageStatus.Completed,
+            actualStart: null,
+            completedOn: new DateOnly(2024, 1, 20));
+        await using var _ = connection;
+        await using var __ = db;
+
+        var result = await service.UpdateAsync(
+            new ActualsEditInput
+            {
+                ProjectId = 1,
+                Rows = new List<ActualsEditRowInput>
+                {
+                    new()
+                    {
+                        StageCode = StageCodes.IPA,
+                        CompletedOn = new DateOnly(2024, 1, 25)
+                    }
+                }
+            },
+            userId: "user-1",
+            userName: "Tester");
+
+        Assert.Equal(1, result.UpdatedCount);
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Null(stage.ActualStart);
+        Assert.Equal(new DateOnly(2024, 1, 25), stage.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AllowsCompletionWithoutStart_ForInProgressStage()
+    {
+        var (connection, db, service) = await CreateServiceWithSingleStageAsync(
+            StageStatus.InProgress,
+            actualStart: null,
+            completedOn: null);
+        await using var _ = connection;
+        await using var __ = db;
+
+        var result = await service.UpdateAsync(
+            new ActualsEditInput
+            {
+                ProjectId = 1,
+                Rows = new List<ActualsEditRowInput>
+                {
+                    new()
+                    {
+                        StageCode = StageCodes.IPA,
+                        CompletedOn = new DateOnly(2024, 1, 25)
+                    }
+                }
+            },
+            userId: "user-1",
+            userName: "Tester");
+
+        Assert.Equal(1, result.UpdatedCount);
+        var stage = await db.ProjectStages.SingleAsync();
+        Assert.Null(stage.ActualStart);
+        Assert.Equal(new DateOnly(2024, 1, 25), stage.CompletedOn);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_IgnoresUnchangedLockedStage_WhenAnotherChangedStageIsValid()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Projects.Add(new Project
+        {
+            Name = "Actuals Test Project",
+            CreatedByUserId = "user-1",
+            WorkflowVersion = PlanConstants.DefaultStageTemplateVersion
+        });
+
+        db.ProjectStages.AddRange(
+            new ProjectStage
+            {
+                ProjectId = 1,
+                StageCode = StageCodes.IPA,
+                SortOrder = 1,
+                Status = StageStatus.InProgress,
+                ActualStart = new DateOnly(2024, 1, 5),
+                CompletedOn = null
+            },
+            new ProjectStage
+            {
+                ProjectId = 1,
+                StageCode = StageCodes.AON,
+                SortOrder = 2,
+                Status = StageStatus.Completed,
+                ActualStart = null,
+                CompletedOn = new DateOnly(2024, 1, 15)
+            });
+
+        db.StageChangeRequests.Add(new StageChangeRequest
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.AON,
+            RequestedByUserId = "user-2",
+            RequestedAt = new DateTimeOffset(2024, 1, 30, 0, 0, 0, TimeSpan.Zero),
+            DecisionStatus = "Pending"
+        });
+
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        var service = new StageActualsUpdateService(db, clock, new FakeAudit(), NullLogger<StageActualsUpdateService>.Instance);
+
+        var result = await service.UpdateAsync(
+            new ActualsEditInput
+            {
+                ProjectId = 1,
+                Rows = new List<ActualsEditRowInput>
+                {
+                    new()
+                    {
+                        StageCode = StageCodes.IPA,
+                        CompletedOn = new DateOnly(2024, 1, 20)
+                    },
+                    new()
+                    {
+                        StageCode = StageCodes.AON
+                    }
+                }
+            },
+            userId: "user-1",
+            userName: "Tester");
+
+        Assert.Equal(1, result.UpdatedCount);
+        var updated = await db.ProjectStages.SingleAsync(s => s.StageCode == StageCodes.IPA);
+        Assert.Equal(new DateOnly(2024, 1, 20), updated.CompletedOn);
+    }
+
     // SECTION: Test helpers
+    private static async Task<(SqliteConnection Connection, ApplicationDbContext Db, StageActualsUpdateService Service)> CreateServiceWithSingleStageAsync(
+        StageStatus status,
+        DateOnly? actualStart,
+        DateOnly? completedOn)
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var db = new ApplicationDbContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Projects.Add(new Project
+        {
+            Name = "Actuals Test Project",
+            CreatedByUserId = "user-1",
+            WorkflowVersion = PlanConstants.DefaultStageTemplateVersion
+        });
+
+        db.ProjectStages.Add(new ProjectStage
+        {
+            ProjectId = 1,
+            StageCode = StageCodes.IPA,
+            SortOrder = 1,
+            Status = status,
+            ActualStart = actualStart,
+            CompletedOn = completedOn
+        });
+
+        await db.SaveChangesAsync();
+
+        var clock = new FixedClock(new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        var service = new StageActualsUpdateService(db, clock, new FakeAudit(), NullLogger<StageActualsUpdateService>.Instance);
+        return (connection, db, service);
+    }
+
     private sealed class FixedClock : IClock
     {
         public FixedClock(DateTimeOffset now) => UtcNow = now;

--- a/Services/Stages/StageActualsUpdateService.cs
+++ b/Services/Stages/StageActualsUpdateService.cs
@@ -103,58 +103,38 @@ public sealed class StageActualsUpdateService
             var stage = stageLookup[row.StageCode];
             var start = row.ActualStart;
             var completed = row.CompletedOn;
-            var resolvedStart = start ?? stage.ActualStart;
-            var resolvedCompleted = completed ?? stage.CompletedOn;
+            var proposedStart = start ?? stage.ActualStart;
+            var proposedCompleted = completed ?? stage.CompletedOn;
+            var isChanged = proposedStart != stage.ActualStart || proposedCompleted != stage.CompletedOn;
 
-            if (stage.Status is not StageStatus.InProgress and not StageStatus.Completed)
+            if (!isChanged)
             {
-                if (start.HasValue || completed.HasValue)
-                {
-                    validationErrors.Add($"{row.StageCode}: Actual dates can only be edited when the stage is InProgress or Completed.");
-                }
-
                 continue;
             }
 
-            if (resolvedStart is not null && resolvedStart > today)
+            if (stage.Status is not StageStatus.InProgress and not StageStatus.Completed)
+            {
+                validationErrors.Add($"{row.StageCode}: Actual dates can only be edited when the stage is InProgress or Completed.");
+                continue;
+            }
+
+            if (proposedStart is not null && proposedStart > today)
             {
                 validationErrors.Add($"{row.StageCode}: Start date cannot be in the future.");
             }
 
-            if (resolvedCompleted is not null && resolvedCompleted > today)
+            if (proposedCompleted is not null && proposedCompleted > today)
             {
                 validationErrors.Add($"{row.StageCode}: Completion date cannot be in the future.");
             }
 
-            if (resolvedStart is not null && resolvedCompleted is not null && resolvedStart > resolvedCompleted)
+            if (proposedStart is not null && proposedCompleted is not null && proposedStart > proposedCompleted)
             {
                 validationErrors.Add($"{row.StageCode}: Completion date must be on or after the start date.");
             }
 
-            switch (stage.Status)
-            {
-                case StageStatus.NotStarted when resolvedStart.HasValue || resolvedCompleted.HasValue:
-                    validationErrors.Add($"{row.StageCode}: Cannot add actual dates until the stage has started.");
-                    break;
-                case StageStatus.Skipped when resolvedStart.HasValue || resolvedCompleted.HasValue:
-                    validationErrors.Add($"{row.StageCode}: Skipped stages cannot record actual dates.");
-                    break;
-                case StageStatus.InProgress when resolvedCompleted.HasValue && !resolvedStart.HasValue:
-                case StageStatus.Blocked when resolvedCompleted.HasValue && !resolvedStart.HasValue:
-                    validationErrors.Add($"{row.StageCode}: Start date is required before marking completion.");
-                    break;
-                case StageStatus.Completed when !resolvedStart.HasValue || !resolvedCompleted.HasValue:
-                    validationErrors.Add($"{row.StageCode}: Completed stages require both start and completion dates.");
-                    break;
-            }
-
-            var updatedStart = resolvedStart;
-            var updatedCompleted = resolvedCompleted;
-
-            if (updatedStart == stage.ActualStart && updatedCompleted == stage.CompletedOn)
-            {
-                continue;
-            }
+            var updatedStart = proposedStart;
+            var updatedCompleted = proposedCompleted;
 
             changes.Add(new StageActualChange(stage, updatedStart, updatedCompleted));
         }

--- a/wwwroot/js/projects/actuals-edit.js
+++ b/wwwroot/js/projects/actuals-edit.js
@@ -50,12 +50,20 @@
   };
 
   const validateRow = (row) => {
+    const code = row.dataset.stageCode ?? '';
+    const original = initialValues.get(code) ?? { start: '', completed: '' };
     const startInput = row.querySelector('[data-field="start"]');
     const completedInput = row.querySelector('[data-field="completed"]');
     const status = (row.dataset.stageStatus ?? '').toLowerCase();
 
     const startValue = startInput instanceof HTMLInputElement ? startInput.value : '';
     const completedValue = completedInput instanceof HTMLInputElement ? completedInput.value : '';
+    const isChanged = startValue !== original.start || completedValue !== original.completed;
+
+    if (!isChanged) {
+      setRowError(row, '');
+      return true;
+    }
 
     const startDate = parseDate(startValue);
     const completedDate = parseDate(completedValue);
@@ -79,27 +87,16 @@
     if (!error) {
       switch (status) {
         case 'notstarted':
-          if (startValue || completedValue) {
-            error = 'This stage has not started yet. Update the status first.';
-          }
+          error = 'This stage has not started yet. Update the status first.';
           break;
         case 'skipped':
-          if (startValue || completedValue) {
-            error = 'Skipped stages cannot record actual dates.';
-          }
+          error = 'Skipped stages cannot record actual dates.';
           break;
         case 'inprogress':
-        case 'blocked':
-          if (completedValue && !startValue) {
-            error = 'Add a start date before recording completion.';
-          }
-          break;
         case 'completed':
-          if (!startValue || !completedValue) {
-            error = 'Completed stages need both start and completion dates.';
-          }
           break;
         default:
+          error = 'Actual dates can only be edited when the stage is InProgress or Completed.';
           break;
       }
     }


### PR DESCRIPTION
### Motivation

- Backfill editors must allow updating a single stage independently so unchanged rows do not block saves.
- Users must be allowed to record a completion date without a start date for historical data entry.
- Preserve safety checks such as authorization/ownership, per-stage pending-decision locks, no future dates, and date ordering when both dates exist.

### Description

- Changed `Services/Stages/StageActualsUpdateService.cs` to compute proposed values, detect and skip unchanged rows, and validate only changed rows while preserving future-date and ordering checks; removed mandatory paired-date requirements for editable stages (`InProgress`/`Completed`).
- Updated client validation in `wwwroot/js/projects/actuals-edit.js` to only validate rows that were changed, allow start-only or completion-only entries, and retain status/date integrity checks.
- Updated helper copy in the edit form `Pages/Projects/Timeline/_EditActualsForm.cshtml` to reflect that start, completion, or both may be recorded.
- Added unit tests in `ProjectManagement.Tests/StageActualsUpdateServiceTests.cs` covering completion-only updates for `Completed` and `InProgress` stages and the case where an unchanged locked stage does not block another changed stage.

### Testing

- Added automated tests (`ProjectManagement.Tests/StageActualsUpdateServiceTests`) that exercise completion-only updates and unchanged locked-stage behavior, and they were committed with the change.  
- Attempted to run the test suite with `dotnet test --filter StageActualsUpdateServiceTests` but the test runner could not be executed in this environment because `dotnet` was not available (error: `dotnet: command not found`).
- No other automated CI was run in this environment; local verification can be performed by running `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter StageActualsUpdateServiceTests` in a .NET-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9119088ac83299da970a86dd3e5aa)