### PR TITLE
Refine ongoing analytics parent-category filter UX

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -14,11 +14,18 @@
         ? ongoingAnalytics.ByStageByParentCategory.Cast<object>().ToList()
         : ongoingAnalytics.ByStage.Cast<object>().ToList();
     var selectedStageParentCategoryIds = Model.ActiveOngoingStageParentCategoryIds;
+    var stageParentCategoryOptions = Model.OngoingStageParentCategoryOptions.ToList();
     var selectedCount = selectedStageParentCategoryIds.Count;
-    var categorySummaryText = selectedCount == 0
-        ? "All parent categories"
-        : selectedCount == 1
-            ? "1 selected"
+    var hasExplicitSelection = selectedCount > 0;
+    var selectAllByDefault = !hasExplicitSelection;
+    var selectedNames = stageParentCategoryOptions
+        .Where(option => selectedStageParentCategoryIds.Contains(option.Id))
+        .Select(option => option.Name)
+        .ToList();
+    var categorySummaryValue = !hasExplicitSelection || selectedCount >= stageParentCategoryOptions.Count
+        ? "All"
+        : selectedCount == 1 && selectedNames.Count == 1
+            ? selectedNames[0]
             : $"{selectedCount} selected";
     // END SECTION
 }
@@ -70,33 +77,62 @@
                               aria-label="Filter ongoing projects by parent category">
                             <input type="hidden" name="tab" value="ongoing" />
 
-                            <label for="ongoing-stage-parent-category-filter" class="analytics-stage-filter-label">
-                                Parent categories
-                            </label>
-                            <select id="ongoing-stage-parent-category-filter"
-                                    name="ongoingStageParentCategoryIds"
-                                    class="form-select form-select-sm analytics-stage-filter-select"
-                                    multiple
-                                    size="4"
-                                    aria-describedby="ongoing-stage-parent-category-selection-summary">
-                                @foreach (var option in Model.OngoingStageParentCategoryOptions)
-                                {
-                                    <option value="@option.Id"
-                                            selected="@(selectedStageParentCategoryIds.Contains(option.Id) ? "selected" : null)">
-                                        @option.Name
-                                    </option>
-                                }
-                            </select>
-                            <span id="ongoing-stage-parent-category-selection-summary"
-                                  class="analytics-stage-filter-summary">
-                                @categorySummaryText
-                            </span>
+                            <button type="button"
+                                    class="analytics-stage-filter-trigger"
+                                    data-stage-filter-trigger
+                                    aria-haspopup="dialog"
+                                    aria-expanded="false"
+                                    aria-controls="ongoing-stage-parent-category-popover">
+                                <span class="analytics-stage-filter-trigger__label">Parent categories:</span>
+                                <span class="analytics-stage-filter-trigger__value"
+                                      data-stage-filter-summary>@categorySummaryValue</span>
+                                <i class="bi bi-chevron-down analytics-stage-filter-trigger__icon" aria-hidden="true"></i>
+                            </button>
 
-                            <div class="analytics-stage-filter-actions">
-                                <button type="submit" class="btn btn-sm btn-primary">Apply</button>
-                                <a asp-page="/Analytics/Index"
-                                   asp-route-tab="ongoing"
-                                   class="btn btn-sm btn-outline-secondary">Clear</a>
+                            <div id="ongoing-stage-parent-category-popover"
+                                 class="analytics-stage-filter-popover"
+                                 data-stage-filter-popover
+                                 role="dialog"
+                                 aria-label="Parent categories filter"
+                                 hidden>
+                                <p class="analytics-stage-filter-popover__title">Parent categories</p>
+
+                                <div class="analytics-stage-filter-options">
+                                    @foreach (var option in stageParentCategoryOptions)
+                                    {
+                                        var isChecked = selectAllByDefault || selectedStageParentCategoryIds.Contains(option.Id);
+                                        var optionId = $"ongoing-stage-parent-category-option-{option.Id}";
+
+                                        <label for="@optionId" class="analytics-stage-filter-option">
+                                            <input id="@optionId"
+                                                   type="checkbox"
+                                                   name="ongoingStageParentCategoryIds"
+                                                   value="@option.Id"
+                                                   class="form-check-input analytics-stage-filter-option__checkbox"
+                                                   checked="@isChecked"
+                                                   data-stage-filter-option />
+                                            <span class="analytics-stage-filter-option__label">@option.Name</span>
+                                        </label>
+                                    }
+                                </div>
+
+                                <div class="analytics-stage-filter-actions">
+                                    <div class="analytics-stage-filter-actions__left">
+                                        <button type="button"
+                                                class="btn btn-sm btn-link"
+                                                data-stage-filter-select-all>
+                                            Select all
+                                        </button>
+                                        <button type="button"
+                                                class="btn btn-sm btn-link"
+                                                data-stage-filter-clear>
+                                            Clear
+                                        </button>
+                                    </div>
+                                    <button type="submit" class="btn btn-sm btn-primary" data-stage-filter-apply>
+                                        Apply
+                                    </button>
+                                </div>
                             </div>
                         </form>
                         <!-- END SECTION -->

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -277,30 +277,119 @@
 
 /* SECTION: Ongoing stage filter controls */
 .analytics-stage-filter-form {
-  display: grid;
+  position: relative;
+}
+
+.analytics-stage-filter-trigger {
+  display: inline-flex;
+  align-items: center;
   gap: 0.4rem;
-  min-width: 220px;
-}
-
-.analytics-stage-filter-label {
-  margin: 0;
+  border: 1px solid var(--pm-border);
+  border-radius: 0.65rem;
+  background-color: #fff;
+  color: var(--pm-text, #1f2937);
+  padding: 0.38rem 0.62rem;
   font-size: var(--pm-font-size-xs);
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.analytics-stage-filter-trigger:hover,
+.analytics-stage-filter-trigger[data-stage-filter-open="true"] {
+  border-color: rgba(45, 108, 223, 0.45);
+  background-color: rgba(37, 99, 235, 0.04);
+}
+
+.analytics-stage-filter-trigger:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.25);
+  outline-offset: 1px;
+}
+
+.analytics-stage-filter-trigger__label {
   color: var(--pm-text-secondary);
+  font-weight: 500;
 }
 
-.analytics-stage-filter-select {
-  min-height: 7.75rem;
+.analytics-stage-filter-trigger__value {
+  color: var(--pm-text, #111827);
+  font-weight: 600;
 }
 
-.analytics-stage-filter-summary {
+.analytics-stage-filter-trigger__icon {
+  font-size: 0.65rem;
+  transition: transform 0.18s ease;
+}
+
+.analytics-stage-filter-trigger[data-stage-filter-open="true"] .analytics-stage-filter-trigger__icon {
+  transform: rotate(180deg);
+}
+
+.analytics-stage-filter-popover {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  z-index: 20;
+  width: min(320px, 84vw);
+  border: 1px solid var(--pm-border);
+  border-radius: 0.75rem;
+  background-color: #fff;
+  box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.55);
+  padding: 0.72rem;
+}
+
+.analytics-stage-filter-popover__title {
+  margin: 0 0 0.45rem;
   font-size: var(--pm-font-size-xs);
-  color: var(--pm-text-secondary);
+  font-weight: 600;
+  color: var(--pm-text, #1f2937);
+}
+
+.analytics-stage-filter-options {
+  display: grid;
+  gap: 0.22rem;
+  margin-bottom: 0.55rem;
+}
+
+.analytics-stage-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.58rem;
+  border-radius: 0.42rem;
+  padding: 0.3rem 0.38rem;
+  cursor: pointer;
+}
+
+.analytics-stage-filter-option:hover {
+  background-color: rgba(37, 99, 235, 0.06);
+}
+
+.analytics-stage-filter-option__checkbox {
+  margin-top: 0;
+}
+
+.analytics-stage-filter-option__label {
+  font-size: 0.88rem;
+  color: var(--pm-text, #1f2937);
 }
 
 .analytics-stage-filter-actions {
   display: flex;
-  gap: 0.5rem;
+  justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
+}
+
+.analytics-stage-filter-actions__left {
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+}
+
+.analytics-stage-filter-actions .btn-link {
+  --bs-btn-padding-y: 0.1rem;
+  --bs-btn-padding-x: 0.22rem;
+  text-decoration: none;
 }
 /* END SECTION */
 

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -758,8 +758,126 @@ function initCompletedAnalytics() {
 }
 // END SECTION
 
+// SECTION: Ongoing stage parent-category filter popover
+function initOngoingStageFilterPopover() {
+  const filterForm = document.querySelector('.analytics-stage-filter-form');
+  if (!filterForm) {
+    return;
+  }
+
+  const trigger = filterForm.querySelector('[data-stage-filter-trigger]');
+  const popover = filterForm.querySelector('[data-stage-filter-popover]');
+  const summary = filterForm.querySelector('[data-stage-filter-summary]');
+  const selectAllButton = filterForm.querySelector('[data-stage-filter-select-all]');
+  const clearButton = filterForm.querySelector('[data-stage-filter-clear]');
+  const applyButton = filterForm.querySelector('[data-stage-filter-apply]');
+  const options = Array.from(filterForm.querySelectorAll('[data-stage-filter-option]'));
+  const optionLabels = new Map(
+    options.map((option) => {
+      const label = filterForm.querySelector(`label[for="${option.id}"] .analytics-stage-filter-option__label`);
+      return [option, label ? label.textContent?.trim() ?? '' : ''];
+    })
+  );
+
+  if (!trigger || !popover || !summary || !options.length) {
+    return;
+  }
+
+  function setPopoverState(isOpen) {
+    trigger.dataset.stageFilterOpen = isOpen ? 'true' : 'false';
+    trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    popover.hidden = !isOpen;
+  }
+
+  function setAllOptionsChecked(checked) {
+    options.forEach((option) => {
+      option.checked = checked;
+    });
+  }
+
+  function selectedOptions() {
+    return options.filter((option) => option.checked);
+  }
+
+  function updateSummaryText() {
+    const selected = selectedOptions();
+    const selectedCount = selected.length;
+    const totalCount = options.length;
+    let text = 'All';
+
+    if (selectedCount === 1) {
+      text = optionLabels.get(selected[0]) || '1 selected';
+    } else if (selectedCount > 1 && selectedCount < totalCount) {
+      text = `${selectedCount} selected`;
+    }
+
+    summary.textContent = text;
+  }
+
+  function ensureAtLeastOneOrAllSelected() {
+    if (!selectedOptions().length) {
+      setAllOptionsChecked(true);
+    }
+  }
+
+  trigger.addEventListener('click', () => {
+    const nextState = popover.hidden;
+    setPopoverState(nextState);
+  });
+
+  selectAllButton?.addEventListener('click', () => {
+    setAllOptionsChecked(true);
+    updateSummaryText();
+  });
+
+  clearButton?.addEventListener('click', () => {
+    setAllOptionsChecked(true);
+    updateSummaryText();
+  });
+
+  options.forEach((option) => {
+    option.addEventListener('change', () => {
+      updateSummaryText();
+    });
+  });
+
+  applyButton?.addEventListener('click', () => {
+    ensureAtLeastOneOrAllSelected();
+  });
+
+  filterForm.addEventListener('submit', () => {
+    ensureAtLeastOneOrAllSelected();
+    setPopoverState(false);
+    updateSummaryText();
+  });
+
+  document.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    if (!filterForm.contains(target)) {
+      setPopoverState(false);
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      setPopoverState(false);
+      trigger.focus();
+    }
+  });
+
+  setPopoverState(false);
+  updateSummaryText();
+}
+// END SECTION
+
 // SECTION: Ongoing analytics initialiser
 function initOngoingAnalytics() {
+  initOngoingStageFilterPopover();
+
   const categoryCanvas = document.getElementById('ongoing-by-category-chart');
   const stageCanvas = document.getElementById('ongoing-by-stage-chart');
   const durationCanvas = document.getElementById('ongoing-stage-duration-chart');


### PR DESCRIPTION
### Motivation
- Replace the permanently visible native multi-select in the "Ongoing projects by current stage" card with a compact header-level filter so the control feels like an analytics filter and does not visually compete with the chart.
- Provide a modern checkbox-based interaction (scanable, keyboard-friendly) that supports multi-select, `Select all`, `Clear`, and `Apply` while preserving existing server-side filtering semantics.
- Keep the UI modular, accessible, and compliant with the app's CSP/offline deployment constraints (no inline scripts).

### Description
- Updated Razor markup in `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` to compute a concise trigger summary and render a header-level trigger plus a checkbox popover that posts `ongoingStageParentCategoryIds` via the existing GET form flow.
- Added compact styles in `wwwroot/css/analytics.css` to style the trigger, chevron state, popover shell, checkbox rows, hover states, and footer action layout so the filter occupies minimal header space.
- Implemented modular client behavior in `wwwroot/js/analytics-projects.js` with `initOngoingStageFilterPopover()` to control open/close (trigger, outside-click, Escape), live summary updates, `Select all`/`Clear` actions, and logic that treats an empty staged selection as `All` before submit.
- Preserved chart rendering and server-side GET filtering; no inline scripts were introduced and changes are scoped to the ongoing analytics filter.

### Testing
- Attempted to run a full build with `dotnet build`, but the command failed in this environment because `dotnet` is not installed (automated build unavailable here).
- No automated frontend test runner was executed in this environment; JavaScript behavior was added modularly to be testable in-browser or via existing frontend test suites.
- Changes were linted/committed locally and verified syntactically (markup, CSS, JS) by static inspection prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5df38852883299e5efa0522077b07)