### PR TITLE
Fix movement board to use full stage movement history

### DIFF
--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -121,6 +121,7 @@ public sealed record ProjectReviewRowVm(
     string? ProjectCategoryName,
     PresentStageSnapshot PresentStage,
     string MovementPathText,
+    IReadOnlyList<ProjectStageMovementVm> FullStageMovements,
     IReadOnlyList<ProjectStageMovementVm> StageMovements,
     int MovementCountInRange,
     DateOnly? LastStageMovementDate,

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1110,6 +1110,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 categoryName,
                 presentStage,
                 BuildMovementPathText(movements),
+                movements,
                 TrimHistory(movements).Display,
                 movements.Count,
                 lastStageMovementDate,
@@ -1149,6 +1150,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 categoryName,
                 presentStage,
                 BuildMovementPathText(stageMovements),
+                stageMovements,
                 TrimHistory(stageMovements).Display,
                 stageMovements.Count,
                 GetLastStageMovementDate(stageMovements),
@@ -1186,6 +1188,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 categoryName,
                 presentStage,
                 BuildMovementPathText(stageMovements),
+                stageMovements,
                 TrimHistory(stageMovements).Display,
                 stageMovements.Count,
                 GetLastStageMovementDate(stageMovements),
@@ -1356,7 +1359,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         var rows = advancedRows
             .Select(row =>
             {
-                var orderedSteps = row.StageMovements
+                var orderedSteps = row.FullStageMovements
                     .OrderBy(m => GetMovementEventDate(m))
                     .ThenBy(m => m.StageName, StringComparer.OrdinalIgnoreCase)
                     .ToList();


### PR DESCRIPTION
### Motivation
- The movement board was using the trimmed `StageMovements` (produced by `TrimHistory(...)`) which can omit earlier movements for projects with >3 changes in-range, causing incorrect path rendering and wrong "First movement" dates.
- Preserve the complete in-range movement history so the per-project movement board and its date calculations remain accurate.

### Description
- Added `FullStageMovements` to the `ProjectReviewRowVm` record to carry the untrimmed movement list alongside the existing `StageMovements` display list.
- Updated all `ProjectReviewRowVm` construction sites in `BuildProjectReviewBuckets(...)` to pass the full movement list (e.g., `movements` / `stageMovements`) into the new `FullStageMovements` parameter while continuing to pass `TrimHistory(...).Display` to `StageMovements`.
- Changed `BuildProjectMovementBoard(...)` to build its ordered steps from `row.FullStageMovements` instead of `row.StageMovements`, ensuring complete paths and correct first-movement dates.

### Testing
- Attempted to run `.NET` checks (`dotnet --version` / `dotnet build`) but the .NET SDK is not available in this environment (`dotnet: command not found`), so compilation was not verified here.
- No automated unit or integration tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e798a0f944832992280d16b237eaf1)