### PR TITLE
Align remark default role priority to Commandant-first order and sync UI/tests

### DIFF
--- a/Features/Remarks/RemarkApi.cs
+++ b/Features/Remarks/RemarkApi.cs
@@ -533,14 +533,14 @@ internal static class RemarkApi
     {
         foreach (var candidate in new[]
                  {
-                     RemarkActorRole.ProjectOfficer,
-                     RemarkActorRole.HeadOfDepartment,
                      RemarkActorRole.Commandant,
-                     RemarkActorRole.Administrator,
+                     RemarkActorRole.HeadOfDepartment,
+                     RemarkActorRole.Mco,
+                     RemarkActorRole.ProjectOfficer,
+                     RemarkActorRole.Ta,
                      RemarkActorRole.ProjectOffice,
                      RemarkActorRole.MainOffice,
-                     RemarkActorRole.Mco,
-                     RemarkActorRole.Ta
+                     RemarkActorRole.Administrator
                  })
         {
             if (roles.Contains(candidate))

--- a/ProjectManagement.Tests/RemarkApiTests.cs
+++ b/ProjectManagement.Tests/RemarkApiTests.cs
@@ -72,6 +72,20 @@ public class RemarkApiTests
         }
     }
 
+    public static IEnumerable<object[]> DefaultRolePriorityCases
+    {
+        get
+        {
+            yield return new object[] { new[] { RemarkActorRole.Commandant, RemarkActorRole.HeadOfDepartment, RemarkActorRole.ProjectOfficer }, RemarkActorRole.Commandant };
+            yield return new object[] { new[] { RemarkActorRole.HeadOfDepartment, RemarkActorRole.ProjectOfficer }, RemarkActorRole.HeadOfDepartment };
+            yield return new object[] { new[] { RemarkActorRole.Mco, RemarkActorRole.ProjectOfficer }, RemarkActorRole.Mco };
+            yield return new object[] { new[] { RemarkActorRole.Ta, RemarkActorRole.ProjectOffice }, RemarkActorRole.Ta };
+            yield return new object[] { new[] { RemarkActorRole.MainOffice, RemarkActorRole.ProjectOffice }, RemarkActorRole.ProjectOffice };
+            yield return new object[] { new[] { RemarkActorRole.Administrator }, RemarkActorRole.Administrator };
+            yield return new object[] { new[] { RemarkActorRole.Administrator, RemarkActorRole.ProjectOfficer }, RemarkActorRole.ProjectOfficer };
+        }
+    }
+
     [Fact]
     public async Task CreateAndListRemarksAsync_Succeeds()
     {
@@ -212,6 +226,34 @@ public class RemarkApiTests
         Assert.Equal(RemarkActorRole.HeadOfDepartment, list.Items[0].AuthorRole);
         Assert.Equal("hod-fallback", list.Items[0].AuthorUserId);
         Assert.Equal(RemarkScope.General, list.Items[0].Scope);
+    }
+
+    [Theory]
+    [MemberData(nameof(DefaultRolePriorityCases))]
+    public async Task CreateRemarkAsync_WithoutActorRole_UsesExpectedDefaultPriority(RemarkActorRole[] availableRoles, RemarkActorRole expectedRole)
+    {
+        using var factory = new RemarkApiFactory();
+        var projectId = 9700 + (int)expectedRole + availableRoles.Length;
+        var userId = $"priority-{projectId}";
+        var roleNames = availableRoles.Select(role => role.ToString()).ToArray();
+        var client = await CreateClientForUserAsync(factory, userId, $"Priority {projectId}", roleNames);
+        var leadPoUserId = availableRoles.Contains(RemarkActorRole.ProjectOfficer) ? userId : "po-owner";
+        var hodUserId = availableRoles.Contains(RemarkActorRole.HeadOfDepartment) ? userId : null;
+        await SeedProjectAsync(factory, projectId, leadPoUserId, hodUserId);
+
+        var createResponse = await client.PostAsJsonAsync($"/api/projects/{projectId}/remarks", new
+        {
+            type = RemarkType.Internal,
+            scope = RemarkScope.General,
+            body = $"Priority check for {string.Join(", ", roleNames)}",
+            eventDate = DateOnly.FromDateTime(DateTime.UtcNow.Date),
+            stageRef = StageCodes.FS
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await createResponse.Content.ReadFromJsonAsync<RemarkResponseDto>(SerializerOptions);
+        Assert.NotNull(created);
+        Assert.Equal(expectedRole, created!.AuthorRole);
     }
 
     [Fact]

--- a/Services/Projects/ProjectRemarksPanelService.cs
+++ b/Services/Projects/ProjectRemarksPanelService.cs
@@ -273,14 +273,14 @@ public sealed class ProjectRemarksPanelService
     {
         foreach (var candidate in new[]
                  {
-                     RemarkActorRole.ProjectOfficer,
-                     RemarkActorRole.HeadOfDepartment,
                      RemarkActorRole.Commandant,
-                     RemarkActorRole.Administrator,
+                     RemarkActorRole.HeadOfDepartment,
+                     RemarkActorRole.Mco,
+                     RemarkActorRole.ProjectOfficer,
+                     RemarkActorRole.Ta,
                      RemarkActorRole.ProjectOffice,
                      RemarkActorRole.MainOffice,
-                     RemarkActorRole.Mco,
-                     RemarkActorRole.Ta
+                     RemarkActorRole.Administrator
                  })
         {
             if (roles.Contains(candidate))


### PR DESCRIPTION
### Motivation
- The default fallback selection for remark `AuthorRole` currently uses an order that does not match the requested business priority and produces inconsistent behaviour between backend and UI. 
- The desired business priority is `Commandant → HeadOfDepartment → Mco → ProjectOfficer → Ta → ProjectOffice → MainOffice` with `Administrator` only as a last-resort fallback. 
- Explicitly-requested actor roles must still win and existing enums/permissions must remain unchanged. 

### Description
- Changed the backend fallback selection order in `Features/Remarks/RemarkApi.cs` by updating `SelectDefaultRole(...)` to the new priority and placing `Administrator` last. 
- Updated the UI-side ordering in `Services/Projects/ProjectRemarksPanelService.cs` by aligning `SelectDefaultRemarkRole(...)` to the same ordering for consistent display and default behaviour. 
- Added automated tests in `ProjectManagement.Tests/RemarkApiTests.cs` (`DefaultRolePriorityCases` data and the theory `CreateRemarkAsync_WithoutActorRole_UsesExpectedDefaultPriority`) to assert the new fallback selection for multiple role combinations. 

### Testing
- Added unit test coverage for the default-priority behaviour covering the minimum cases (Comdt over HoD/PO, HoD over PO, MCO over PO, TA over ProjectOffice, ProjectOffice over MainOffice, Administrator-only fallback, and Administrator vs ProjectOfficer). 
- Attempted to run the targeted test run for the new theory (`CreateRemarkAsync_WithoutActorRole_UsesExpectedDefaultPriority`), but test execution could not be performed in this environment because `dotnet` is not installed. 
- Please run the test suite in CI or a local dev environment (`dotnet test`) to validate the new tests and confirm no regressions before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65da1c49c832994e3e41ba9075d5f)