### PR TITLE
Align photo endpoint access with project visibility

### DIFF
--- a/Pages/Projects/Photos/View.cshtml.cs
+++ b/Pages/Projects/Photos/View.cshtml.cs
@@ -39,19 +39,14 @@ public class ViewModel : PageModel
             return NotFound();
         }
 
-        var userId = _userContext.UserId;
-        if (string.IsNullOrEmpty(userId))
-        {
-            return Challenge();
-        }
-
         var project = await _db.Projects.SingleOrDefaultAsync(p => p.Id == id, cancellationToken);
         if (project is null)
         {
             return NotFound();
         }
 
-        if (!ProjectAccessGuard.CanViewProject(project, _userContext.User, userId))
+        // SECTION: Photo visibility follows project information visibility
+        if (!ProjectAccessGuard.CanViewProjectInformation(project, _userContext.User))
         {
             return Forbid();
         }

--- a/Services/Projects/ProjectAccessGuard.cs
+++ b/Services/Projects/ProjectAccessGuard.cs
@@ -6,6 +6,23 @@ namespace ProjectManagement.Services.Projects;
 
 public static class ProjectAccessGuard
 {
+    // SECTION: Project information visibility
+    public static bool CanViewProjectInformation(Project project, ClaimsPrincipal principal)
+    {
+        if (project is null)
+        {
+            throw new ArgumentNullException(nameof(project));
+        }
+
+        if (principal is null)
+        {
+            throw new ArgumentNullException(nameof(principal));
+        }
+
+        return principal.Identity?.IsAuthenticated == true;
+    }
+
+    // SECTION: Restricted project asset visibility and management roles
     public static bool CanViewProject(Project project, ClaimsPrincipal principal, string? userId)
     {
         if (project is null)


### PR DESCRIPTION
### Motivation
- Ensure project thumbnails and cover photos are visible under the same project-visibility rules as other project information while keeping photo management actions restricted to existing roles.

### Description
- Added `ProjectAccessGuard.CanViewProjectInformation(Project, ClaimsPrincipal)` and updated `Pages/Projects/Photos/View.cshtml.cs` to use this helper for photo delivery so photo visibility follows project information visibility, and left the existing role-based `CanViewProject(...)` unchanged for management/restricted checks.

### Testing
- Attempted to run a build with `dotnet build` but the `dotnet` CLI is not available in the execution environment so compilation could not be validated; no automated tests were run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e660f3a4b883299e164ffa8a9035fe)