### PR TITLE
Add Present stage filter to Ongoing Projects

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -19,6 +19,7 @@
         && Model.ProjectCategoryId == Model.ChipOtherRdCategoryId;
     // SECTION: Filter state
     var hasFilters = Model.ProjectCategoryId.HasValue
+        || !string.IsNullOrWhiteSpace(Model.PresentStageCode)
         || !string.IsNullOrWhiteSpace(Model.ProjectOfficerId)
         || !string.IsNullOrWhiteSpace(Model.Search);
 
@@ -207,6 +208,12 @@
                         asp-items="Model.ProjectCategoryOptions"
                         class="form-select form-select-sm"></select>
             </div>
+            <div class="cmdbar__field cmdbar__field--stage">
+                <label asp-for="PresentStageCode" class="cmdbar__label">Present stage</label>
+                <select asp-for="PresentStageCode"
+                        asp-items="Model.PresentStageOptions"
+                        class="form-select form-select-sm"></select>
+            </div>
             <div class="cmdbar__field cmdbar__field--officer">
                 <label asp-for="ProjectOfficerId" class="cmdbar__label">Project officer</label>
                 <select asp-for="ProjectOfficerId"
@@ -224,6 +231,7 @@
             <div class="segmented" role="tablist" aria-label="View">
                 <a asp-page="./Index"
                    asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
+                   asp-route-PresentStageCode="@Model.PresentStageCode"
                    asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
                    asp-route-Search="@Model.Search"
                    asp-route-View="timeline"
@@ -235,6 +243,7 @@
                 </a>
                 <a asp-page="./Index"
                    asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
+                   asp-route-PresentStageCode="@Model.PresentStageCode"
                    asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
                    asp-route-Search="@Model.Search"
                    asp-route-View="table"
@@ -250,6 +259,7 @@
                 <!-- SECTION: Clear filters -->
                 <a asp-page="./Index"
                    asp-route-ProjectCategoryId=""
+                   asp-route-PresentStageCode=""
                    asp-route-ProjectOfficerId=""
                    asp-route-Search=""
                    class="cmdbar__link-button">
@@ -263,6 +273,7 @@
             <a asp-page="./Index"
                asp-page-handler="Export"
                asp-route-ProjectCategoryId="@Model.ProjectCategoryId"
+               asp-route-PresentStageCode="@Model.PresentStageCode"
                asp-route-ProjectOfficerId="@Model.ProjectOfficerId"
                asp-route-Search="@Model.Search"
                asp-route-View="@Model.View"

--- a/Pages/Projects/Ongoing/Index.cshtml.cs
+++ b/Pages/Projects/Ongoing/Index.cshtml.cs
@@ -23,6 +23,7 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         private readonly IOngoingProjectsExcelBuilder _excelBuilder;
         private readonly IClock _clock;
         private readonly ApplicationDbContext _db;
+        private readonly IWorkflowStageMetadataProvider _workflowStageMetadataProvider;
 
         // SECTION: Category cache for header counts
         private IReadOnlyList<ProjectCategory> _categories = Array.Empty<ProjectCategory>();
@@ -31,12 +32,14 @@ namespace ProjectManagement.Pages.Projects.Ongoing
             OngoingProjectsReadService ongoingService,
             IOngoingProjectsExcelBuilder excelBuilder,
             IClock clock,
-            ApplicationDbContext db)
+            ApplicationDbContext db,
+            IWorkflowStageMetadataProvider workflowStageMetadataProvider)
         {
             _ongoingService = ongoingService ?? throw new ArgumentNullException(nameof(ongoingService));
             _excelBuilder = excelBuilder ?? throw new ArgumentNullException(nameof(excelBuilder));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _db = db ?? throw new ArgumentNullException(nameof(db));
+            _workflowStageMetadataProvider = workflowStageMetadataProvider ?? throw new ArgumentNullException(nameof(workflowStageMetadataProvider));
         }
 
         [BindProperty(SupportsGet = true)]
@@ -49,6 +52,10 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         [BindProperty(SupportsGet = true)]
         public string? Search { get; set; }
 
+        // SECTION: Present stage selector
+        [BindProperty(SupportsGet = true)]
+        public string? PresentStageCode { get; set; }
+
         // SECTION: View selector (timeline/table)
         [BindProperty(SupportsGet = true)]
         public string? View { get; set; }
@@ -57,6 +64,9 @@ namespace ProjectManagement.Pages.Projects.Ongoing
             = Array.Empty<SelectListItem>();
 
         public IReadOnlyList<SelectListItem> ProjectOfficerOptions { get; private set; }
+            = Array.Empty<SelectListItem>();
+
+        public IReadOnlyList<SelectListItem> PresentStageOptions { get; private set; }
             = Array.Empty<SelectListItem>();
 
         // SECTION: Header counts summary
@@ -97,6 +107,9 @@ namespace ProjectManagement.Pages.Projects.Ongoing
 
             var officerId = Normalize(ProjectOfficerId);
             var search = Normalize(Search);
+            PresentStageCode = NormalizeStageCode(PresentStageCode);
+            LoadPresentStageOptions();
+            PresentStageCode = ValidateStageCode(PresentStageCode);
 
             ProjectOfficerOptions = await _ongoingService.GetProjectOfficerOptionsAsync(
                 officerId,
@@ -106,6 +119,7 @@ namespace ProjectManagement.Pages.Projects.Ongoing
                 ProjectCategoryId,
                 officerId,
                 search,
+                PresentStageCode,
                 cancellationToken);
 
             // SECTION: Inline external remark editing access + IST date
@@ -119,11 +133,15 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         {
             var officerId = Normalize(ProjectOfficerId);
             var search = Normalize(Search);
+            PresentStageCode = NormalizeStageCode(PresentStageCode);
+            LoadPresentStageOptions();
+            PresentStageCode = ValidateStageCode(PresentStageCode);
 
             var items = await _ongoingService.GetAsync(
                 ProjectCategoryId,
                 officerId,
                 search,
+                PresentStageCode,
                 cancellationToken);
 
             var now = _clock.UtcNow;
@@ -308,6 +326,47 @@ namespace ProjectManagement.Pages.Projects.Ongoing
 
         private static string? Normalize(string? value)
             => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        // SECTION: Present stage normalization
+        private static string? NormalizeStageCode(string? value)
+            => string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToUpperInvariant();
+
+        // SECTION: Present stage options
+        private void LoadPresentStageOptions()
+        {
+            var stages = _workflowStageMetadataProvider.GetStages(null);
+
+            var list = new List<SelectListItem>
+            {
+                new("All stages", string.Empty, string.IsNullOrWhiteSpace(PresentStageCode))
+            };
+
+            foreach (var stage in stages)
+            {
+                list.Add(new SelectListItem(
+                    stage.Name,
+                    stage.Code,
+                    string.Equals(stage.Code, PresentStageCode, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            PresentStageOptions = list;
+        }
+
+        // SECTION: Present stage validation
+        private string? ValidateStageCode(string? stageCode)
+        {
+            if (string.IsNullOrWhiteSpace(stageCode))
+            {
+                return null;
+            }
+
+            var allowed = PresentStageOptions
+                .Where(item => !string.IsNullOrWhiteSpace(item.Value))
+                .Select(item => item.Value!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            return allowed.Contains(stageCode) ? stageCode : null;
+        }
 
         // SECTION: View normalization
         private static string NormalizeView(string? value)

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -35,6 +35,7 @@ namespace ProjectManagement.Services.Projects
             int? projectCategoryId,
             string? leadPoUserId,
             string? search,
+            string? presentStageCode,
             CancellationToken cancellationToken)
         {
             // base query – active projects only
@@ -415,6 +416,16 @@ namespace ProjectManagement.Services.Projects
                     CoverPhotoId = proj.CoverPhotoId,
                     CoverPhotoVersion = resolvedCoverPhotoVersion
                 });
+            }
+
+            if (!string.IsNullOrWhiteSpace(presentStageCode))
+            {
+                result = result
+                    .Where(row => string.Equals(
+                        row.CurrentStageCode,
+                        presentStageCode,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToList();
             }
 
             return result;

--- a/wwwroot/js/projects/ongoing.js
+++ b/wwwroot/js/projects/ongoing.js
@@ -6,6 +6,7 @@
   }
 
   const categorySelect = form.querySelector('[name="ProjectCategoryId"]');
+  const stageSelect = form.querySelector('[name="PresentStageCode"]');
   const officerSelect = form.querySelector('[name="ProjectOfficerId"]');
   const searchInput = form.querySelector('[name="Search"]');
 
@@ -34,6 +35,7 @@
   });
 
   categorySelect?.addEventListener('change', submitFilters);
+  stageSelect?.addEventListener('change', submitFilters);
   officerSelect?.addEventListener('change', submitFilters);
 
   // Pressing Enter in the search box already submits the form, but this keeps behaviour explicit


### PR DESCRIPTION
### Motivation

- Provide a single-select `Present stage` filter on the Ongoing Projects page so users can restrict the list to projects whose computed live stage equals the selected value.
- Ensure filtering uses the exact same present-stage logic used to render rows (`CurrentStageCode` / `PresentStageSnapshot`) to avoid behavioural drift.

### Description

- Added a GET-bound `PresentStageCode` property to the page model and implemented normalization/validation via `NormalizeStageCode` and `ValidateStageCode`. (`Pages/Projects/Ongoing/Index.cshtml.cs`)
- Exposed `PresentStageOptions` built from the canonical workflow metadata provider (`IWorkflowStageMetadataProvider`) so the dropdown uses official stage codes and display names. (`Index.cshtml.cs`)
- Extended `OngoingProjectsReadService.GetAsync(...)` to accept `presentStageCode` and apply filtering after DTO construction by matching `row.CurrentStageCode` (case-insensitive). (`Services/Projects/OngoingProjectsReadService.cs`)
- Added the `Present stage` `<select>` beside `Project category` in the Razor filter bar and preserved the selection through view toggles, clear/Export links, and query-string routing. (`Pages/Projects/Ongoing/Index.cshtml`)
- Enabled client-side auto-submit for the new dropdown so changes act like the existing category/officer filters by adding a change handler in `wwwroot/js/projects/ongoing.js`.

### Testing

- Attempted an automated build with `dotnet build`, but it failed in this environment because the .NET SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eae118988329983143ab7ff5c921)