### PR TITLE
Harden Progress Review date resolution to avoid audit timestamp fallback

### DIFF
--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -183,6 +183,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         }
 
         var rows = stageChanges
+            .Where(x => x.ChangeDate.HasValue)
             .OrderByDescending(x => x.ChangeDate)
             .ThenBy(x => x.ProjectName)
             .Select(x => new ProjectStageChangeVm(
@@ -192,7 +193,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 StageCodes.DisplayNameOf(x.StageCode),
                 x.FromStatus,
                 x.ToStatus,
-                x.ChangeDate,
+                x.ChangeDate!.Value,
                 x.ToActualStart,
                 x.ToCompletedOn))
             .ToList();
@@ -571,6 +572,7 @@ public sealed class ProgressReviewService : IProgressReviewService
     {
         return stageChanges
             .Where(r => string.Equals(r.StageCode, StageCodes.TOT, StringComparison.OrdinalIgnoreCase))
+            .Where(r => r.ChangeDate.HasValue)
             .OrderByDescending(r => r.ChangeDate)
             .Select(r => new TotStageChangeVm(
                 r.ProjectId,
@@ -579,7 +581,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 StageCodes.DisplayNameOf(r.StageCode),
                 r.FromStatus,
                 r.ToStatus,
-                r.ChangeDate))
+                r.ChangeDate!.Value))
             .ToList();
     }
 
@@ -1679,7 +1681,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         rows.Add(new FfcProgressVm(recordId, country, milestone, date.Value, Truncate(remarks, 220)));
     }
 
-    private static DateOnly ResolveChangeDate(StageChangeProjection row)
+    private static DateOnly? ResolveChangeDate(StageChangeProjection row)
     {
         if (row.ToActualStart.HasValue)
         {
@@ -1701,7 +1703,7 @@ public sealed class ProgressReviewService : IProgressReviewService
             return row.FromCompletedOn.Value;
         }
 
-        return DateOnly.FromDateTime(row.AtUtc.DateTime);
+        return null;
     }
 
     private static DateOnly? ResolveActivityDate(DateTimeOffset? start, DateTimeOffset? end)
@@ -1759,7 +1761,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         string StageCode,
         string? FromStatus,
         string? ToStatus,
-        DateOnly ChangeDate,
+        DateOnly? ChangeDate,
         DateOnly? ToActualStart,
         DateOnly? ToCompletedOn,
         string? Note);


### PR DESCRIPTION
### Motivation
- Prevent audit timestamps (`log.At`) from being interpreted as stage movement dates and ensure only semantically valid business dates are used for Progress Review reporting.
- Model unresolved stage-change dates explicitly so downstream consumers cannot unknowingly treat fabricated dates as real movement events.
- Reduce risk of misleading ordering/grouping in front-runner, ToT and other Progress Review flows when business dates are missing.

### Description
- Changed `ResolveChangeDate(StageChangeProjection)` to return `DateOnly?` and removed the final `log.At` fallback so it now returns `null` when no business date is present.
- Made `StageChangeLogRow.ChangeDate` nullable (`DateOnly?`) to represent unresolved movement dates explicitly.
- Updated front-runner shaping (`LoadFrontRunnerProjectsAsync`) to filter to `ChangeDate.HasValue` and project `ChangeDate!.Value` when building `ProjectStageChangeVm` so only resolved dates are ordered and surfaced.
- Updated ToT shaping (`LoadTotStageChanges`) to filter out unresolved `ChangeDate` rows and project the non-null date value.

### Testing
- Attempted an automated build with `dotnet build ProjectManagement.sln`, but the environment lacks the `dotnet` CLI (`dotnet: command not found`), so no build/tests could be executed here.
- Performed static inspection of the modified file to verify type changes and updated call sites compile-time usage (local search and diff review succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b078440883298ad58bc9ff047e7a)