### PR TITLE
Fix Analytics compile errors and remove unused Progress Review Razor helpers

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -1,9 +1,6 @@
 @page
 @using System
-@using System.Collections.Generic
-@using System.Net
 @using System.Globalization
-@using System.Text.RegularExpressions
 @using ProjectManagement.Models.Remarks
 @using ProjectManagement.Services.Reports.ProgressReview
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.ProgressReview.IndexModel
@@ -11,26 +8,6 @@
     ViewData["Title"] = "Progress Review";
     ViewData["UseFullWidth"] = true;
     var vm = Model.Report;
-
-    string RenderRemarkHtml(string? text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return string.Empty;
-        }
-
-        var encoded = WebUtility.HtmlEncode(text)
-            .Replace("\r\n", "<br>")
-            .Replace("\n", "<br>");
-        // Match any encoded <span class="remark-mention" ...>...</span> regardless of extra attributes.
-        const string mentionPattern =
-            "&lt;span\\s+class=&quot;remark-mention&quot;.*?&gt;(.*?)&lt;/span&gt;";
-        return Regex.Replace(
-            encoded,
-            mentionPattern,
-            match => $"<span class=\"badge remark-pill\">{match.Groups[1].Value}</span>",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline);
-    }
 
     string FormatDateIso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
@@ -45,51 +22,6 @@
             ? d.ToString("dd MMM")
             : d.ToString("dd MMM yyyy");
     }
-
-
-
-    string? FormatRemarkRole(RemarkActorRole? role) => role switch
-    {
-        RemarkActorRole.ProjectOfficer => "PO",
-        RemarkActorRole.HeadOfDepartment => "HoD",
-        RemarkActorRole.Commandant => "Comdt",
-        RemarkActorRole.Administrator => "Admin",
-        RemarkActorRole.Mco => "MCO",
-        RemarkActorRole.ProjectOffice => "Project Office",
-        RemarkActorRole.MainOffice => "Main Office",
-        RemarkActorRole.Ta => "TA",
-        _ => null
-    };
-
-    string? BuildRemarkTooltip(ProjectRemarkSummaryVm summary)
-    {
-        if (!summary.LatestRemarkDate.HasValue && string.IsNullOrWhiteSpace(summary.LatestRemarkSummary))
-        {
-            return null;
-        }
-
-        var parts = new List<string>();
-        if (summary.LatestRemarkDate.HasValue)
-        {
-            parts.Add(summary.LatestRemarkDate.Value.ToString("dd MMM yyyy"));
-        }
-
-        var roleLabel = FormatRemarkRole(summary.LatestRemarkAuthorRole);
-        if (!string.IsNullOrWhiteSpace(roleLabel))
-        {
-            parts.Add(roleLabel!);
-        }
-
-        if (!string.IsNullOrWhiteSpace(summary.LatestRemarkSummary))
-        {
-            parts.Add(summary.LatestRemarkSummary!);
-        }
-
-        return parts.Count == 0 ? null : WebUtility.HtmlEncode(string.Join(" — ", parts));
-    }
-
-    DateOnly? GetMovementDate(ProjectStageMovementVm movement) => movement.IsOngoing ? movement.StartedOn : movement.CompletedOn;
-
     string? BuildVisitPhotoUrl(Guid visitId, Guid? photoId)
     {
         if (!photoId.HasValue)

--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -820,6 +820,7 @@ namespace ProjectManagement.Pages.Analytics
             }
 
             var orderedStageCodes = BuildOrderedStageCodes(stageRows.Select(row => row.StageCode));
+            var stageOrderLookup = BuildStageOrderLookup(orderedStageCodes);
 
             return stageRows
                 .GroupBy(row => new { row.StageCode, row.StageName, row.ParentCategoryName })
@@ -828,7 +829,7 @@ namespace ProjectManagement.Pages.Analytics
                     StageName: group.Key.StageName,
                     CategoryName: group.Key.ParentCategoryName,
                     Count: group.Count()))
-                .OrderBy(point => orderedStageCodes.IndexOf(point.StageCode))
+                .OrderBy(point => ResolveStageOrder(point.StageCode, stageOrderLookup))
                 .ThenBy(point => point.CategoryName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
             // END SECTION
@@ -847,13 +848,14 @@ namespace ProjectManagement.Pages.Analytics
             }
 
             var orderedStageCodes = BuildOrderedStageCodes(stageRows.Select(row => row.StageCode));
+            var stageOrderLookup = BuildStageOrderLookup(orderedStageCodes);
             var parentCategoryOrder = orderedParentCategories
                 .Select((option, index) => new { option.Id, Order = index })
                 .ToDictionary(x => x.Id, x => x.Order);
 
             return stageRows
                 .GroupBy(row => new { row.StageCode, row.StageName })
-                .OrderBy(group => orderedStageCodes.IndexOf(group.Key.StageCode))
+                .OrderBy(group => ResolveStageOrder(group.Key.StageCode, stageOrderLookup))
                 .Select(stageGroup =>
                 {
                     var categories = stageGroup
@@ -861,9 +863,9 @@ namespace ProjectManagement.Pages.Analytics
                         .OrderBy(group =>
                         {
                             if (group.Key.ParentCategoryId.HasValue &&
-                                parentCategoryOrder.TryGetValue(group.Key.ParentCategoryId.Value, out var order))
+                                parentCategoryOrder.TryGetValue(group.Key.ParentCategoryId.Value, out var categoryOrder))
                             {
-                                return order;
+                                return categoryOrder;
                             }
 
                             return int.MaxValue;
@@ -892,6 +894,31 @@ namespace ProjectManagement.Pages.Analytics
                         Categories: categories);
                 })
                 .ToList();
+            // END SECTION
+        }
+
+        private static IReadOnlyDictionary<string, int> BuildStageOrderLookup(IReadOnlyList<string> orderedStageCodes)
+        {
+            // SECTION: Stage ordering lookup helper
+            var stageOrderLookup = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            for (var index = 0; index < orderedStageCodes.Count; index++)
+            {
+                stageOrderLookup[orderedStageCodes[index]] = index;
+            }
+
+            return stageOrderLookup;
+            // END SECTION
+        }
+
+        private static int ResolveStageOrder(
+            string stageCode,
+            IReadOnlyDictionary<string, int> stageOrderLookup)
+        {
+            // SECTION: Stage ordering resolver
+            return stageOrderLookup.TryGetValue(stageCode, out var orderIndex)
+                ? orderIndex
+                : int.MaxValue;
             // END SECTION
         }
 


### PR DESCRIPTION
### Motivation
- Resolve compile-time errors caused by using `IReadOnlyList<string>.IndexOf(...)` and an unassigned local `out` variable during LINQ ordering in the Analytics page.
- Remove unused local Razor helper functions that produced `CS8321` warnings in the Progress Review page and clean up now-unneeded directives.

### Description
- Replaced `IndexOf(...)` usage with a dictionary-based lookup by adding `BuildStageOrderLookup(...)` and `ResolveStageOrder(...)` helpers and used `ResolveStageOrder(...)` in both ordering queries to maintain deterministic stage ordering with `IReadOnlyList` inputs.
- Added `BuildStageOrderLookup(...)` which builds a case-insensitive mapping of stage code to order index and `ResolveStageOrder(...)` which safely resolves a stage's order or returns `int.MaxValue` when missing, and included section comments for readability.
- Fixed the `CS0165` issue by renaming the `out var order` to `out var categoryOrder` in the parent-category ordering lambda to avoid an unassigned local variable misuse.
- Removed unused local Razor helpers (`RenderRemarkHtml`, `BuildRemarkTooltip`, `GetMovementDate`) and cleaned related now-unused `@using` directives in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` to eliminate dead code and warnings.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln` to validate the changes but it failed in this environment because the `dotnet` CLI is not available (`dotnet: command not found`).
- No automated tests were executed in this environment due to the missing .NET tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e95ea6c48329bcda9951331bc705)