### PR TITLE
Reduce desktop height of "Ongoing projects by current stage" chart

### DIFF
--- a/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_OngoingAnalytics.cshtml
@@ -122,7 +122,7 @@
                     </div>
                 </header>
                 <div class="analytics-card__body">
-                    <div class="analytics-card__chart">
+                    <div class="analytics-card__chart analytics-card__chart--ongoing-stage">
                         <canvas id="ongoing-by-stage-chart"
                                 aria-label="Ongoing projects by current stage"
                                 role="img"

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -447,6 +447,14 @@
   padding: 1rem 1.25rem 1.5rem;
 }
 
+/* SECTION: Ongoing stage chart desktop height tuning */
+@media (min-width: 992px) {
+  .analytics-card__chart--ongoing-stage {
+    min-height: 210px;
+  }
+}
+/* END SECTION */
+
 /* SECTION: Stage delay hotspots card */
 .analytics-card--insights-hotspots .analytics-card__chart {
   min-height: 320px;


### PR DESCRIPTION
### Motivation

- Reduce the vertical height of the "Ongoing projects by current stage" chart on desktop so the drill-down board below is more visible while preserving all chart behaviour and data.

### Description

- Add a dedicated wrapper modifier class `analytics-card__chart--ongoing-stage` to the chart container in `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` so this chart can be sized independently.
- Add a desktop-only CSS rule in `wwwroot/css/analytics.css` (`@media (min-width: 992px)`) that sets `.analytics-card__chart--ongoing-stage { min-height: 210px; }` to moderately reduce the chart height while keeping responsiveness intact.
- No changes were made to chart data, chart type, scales, legend, filters, drill-down rendering logic, or chart initialization in JS.

### Testing

- Verified the new class is present and the CSS rule exists using `rg`/search of the modified files, which succeeded and showed the expected lines in `Pages/Analytics/Partials/_OngoingAnalytics.cshtml` and `wwwroot/css/analytics.css`.
- Confirmed the change is scoped to desktop via the `@media (min-width: 992px)` rule in `wwwroot/css/analytics.css` and did not modify any Chart.js options in `wwwroot/js/analytics-projects.js`.
- Attempted to run `dotnet build` but the environment lacks the `dotnet` tool so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e652b34ed483298a97c0e19c9f7d86)