### PR TITLE
Redesign ongoing project card remarks into compact 70:30 two-column summary

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -540,39 +540,110 @@ else
                         </div>
 
                         <!-- SECTION: Remarks -->
-                        <section class="ongoing-remarks border-top">
-                            <div class="d-flex justify-content-between align-items-center mb-2">
-                                <span class="ongoing-remarks__title">Recent internal remarks (last 10 days)</span>
-                                @if (!string.IsNullOrWhiteSpace(item.LatestExternalRemark?.Body))
+                        <section class="ongoing-remarks border-top"
+                                 data-remarks-panel
+                                 data-expanded="0">
+                            @{
+                                // SECTION: Remarks preview settings
+                                const int collapsedInternalCount = 2;
+                                var internalRemarksCollapsed = item.RecentInternalRemarks.Take(collapsedInternalCount).ToList();
+                                var internalRemarksExpandedOnly = item.RecentInternalRemarks.Skip(collapsedInternalCount).ToList();
+                                var hasExpandableInternalRemarks = internalRemarksExpandedOnly.Count > 0;
+                                var latestExternalRemark = item.LatestExternalRemark;
+                                var hasExternalRemark = !string.IsNullOrWhiteSpace(latestExternalRemark?.Body);
+                            }
+
+                            <!-- SECTION: Remarks panel heading and toggle -->
+                            <div class="ongoing-remarks__header">
+                                <span class="ongoing-remarks__title">Remarks summary</span>
+                                @if (hasExpandableInternalRemarks)
                                 {
-                                    <span class="oc-pill oc-pill--neutral">has external note</span>
+                                    <button type="button"
+                                            class="ongoing-remarks__toggle btn btn-sm btn-link p-0 text-decoration-none"
+                                            data-remarks-toggle
+                                            aria-expanded="false">
+                                        <span data-remarks-toggle-label>Expand remarks</span>
+                                    </button>
                                 }
                             </div>
 
-                            @if (item.RecentInternalRemarks.Count == 0)
-                            {
-                                <p class="small text-muted mb-0">No internal remarks in the last 10 days.</p>
-                            }
-                            else
-                            {
-                                <ul class="ongoing-remarks__list">
-                                    @foreach (var r in item.RecentInternalRemarks)
+                            <!-- SECTION: Remarks two-column summary -->
+                            <div class="ongoing-remarks__summary">
+                                <!-- SECTION: Internal remarks (70%) -->
+                                <div class="ongoing-remarks__column ongoing-remarks__column--internal">
+                                    <h3 class="ongoing-remarks__column-title">Recent internal remarks (last 10 days)</h3>
+                                    @if (item.RecentInternalRemarks.Count == 0)
                                     {
-                                        <li class="ongoing-remarks__item">
-                                            <div class="ongoing-remarks__meta">
-                                                @r.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")
-                                                @if (r.ActorRole != RemarkActorRole.Unknown)
-                                                {
-                                                    @: • @r.ActorRole
-                                                }
-                                            </div>
-                                            <div class="ongoing-remarks__body">
-                                                @Html.Raw(RenderRemark(r.Text))
-                                            </div>
-                                        </li>
+                                        <p class="small text-muted mb-0">No internal remarks in the last 10 days.</p>
                                     }
-                                </ul>
-                            }
+                                    else
+                                    {
+                                        <ul class="ongoing-remarks__list">
+                                            @foreach (var r in internalRemarksCollapsed)
+                                            {
+                                                <li class="ongoing-remarks__item">
+                                                    <div class="ongoing-remarks__meta">
+                                                        @r.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")
+                                                        @if (r.ActorRole != RemarkActorRole.Unknown)
+                                                        {
+                                                            @: • @r.ActorRole
+                                                        }
+                                                    </div>
+                                                    <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
+                                                        @Html.Raw(RenderRemark(r.Text))
+                                                    </div>
+                                                </li>
+                                            }
+                                        </ul>
+
+                                        @if (hasExpandableInternalRemarks)
+                                        {
+                                            <ul class="ongoing-remarks__list ongoing-remarks__list--expanded" data-remarks-expanded-list hidden>
+                                                @foreach (var r in internalRemarksExpandedOnly)
+                                                {
+                                                    <li class="ongoing-remarks__item">
+                                                        <div class="ongoing-remarks__meta">
+                                                            @r.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")
+                                                            @if (r.ActorRole != RemarkActorRole.Unknown)
+                                                            {
+                                                                @: • @r.ActorRole
+                                                            }
+                                                        </div>
+                                                        <div class="ongoing-remarks__body">
+                                                            @Html.Raw(RenderRemark(r.Text))
+                                                        </div>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
+                                    }
+                                </div>
+
+                                <!-- SECTION: Latest external remark (30%) -->
+                                <div class="ongoing-remarks__column ongoing-remarks__column--external">
+                                    <h3 class="ongoing-remarks__column-title">Latest external remark</h3>
+                                    @if (!hasExternalRemark)
+                                    {
+                                        <p class="small text-muted mb-0">No external remarks.</p>
+                                    }
+                                    else
+                                    {
+                                        <article class="ongoing-remarks__item">
+                                            <div class="ongoing-remarks__meta">
+                                                @latestExternalRemark!.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")
+                                                @if (latestExternalRemark.ActorRole != RemarkActorRole.Unknown)
+                                                {
+                                                    @: • @latestExternalRemark.ActorRole
+                                                }
+                                                @: • Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")
+                                            </div>
+                                            <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
+                                                @Html.Raw(RenderRemark(latestExternalRemark.Body))
+                                            </div>
+                                        </article>
+                                    }
+                                </div>
+                            </div>
                         </section>
                     </div>
                 </article>

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -383,6 +383,8 @@ namespace ProjectManagement.Services.Projects
                     {
                         Id = latestExternal.Id,
                         Body = latestExternal.Body,
+                        CreatedAtUtc = latestExternal.CreatedAtUtc,
+                        ActorRole = latestExternal.AuthorRole,
                         EventDate = latestExternal.EventDate,
                         Scope = latestExternal.Scope,
                         RowVersion = latestExternal.RowVersion is { Length: > 0 } rowVersion
@@ -565,6 +567,8 @@ namespace ProjectManagement.Services.Projects
     {
         public int Id { get; init; }
         public string Body { get; init; } = "";
+        public DateTime CreatedAtUtc { get; init; }
+        public RemarkActorRole ActorRole { get; init; }
         public DateOnly EventDate { get; init; }
         public RemarkScope Scope { get; init; } = RemarkScope.General;
         public string RowVersion { get; init; } = "";

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -6807,10 +6807,49 @@ body.has-project-photo-preview-dialog {
 
 .ongoing-remarks {
     padding: 0.75rem 1.25rem 1.25rem 1.25rem;
+    background: var(--pm-card);
+}
+
+.ongoing-remarks__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    margin-bottom: .55rem;
 }
 
 .ongoing-remarks__title {
     font-size: .65rem;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+    color: #6c757d;
+}
+
+.ongoing-remarks__toggle {
+    font-size: .72rem;
+    font-weight: 500;
+    color: var(--pm-primary);
+}
+
+.ongoing-remarks__summary {
+    display: grid;
+    grid-template-columns: minmax(0, 7fr) minmax(0, 3fr);
+    gap: 1rem;
+}
+
+.ongoing-remarks__column {
+    min-width: 0;
+}
+
+.ongoing-remarks__column--external {
+    border-left: 1px solid var(--pm-border-subtle);
+    padding-left: 1rem;
+}
+
+.ongoing-remarks__column-title {
+    margin: 0 0 .45rem 0;
+    font-size: .68rem;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: .03em;
     color: #6c757d;
@@ -6824,8 +6863,12 @@ body.has-project-photo-preview-dialog {
     gap: .5rem;
 }
 
+.ongoing-remarks__list--expanded {
+    margin-top: .5rem;
+}
+
 .ongoing-remarks__item {
-    background: #fff;
+    background: transparent;
 }
 
 .ongoing-remarks__meta {
@@ -6837,6 +6880,28 @@ body.has-project-photo-preview-dialog {
 .ongoing-remarks__body {
     font-size: .78rem;
     white-space: pre-line;
+    line-height: 1.35;
+}
+
+.ongoing-remarks__body--collapsed {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+}
+
+@media (max-width: 991.98px) {
+    .ongoing-remarks__summary {
+        grid-template-columns: 1fr;
+    }
+
+    .ongoing-remarks__column--external {
+        border-left: 0;
+        border-top: 1px solid var(--pm-border-subtle);
+        padding-left: 0;
+        padding-top: .75rem;
+    }
 }
 
 /* --- SECTION: Preserve line breaks in ongoing table latest remark previews --- */

--- a/wwwroot/js/projects/ongoing.js
+++ b/wwwroot/js/projects/ongoing.js
@@ -44,4 +44,27 @@
       submitFilters();
     }
   });
+
+  // SECTION: Per-card remarks expand/collapse
+  const remarkPanels = document.querySelectorAll('[data-remarks-panel]');
+
+  remarkPanels.forEach((panel) => {
+    const toggleButton = panel.querySelector('[data-remarks-toggle]');
+    const expandedList = panel.querySelector('[data-remarks-expanded-list]');
+    const toggleLabel = panel.querySelector('[data-remarks-toggle-label]');
+
+    if (!toggleButton || !expandedList || !toggleLabel) {
+      return;
+    }
+
+    toggleButton.addEventListener('click', () => {
+      const isExpanded = panel.dataset.expanded === '1';
+      const nextExpanded = !isExpanded;
+
+      panel.dataset.expanded = nextExpanded ? '1' : '0';
+      expandedList.hidden = !nextExpanded;
+      toggleButton.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+      toggleLabel.textContent = nextExpanded ? 'Collapse remarks' : 'Expand remarks';
+    });
+  });
 })();


### PR DESCRIPTION
### Motivation

- Make the Ongoing project card remarks area more structured and scannable by surfacing recent internal remarks and the latest external remark side-by-side instead of a detached `has external note` pill. 
- Reduce vertical weight on cards by showing a compact preview by default and allowing per-card expand/collapse to reveal more internal remarks. 
- Preserve existing remark semantics (line breaks, timestamps, roles) while improving visual hierarchy and responsiveness.

### Description

- Replaced the single full-width remarks block with a two-column 70:30 remarks summary in `Pages/Projects/Ongoing/Index.cshtml`, showing up to 2 internal remarks collapsed and the latest external remark in the companion column. 
- Extended the DTO and service mapping in `Services/Projects/OngoingProjectsReadService.cs` to include `CreatedAtUtc` and `ActorRole` on `OngoingProjectExternalRemarkDto` so the external column can render metadata, not just a presence flag. 
- Added CSS for the new layout, compact headings, collapsed preview clamping and responsive stacking in `wwwroot/css/site.css`. 
- Implemented a per-card, unobtrusive expand/collapse toggle using data attributes and ARIA state in `wwwroot/js/projects/ongoing.js` (no inline scripts; CSP-safe). 

### Testing

- Attempted to run a full build with `dotnet build`, but the SDK is not available in this environment so the build could not be executed (`/bin/bash: dotnet: command not found`).
- No automated unit or integration tests were run in this session due to the missing .NET toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d9a5a98c8329aed3e44d4fa4893a)