### PR TITLE
Tighten ongoing-stage chart height and lighten stage-board cards

### DIFF
--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -450,7 +450,8 @@
 /* SECTION: Ongoing stage chart desktop height tuning */
 @media (min-width: 992px) {
   .analytics-card__chart--ongoing-stage {
-    min-height: 210px;
+    min-height: 198px;
+    padding: 0.85rem 1.1rem 1.35rem;
   }
 }
 /* END SECTION */
@@ -470,11 +471,11 @@
 .analytics-stage-board {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(260px, 320px);
-  gap: 0.85rem;
+  grid-auto-columns: minmax(280px, 340px);
+  gap: 0.9rem;
   width: 100%;
   overflow-x: auto;
-  padding: 0.1rem 0.1rem 0.4rem;
+  padding: 0.05rem 0.1rem 0.35rem;
 }
 
 .analytics-stage-board__empty {
@@ -482,13 +483,13 @@
 }
 
 .analytics-stage-board__stage-column {
-  background-color: var(--pm-page-bg);
-  border: 1px solid var(--pm-border);
+  background-color: rgba(248, 250, 252, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 0.8rem;
-  padding: 0.75rem;
+  padding: 0.68rem 0.72rem;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.58rem;
 }
 
 .analytics-stage-board__stage-title {
@@ -499,7 +500,7 @@
 }
 
 .analytics-stage-board__category-group {
-  padding-top: 0.55rem;
+  padding-top: 0.48rem;
   border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
@@ -510,12 +511,12 @@
 
 .analytics-stage-board__category-title {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: var(--pm-text-secondary);
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.34rem;
 }
 
 .analytics-stage-board__category-dot {
@@ -538,17 +539,17 @@
 .analytics-stage-board__category-dot--neutral { background: #9ca3af; }
 
 .analytics-stage-board__project-list {
-  margin: 0.4rem 0 0;
+  margin: 0.34rem 0 0;
   padding-left: 1.2rem;
   list-style: decimal;
 }
 
 .analytics-stage-board__project-item {
-  font-size: 0.8rem;
-  color: var(--pm-text, #111827);
-  line-height: 1.4;
+  font-size: 0.79rem;
+  color: rgba(17, 24, 39, 0.9);
+  line-height: 1.46;
   overflow-wrap: anywhere;
-  margin: 0.12rem 0;
+  margin: 0.14rem 0;
 }
 /* END SECTION */
 


### PR DESCRIPTION
### Motivation
- Final visual tuning for the "Ongoing projects by current stage" component to surface more board content in the first viewport while preserving chart readability. 
- Make stage-board columns slightly wider and stage cards visually lighter so long project names wrap less and dense lists breathe a bit more.

### Description
- Adjusted the desktop-only ongoing-stage chart rule to reduce `min-height` and slightly tighten internal padding in the `@media (min-width: 992px)` block for `.analytics-card__chart--ongoing-stage` in `wwwroot/css/analytics.css`.
- Increased stage-board column sizing from `minmax(260px, 320px)` to `minmax(280px, 340px)` and nudged the board gap/padding to improve horizontal density while keeping horizontal scrolling and column flow.
- Lightened stage-column appearance by softening background and border colors, reducing internal padding and column gap for `.analytics-stage-board__stage-column`.
- Tuned category and list typography/spacing (`.analytics-stage-board__category-*`, `.analytics-stage-board__project-list`, `.analytics-stage-board__project-item`) by small adjustments to font-size, line-height, margins, and spacing to improve scanability without increasing card height.

### Testing
- Ran `git status --short` and inspected the CSS diff via `git diff -- wwwroot/css/analytics.css` to confirm only `wwwroot/css/analytics.css` was modified and no JS/CSHTML or data logic files were changed, and the diff reflects the intended CSS tweaks. 
- Attempted `dotnet build` in this environment but it failed because the `dotnet` CLI is not available (`dotnet: command not found`), so a full build/test was not executed here.
- No automated visual/UI tests were available in this environment; changes are CSS-only and should be validated in a browser to confirm chart labels/legend/tooltips remain readable and the board layout behaves as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6552e15fc8329aa17efabebe0ee69)