### PR TITLE
Add parent-category multi-select filter to ongoing stage chart

### DIFF
--- a/Pages/Analytics/Index.cshtml
+++ b/Pages/Analytics/Index.cshtml
@@ -83,7 +83,7 @@
               break;
 
             case AnalyticsTab.Ongoing:
-              @await Html.PartialAsync("Partials/_OngoingAnalytics", Model.Ongoing!)
+              @await Html.PartialAsync("Partials/_OngoingAnalytics", Model)
               break;
 
             case AnalyticsTab.Coe:

--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -61,8 +61,14 @@ namespace ProjectManagement.Pages.Analytics
         [BindProperty(SupportsGet = true, Name = "hotspotCategoryId")]
         public int? StageHotspotCategoryId { get; set; }
 
+        [BindProperty(SupportsGet = true, Name = "ongoingStageParentCategoryIds")]
+        public List<int> OngoingStageParentCategoryIds { get; set; } = new();
+
         public IReadOnlyList<CategoryOption> Categories { get; private set; } = Array.Empty<CategoryOption>();
         public IReadOnlyList<TechnicalCategoryOption> TechnicalCategories { get; private set; } = Array.Empty<TechnicalCategoryOption>();
+        public IReadOnlyList<AnalyticsFilterOption> OngoingStageParentCategoryOptions { get; private set; } =
+            Array.Empty<AnalyticsFilterOption>();
+        public IReadOnlyList<int> ActiveOngoingStageParentCategoryIds { get; private set; } = Array.Empty<int>();
 
         public int CompletedCount { get; private set; }
         public int OngoingCount { get; private set; }
@@ -156,6 +162,20 @@ namespace ProjectManagement.Pages.Analytics
                 .Select(c => new TechnicalCategoryOption(c.Id, c.Name))
                 .ToListAsync(cancellationToken);
 
+            OngoingStageParentCategoryOptions = await _db.ProjectCategories
+                .AsNoTracking()
+                .Where(c => c.IsActive && c.ParentId == null)
+                .OrderBy(c => c.SortOrder)
+                .ThenBy(c => c.Name)
+                .Select(c => new AnalyticsFilterOption(c.Id, c.Name))
+                .ToListAsync(cancellationToken);
+
+            ActiveOngoingStageParentCategoryIds = OngoingStageParentCategoryIds
+                .Where(id => id > 0)
+                .Distinct()
+                .Where(id => OngoingStageParentCategoryOptions.Any(option => option.Id == id))
+                .ToList();
+
             if (ActiveTab != AnalyticsTab.Completed)
             {
                 CompletedCount = await _db.Projects
@@ -224,7 +244,9 @@ namespace ProjectManagement.Pages.Analytics
 
             var byCategory = await BuildParentCategoryCountsAsync(ongoingQuery, cancellationToken);
             var byStage = await BuildOngoingStageDistributionAsync(cancellationToken);
-            var byStageByParentCategory = await BuildOngoingStageDistributionByParentCategoryAsync(cancellationToken);
+            var byStageByParentCategory = await BuildOngoingStageDistributionByParentCategoryAsync(
+                ActiveOngoingStageParentCategoryIds,
+                cancellationToken);
             var stageDurations = await BuildOngoingStageDurationsAsync(cancellationToken);
 
             return new OngoingAnalyticsVm
@@ -781,12 +803,28 @@ namespace ProjectManagement.Pages.Analytics
         }
 
         private async Task<IReadOnlyList<OngoingStageByParentCategoryPoint>>
-            BuildOngoingStageDistributionByParentCategoryAsync(CancellationToken cancellationToken)
+            BuildOngoingStageDistributionByParentCategoryAsync(
+                IReadOnlyCollection<int>? selectedParentCategoryIds,
+                CancellationToken cancellationToken)
         {
             // SECTION: Ongoing stage distribution by parent category
-            var stageSnapshots = await _db.Projects
+            var selectedIds = selectedParentCategoryIds?
+                .Where(id => id > 0)
+                .Distinct()
+                .ToList();
+
+            var projectsQuery = _db.Projects
                 .AsNoTracking()
-                .Where(p => !p.IsDeleted && !p.IsArchived && p.LifecycleStatus == ProjectLifecycleStatus.Active)
+                .Where(p => !p.IsDeleted && !p.IsArchived && p.LifecycleStatus == ProjectLifecycleStatus.Active);
+
+            if (selectedIds is { Count: > 0 })
+            {
+                projectsQuery = projectsQuery
+                    .Where(p => p.CategoryId.HasValue
+                        && selectedIds.Contains(p.Category!.ParentId ?? p.CategoryId.Value));
+            }
+
+            var stageSnapshots = await projectsQuery
                 .Include(p => p.ProjectStages)
                 .Select(p => new
                 {
@@ -1040,5 +1078,6 @@ namespace ProjectManagement.Pages.Analytics
 
         public sealed record CategoryOption(int Id, string Name);
         public sealed record TechnicalCategoryOption(int Id, string Name);
+        public sealed record AnalyticsFilterOption(int Id, string Name);
     }
 }

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -1,17 +1,25 @@
-@model ProjectManagement.Models.Analytics.OngoingAnalyticsVm
+@model ProjectManagement.Pages.Analytics.IndexModel
 @using System.Linq
 @using System.Text.Json
 
 @{
     // SECTION: Ongoing analytics serialization
+    var ongoingAnalytics = Model.Ongoing!;
     var jsonOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    var stageSeries = Model.ByStageByParentCategory.Count > 0
-        ? Model.ByStageByParentCategory.Cast<object>().ToList()
-        : Model.ByStage.Cast<object>().ToList();
+    var stageSeries = ongoingAnalytics.ByStageByParentCategory.Count > 0
+        ? ongoingAnalytics.ByStageByParentCategory.Cast<object>().ToList()
+        : ongoingAnalytics.ByStage.Cast<object>().ToList();
+    var selectedStageParentCategoryIds = Model.ActiveOngoingStageParentCategoryIds;
+    var selectedCount = selectedStageParentCategoryIds.Count;
+    var categorySummaryText = selectedCount == 0
+        ? "All parent categories"
+        : selectedCount == 1
+            ? "1 selected"
+            : $"{selectedCount} selected";
     // END SECTION
 }
 
@@ -41,7 +49,7 @@
                         <canvas id="ongoing-by-category-chart"
                                 aria-label="Ongoing projects by category"
                                 role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.ByCategory, jsonOptions))'></canvas>
+                                data-series='@Html.Raw(JsonSerializer.Serialize(ongoingAnalytics.ByCategory, jsonOptions))'></canvas>
                     </div>
                 </div>
             </article>
@@ -54,19 +62,60 @@
                         <p class="analytics-card__meta">How many ongoing projects are currently in each stage.</p>
                     </div>
 
-                    <button type="button"
-                            class="analytics-chart-download-btn"
-                            data-chart-download-target="ongoing-by-stage-chart"
-                            aria-label="Download chart as PNG"
-                            title="Download chart as PNG">
-                        <i class="bi bi-download" aria-hidden="true"></i>
-                    </button>
+                    <div class="analytics-card__header-actions">
+                        <!-- SECTION: Ongoing stage parent category filter -->
+                        <form method="get"
+                              asp-page="/Analytics/Index"
+                              class="analytics-stage-filter-form"
+                              aria-label="Filter ongoing projects by parent category">
+                            <input type="hidden" name="tab" value="ongoing" />
+
+                            <label for="ongoing-stage-parent-category-filter" class="analytics-stage-filter-label">
+                                Parent categories
+                            </label>
+                            <select id="ongoing-stage-parent-category-filter"
+                                    name="ongoingStageParentCategoryIds"
+                                    class="form-select form-select-sm analytics-stage-filter-select"
+                                    multiple
+                                    size="4"
+                                    aria-describedby="ongoing-stage-parent-category-selection-summary">
+                                @foreach (var option in Model.OngoingStageParentCategoryOptions)
+                                {
+                                    <option value="@option.Id"
+                                            selected="@(selectedStageParentCategoryIds.Contains(option.Id) ? "selected" : null)">
+                                        @option.Name
+                                    </option>
+                                }
+                            </select>
+                            <span id="ongoing-stage-parent-category-selection-summary"
+                                  class="analytics-stage-filter-summary">
+                                @categorySummaryText
+                            </span>
+
+                            <div class="analytics-stage-filter-actions">
+                                <button type="submit" class="btn btn-sm btn-primary">Apply</button>
+                                <a asp-page="/Analytics/Index"
+                                   asp-route-tab="ongoing"
+                                   class="btn btn-sm btn-outline-secondary">Clear</a>
+                            </div>
+                        </form>
+                        <!-- END SECTION -->
+
+                        <button type="button"
+                                class="analytics-chart-download-btn"
+                                data-chart-download-target="ongoing-by-stage-chart"
+                                aria-label="Download chart as PNG"
+                                title="Download chart as PNG">
+                            <i class="bi bi-download" aria-hidden="true"></i>
+                        </button>
+                    </div>
                 </header>
                 <div class="analytics-card__body">
                     <div class="analytics-card__chart">
                         <canvas id="ongoing-by-stage-chart"
                                 aria-label="Ongoing projects by current stage"
                                 role="img"
+                                data-empty-message="No ongoing projects found for the selected parent categories."
                                 data-series='@Html.Raw(JsonSerializer.Serialize(stageSeries, jsonOptions))'></canvas>
                     </div>
                 </div>
@@ -95,7 +144,7 @@
                         <canvas id="ongoing-stage-duration-chart"
                                 aria-label="Average time spent in each stage"
                                 role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(Model.AvgStageDurations, jsonOptions))'></canvas>
+                                data-series='@Html.Raw(JsonSerializer.Serialize(ongoingAnalytics.AvgStageDurations, jsonOptions))'></canvas>
                     </div>
                 </div>
             </article>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -275,6 +275,35 @@
 }
 /* END SECTION */
 
+/* SECTION: Ongoing stage filter controls */
+.analytics-stage-filter-form {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 220px;
+}
+
+.analytics-stage-filter-label {
+  margin: 0;
+  font-size: var(--pm-font-size-xs);
+  color: var(--pm-text-secondary);
+}
+
+.analytics-stage-filter-select {
+  min-height: 7.75rem;
+}
+
+.analytics-stage-filter-summary {
+  font-size: var(--pm-font-size-xs);
+  color: var(--pm-text-secondary);
+}
+
+.analytics-stage-filter-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+/* END SECTION */
+
 .analytics-card__title {
   margin: 0;
   font-size: 1rem;


### PR DESCRIPTION
### Motivation
- Provide a card-level multi-select filter so users can view the "Ongoing projects by current stage" stacked bar chart scoped to any combination of parent categories.
- Preserve existing chart semantics (x-axis = stage, stacks = parent category, value = count) while keeping the filter server-driven and bookmarkable via GET.

### Description
- Added a GET-bound property `ongoingStageParentCategoryIds` and exposed validated top-level parent-category options as `OngoingStageParentCategoryOptions` on the `IndexModel` and computed `ActiveOngoingStageParentCategoryIds` from the query input.
- Refactored `BuildOngoingStageDistributionByParentCategoryAsync` to accept `selectedParentCategoryIds` and apply the filter at the database project query level before materialising stage snapshots so aggregation reflects the selection.
- Updated the ongoing analytics partial to accept the full page model, added a compact multi-select filter UI (Apply/Clear buttons and selection summary) in the "Ongoing projects by current stage" card header, and added a chart-specific empty-state message; kept frontend chart rendering code unchanged so filtered payloads render normally.
- Added scoped CSS for the new filter controls and minor wiring in `Pages/Analytics/Index.cshtml` to render the updated partial.
- Modified files: `Pages/Analytics/Index.cshtml`, `Pages/Analytics/Index.cshtml.cs`, `Pages/Analytics/Partials/_OngoingAnalytics.cshtml`, and `wwwroot/css/analytics.css`.

### Testing
- Attempted an automated build with `dotnet build`, but the command failed in this environment because `dotnet` is not installed, so no build or unit tests were executed.
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c9005d0c8329a41399b5390bcbe5)