### PR TITLE
Redesign Progress Review Section 01 into executive review buckets

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -173,90 +173,159 @@
                             <h2 class="progress-review__section-title pr-section-title">Ongoing projects progress</h2>
                             <div class="pr-section-divider"></div>
                         </div>
-                        <p class="progress-review__section-meta pr-meta">@vm.Projects.SummaryRows.Count projects in scope</p>
+                        <p class="progress-review__section-meta pr-meta">@vm.Projects.Review.Summary.ProjectsInScope projects in scope</p>
                     </header>
 
-                    @if (!vm.Projects.CategoryGroups.Any())
+                    @if (vm.Projects.Review.Summary.ProjectsInScope == 0)
                     {
                         <p class="text-muted small mb-0">No qualifying projects for the selected range.</p>
                     }
                     else
                     {
-                        <div class="pr-category-stack">
-                            @foreach (var group in vm.Projects.CategoryGroups)
+                        @* SECTION: Executive review band *@
+                        <div class="pr-review-band">
+                            <div class="pr-review-band__head">
+                                <div>
+                                    <div class="pr-review-band__title">Ongoing projects progress</div>
+                                    <div class="pr-review-band__period">
+                                        Review window: @vm.Range.From.ToString("dd MMM yyyy") to @vm.Range.To.ToString("dd MMM yyyy")
+                                    </div>
+                                </div>
+                                <div class="pr-review-band__scope">@vm.Projects.Review.Summary.ProjectsInScope in scope</div>
+                            </div>
+                            <div class="pr-review-metrics">
+                                <div class="pr-review-metric"><span class="pr-review-metric__label">Advanced</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.AdvancedCount</span></div>
+                                <div class="pr-review-metric"><span class="pr-review-metric__label">Active, no advancement</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.ActiveWithoutAdvancementCount</span></div>
+                                <div class="pr-review-metric"><span class="pr-review-metric__label">No movement</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.NoMovementCount</span></div>
+                                <div class="pr-review-metric"><span class="pr-review-metric__label">Attention</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.AttentionCount</span></div>
+                            </div>
+                            @if (!string.IsNullOrWhiteSpace(vm.Projects.Review.Summary.InterpretiveSummaryText))
                             {
-                                <section class="pr-category-block" aria-label="@group.CategoryName">
-                                    <div class="pr-category-header">
-                                        <span>@group.CategoryName</span>
-                                        <span class="pr-category-count">@group.Projects.Count projects</span>
-                                    </div>
-                                    <div class="pr-project-list">
-                                        @foreach (var row in group.Projects)
-                                        {
-                                            var stageMovements = row.StageMovements ?? Array.Empty<ProjectStageMovementVm>();
-                                            var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
-                                            var stageName = string.IsNullOrWhiteSpace(row.PresentStage.CurrentStageName) ? "Stage pending" : row.PresentStage.CurrentStageName;
-                                            <article class="pr-project-row">
-                                                <div>
-                                                    <a class="progress-review__link pr-project-name" href="@projectDetailsUrl">@row.ProjectName</a>
-                                                    @if (!string.IsNullOrWhiteSpace(row.ProjectCategoryName))
-                                                    {
-                                                        <div class="pr-meta">@row.ProjectCategoryName</div>
-                                                    }
-                                                </div>
-                                                <div class="pr-stage-line">Present stage — <span class="fw-semibold">@stageName</span></div>
-                                                <div class="pr-meta">@((row.PresentStage.DaysSinceStartOrLastCompletion ?? 0)) days passed</div>
-                                                @if (stageMovements.Any())
-                                                {
-                                                    @foreach (var movement in stageMovements)
-                                                    {
-                                                        var movementDate = GetMovementDate(movement);
-                                                        var actionText = movement.IsOngoing ? "started on" : "completed on";
-                                                        <div class="pr-movement-line">
-                                                            <strong>@movement.StageName</strong> @actionText
-                                                            @if (movementDate.HasValue)
-                                                            {
-                                                                <time datetime="@FormatDateIso(movementDate.Value)">@FormatDay(movementDate.Value)</time>
-                                                            }
-                                                            else
-                                                            {
-                                                                <span>date N/A</span>
-                                                            }
-                                                        </div>
-                                                    }
-                                                    @if (row.StageMovementOverflowCount > 0)
-                                                    {
-                                                        <div class="pr-meta">Showing top @stageMovements.Count of @(stageMovements.Count + row.StageMovementOverflowCount) movements</div>
-                                                    }
-                                                }
-                                                else
-                                                {
-                                                    <div class="pr-meta">No stage movements recorded in this range.</div>
-                                                }
-                                                @if (!string.IsNullOrWhiteSpace(row.RemarkSummary.LatestRemarkSummary))
-                                                {
-                                                    var remarkHtml = RenderRemarkHtml(row.RemarkSummary.LatestRemarkSummary);
-                                                    var tooltip = BuildRemarkTooltip(row.RemarkSummary);
-                                                    <div class="pr-remark-line" title="@tooltip">
-                                                        <span class="pr-meta">@((row.RemarkSummary.LatestRemarkDate.HasValue ? FormatDay(row.RemarkSummary.LatestRemarkDate.Value) : "Date N/A"))</span>
-                                                        <span class="pr-meta">·</span>
-                                                        <span class="pr-body">@Html.Raw(remarkHtml)</span>
-                                                    </div>
-                                                    @if (row.RemarkSummary.MoreRemarkCount > 0)
-                                                    {
-                                                        <div class="pr-meta">Latest external remark shown</div>
-                                                    }
-                                                }
-                                                else
-                                                {
-                                                    <div class="pr-meta fst-italic">No external remarks in range.</div>
-                                                }
-                                            </article>
-                                        }
-                                    </div>
-                                </section>
+                                <p class="pr-review-band__insight">@vm.Projects.Review.Summary.InterpretiveSummaryText</p>
                             }
                         </div>
+
+                        @* SECTION: Highlights this period *@
+                        @if (vm.Projects.Review.Highlights.Any())
+                        {
+                            <section class="pr-highlights" aria-label="Highlights this period">
+                                <h3 class="h6 mb-2">Highlights this period</h3>
+                                <ul class="pr-highlight-list list-unstyled mb-0">
+                                    @foreach (var highlight in vm.Projects.Review.Highlights)
+                                    {
+                                        var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = highlight.ProjectId });
+                                        <li class="pr-highlight-item">
+                                            <a class="progress-review__link" href="@projectDetailsUrl">@highlight.ProjectName</a>
+                                            <span class="pr-body"> — @highlight.HighlightText</span>
+                                        </li>
+                                    }
+                                </ul>
+                            </section>
+                        }
+
+                        @* SECTION: Projects advanced in this period *@
+                        <section class="pr-advanced-list" aria-label="Projects advanced in this period">
+                            <h3 class="h6 mb-2">Projects advanced in this period</h3>
+                            @if (!vm.Projects.Review.Advanced.Any())
+                            {
+                                <p class="pr-meta mb-0">No projects recorded formal stage advancement in this period.</p>
+                            }
+                            else
+                            {
+                                @foreach (var row in vm.Projects.Review.Advanced)
+                                {
+                                    var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
+                                    <article class="pr-advanced-row">
+                                        <div class="pr-advanced-row__head">
+                                            <a class="progress-review__link pr-project-name" href="@projectDetailsUrl">@row.ProjectName</a>
+                                            @if (!string.IsNullOrWhiteSpace(row.ProjectCategoryName))
+                                            {
+                                                <span class="pr-meta">@row.ProjectCategoryName</span>
+                                            }
+                                        </div>
+                                        <div class="pr-advanced-row__path">@row.MovementPathText</div>
+                                        <div class="pr-advanced-row__meta">
+                                            Present stage: @(string.IsNullOrWhiteSpace(row.PresentStage.CurrentStageName) ? "Stage pending" : row.PresentStage.CurrentStageName)
+                                            · Movement events: @row.MovementCountInRange
+                                        </div>
+                                        @if (!string.IsNullOrWhiteSpace(row.RemarkSummary.LatestRemarkSummary))
+                                        {
+                                            <div class="pr-advanced-row__remark">@row.RemarkSummary.LatestRemarkSummary</div>
+                                        }
+                                    </article>
+                                }
+                            }
+                        </section>
+
+                        @* SECTION: Projects active in this period without stage advancement *@
+                        <section class="pr-activity-table" aria-label="Projects active in this period without stage advancement">
+                            <h3 class="h6 mb-2">Projects active in this period without stage advancement</h3>
+                            @if (!vm.Projects.Review.ActiveWithoutAdvancement.Any())
+                            {
+                                <p class="pr-meta mb-0">No projects were active-by-remark without stage movement.</p>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm align-middle mb-0">
+                                        <thead>
+                                            <tr><th>Project</th><th>Present stage</th><th>Latest external remark</th><th>Last activity</th></tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var row in vm.Projects.Review.ActiveWithoutAdvancement)
+                                            {
+                                                var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
+                                                <tr>
+                                                    <td><a class="progress-review__link" href="@projectDetailsUrl">@row.ProjectName</a></td>
+                                                    <td>@(string.IsNullOrWhiteSpace(row.PresentStage.CurrentStageName) ? "Stage pending" : row.PresentStage.CurrentStageName)</td>
+                                                    <td>@(string.IsNullOrWhiteSpace(row.RemarkSummary.LatestRemarkSummary) ? "—" : row.RemarkSummary.LatestRemarkSummary)</td>
+                                                    <td>@(row.LastRecordedActivityDate.HasValue ? FormatDay(row.LastRecordedActivityDate.Value) : "Date N/A")</td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+
+                        @* SECTION: Projects requiring attention *@
+                        <section class="pr-attention-table" aria-label="Projects requiring attention">
+                            <h3 class="h6 mb-2">Projects requiring attention</h3>
+                            @if (!vm.Projects.Review.Attention.Any())
+                            {
+                                <p class="pr-meta mb-0">No projects currently in the attention bucket.</p>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm align-middle mb-0">
+                                        <thead>
+                                            <tr><th>Project</th><th>Present stage</th><th>Last recorded activity</th><th>Days since activity</th><th>Status</th></tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var row in vm.Projects.Review.Attention)
+                                            {
+                                                var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
+                                                var statusClass = row.AttentionStatus switch
+                                                {
+                                                    ProjectAttentionStatus.Watch => "is-watch",
+                                                    ProjectAttentionStatus.Delayed => "is-delayed",
+                                                    ProjectAttentionStatus.LongPending => "is-long-pending",
+                                                    _ => string.Empty
+                                                };
+                                                <tr>
+                                                    <td><a class="progress-review__link" href="@projectDetailsUrl">@row.ProjectName</a></td>
+                                                    <td>@(string.IsNullOrWhiteSpace(row.PresentStage.CurrentStageName) ? "Stage pending" : row.PresentStage.CurrentStageName)</td>
+                                                    <td>@(row.LastRecordedActivityDate.HasValue ? FormatDay(row.LastRecordedActivityDate.Value) : "Date N/A")</td>
+                                                    <td>@row.DaysSinceLastRecordedActivity</td>
+                                                    <td><span class="pr-status-pill @statusClass">@row.AttentionStatus</span></td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
                     }
                 </section>
 

--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -39,7 +39,8 @@ public sealed record ProjectSectionVm(
     IReadOnlyList<ProjectRemarkOnlyVm> WorkInProgress,
     IReadOnlyList<ProjectNonMoverVm> NonMovers,
     IReadOnlyList<ProjectProgressRowVm> SummaryRows,
-    IReadOnlyList<ProjectCategoryGroupVm> CategoryGroups
+    IReadOnlyList<ProjectCategoryGroupVm> CategoryGroups,
+    ProjectReviewBucketsVm Review
 );
 
 public sealed record ProjectStageChangeVm(
@@ -65,7 +66,8 @@ public sealed record ProjectNonMoverVm(
     string ProjectName,
     string StageCode,
     string StageName,
-    int DaysSinceActivity
+    int DaysSinceActivity,
+    DateOnly? LastRecordedActivityDate
 );
 
 public sealed record ProjectProgressRowVm(
@@ -78,6 +80,63 @@ public sealed record ProjectProgressRowVm(
     ProjectRemarkSummaryVm RemarkSummary
 );
 
+
+public sealed record ProjectReviewSummaryVm(
+    int ProjectsInScope,
+    int AdvancedCount,
+    int ActiveWithoutAdvancementCount,
+    int NoMovementCount,
+    int AttentionCount,
+    string? InterpretiveSummaryText
+);
+
+public sealed record ProjectReviewHighlightVm(
+    int ProjectId,
+    string ProjectName,
+    string? ProjectCategoryName,
+    string HighlightText,
+    DateOnly? LastStageMovementDate,
+    int MovementCountInRange
+);
+
+public enum ProjectReviewBucket
+{
+    Advanced = 1,
+    ActiveWithoutAdvancement = 2,
+    Attention = 3
+}
+
+public enum ProjectAttentionStatus
+{
+    Normal = 0,
+    Watch = 1,
+    Delayed = 2,
+    LongPending = 3
+}
+
+public sealed record ProjectReviewRowVm(
+    int ProjectId,
+    string ProjectName,
+    string? ProjectCategoryName,
+    PresentStageSnapshot PresentStage,
+    string MovementPathText,
+    IReadOnlyList<ProjectStageMovementVm> StageMovements,
+    int MovementCountInRange,
+    DateOnly? LastStageMovementDate,
+    ProjectRemarkSummaryVm RemarkSummary,
+    DateOnly? LastRecordedActivityDate,
+    int DaysSinceLastRecordedActivity,
+    ProjectReviewBucket ReviewBucket,
+    ProjectAttentionStatus AttentionStatus
+);
+
+public sealed record ProjectReviewBucketsVm(
+    ProjectReviewSummaryVm Summary,
+    IReadOnlyList<ProjectReviewHighlightVm> Highlights,
+    IReadOnlyList<ProjectReviewRowVm> Advanced,
+    IReadOnlyList<ProjectReviewRowVm> ActiveWithoutAdvancement,
+    IReadOnlyList<ProjectReviewRowVm> Attention
+);
 public sealed record ProjectCategoryGroupVm(
     string CategoryName,
     IReadOnlyList<ProjectProgressRowVm> Projects

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -82,6 +82,15 @@ public sealed class ProgressReviewService : IProgressReviewService
             projectCategoryLookup,
             from,
             to);
+        var projectReviewBuckets = BuildProjectReviewBuckets(
+            projectFrontRunners,
+            projectRemarksOnly,
+            projectNonMovers,
+            presentStageLookup,
+            remarkLookup,
+            projectCategoryLookup,
+            from,
+            to);
         var projectCategoryGroups = projectSummaryRows
             .GroupBy(row => string.IsNullOrWhiteSpace(row.ProjectCategoryName) ? "Uncategorised" : row.ProjectCategoryName)
             .OrderBy(group => group.Key)
@@ -135,7 +144,7 @@ public sealed class ProgressReviewService : IProgressReviewService
 
         return new ProgressReviewVm(
             Range: new RangeVm(from, to),
-            Projects: new ProjectSectionVm(projectFrontRunners, projectRemarksOnly, projectNonMovers, projectSummaryRows, projectCategoryGroups),
+            Projects: new ProjectSectionVm(projectFrontRunners, projectRemarksOnly, projectNonMovers, projectSummaryRows, projectCategoryGroups, projectReviewBuckets),
             Visits: visits,
             SocialMedia: socialMedia,
             Tot: new TotSectionVm(totStage, totRemarks),
@@ -456,7 +465,8 @@ public sealed class ProgressReviewService : IProgressReviewService
                     p.Name,
                     stage.StageCode,
                     StageCodes.DisplayNameOf(stage.StageCode),
-                    days);
+                    days,
+                    lastActivity);
             })
             .OrderByDescending(p => p.DaysSinceActivity)
             .ThenBy(p => p.ProjectName)
@@ -1045,6 +1055,273 @@ public sealed class ProgressReviewService : IProgressReviewService
         return rows.Values
             .OrderBy(r => r.ProjectName)
             .ToList();
+    }
+
+    // -----------------------------------------------------------------
+    // SECTION: Project review buckets (Section 01 executive surface)
+    // -----------------------------------------------------------------
+    private static ProjectReviewBucketsVm BuildProjectReviewBuckets(
+        IReadOnlyList<ProjectStageChangeVm> frontRunners,
+        IReadOnlyList<ProjectRemarkOnlyVm> remarkOnly,
+        IReadOnlyList<ProjectNonMoverVm> nonMovers,
+        IReadOnlyDictionary<int, PresentStageSnapshot> presentStageLookup,
+        IReadOnlyDictionary<int, ProjectRemarkSummaryVm> remarkLookup,
+        IReadOnlyDictionary<int, string?> projectCategoryLookup,
+        DateOnly rangeFrom,
+        DateOnly rangeTo)
+    {
+        var stageHistoryLookup = BuildStageMovementLookup(frontRunners, presentStageLookup, rangeFrom, rangeTo);
+        var reviewRows = new Dictionary<int, ProjectReviewRowVm>();
+        var nonMoverLookup = nonMovers.ToDictionary(n => n.ProjectId);
+
+        // SECTION: Advanced bucket
+        foreach (var pair in stageHistoryLookup.Where(pair => pair.Value.Count > 0))
+        {
+            var projectId = pair.Key;
+            var movements = pair.Value;
+            var projectName = frontRunners
+                .FirstOrDefault(r => r.ProjectId == projectId)?.ProjectName
+                ?? remarkOnly.FirstOrDefault(r => r.ProjectId == projectId)?.ProjectName
+                ?? nonMovers.FirstOrDefault(r => r.ProjectId == projectId)?.ProjectName
+                ?? $"Project {projectId}";
+
+            var presentStage = presentStageLookup.TryGetValue(projectId, out var advancedSnapshot)
+                ? advancedSnapshot
+                : PresentStageSnapshot.Empty;
+            var remarks = remarkLookup.TryGetValue(projectId, out var advancedRemarks)
+                ? advancedRemarks
+                : ProjectRemarkSummaryVm.Empty;
+            var categoryName = projectCategoryLookup.TryGetValue(projectId, out var advancedCategory)
+                ? advancedCategory
+                : null;
+            var lastStageMovementDate = GetLastStageMovementDate(movements);
+
+            reviewRows[projectId] = new ProjectReviewRowVm(
+                projectId,
+                projectName,
+                categoryName,
+                presentStage,
+                BuildMovementPathText(movements),
+                TrimHistory(movements).Display,
+                movements.Count,
+                lastStageMovementDate,
+                remarks,
+                lastStageMovementDate,
+                lastStageMovementDate.HasValue ? Math.Max(0, rangeTo.DayNumber - lastStageMovementDate.Value.DayNumber) : 0,
+                ProjectReviewBucket.Advanced,
+                ProjectAttentionStatus.Normal);
+        }
+
+        // SECTION: Active without advancement bucket
+        foreach (var row in remarkOnly)
+        {
+            if (reviewRows.ContainsKey(row.ProjectId))
+            {
+                continue;
+            }
+
+            var stageMovements = stageHistoryLookup.TryGetValue(row.ProjectId, out var history)
+                ? history
+                : new List<ProjectStageMovementVm>();
+            var presentStage = presentStageLookup.TryGetValue(row.ProjectId, out var activeSnapshot)
+                ? activeSnapshot
+                : PresentStageSnapshot.Empty;
+            var categoryName = projectCategoryLookup.TryGetValue(row.ProjectId, out var activeCategory)
+                ? activeCategory
+                : null;
+            var lastRecordedActivityDate = row.RemarkSummary.LatestRemarkDate
+                ?? (nonMoverLookup.TryGetValue(row.ProjectId, out var nonMover) ? nonMover.LastRecordedActivityDate : null);
+            var daysSinceLastRecordedActivity = lastRecordedActivityDate.HasValue
+                ? Math.Max(0, rangeTo.DayNumber - lastRecordedActivityDate.Value.DayNumber)
+                : 0;
+
+            reviewRows[row.ProjectId] = new ProjectReviewRowVm(
+                row.ProjectId,
+                row.ProjectName,
+                categoryName,
+                presentStage,
+                BuildMovementPathText(stageMovements),
+                TrimHistory(stageMovements).Display,
+                stageMovements.Count,
+                GetLastStageMovementDate(stageMovements),
+                row.RemarkSummary,
+                lastRecordedActivityDate,
+                daysSinceLastRecordedActivity,
+                ProjectReviewBucket.ActiveWithoutAdvancement,
+                DetermineAttentionStatus(daysSinceLastRecordedActivity));
+        }
+
+        // SECTION: Attention bucket
+        foreach (var row in nonMovers)
+        {
+            if (reviewRows.ContainsKey(row.ProjectId))
+            {
+                continue;
+            }
+
+            var stageMovements = stageHistoryLookup.TryGetValue(row.ProjectId, out var history)
+                ? history
+                : new List<ProjectStageMovementVm>();
+            var remarks = remarkLookup.TryGetValue(row.ProjectId, out var remarkSummary)
+                ? remarkSummary
+                : ProjectRemarkSummaryVm.Empty;
+            var presentStage = presentStageLookup.TryGetValue(row.ProjectId, out var attentionSnapshot)
+                ? attentionSnapshot
+                : PresentStageSnapshot.Empty;
+            var categoryName = projectCategoryLookup.TryGetValue(row.ProjectId, out var attentionCategory)
+                ? attentionCategory
+                : null;
+
+            reviewRows[row.ProjectId] = new ProjectReviewRowVm(
+                row.ProjectId,
+                row.ProjectName,
+                categoryName,
+                presentStage,
+                BuildMovementPathText(stageMovements),
+                TrimHistory(stageMovements).Display,
+                stageMovements.Count,
+                GetLastStageMovementDate(stageMovements),
+                remarks,
+                row.LastRecordedActivityDate,
+                row.DaysSinceActivity,
+                ProjectReviewBucket.Attention,
+                DetermineAttentionStatus(row.DaysSinceActivity));
+        }
+
+        var advancedRows = reviewRows.Values
+            .Where(r => r.ReviewBucket == ProjectReviewBucket.Advanced)
+            .OrderByDescending(r => r.MovementCountInRange)
+            .ThenByDescending(r => r.LastStageMovementDate)
+            .ThenBy(r => r.ProjectName)
+            .ToList();
+        var activeWithoutAdvancementRows = reviewRows.Values
+            .Where(r => r.ReviewBucket == ProjectReviewBucket.ActiveWithoutAdvancement)
+            .OrderByDescending(r => r.LastRecordedActivityDate)
+            .ThenBy(r => r.ProjectName)
+            .ToList();
+        var attentionRows = reviewRows.Values
+            .Where(r => r.ReviewBucket == ProjectReviewBucket.Attention)
+            .OrderByDescending(r => r.DaysSinceLastRecordedActivity)
+            .ThenBy(r => r.ProjectName)
+            .ToList();
+
+        var noMovementCount = activeWithoutAdvancementRows.Count + attentionRows.Count;
+        var summary = new ProjectReviewSummaryVm(
+            ProjectsInScope: reviewRows.Count,
+            AdvancedCount: advancedRows.Count,
+            ActiveWithoutAdvancementCount: activeWithoutAdvancementRows.Count,
+            NoMovementCount: noMovementCount,
+            AttentionCount: attentionRows.Count,
+            InterpretiveSummaryText: BuildInterpretiveSummaryText(
+                advancedRows.Count,
+                activeWithoutAdvancementRows.Count,
+                noMovementCount,
+                advancedRows,
+                attentionRows));
+
+        return new ProjectReviewBucketsVm(
+            Summary: summary,
+            Highlights: BuildHighlights(advancedRows),
+            Advanced: advancedRows,
+            ActiveWithoutAdvancement: activeWithoutAdvancementRows,
+            Attention: attentionRows);
+    }
+
+    private static string BuildMovementPathText(IReadOnlyList<ProjectStageMovementVm> movements)
+    {
+        if (movements.Count == 0)
+        {
+            return "No formal stage movement recorded.";
+        }
+
+        return string.Join(" \u2192 ", movements
+            .Take(3)
+            .Select(movement => $"{movement.StageName} {(movement.IsOngoing ? "started" : "completed")}"));
+    }
+
+    private static DateOnly? GetLastStageMovementDate(IReadOnlyList<ProjectStageMovementVm> movements)
+    {
+        var latest = movements
+            .Select(movement => movement.IsOngoing ? movement.StartedOn : movement.CompletedOn)
+            .Where(date => date.HasValue)
+            .OrderByDescending(date => date)
+            .FirstOrDefault();
+
+        return latest;
+    }
+
+    private static ProjectAttentionStatus DetermineAttentionStatus(int daysSinceLastActivity)
+    {
+        return daysSinceLastActivity switch
+        {
+            >= 180 => ProjectAttentionStatus.LongPending,
+            >= 120 => ProjectAttentionStatus.Delayed,
+            >= 60 => ProjectAttentionStatus.Watch,
+            _ => ProjectAttentionStatus.Normal
+        };
+    }
+
+    private static string? BuildInterpretiveSummaryText(
+        int advancedCount,
+        int activeWithoutAdvancementCount,
+        int noMovementCount,
+        IReadOnlyList<ProjectReviewRowVm> advancedRows,
+        IReadOnlyList<ProjectReviewRowVm> attentionRows)
+    {
+        if (advancedCount == 0 && noMovementCount == 0)
+        {
+            return null;
+        }
+
+        if (advancedCount == 0)
+        {
+            return "The selected period recorded no formal stage movement, with attention focused on projects awaiting renewed activity.";
+        }
+
+        if (attentionRows.Any(row => row.AttentionStatus == ProjectAttentionStatus.LongPending))
+        {
+            return "Movement was recorded in the reporting period, but several projects remain long-pending and require management attention.";
+        }
+
+        if (advancedRows.Any(row => row.MovementCountInRange >= 2))
+        {
+            return "Most movement in the selected period came from projects that progressed through multiple stage updates.";
+        }
+
+        if (activeWithoutAdvancementCount > advancedCount)
+        {
+            return "The period showed broader activity through remarks, but formal stage advancement remained limited.";
+        }
+
+        return "The selected period recorded measurable stage advancement with a manageable set of projects requiring closer follow-up.";
+    }
+
+    private static IReadOnlyList<ProjectReviewHighlightVm> BuildHighlights(
+        IReadOnlyList<ProjectReviewRowVm> advancedRows)
+    {
+        return advancedRows
+            .OrderByDescending(row => row.MovementCountInRange)
+            .ThenByDescending(row => row.LastStageMovementDate)
+            .ThenBy(row => row.ProjectName)
+            .Take(5)
+            .Select(row => new ProjectReviewHighlightVm(
+                row.ProjectId,
+                row.ProjectName,
+                row.ProjectCategoryName,
+                BuildHighlightText(row),
+                row.LastStageMovementDate,
+                row.MovementCountInRange))
+            .ToList();
+
+        static string BuildHighlightText(ProjectReviewRowVm row)
+        {
+            if (row.MovementCountInRange >= 2)
+            {
+                return $"{row.ProjectName} registered multi-stage progression during the reporting period.";
+            }
+
+            return $"{row.ProjectName} recorded formal movement in the selected period.";
+        }
     }
 
     private async Task<IReadOnlyDictionary<int, PresentStageSnapshot>> BuildPresentStageLookupAsync(

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -449,3 +449,95 @@
         height: 56px;
     }
 }
+
+/* =========================================================
+   SECTION: Section 01 executive review redesign
+   ========================================================= */
+
+.pr-review-band {
+    border: 1px solid var(--pm-surface-silver);
+    border-radius: 12px;
+    padding: 0.9rem 1rem;
+    background: var(--pm-surface-mist);
+    margin-bottom: 0.9rem;
+}
+
+.pr-review-band__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.pr-review-band__title { font-weight: 600; color: var(--pm-text-contrast); }
+.pr-review-band__period,
+.pr-review-band__scope { font-size: 0.82rem; color: var(--pr-muted); }
+
+.pr-review-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.55rem;
+    margin-top: 0.8rem;
+}
+
+.pr-review-metric {
+    background: var(--pm-card);
+    border: 1px solid var(--pm-surface-silver);
+    border-radius: 10px;
+    padding: 0.45rem 0.55rem;
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.pr-review-metric__label { font-size: 0.8rem; color: var(--pr-muted); }
+.pr-review-metric__value { font-weight: 600; color: var(--pm-text-contrast); }
+.pr-review-band__insight { margin: 0.75rem 0 0; font-size: 0.88rem; }
+
+.pr-highlights,
+.pr-advanced-list,
+.pr-activity-table,
+.pr-attention-table {
+    border: 1px solid var(--pm-surface-silver);
+    border-radius: 12px;
+    background: var(--pm-card);
+    padding: 0.85rem 1rem;
+    margin-top: 0.8rem;
+}
+
+.pr-highlight-list { display: grid; gap: 0.45rem; }
+.pr-highlight-item { font-size: 0.88rem; }
+
+.pr-advanced-list { display: grid; gap: 0.55rem; }
+.pr-advanced-row {
+    border: 1px solid var(--pm-surface-ice);
+    border-radius: 10px;
+    padding: 0.55rem 0.65rem;
+}
+
+.pr-advanced-row__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+}
+
+.pr-advanced-row__path { font-size: 0.9rem; margin-top: 0.25rem; }
+.pr-advanced-row__meta { font-size: 0.8rem; color: var(--pr-muted); margin-top: 0.25rem; }
+.pr-advanced-row__remark { font-size: 0.82rem; margin-top: 0.3rem; color: var(--pm-text); }
+
+.pr-activity-table .table,
+.pr-attention-table .table { margin-bottom: 0; }
+
+.pr-status-pill {
+    border: 1px solid var(--pm-border-outline);
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.75rem;
+    color: var(--pm-text-contrast);
+    background: var(--pm-card);
+}
+
+.pr-status-pill.is-watch { border-color: #8d8d8d; }
+.pr-status-pill.is-delayed { border-color: #6f6f6f; font-weight: 600; }
+.pr-status-pill.is-long-pending { border-color: #4f4f4f; font-weight: 700; }

--- a/wwwroot/css/progress-review.print.css
+++ b/wwwroot/css/progress-review.print.css
@@ -107,3 +107,37 @@
         page-break-inside: avoid;
     }
 }
+
+@media print {
+    /* SECTION: Section 01 print-safe review layout */
+    .pr-review-band,
+    .pr-highlights,
+    .pr-advanced-list,
+    .pr-activity-table,
+    .pr-attention-table,
+    .pr-advanced-row {
+        background: transparent !important;
+        border: 1px solid var(--pr-border) !important;
+        box-shadow: none !important;
+    }
+
+    .pr-review-metric {
+        background: transparent !important;
+        border: 1px solid var(--pr-border) !important;
+    }
+
+    .pr-advanced-row,
+    .pr-highlight-item,
+    .pr-review-band,
+    .pr-attention-table tr,
+    .pr-activity-table tr {
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+
+    .pr-status-pill {
+        background: transparent !important;
+        color: #000 !important;
+        border-color: #000 !important;
+    }
+}


### PR DESCRIPTION
### Motivation
- Convert Section 01 from a category-driven ledger into an executive-grade review surface that communicates the reporting-window outcome up-front and separates stage advancement from remark-only activity and ageing/no-movement attention items.
- Keep the change scoped to Section 01 presentation and read-side composition while leaving Sections 02+ unchanged and preserving existing VMs for compatibility.

### Description
- Added review-focused types and enums to the report contract (`ProjectReviewSummaryVm`, `ProjectReviewHighlightVm`, `ProjectReviewRowVm`, `ProjectReviewBucketsVm`, `ProjectReviewBucket`, `ProjectAttentionStatus`) and extended `ProjectSectionVm` with a `Review` payload to support the new surface while retaining `SummaryRows`/`CategoryGroups` for backwards compatibility.
- Extended `ProjectNonMoverVm` to include `LastRecordedActivityDate` and updated non-mover population so attention-ageing can be derived.
- Implemented `BuildProjectReviewBuckets(...)` plus helpers (`BuildMovementPathText`, `GetLastStageMovementDate`, `DetermineAttentionStatus`, `BuildInterpretiveSummaryText`, `BuildHighlights`) inside `ProgressReviewService` and wired the result into `GetAsync(...)` as `Projects.Review`.
- Replaced the Section 01 Razor body (`Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml`) to render: executive review band, highlights, advanced projects list, active-without-advancement table, and attention table, and updated the section count to use `vm.Projects.Review.Summary.ProjectsInScope`.
- Added CSS and print rules (`wwwroot/css/progress-review.css` and `wwwroot/css/progress-review.print.css`) for the new Section 01 components and ensured print-safe flattening and status-pill legibility.

### Testing
- Attempted to run a build with `dotnet build` but the `dotnet` CLI is not available in the execution environment, so a full compile/pass could not be executed (`dotnet: command not found`).
- Performed static checks and local source updates: the new types and helpers are declared in `Services/Reports/ProgressReview/IProgressReviewService.cs` and implemented in `Services/Reports/ProgressReview/ProgressReviewService.cs`, and the Razor and CSS changes are in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` and `wwwroot/css/progress-review*.css`.
- Verified via static inspection that Sections 02+ markup was left intact and that the new `Projects.Review` payload is populated by `GetAsync(...)` for Section 01 rendering.
- Recommend running `dotnet build` and integration/site QA in CI or a developer machine to validate compilation and visual/print rendering before deploying.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc0adfc6083299ad9db01b498fe98)