### PR TITLE
Fix Razor parsing error in Ongoing Projects Index view

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -635,7 +635,7 @@ else
                                                 {
                                                     @: • @latestExternalRemark.ActorRole
                                                 }
-                                                @: • Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")
+                                                <span>• Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")</span>
                                             </div>
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
                                                 @Html.Raw(RenderRemark(latestExternalRemark.Body))


### PR DESCRIPTION
### Motivation
- A Razor inline-text transition (`@:`) was used outside a code block in `Pages/Projects/Ongoing/Index.cshtml`, which caused the Razor parser error `RZ1005` and a downstream generated-file compile error (`CS1501`).

### Description
- Replaced the invalid inline Razor transition line with standard markup by changing `@: • Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")` to `<span>• Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")</span>` in `Pages/Projects/Ongoing/Index.cshtml` so the event date renders correctly without Razor syntax errors.

### Testing
- Attempted to run `dotnet build -c Release` but the environment does not have the .NET CLI installed, so a full build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ddf8c3308329896e662a712888cc)