### PR TITLE
Sync ongoing stage-board colors with chart mapping and number project lists

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -16,9 +16,6 @@
     var stageBoard = ongoingAnalytics.StageBoard ?? Array.Empty<ProjectManagement.Models.Analytics.OngoingStageBoardItemVm>();
     var selectedStageParentCategoryIds = Model.ActiveOngoingStageParentCategoryIds;
     var stageParentCategoryOptions = Model.OngoingStageParentCategoryOptions.ToList();
-    var categoryColorClassById = stageParentCategoryOptions
-        .Select((option, index) => new { option.Id, ColorIndex = index % 10 })
-        .ToDictionary(item => item.Id, item => $"analytics-stage-board__category-dot--{item.ColorIndex}");
     var selectedCount = selectedStageParentCategoryIds.Count;
     var hasExplicitSelection = selectedCount > 0;
     var selectAllByDefault = !hasExplicitSelection;
@@ -151,25 +148,22 @@
 
                                     @foreach (var category in stageItem.Categories)
                                     {
-                                        var categoryColorClass = category.ParentCategoryId.HasValue
-                                            && categoryColorClassById.TryGetValue(category.ParentCategoryId.Value, out var resolvedColorClass)
-                                            ? resolvedColorClass
-                                            : "analytics-stage-board__category-dot--neutral";
-
                                         <section class="analytics-stage-board__category-group"
                                                  aria-label="@($"{category.ParentCategoryName} with {category.CategoryCount} projects")">
                                             <h4 class="analytics-stage-board__category-title">
-                                                <span class="analytics-stage-board__category-dot @categoryColorClass" aria-hidden="true"></span>
+                                                <span class="analytics-stage-board__category-dot analytics-stage-board__category-dot--neutral"
+                                                      data-category-name="@category.ParentCategoryName"
+                                                      aria-hidden="true"></span>
                                                 @category.ParentCategoryName (@category.CategoryCount)
                                             </h4>
-                                            <ul class="analytics-stage-board__project-list">
+                                            <ol class="analytics-stage-board__project-list">
                                                 @foreach (var project in category.Projects)
                                                 {
                                                     <li class="analytics-stage-board__project-item" title="@project.ProjectName">
                                                         @project.ProjectName
                                                     </li>
                                                 }
-                                            </ul>
+                                            </ol>
                                         </section>
                                     }
                                 </article>

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -530,19 +530,17 @@
 .analytics-stage-board__category-dot--neutral { background: #9ca3af; }
 
 .analytics-stage-board__project-list {
-  margin: 0.35rem 0 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.18rem;
+  margin: 0.4rem 0 0;
+  padding-left: 1.2rem;
+  list-style: decimal;
 }
 
 .analytics-stage-board__project-item {
   font-size: 0.8rem;
   color: var(--pm-text, #111827);
-  line-height: 1.35;
+  line-height: 1.4;
   overflow-wrap: anywhere;
+  margin: 0.12rem 0;
 }
 /* END SECTION */
 

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -409,6 +409,28 @@ function buildCategoryColorMapping(stackedPoints) {
     rankedCategories
   };
 }
+
+// SECTION: Ongoing stage board color sync
+function applyStageBoardCategoryColors(categoryColorMap = new Map()) {
+  const categoryDots = document.querySelectorAll('.analytics-stage-board__category-dot[data-category-name]');
+  if (!categoryDots.length) {
+    return;
+  }
+
+  const palette = getPalette();
+  const neutralColor = palette.neutral ?? '#9ca3af';
+
+  categoryDots.forEach((dot) => {
+    if (!(dot instanceof HTMLElement)) {
+      return;
+    }
+
+    const categoryName = (dot.dataset.categoryName ?? '').trim();
+    const color = categoryColorMap.get(categoryName) ?? neutralColor;
+    dot.style.backgroundColor = color;
+  });
+}
+// END SECTION
 // END SECTION
 
 // SECTION: Stage axis helpers
@@ -877,6 +899,7 @@ function initOngoingAnalytics() {
 
   const stageSeries = stageCanvas ? parseSeries(stageCanvas) : [];
   const { categoryColorMap, rankedCategories } = buildCategoryColorMapping(stageSeries);
+  applyStageBoardCategoryColors(categoryColorMap);
 
   if (stageCanvas) {
     if (stageSeries.length) {


### PR DESCRIPTION
### Motivation

- Ensure the parent-category colour used in the stage drill-down board is the same single source-of-truth used by the stacked chart so markers never visually drift. 
- Improve readability of dense stage cards by rendering project names as numbered lists that restart per parent-category block.

### Description

- Removed the server-side color-class assignment in the ongoing stage-board Razor markup and added a neutral marker element with `data-category-name` to each category header, and changed project containers from `<ul>` to semantic `<ol><li>` so numbering restarts per category. 
- Added `applyStageBoardCategoryColors(categoryColorMap)` in `wwwroot/js/analytics-projects.js` which consumes the existing `buildCategoryColorMapping(...)` output and sets the stage-board marker `backgroundColor` inline for each `data-category-name`, and invoked it from `initOngoingAnalytics` so chart and board share the same mapping. 
- Updated `wwwroot/css/analytics.css` to style ordered project lists (decimal numbering, indentation, spacing and line-height) for compact, readable numbered lists; neutral fallback styling remains for unknown categories. 
- No data-model or analytics computation changes; this is a UI-only consistency and accessibility improvement and does not add inline scripts (CSP-friendly).

### Testing

- Attempted to run unit tests with `dotnet test --no-build`, but the runtime is not available in this environment and the command failed with `/bin/bash: dotnet: command not found`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6510746e48329834d49cb372e598a)