### PR TITLE
Fix backfill flag handling for partial completed actuals

### DIFF
--- a/Services/Stages/StageActualsUpdateService.cs
+++ b/Services/Stages/StageActualsUpdateService.cs
@@ -202,7 +202,14 @@ public sealed class StageActualsUpdateService
 
             stage.ActualStart = change.NewStart;
             stage.CompletedOn = change.NewCompleted;
-            stage.RequiresBackfill = false;
+
+            // SECTION: Completed stage backfill state
+            if (stage.Status == StageStatus.Completed)
+            {
+                var hasBothActualDates = stage.ActualStart.HasValue && stage.CompletedOn.HasValue;
+                stage.RequiresBackfill = !hasBothActualDates;
+            }
+
             stage.IsAutoCompleted = false;
             stage.AutoCompletedFromCode = null;
 


### PR DESCRIPTION
### Motivation
- The update flow was clearing `RequiresBackfill` unconditionally when actual dates were edited, which causes DB constraint failures for `Completed` stages if only one of `ActualStart`/`CompletedOn` is provided and prevents partial saves.

### Description
- Change `Services/Stages/StageActualsUpdateService.cs` so that for `stage.Status == StageStatus.Completed` the service sets `RequiresBackfill = !(stage.ActualStart.HasValue && stage.CompletedOn.HasValue)` after updating the dates, while preserving the existing logging and `IsAutoCompleted`/`AutoCompletedFromCode` reset behavior.

### Testing
- Attempted to run the automated test suite with `dotnet test --no-build`, but the environment does not have the `dotnet` CLI installed so tests could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99145393083298cf87ce136401857)