### PR TITLE
Fix Section 01 movement path chronology in Progress Review

### DIFF
--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1234,9 +1234,24 @@ public sealed class ProgressReviewService : IProgressReviewService
             return "No formal stage movement recorded.";
         }
 
-        return string.Join(" \u2192 ", movements
+        var orderedForPath = movements
             .Take(3)
-            .Select(movement => $"{movement.StageName} {(movement.IsOngoing ? "started" : "completed")}"));
+            .OrderBy(GetMovementEventDate)
+            .ThenBy(movement => movement.StageName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return string.Join(" \u2192 ", orderedForPath.Select(FormatMovementLabel));
+    }
+
+    private static DateOnly? GetMovementEventDate(ProjectStageMovementVm movement)
+    {
+        return movement.CompletedOn ?? movement.StartedOn;
+    }
+
+    private static string FormatMovementLabel(ProjectStageMovementVm movement)
+    {
+        var suffix = movement.IsOngoing ? "started" : "completed";
+        return $"{movement.StageName} {suffix}";
     }
 
     private static DateOnly? GetLastStageMovementDate(IReadOnlyList<ProjectStageMovementVm> movements)


### PR DESCRIPTION
### Motivation
- The movement path text in "Progress Review > Section 01 > Projects advanced in this period" was displayed in reverse chronological order for some projects, producing misleading paths (newest→oldest) instead of chronological progression (oldest→newest).

### Description
- Updated `BuildMovementPathText` to explicitly order the selected display subset ascending by an effective event date before joining items with the arrow, ensuring path text reads oldest → newest; the display subset still uses the existing `Take(3)` trim behaviour. (file: `Services/Reports/ProgressReview/ProgressReviewService.cs`)
- Introduced `GetMovementEventDate(ProjectStageMovementVm)` which returns `CompletedOn ?? StartedOn` to implement the effective event date rule for ordering.
- Added `FormatMovementLabel(ProjectStageMovementVm)` to centralise label formatting as `"<StageName> started/completed"` and keep rendering logic explicit.
- Preserved existing row-level behaviour and metadata (row ordering and `GetLastStageMovementDate` remain unchanged) so only the path string rendering is affected.

### Testing
- Attempted to run targeted unit tests for Progress Review via `dotnet test`, but the environment lacks the .NET SDK so the test run failed (`dotnet` not found).
- Ran repository sanity checks `git diff --check` and `git status --short` to validate the patch format and working tree state; these checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc50504408329a156ca455e719690)