### PR TITLE
Remove ongoing category donut and promote full-width stage analytics card

### DIFF
--- a/Models/Analytics/OngoingAnalyticsVm.cs
+++ b/Models/Analytics/OngoingAnalyticsVm.cs
@@ -5,9 +5,6 @@ public sealed class OngoingAnalyticsVm
 {
     public int TotalOngoingProjects { get; init; }
 
-    public IReadOnlyList<AnalyticsCategoryCountPoint> ByCategory { get; init; } =
-        Array.Empty<AnalyticsCategoryCountPoint>();
-
     public IReadOnlyList<AnalyticsStageCountPoint> ByStage { get; init; } =
         Array.Empty<AnalyticsStageCountPoint>();
 

--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -241,8 +241,6 @@ namespace ProjectManagement.Pages.Analytics
                 .Where(p => !p.IsDeleted && !p.IsArchived && p.LifecycleStatus == ProjectLifecycleStatus.Active);
 
             var total = await ongoingQuery.CountAsync(cancellationToken);
-
-            var byCategory = await BuildParentCategoryCountsAsync(ongoingQuery, cancellationToken);
             var byStage = await BuildOngoingStageDistributionAsync(cancellationToken);
             var byStageByParentCategory = await BuildOngoingStageDistributionByParentCategoryAsync(
                 ActiveOngoingStageParentCategoryIds,
@@ -256,7 +254,6 @@ namespace ProjectManagement.Pages.Analytics
             return new OngoingAnalyticsVm
             {
                 TotalOngoingProjects = total,
-                ByCategory = byCategory,
                 ByStage = byStage,
                 ByStageByParentCategory = byStageByParentCategory,
                 StageBoard = stageBoard,

--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -39,34 +39,8 @@
     <div class="analytics-layout">
         <div class="analytics-grid analytics-grid--ongoing">
 
-            <!-- Card: category distribution -->
-            <article class="analytics-card">
-                <header class="analytics-card__header analytics-card__header--with-actions">
-                    <div class="analytics-card__header-text">
-                        <h2 class="analytics-card__title">Ongoing projects by category</h2>
-                        <p class="analytics-card__meta">Breakdown of ongoing projects in each project category.</p>
-                    </div>
-
-                    <button type="button"
-                            class="analytics-chart-download-btn"
-                            data-chart-download-target="ongoing-by-category-chart"
-                            aria-label="Download chart as PNG"
-                            title="Download chart as PNG">
-                        <i class="bi bi-download" aria-hidden="true"></i>
-                    </button>
-                </header>
-                <div class="analytics-card__body">
-                    <div class="analytics-card__chart">
-                        <canvas id="ongoing-by-category-chart"
-                                aria-label="Ongoing projects by category"
-                                role="img"
-                                data-series='@Html.Raw(JsonSerializer.Serialize(ongoingAnalytics.ByCategory, jsonOptions))'></canvas>
-                    </div>
-                </div>
-            </article>
-
             <!-- Card: stage distribution -->
-            <article class="analytics-card">
+            <article class="analytics-card analytics-card--wide">
                 <header class="analytics-card__header analytics-card__header--with-actions">
                     <div class="analytics-card__header-text">
                         <h2 class="analytics-card__title">Ongoing projects by current stage</h2>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -175,7 +175,7 @@
 
 /* SECTION: Ongoing analytics ratio */
 .analytics-grid--ongoing {
-  grid-template-columns: minmax(0, 4fr) minmax(0, 8fr);
+  grid-template-columns: minmax(0, 1fr);
 }
 /* END SECTION */
 
@@ -462,7 +462,7 @@
 .analytics-stage-board {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(220px, 260px);
+  grid-auto-columns: minmax(260px, 320px);
   gap: 0.85rem;
   width: 100%;
   overflow-x: auto;

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -360,17 +360,11 @@ function renderEmptyState(canvas) {
 // END SECTION
 
 // SECTION: Category color mapping
-function buildCategoryColorMapping({ donutPoints, stackedPoints }) {
+function buildCategoryColorMapping(stackedPoints) {
   const totals = new Map();
-  const hasDonutPoints = Array.isArray(donutPoints) && donutPoints.length;
   const hasStackedPoints = Array.isArray(stackedPoints) && stackedPoints.length;
 
-  if (hasDonutPoints) {
-    donutPoints.forEach((point) => {
-      const key = point?.name ?? 'Unassigned';
-      totals.set(key, ensureNumber(point?.count));
-    });
-  } else if (hasStackedPoints) {
+  if (hasStackedPoints) {
     stackedPoints.forEach((point) => {
       const key = point?.categoryName ?? 'Unassigned';
       totals.set(key, (totals.get(key) ?? 0) + ensureNumber(point?.count));
@@ -878,37 +872,11 @@ function initOngoingStageFilterPopover() {
 function initOngoingAnalytics() {
   initOngoingStageFilterPopover();
 
-  const categoryCanvas = document.getElementById('ongoing-by-category-chart');
   const stageCanvas = document.getElementById('ongoing-by-stage-chart');
   const durationCanvas = document.getElementById('ongoing-stage-duration-chart');
 
-  const categorySeries = categoryCanvas ? parseSeries(categoryCanvas) : [];
   const stageSeries = stageCanvas ? parseSeries(stageCanvas) : [];
-  const { categoryColorMap, rankedCategories } = buildCategoryColorMapping({
-    donutPoints: categorySeries,
-    stackedPoints: stageSeries
-  });
-
-  if (categoryCanvas) {
-    if (categorySeries.length) {
-      const categoryLookup = new Map(
-        categorySeries.map((point) => [point.name ?? 'Unassigned', ensureNumber(point.count)])
-      );
-      const orderedLabels = rankedCategories.length
-        ? rankedCategories.filter((label) => categoryLookup.has(label))
-        : categorySeries.map((point) => point.name ?? 'Unassigned');
-      const orderedValues = orderedLabels.map((label) => categoryLookup.get(label) ?? 0);
-      const orderedColors = orderedLabels.map(
-        (label, index) => categoryColorMap.get(label) ?? getAccentColor(index)
-      );
-
-      createDoughnutChart(categoryCanvas, {
-        labels: orderedLabels,
-        values: orderedValues,
-        colors: orderedColors
-      });
-    }
-  }
+  const { categoryColorMap, rankedCategories } = buildCategoryColorMapping(stageSeries);
 
   if (stageCanvas) {
     if (stageSeries.length) {


### PR DESCRIPTION
### Motivation

- Simplify the Ongoing analytics layout by removing the lower-value “Ongoing projects by category” donut and make the stage view the primary full-width card to improve readability and allow wider charts and drill-downs.

### Description

- Removed the donut card markup and its download trigger from the Ongoing partial by editing `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` so the stage card becomes full-width (`analytics-card--wide`).
- Eliminated the Ongoing-only `ByCategory` payload from the view model by removing `ByCategory` from `Models/Analytics/OngoingAnalyticsVm.cs` and stopping its construction in `Pages/Analytics/Index.cshtml.cs` (removed the `BuildParentCategoryCountsAsync` call and assignment).
- Cleaned up the front-end chart initialization in `wwwroot/js/analytics-projects.js` by removing donut-specific wiring, refactoring `buildCategoryColorMapping` to derive category colours/order from the stacked stage series, and removing donut canvas/series parsing logic.
- Updated analytics layout styles in `wwwroot/css/analytics.css` by changing `.analytics-grid--ongoing` to a single-column main content layout and widening `.analytics-stage-board` columns for improved drill-down readability.

### Testing

- Attempted to run `dotnet build` in this environment but it failed with `dotnet: command not found`, so no automated build/tests ran here.
- No other automated test runs were available in this runtime; manual/visual validation of the updated layout is recommended during CI or a local build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64c67727083298445c8d06e2a0c05)