### PR TITLE
Fix StageActualsUpdateServiceTests: use correct `RequestedOn` property

### DIFF
--- a/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
+++ b/ProjectManagement.Tests/StageActualsUpdateServiceTests.cs
@@ -193,7 +193,7 @@ public sealed class StageActualsUpdateServiceTests
             ProjectId = 1,
             StageCode = StageCodes.AON,
             RequestedByUserId = "user-2",
-            RequestedAt = new DateTimeOffset(2024, 1, 30, 0, 0, 0, TimeSpan.Zero),
+            RequestedOn = new DateTimeOffset(2024, 1, 30, 0, 0, 0, TimeSpan.Zero),
             DecisionStatus = "Pending"
         });
 


### PR DESCRIPTION
### Motivation
- Fix a compile error (`CS0117`) by aligning the test seed with the `StageChangeRequest` model property name (`RequestedOn`) instead of the non-existent `RequestedAt`.

### Description
- Updated `ProjectManagement.Tests/StageActualsUpdateServiceTests.cs` to set `RequestedOn = new DateTimeOffset(...)` when adding the `StageChangeRequest` test record.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~StageActualsUpdateServiceTests"`, but the environment lacks the .NET SDK (`dotnet: command not found`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91701cf3c8329a79ca580a3bebb01)