### PR TITLE
Preserve user-entered new lines in project remark displays

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -4566,9 +4566,11 @@ summary::marker {
 }
 
 .remarks-body {
+    /* --- SECTION: Preserve user-entered remark line breaks --- */
     font-size: var(--pm-font-size-comfortable);
     line-height: 1.45;
     word-break: break-word;
+    white-space: pre-line;
 }
 
 .remarks-body .remark-mention,
@@ -6834,6 +6836,12 @@ body.has-project-photo-preview-dialog {
 
 .ongoing-remarks__body {
     font-size: .78rem;
+    white-space: pre-line;
+}
+
+/* --- SECTION: Preserve line breaks in ongoing table latest remark previews --- */
+.pm-remark-text {
+    white-space: pre-line;
 }
 
 /* mention pill */


### PR DESCRIPTION
### Motivation
- Remarks entered in textareas were rendered with collapsed line breaks, reducing readability and losing user-entered structure; the goal is to preserve newline characters at the display layer without enabling raw HTML rendering.

### Description
- Updated `wwwroot/css/site.css` to add `white-space: pre-line;` to `.remarks-body` so remark text preserves newline characters while remaining plain text.
- Added `white-space: pre-line;` to `.ongoing-remarks__body` to preserve line breaks in the ongoing-projects remarks list.
- Added a `.pm-remark-text` rule with `white-space: pre-line;` to preserve new lines in remark previews shown in table/card surfaces.
- No changes were made to remark storage or HTML encoding; this is a display-only CSS fix.

### Testing
- Attempted to run a project build with `dotnet build ProjectManagement.sln`, but the environment does not have the `dotnet` CLI installed so the build could not be executed (automated validation unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d34e7d4c8329a704949f2e4ac049)