### PR TITLE
Remove detailed FFC in‑progress section from Progress Review page

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -714,25 +714,6 @@
                                 }
                             </div>
                         </div>
-                        <div class="progress-review__block mt-3">
-                            @{
-                                var gCount = vm.FfcDetailedIncompleteGroups.Length;
-                                var gLabel = gCount == 1 ? "group" : "groups";
-                            }
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <h3 class="progress-review__subheading mb-0">FFC simulators - detailed (in progress only)</h3>
-                                <span class="text-muted small">@gCount in progress @gLabel</span>
-                            </div>
-                            @if (vm.FfcDetailedIncompleteGroups.Any())
-                            {
-                                <partial name="~/Areas/ProjectOfficeReports/Pages/FFC/_DetailedTablePartial.cshtml"
-                                         model="vm.FfcDetailedIncompleteGroups" />
-                            }
-                            else
-                            {
-                                <p class="text-muted mb-0">No in-progress FFC country-year records right now.</p>
-                            }
-                        </div>
                     </div>
                 </section>
 


### PR DESCRIPTION
### Motivation

- The Progress Review page must remain high‑level and should not include the operational FFC detailed table or counts that duplicate the dedicated FFC page.

### Description

- Removed the entire detailed FFC block from the Progress Review Razor view by deleting the heading, right‑aligned in‑progress count, conditional wrapper and the partial render call in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml`.
- The change removes the `FFC simulators - detailed (in progress only)` heading, the `X in progress groups` text, and the `<partial ... model="vm.FfcDetailedIncompleteGroups" />` usage so no empty container or gap remains.
- Backend/service loading and the `vm.FfcDetailedIncompleteGroups` data shape were intentionally left unchanged to keep this as a UI‑only removal.

### Testing

- Verified the removal by searching the updated file with ripgrep for `FFC simulators - detailed`, `FfcDetailedIncompleteGroups`, `_DetailedTablePartial` and related strings which returned no matches.
- Attempted to run `dotnet build` but the environment lacks the .NET SDK so a full compile/test could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df07efec688329b040823df49ff730)