### PR TITLE
Keep Ongoing Projects filters in one desktop row and move actions to a separate row

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -201,7 +201,7 @@
         <input type="hidden" asp-for="View" />
 
         <!-- SECTION: Filters row -->
-        <div class="cmdbar__filters">
+        <div class="cmdbar__filters cmdbar__filters-row">
             <div class="cmdbar__field cmdbar__field--category">
                 <label asp-for="ProjectCategoryId" class="cmdbar__label">Project category</label>
                 <select asp-for="ProjectCategoryId"
@@ -227,7 +227,7 @@
         </div>
 
         <!-- SECTION: Actions row -->
-        <div class="cmdbar__actions">
+        <div class="cmdbar__actions cmdbar__actions-row">
             <div class="segmented" role="tablist" aria-label="View">
                 <a asp-page="./Index"
                    asp-route-ProjectCategoryId="@Model.ProjectCategoryId"

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -8883,10 +8883,10 @@ body {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-/* Filters row: filters-first */
+/* -- SECTION: Ongoing projects filter row (desktop first) -- */
 .cmdbar__filters {
     display: grid;
-    grid-template-columns: 240px minmax(320px, 1fr) minmax(280px, 1fr);
+    grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) minmax(220px, 1.3fr) minmax(260px, 1.4fr);
     gap: 1rem;
     align-items: end;
 }
@@ -8905,7 +8905,7 @@ body {
     margin-bottom: 0.35rem;
 }
 
-/* Actions row */
+/* -- SECTION: Ongoing projects actions row -- */
 .cmdbar__actions {
     display: flex;
     justify-content: flex-end;
@@ -8970,7 +8970,14 @@ body {
     color: #fff;
 }
 
-/* Responsive: stack filters cleanly */
+/* -- SECTION: Ongoing projects filter row (laptop fallback) -- */
+@media (max-width: 1200px) {
+    .cmdbar__filters {
+        grid-template-columns: repeat(2, minmax(220px, 1fr));
+    }
+}
+
+/* -- SECTION: Ongoing projects filter row (tablet/mobile fallback) -- */
 @media (max-width: 992px) {
     .cmdbar__filters {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Ensure the Ongoing Projects command bar reads as a single coherent filter set on desktop by keeping all four filter controls on one deliberate row and moving the view/action controls to a separate row below.
- Improve visual balance and prevent accidental wrapping after the addition of the `Present stage` filter, without changing any filter behavior or routes.

### Description
- Added semantic row classes to the command bar markup in `Pages/Projects/Ongoing/Index.cshtml` (`cmdbar__filters-row` and `cmdbar__actions-row`) while preserving existing form fields and routes.
- Reworked the desktop-first grid for the filters in `wwwroot/css/site.css` to a four-column layout with proportional widths so `category`, `present stage`, `officer`, and `search` fit on one row, and kept the actions row right-aligned below.
- Introduced explicit responsive fallbacks: a 2-column layout at `max-width: 1200px` and a 1-column layout at `max-width: 992px`, to avoid accidental wrapping on narrower viewports.
- No JavaScript or backend logic was changed; selector usage in `wwwroot/js/projects/ongoing.js` was validated to remain compatible with the updated DOM structure.

### Testing
- Ran a code/diff review via `git diff` to verify the intended changes to `Pages/Projects/Ongoing/Index.cshtml` and `wwwroot/css/site.css` were applied successfully.
- Verified DOM/selector compatibility with a repository search (`rg`) to ensure no JS selectors break due to the markup tweak, which passed.
- Attempted an automated build with `dotnet build`, but the environment lacks the `dotnet` CLI so the build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64de1a1dc832988a2f5d40fe1b6a2)