### PR TITLE
Add per-project movement board to Progress Review

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -57,6 +57,25 @@
             "/Activities/ViewPhoto",
             new { area = "ProjectOfficeReports", id = activityId, photoId = photoId.Value, size = "thumb" });
     }
+
+    string MovementStageTone(string stageCode) => (stageCode ?? string.Empty).Trim().ToUpperInvariant() switch
+    {
+        "FS" => "is-fs",
+        "SOW" => "is-sow",
+        "IPA" => "is-ipa",
+        "AON" => "is-aon",
+        "BID" => "is-bid",
+        "BM" => "is-bm",
+        "TEC" => "is-tec",
+        "COB" => "is-cob",
+        "PNC" => "is-pnc",
+        "EAS" => "is-eas",
+        "SO" => "is-so",
+        "DEVP" => "is-devp",
+        "ATP" => "is-atp",
+        "PAYMENT" => "is-payment",
+        _ => "is-default"
+    };
 }
 
 @section Styles {
@@ -155,37 +174,86 @@
                             </section>
                         }
 
-                        @* SECTION: Projects advanced in this period *@
-                        <section class="pr-advanced-list" aria-label="Projects advanced in this period">
-                            <h3 class="h6 mb-2">Projects advanced in this period</h3>
-                            @if (!vm.Projects.Review.Advanced.Any())
+                        @* SECTION: Project movement in this period *@
+                        <section class="pr-movement-board" aria-label="Project movement in this period">
+                            <div class="pr-movement-board__header">
+                                <div>
+                                    <h3 class="h6 mb-1">Project movement in this period</h3>
+                                    <p class="pr-meta mb-0">
+                                        Projects that moved from one stage to another between
+                                        @vm.Range.From.ToString("dd MMM yyyy") and @vm.Range.To.ToString("dd MMM yyyy").
+                                    </p>
+                                </div>
+                                <div class="pr-movement-board__count">@vm.Projects.MovementBoard.TotalMovedProjects moved projects</div>
+                            </div>
+
+                            @if (!vm.Projects.MovementBoard.Rows.Any())
                             {
                                 <p class="pr-meta mb-0">No projects recorded formal stage advancement in this period.</p>
                             }
                             else
                             {
-                                @foreach (var row in vm.Projects.Review.Advanced)
-                                {
-                                    var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
-                                    <article class="pr-advanced-row">
-                                        <div class="pr-advanced-row__head">
-                                            <a class="progress-review__link pr-project-name" href="@projectDetailsUrl">@row.ProjectName</a>
-                                            @if (!string.IsNullOrWhiteSpace(row.ProjectCategoryName))
-                                            {
-                                                <span class="pr-meta">@row.ProjectCategoryName</span>
-                                            }
-                                        </div>
-                                        <div class="pr-advanced-row__path">@row.MovementPathText</div>
-                                        <div class="pr-advanced-row__meta">
-                                            Present stage: @(string.IsNullOrWhiteSpace(row.PresentStage.CurrentStageName) ? "Stage pending" : row.PresentStage.CurrentStageName)
-                                            · Movement events: @row.MovementCountInRange
-                                        </div>
-                                        @if (!string.IsNullOrWhiteSpace(row.RemarkSummary.LatestRemarkSummary))
-                                        {
-                                            <div class="pr-advanced-row__remark">@row.RemarkSummary.LatestRemarkSummary</div>
-                                        }
-                                    </article>
-                                }
+                                <div class="pr-movement-table">
+                                    <div class="pr-movement-table__head">
+                                        <div>Project</div>
+                                        <div>Category</div>
+                                        <div>Stage movement during period</div>
+                                        <div>Moves</div>
+                                        <div>First movement</div>
+                                        <div>Current stage</div>
+                                    </div>
+
+                                    @foreach (var row in vm.Projects.MovementBoard.Rows)
+                                    {
+                                        var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = row.ProjectId });
+                                        <article class="pr-movement-table__row">
+                                            <div class="pr-movement-table__project">
+                                                <a class="progress-review__link pr-project-name" href="@projectDetailsUrl">@row.ProjectName</a>
+                                            </div>
+
+                                            <div class="pr-movement-table__category">
+                                                @(string.IsNullOrWhiteSpace(row.ProjectCategoryName) ? "—" : row.ProjectCategoryName)
+                                            </div>
+
+                                            <div class="pr-movement-table__path">
+                                                <div class="pr-stage-flow">
+                                                    @for (var i = 0; i < row.Steps.Count; i++)
+                                                    {
+                                                        var step = row.Steps[i];
+                                                        <div class="pr-stage-flow__step">
+                                                            <span class="pr-stage-chip @MovementStageTone(step.StageCode) @(step.IsTerminal ? "is-terminal" : "")">
+                                                                @step.StageCode
+                                                            </span>
+                                                            <span class="pr-stage-flow__date">
+                                                                @(step.EventDate.HasValue ? FormatDay(step.EventDate.Value) : "—")
+                                                            </span>
+                                                        </div>
+
+                                                        @if (i < row.Steps.Count - 1)
+                                                        {
+                                                            <span class="pr-stage-flow__arrow" aria-hidden="true">→</span>
+                                                        }
+                                                    }
+                                                </div>
+                                            </div>
+
+                                            <div class="pr-movement-table__moves">@row.MovementCount</div>
+                                            <div class="pr-movement-table__first">
+                                                @(row.FirstMovementDate.HasValue ? row.FirstMovementDate.Value.ToString("dd MMM yyyy") : "—")
+                                            </div>
+                                            <div class="pr-movement-table__current">
+                                                @if (string.IsNullOrWhiteSpace(row.CurrentStageName))
+                                                {
+                                                    <span class="pr-stage-badge">Stage pending</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="pr-stage-badge">@row.CurrentStageName</span>
+                                                }
+                                            </div>
+                                        </article>
+                                    }
+                                </div>
                             }
                         </section>
 

--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -40,7 +40,8 @@ public sealed record ProjectSectionVm(
     IReadOnlyList<ProjectNonMoverVm> NonMovers,
     IReadOnlyList<ProjectProgressRowVm> SummaryRows,
     IReadOnlyList<ProjectCategoryGroupVm> CategoryGroups,
-    ProjectReviewBucketsVm Review
+    ProjectReviewBucketsVm Review,
+    ProjectMovementBoardVm MovementBoard
 );
 
 public sealed record ProjectStageChangeVm(
@@ -137,12 +138,35 @@ public sealed record ProjectReviewBucketsVm(
     IReadOnlyList<ProjectReviewRowVm> ActiveWithoutAdvancement,
     IReadOnlyList<ProjectReviewRowVm> Attention
 );
+
+public sealed record ProjectMovementBoardVm(
+    IReadOnlyList<ProjectMovementRowVm> Rows,
+    int TotalMovedProjects
+);
+
+public sealed record ProjectMovementRowVm(
+    int ProjectId,
+    string ProjectName,
+    string? ProjectCategoryName,
+    IReadOnlyList<ProjectMovementStepVm> Steps,
+    int MovementCount,
+    DateOnly? FirstMovementDate,
+    string? CurrentStageName
+);
+
+public sealed record ProjectMovementStepVm(
+    string StageCode,
+    string StageName,
+    DateOnly? EventDate,
+    bool IsTerminal
+);
 public sealed record ProjectCategoryGroupVm(
     string CategoryName,
     IReadOnlyList<ProjectProgressRowVm> Projects
 );
 
 public sealed record ProjectStageMovementVm(
+    string StageCode,
     string StageName,
     bool IsOngoing,
     DateOnly? StartedOn,

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -91,6 +91,7 @@ public sealed class ProgressReviewService : IProgressReviewService
             projectCategoryLookup,
             from,
             to);
+        var projectMovementBoard = BuildProjectMovementBoard(projectReviewBuckets.Advanced);
         var projectCategoryGroups = projectSummaryRows
             .GroupBy(row => string.IsNullOrWhiteSpace(row.ProjectCategoryName) ? "Uncategorised" : row.ProjectCategoryName)
             .OrderBy(group => group.Key)
@@ -144,7 +145,14 @@ public sealed class ProgressReviewService : IProgressReviewService
 
         return new ProgressReviewVm(
             Range: new RangeVm(from, to),
-            Projects: new ProjectSectionVm(projectFrontRunners, projectRemarksOnly, projectNonMovers, projectSummaryRows, projectCategoryGroups, projectReviewBuckets),
+            Projects: new ProjectSectionVm(
+                projectFrontRunners,
+                projectRemarksOnly,
+                projectNonMovers,
+                projectSummaryRows,
+                projectCategoryGroups,
+                projectReviewBuckets,
+                projectMovementBoard),
             Visits: visits,
             SocialMedia: socialMedia,
             Tot: new TotSectionVm(totStage, totRemarks),
@@ -1339,6 +1347,51 @@ public sealed class ProgressReviewService : IProgressReviewService
         }
     }
 
+    // -----------------------------------------------------------------
+    // SECTION: Project movement board helpers
+    // -----------------------------------------------------------------
+    private static ProjectMovementBoardVm BuildProjectMovementBoard(
+        IReadOnlyList<ProjectReviewRowVm> advancedRows)
+    {
+        var rows = advancedRows
+            .Select(row =>
+            {
+                var orderedSteps = row.StageMovements
+                    .OrderBy(m => GetMovementEventDate(m))
+                    .ThenBy(m => m.StageName, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                var movementSteps = orderedSteps
+                    .Select((movement, index) => new ProjectMovementStepVm(
+                        movement.StageCode,
+                        movement.StageName,
+                        GetMovementEventDate(movement),
+                        index == orderedSteps.Count - 1))
+                    .ToList();
+
+                var firstMovementDate = movementSteps
+                    .Select(step => step.EventDate)
+                    .Where(date => date.HasValue)
+                    .OrderBy(date => date)
+                    .FirstOrDefault();
+
+                return new ProjectMovementRowVm(
+                    row.ProjectId,
+                    row.ProjectName,
+                    row.ProjectCategoryName,
+                    movementSteps,
+                    row.MovementCountInRange,
+                    firstMovementDate,
+                    row.PresentStage.CurrentStageName);
+            })
+            .OrderByDescending(r => r.MovementCount)
+            .ThenByDescending(r => r.FirstMovementDate)
+            .ThenBy(r => r.ProjectName)
+            .ToList();
+
+        return new ProjectMovementBoardVm(rows, rows.Count);
+    }
+
     private async Task<IReadOnlyDictionary<int, PresentStageSnapshot>> BuildPresentStageLookupAsync(
         IReadOnlyCollection<int> projectIds,
         CancellationToken cancellationToken)
@@ -1422,6 +1475,7 @@ public sealed class ProgressReviewService : IProgressReviewService
             if (change.ToCompletedOn.HasValue && change.ToCompletedOn.Value >= rangeFrom && change.ToCompletedOn.Value <= rangeTo)
             {
                 AppendMovement(change.ProjectId, new ProjectStageMovementVm(
+                    change.StageCode,
                     change.StageName,
                     false,
                     null,
@@ -1443,6 +1497,7 @@ public sealed class ProgressReviewService : IProgressReviewService
             }
 
             AppendMovement(projectId, new ProjectStageMovementVm(
+                snapshot.CurrentStageCode ?? string.Empty,
                 snapshot.CurrentStageName ?? "Stage update",
                 true,
                 snapshot.CurrentStageStartDate,

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -495,7 +495,6 @@
 .pr-review-band__insight { margin: 0.75rem 0 0; font-size: 0.88rem; }
 
 .pr-highlights,
-.pr-advanced-list,
 .pr-activity-table,
 .pr-attention-table {
     border: 1px solid var(--pm-surface-silver);
@@ -508,23 +507,178 @@
 .pr-highlight-list { display: grid; gap: 0.45rem; }
 .pr-highlight-item { font-size: 0.88rem; }
 
-.pr-advanced-list { display: grid; gap: 0.55rem; }
-.pr-advanced-row {
-    border: 1px solid var(--pm-surface-ice);
-    border-radius: 10px;
-    padding: 0.55rem 0.65rem;
+/* =========================================================
+   SECTION: Project movement board
+   ========================================================= */
+
+.pr-movement-board {
+    background: var(--pm-card);
+    border: 1px solid var(--pr-border);
+    border-radius: 0.95rem;
+    padding: 1rem 1.1rem 1.15rem;
+    margin-top: 0.8rem;
 }
 
-.pr-advanced-row__head {
+.pr-movement-board__header {
     display: flex;
+    align-items: flex-start;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 0.75rem;
+    gap: 1rem;
+    margin-bottom: 0.9rem;
 }
 
-.pr-advanced-row__path { font-size: 0.9rem; margin-top: 0.25rem; }
-.pr-advanced-row__meta { font-size: 0.8rem; color: var(--pr-muted); margin-top: 0.25rem; }
-.pr-advanced-row__remark { font-size: 0.82rem; margin-top: 0.3rem; color: var(--pm-text); }
+.pr-movement-board__count {
+    font-size: 0.84rem;
+    color: var(--pr-muted);
+    white-space: nowrap;
+}
+
+.pr-movement-table {
+    border: 1px solid var(--pm-surface-ice);
+    border-radius: 0.85rem;
+    overflow: hidden;
+    background: #fff;
+}
+
+.pr-movement-table__head,
+.pr-movement-table__row {
+    display: grid;
+    grid-template-columns: minmax(220px, 1.4fr) minmax(120px, 0.7fr) minmax(440px, 2.8fr) 72px 120px 160px;
+    align-items: start;
+    gap: 0.85rem;
+}
+
+.pr-movement-table__head {
+    background: var(--pm-surface-mist);
+    border-bottom: 1px solid var(--pm-surface-ice);
+    padding: 0.85rem 1rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--pm-text-gray-soft);
+}
+
+.pr-movement-table__row {
+    padding: 0.95rem 1rem;
+    border-top: 1px solid var(--pm-surface-ice);
+}
+
+.pr-movement-table__row:first-of-type {
+    border-top: none;
+}
+
+.pr-movement-table__project,
+.pr-movement-table__category,
+.pr-movement-table__moves,
+.pr-movement-table__first,
+.pr-movement-table__current {
+    padding-top: 0.15rem;
+}
+
+.pr-movement-table__category,
+.pr-movement-table__moves,
+.pr-movement-table__first {
+    font-size: 0.86rem;
+    color: var(--pm-text-secondary);
+}
+
+.pr-stage-flow {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.pr-stage-flow__step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.28rem;
+    min-width: 58px;
+}
+
+.pr-stage-flow__arrow {
+    color: #6c757d;
+    font-size: 1.05rem;
+    line-height: 1;
+    padding-top: 0.4rem;
+}
+
+.pr-stage-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 54px;
+    padding: 0.28rem 0.7rem;
+    border-radius: 0.7rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    border: 1px solid transparent;
+    background: var(--pm-surface-mist);
+    color: var(--pm-text-contrast);
+}
+
+.pr-stage-chip.is-terminal {
+    box-shadow: 0 0 0 1px rgba(31, 41, 55, 0.06), 0 4px 10px rgba(15, 30, 65, 0.06);
+}
+
+.pr-stage-chip.is-fs,
+.pr-stage-chip.is-sow,
+.pr-stage-chip.is-ipa,
+.pr-stage-chip.is-aon {
+    background: #e8f5e9;
+    color: #2f6b39;
+}
+
+.pr-stage-chip.is-bid,
+.pr-stage-chip.is-bm,
+.pr-stage-chip.is-tec,
+.pr-stage-chip.is-cob,
+.pr-stage-chip.is-pnc,
+.pr-stage-chip.is-eas,
+.pr-stage-chip.is-so {
+    background: #e8f0fe;
+    color: #2754c5;
+}
+
+.pr-stage-chip.is-devp,
+.pr-stage-chip.is-atp,
+.pr-stage-chip.is-payment {
+    background: #efe7fb;
+    color: #6b46c1;
+}
+
+.pr-stage-chip.is-default {
+    background: var(--pm-surface-mist);
+    color: var(--pm-text-contrast);
+}
+
+.pr-stage-flow__date {
+    font-size: 0.72rem;
+    color: var(--pr-muted);
+    line-height: 1.1;
+}
+
+.pr-stage-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.32rem 0.65rem;
+    border-radius: 0.7rem;
+    background: var(--pm-surface-mist);
+    color: var(--pm-primary);
+    font-size: 0.78rem;
+    font-weight: 600;
+}
+
+@media (max-width: 1199.98px) {
+    .pr-movement-table {
+        overflow-x: auto;
+    }
+
+    .pr-movement-table__head,
+    .pr-movement-table__row {
+        min-width: 1100px;
+    }
+}
 
 .pr-activity-table .table,
 .pr-attention-table .table { margin-bottom: 0; }


### PR DESCRIPTION
### Motivation
- Replace the text-only “Projects advanced in this period” list with a compact, visual per-project movement board that shows the exact stage path taken during the selected reporting period.  
- Provide reliable stage identification and consistent chip styling by exposing `StageCode` on stage movement records and avoid presentation logic in the Razor view by introducing dedicated movement-board view models.  

### Description
- Extended report contracts in `IProgressReviewService.cs`: added `StageCode` to `ProjectStageMovementVm`, and introduced `ProjectMovementBoardVm`, `ProjectMovementRowVm`, and `ProjectMovementStepVm`; `ProjectSectionVm` now carries a `MovementBoard` payload.  
- Updated `ProgressReviewService` to populate `StageCode` when building stage movements and added `BuildProjectMovementBoard(...)` helper to construct ordered per-project movement rows (ordered steps, first movement date, movement count, current stage) and attach the board to the returned `ProgressReviewVm`.  
- Replaced the old advanced-projects block in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` with the new `pr-movement-board` section and a `MovementStageTone` helper to map stage codes to CSS tone classes; the new UI renders stage chips, arrows, dates, movement count, first movement date, and current stage per row.  
- Added CSS in `wwwroot/css/progress-review.css` for the movement board: table layout, stage-chip styles and color tones, terminal highlighting, responsive horizontal overflow, and badges.  

### Testing
- Attempted an automated build with `dotnet build`, but it could not be run in this environment due to missing runtime (`dotnet: command not found`), so compilation was not verified here.  
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e795f5c3e08329bdab90ddc08a3893)