### PR TITLE
Add stage-column textual drill-down for ongoing-stage analytics

### DIFF
--- a/Models/Analytics/OngoingAnalyticsVm.cs
+++ b/Models/Analytics/OngoingAnalyticsVm.cs
@@ -14,7 +14,24 @@ public sealed class OngoingAnalyticsVm
     public IReadOnlyList<OngoingStageByParentCategoryPoint> ByStageByParentCategory { get; init; } =
         Array.Empty<OngoingStageByParentCategoryPoint>();
 
+    public IReadOnlyList<OngoingStageBoardItemVm> StageBoard { get; init; } =
+        Array.Empty<OngoingStageBoardItemVm>();
+
     public IReadOnlyList<AnalyticsStageDurationPoint> AvgStageDurations { get; init; } =
         Array.Empty<AnalyticsStageDurationPoint>();
 }
+
+public sealed record OngoingStageBoardItemVm(
+    string StageCode,
+    string StageName,
+    int StageCount,
+    IReadOnlyList<OngoingStageBoardCategoryVm> Categories);
+
+public sealed record OngoingStageBoardCategoryVm(
+    int? ParentCategoryId,
+    string ParentCategoryName,
+    int CategoryCount,
+    IReadOnlyList<OngoingStageBoardProjectVm> Projects);
+
+public sealed record OngoingStageBoardProjectVm(int ProjectId, string ProjectName);
 // END SECTION

--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -247,6 +247,10 @@ namespace ProjectManagement.Pages.Analytics
             var byStageByParentCategory = await BuildOngoingStageDistributionByParentCategoryAsync(
                 ActiveOngoingStageParentCategoryIds,
                 cancellationToken);
+            var stageBoard = await BuildOngoingStageBoardAsync(
+                ActiveOngoingStageParentCategoryIds,
+                OngoingStageParentCategoryOptions,
+                cancellationToken);
             var stageDurations = await BuildOngoingStageDurationsAsync(cancellationToken);
 
             return new OngoingAnalyticsVm
@@ -255,6 +259,7 @@ namespace ProjectManagement.Pages.Analytics
                 ByCategory = byCategory,
                 ByStage = byStage,
                 ByStageByParentCategory = byStageByParentCategory,
+                StageBoard = stageBoard,
                 AvgStageDurations = stageDurations
             };
             // END SECTION
@@ -808,6 +813,93 @@ namespace ProjectManagement.Pages.Analytics
                 CancellationToken cancellationToken)
         {
             // SECTION: Ongoing stage distribution by parent category
+            var stageRows = await BuildOngoingStageRowsAsync(selectedParentCategoryIds, cancellationToken);
+            if (stageRows.Count == 0)
+            {
+                return Array.Empty<OngoingStageByParentCategoryPoint>();
+            }
+
+            var orderedStageCodes = BuildOrderedStageCodes(stageRows.Select(row => row.StageCode));
+
+            return stageRows
+                .GroupBy(row => new { row.StageCode, row.StageName, row.ParentCategoryName })
+                .Select(group => new OngoingStageByParentCategoryPoint(
+                    StageCode: group.Key.StageCode,
+                    StageName: group.Key.StageName,
+                    CategoryName: group.Key.ParentCategoryName,
+                    Count: group.Count()))
+                .OrderBy(point => orderedStageCodes.IndexOf(point.StageCode))
+                .ThenBy(point => point.CategoryName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            // END SECTION
+        }
+
+        private async Task<IReadOnlyList<OngoingStageBoardItemVm>> BuildOngoingStageBoardAsync(
+            IReadOnlyCollection<int>? selectedParentCategoryIds,
+            IReadOnlyList<AnalyticsFilterOption> orderedParentCategories,
+            CancellationToken cancellationToken)
+        {
+            // SECTION: Ongoing stage drill-down board
+            var stageRows = await BuildOngoingStageRowsAsync(selectedParentCategoryIds, cancellationToken);
+            if (stageRows.Count == 0)
+            {
+                return Array.Empty<OngoingStageBoardItemVm>();
+            }
+
+            var orderedStageCodes = BuildOrderedStageCodes(stageRows.Select(row => row.StageCode));
+            var parentCategoryOrder = orderedParentCategories
+                .Select((option, index) => new { option.Id, Order = index })
+                .ToDictionary(x => x.Id, x => x.Order);
+
+            return stageRows
+                .GroupBy(row => new { row.StageCode, row.StageName })
+                .OrderBy(group => orderedStageCodes.IndexOf(group.Key.StageCode))
+                .Select(stageGroup =>
+                {
+                    var categories = stageGroup
+                        .GroupBy(row => new { row.ParentCategoryId, row.ParentCategoryName })
+                        .OrderBy(group =>
+                        {
+                            if (group.Key.ParentCategoryId.HasValue &&
+                                parentCategoryOrder.TryGetValue(group.Key.ParentCategoryId.Value, out var order))
+                            {
+                                return order;
+                            }
+
+                            return int.MaxValue;
+                        })
+                        .ThenBy(group => group.Key.ParentCategoryName, StringComparer.OrdinalIgnoreCase)
+                        .Select(categoryGroup =>
+                        {
+                            var projects = categoryGroup
+                                .OrderBy(row => row.ProjectName, StringComparer.OrdinalIgnoreCase)
+                                .ThenBy(row => row.ProjectId)
+                                .Select(row => new OngoingStageBoardProjectVm(row.ProjectId, row.ProjectName))
+                                .ToList();
+
+                            return new OngoingStageBoardCategoryVm(
+                                ParentCategoryId: categoryGroup.Key.ParentCategoryId,
+                                ParentCategoryName: categoryGroup.Key.ParentCategoryName,
+                                CategoryCount: projects.Count,
+                                Projects: projects);
+                        })
+                        .ToList();
+
+                    return new OngoingStageBoardItemVm(
+                        StageCode: stageGroup.Key.StageCode,
+                        StageName: stageGroup.Key.StageName,
+                        StageCount: stageGroup.Count(),
+                        Categories: categories);
+                })
+                .ToList();
+            // END SECTION
+        }
+
+        private async Task<IReadOnlyList<OngoingStageRow>> BuildOngoingStageRowsAsync(
+            IReadOnlyCollection<int>? selectedParentCategoryIds,
+            CancellationToken cancellationToken)
+        {
+            // SECTION: Ongoing stage row projection
             var selectedIds = selectedParentCategoryIds?
                 .Where(id => id > 0)
                 .Distinct()
@@ -828,6 +920,8 @@ namespace ProjectManagement.Pages.Analytics
                 .Include(p => p.ProjectStages)
                 .Select(p => new
                 {
+                    p.Id,
+                    p.Name,
                     p.LifecycleStatus,
                     ParentCategoryId = p.CategoryId.HasValue
                         ? (p.Category!.ParentId ?? p.CategoryId)
@@ -844,61 +938,51 @@ namespace ProjectManagement.Pages.Analytics
                 })
                 .ToListAsync(cancellationToken);
 
-            var counts = new Dictionary<(string StageCode, int? CategoryId), int>();
-
-            foreach (var project in stageSnapshots)
+            if (stageSnapshots.Count == 0)
             {
-                var stage = DetermineCurrentStage(new ProjectStageSnapshot(project.LifecycleStatus, project.Stages));
-                var stageCode = string.IsNullOrWhiteSpace(stage?.StageCode)
-                    ? UnassignedStageCode
-                    : stage!.StageCode.Trim();
-                var key = (StageCode: stageCode, CategoryId: project.ParentCategoryId);
-                counts.TryGetValue(key, out var existing);
-                counts[key] = existing + 1;
+                return Array.Empty<OngoingStageRow>();
             }
 
-            if (counts.Count == 0)
-            {
-                return Array.Empty<OngoingStageByParentCategoryPoint>();
-            }
-
-            var stageCodesPresent = counts.Keys
-                .Select(k => k.StageCode)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            var orderedStageCodes = StageCodes.All
-                .Where(code => stageCodesPresent.Contains(code, StringComparer.OrdinalIgnoreCase))
-                .Concat(stageCodesPresent.Where(code => !StageCodes.All.Contains(code, StringComparer.OrdinalIgnoreCase)))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            var categoryAggregations = counts.Keys
-                .Select(k => new CategoryAggregation { Id = k.CategoryId, Count = 0 })
+            var categoryAggregations = stageSnapshots
+                .Select(snapshot => new CategoryAggregation { Id = snapshot.ParentCategoryId, Count = 0 })
                 .DistinctBy(x => x.Id)
                 .ToList();
 
             var parentCategoryNames = await LoadCategoryNamesAsync(categoryAggregations, cancellationToken);
 
-            var points = new List<OngoingStageByParentCategoryPoint>();
-            foreach (var stageCode in orderedStageCodes)
-            {
-                foreach (var kvp in counts.Where(k =>
-                    string.Equals(k.Key.StageCode, stageCode, StringComparison.OrdinalIgnoreCase)))
+            return stageSnapshots
+                .Select(snapshot =>
                 {
-                    points.Add(new OngoingStageByParentCategoryPoint(
+                    var stage = DetermineCurrentStage(new ProjectStageSnapshot(snapshot.LifecycleStatus, snapshot.Stages));
+                    var stageCode = string.IsNullOrWhiteSpace(stage?.StageCode)
+                        ? UnassignedStageCode
+                        : stage!.StageCode.Trim();
+
+                    return new OngoingStageRow(
+                        ProjectId: snapshot.Id,
+                        ProjectName: snapshot.Name ?? "Untitled project",
                         StageCode: stageCode,
                         StageName: string.Equals(stageCode, UnassignedStageCode, StringComparison.OrdinalIgnoreCase)
                             ? UnassignedStageName
                             : StageCodes.DisplayNameOf(stageCode),
-                        CategoryName: ResolveName(kvp.Key.CategoryId, parentCategoryNames),
-                        Count: kvp.Value));
-                }
-            }
+                        ParentCategoryId: snapshot.ParentCategoryId,
+                        ParentCategoryName: ResolveName(snapshot.ParentCategoryId, parentCategoryNames));
+                })
+                .ToList();
+            // END SECTION
+        }
 
-            return points
-                .OrderBy(point => orderedStageCodes.IndexOf(point.StageCode))
-                .ThenBy(point => point.CategoryName, StringComparer.OrdinalIgnoreCase)
+        private static IReadOnlyList<string> BuildOrderedStageCodes(IEnumerable<string> stageCodes)
+        {
+            // SECTION: Stage ordering helper
+            var stageCodesPresent = stageCodes
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return StageCodes.All
+                .Where(code => stageCodesPresent.Contains(code, StringComparer.OrdinalIgnoreCase))
+                .Concat(stageCodesPresent.Where(code => !StageCodes.All.Contains(code, StringComparer.OrdinalIgnoreCase)))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
             // END SECTION
         }
@@ -1074,6 +1158,14 @@ namespace ProjectManagement.Pages.Analytics
             public int? Id { get; init; }
             public int Count { get; init; }
         }
+
+        private sealed record OngoingStageRow(
+            int ProjectId,
+            string ProjectName,
+            string StageCode,
+            string StageName,
+            int? ParentCategoryId,
+            string ParentCategoryName);
         // END SECTION
 
         public sealed record CategoryOption(int Id, string Name);

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -13,8 +13,12 @@
     var stageSeries = ongoingAnalytics.ByStageByParentCategory.Count > 0
         ? ongoingAnalytics.ByStageByParentCategory.Cast<object>().ToList()
         : ongoingAnalytics.ByStage.Cast<object>().ToList();
+    var stageBoard = ongoingAnalytics.StageBoard ?? Array.Empty<ProjectManagement.Models.Analytics.OngoingStageBoardItemVm>();
     var selectedStageParentCategoryIds = Model.ActiveOngoingStageParentCategoryIds;
     var stageParentCategoryOptions = Model.OngoingStageParentCategoryOptions.ToList();
+    var categoryColorClassById = stageParentCategoryOptions
+        .Select((option, index) => new { option.Id, ColorIndex = index % 10 })
+        .ToDictionary(item => item.Id, item => $"analytics-stage-board__category-dot--{item.ColorIndex}");
     var selectedCount = selectedStageParentCategoryIds.Count;
     var hasExplicitSelection = selectedCount > 0;
     var selectAllByDefault = !hasExplicitSelection;
@@ -154,6 +158,51 @@
                                 data-empty-message="No ongoing projects found for the selected parent categories."
                                 data-series='@Html.Raw(JsonSerializer.Serialize(stageSeries, jsonOptions))'></canvas>
                     </div>
+
+                    <!-- SECTION: Ongoing stage textual drill-down board -->
+                    @if (stageBoard.Count == 0)
+                    {
+                        <p class="analytics-card__empty-text analytics-stage-board__empty">
+                            No ongoing projects found for the selected parent categories.
+                        </p>
+                    }
+                    else
+                    {
+                        <section class="analytics-stage-board" aria-label="Ongoing projects stage drill-down">
+                            @foreach (var stageItem in stageBoard)
+                            {
+                                <article class="analytics-stage-board__stage-column"
+                                         aria-label="@($"{stageItem.StageName} stage with {stageItem.StageCount} projects")">
+                                    <h3 class="analytics-stage-board__stage-title">@stageItem.StageName (@stageItem.StageCount)</h3>
+
+                                    @foreach (var category in stageItem.Categories)
+                                    {
+                                        var categoryColorClass = category.ParentCategoryId.HasValue
+                                            && categoryColorClassById.TryGetValue(category.ParentCategoryId.Value, out var resolvedColorClass)
+                                            ? resolvedColorClass
+                                            : "analytics-stage-board__category-dot--neutral";
+
+                                        <section class="analytics-stage-board__category-group"
+                                                 aria-label="@($"{category.ParentCategoryName} with {category.CategoryCount} projects")">
+                                            <h4 class="analytics-stage-board__category-title">
+                                                <span class="analytics-stage-board__category-dot @categoryColorClass" aria-hidden="true"></span>
+                                                @category.ParentCategoryName (@category.CategoryCount)
+                                            </h4>
+                                            <ul class="analytics-stage-board__project-list">
+                                                @foreach (var project in category.Projects)
+                                                {
+                                                    <li class="analytics-stage-board__project-item" title="@project.ProjectName">
+                                                        @project.ProjectName
+                                                    </li>
+                                                }
+                                            </ul>
+                                        </section>
+                                    }
+                                </article>
+                            }
+                        </section>
+                    }
+                    <!-- END SECTION -->
                 </div>
             </article>
 

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -458,6 +458,94 @@
   height: 100%;
 }
 
+/* SECTION: Ongoing stage textual drill-down board */
+.analytics-stage-board {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 260px);
+  gap: 0.85rem;
+  width: 100%;
+  overflow-x: auto;
+  padding: 0.1rem 0.1rem 0.4rem;
+}
+
+.analytics-stage-board__empty {
+  margin-top: 0.25rem;
+}
+
+.analytics-stage-board__stage-column {
+  background-color: var(--pm-page-bg);
+  border: 1px solid var(--pm-border);
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.analytics-stage-board__stage-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--pm-text, #1f2937);
+}
+
+.analytics-stage-board__category-group {
+  padding-top: 0.55rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.analytics-stage-board__category-group:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.analytics-stage-board__category-title {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--pm-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.analytics-stage-board__category-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.analytics-stage-board__category-dot--0 { background: #2563eb; }
+.analytics-stage-board__category-dot--1 { background: #f97316; }
+.analytics-stage-board__category-dot--2 { background: #22c55e; }
+.analytics-stage-board__category-dot--3 { background: #a855f7; }
+.analytics-stage-board__category-dot--4 { background: #9c27b0; }
+.analytics-stage-board__category-dot--5 { background: #fb8c00; }
+.analytics-stage-board__category-dot--6 { background: #00acc1; }
+.analytics-stage-board__category-dot--7 { background: #8d6e63; }
+.analytics-stage-board__category-dot--8 { background: #5c6bc0; }
+.analytics-stage-board__category-dot--9 { background: #43a047; }
+.analytics-stage-board__category-dot--neutral { background: #9ca3af; }
+
+.analytics-stage-board__project-list {
+  margin: 0.35rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.analytics-stage-board__project-item {
+  font-size: 0.8rem;
+  color: var(--pm-text, #111827);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+/* END SECTION */
+
 
 /* SECTION: Analytics roadmap / subcategory listing */
 .analytics-roadmap {


### PR DESCRIPTION
### Motivation

- Provide a textual drill-down below the existing "Ongoing projects by current stage" stacked chart so users can read the underlying projects using the same hierarchy (stage → parent category → projects).
- Ensure the textual board is driven from the same filtered server-side dataset and stage-resolution logic as the chart so counts reconcile exactly.

### Description

- Added a structured stage-board view model to `OngoingAnalyticsVm` (`StageBoard`, `OngoingStageBoardItemVm`, `OngoingStageBoardCategoryVm`, `OngoingStageBoardProjectVm`). (`Models/Analytics/OngoingAnalyticsVm.cs`).
- Introduced a shared server-side row projection and board builder: `BuildOngoingStageRowsAsync`, `BuildOngoingStageBoardAsync`, and `BuildOrderedStageCodes`, plus `OngoingStageRow` to reuse the same stage resolution for charts and the drill-down, and wired `StageBoard` into `BuildOngoingAnalyticsAsync`. (`Pages/Analytics/Index.cshtml.cs`).
- Refactored `BuildOngoingStageDistributionByParentCategoryAsync` to use the shared `stageRows` projection so chart series and textual data come from the same source. (`Pages/Analytics/Index.cshtml.cs`).
- Rendered the new horizontally-scrollable stage-board directly below the `ongoing-by-stage-chart` in the same card, showing stage headers with totals, per-stage parent-category subdivisions with counts, and alphabetically ordered project name rows, with an empty-state message when no projects match filters. (`Pages/Analytics/Partials/_OngoingAnalytics.cshtml`).
- Added CSS for the stage-board layout, lane visuals, subtle separators and category color dots to map lightly to chart colors. (`wwwroot/css/analytics.css`).
- No inline scripts were added and the new UI is rendered from server-shaped data as recommended.

### Testing

- Attempted to run a build with `dotnet build`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found`, so no compile/test run was completed.
- No automated unit or integration tests were executed in this environment; changes are covered by server-side data shaping and view updates and should be validated with a local build or CI that has `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e6d4e9d08329a38994c8604cc82c)