### PR TITLE
Fix present-stage dropdown filtering to match displayed snapshot stage

### DIFF
--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -422,7 +422,7 @@ namespace ProjectManagement.Services.Projects
             {
                 result = result
                     .Where(row => string.Equals(
-                        row.CurrentStageCode,
+                        row.PresentStage.CurrentStageCode,
                         presentStageCode,
                         StringComparison.OrdinalIgnoreCase))
                     .ToList();


### PR DESCRIPTION
### Motivation

- Ensure the server-side `presentStageCode` filter matches the same present-stage snapshot shown in the UI so selecting a stage does not incorrectly exclude projects when no stage is `InProgress`.

### Description

- Update the comparison in `Services/Projects/OngoingProjectsReadService.cs` to use `row.PresentStage.CurrentStageCode` instead of `row.CurrentStageCode` so filtering matches the `PresentStage` snapshot used to render rows.

### Testing

- Attempted `dotnet build` in this environment but the .NET SDK is not available (`dotnet: command not found`), so no automated build/tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64a8dc8148329acf107867a913700)