### PR TITLE
[PR #2295 Follow-up] Fix ongoing stage chart fallback when parent-category filter has no matches

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -10,11 +10,13 @@
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    var stageSeries = ongoingAnalytics.ByStageByParentCategory.Count > 0
-        ? ongoingAnalytics.ByStageByParentCategory.Cast<object>().ToList()
-        : ongoingAnalytics.ByStage.Cast<object>().ToList();
     var selectedStageParentCategoryIds = Model.ActiveOngoingStageParentCategoryIds;
     var selectedCount = selectedStageParentCategoryIds.Count;
+    var stageSeries = ongoingAnalytics.ByStageByParentCategory.Count > 0
+        ? ongoingAnalytics.ByStageByParentCategory.Cast<object>().ToList()
+        : selectedCount == 0
+            ? ongoingAnalytics.ByStage.Cast<object>().ToList()
+            : Enumerable.Empty<object>().ToList();
     var categorySummaryText = selectedCount == 0
         ? "All parent categories"
         : selectedCount == 1


### PR DESCRIPTION
### Motivation
- Prevent the ongoing-stage chart from showing unrelated global `ByStage` data when a user applies parent-category filters that match zero ongoing projects, so filtered requests correctly render an empty state instead of unfiltered totals.

### Description
- Updated the stage-series selection in `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` to compute `selectedCount` before choosing the payload and to use `Enumerable.Empty<object>().ToList()` when parent-category filters are active but produce no matches, while preserving the `ByStage` fallback only when no filters are selected.

### Testing
- Attempted `dotnet build` in the environment but it failed due to missing `dotnet` (`/bin/bash: line 1: dotnet: command not found`), so no build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5de63976483299f8704bce363935a)