### PR TITLE
Fix non-mover activity merge for unresolved stage dates

### DIFF
--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -444,7 +444,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         {
             if (stageActivityLookup.TryGetValue(remark.ProjectId, out var stageDate))
             {
-                if (remark.LastRemark > stageDate)
+                if (!stageDate.HasValue || remark.LastRemark > stageDate.Value)
                 {
                     stageActivityLookup[remark.ProjectId] = remark.LastRemark;
                 }


### PR DESCRIPTION
### Motivation
- Fix a regression where projects with unresolved stage-change dates could end up with `LastActivity = null`, which overstated `DaysSinceActivity` and misordered/misclassified non-movers in Progress Review reports.

### Description
- Update `LoadProjectNonMoversAsync` in `Services/Reports/ProgressReview/ProgressReviewService.cs` to allow remark dates to replace unresolved stage activity by changing the merge condition to `if (!stageDate.HasValue || remark.LastRemark > stageDate.Value)`, ensuring valid remark dates set `LastActivity`.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln` in this environment but the `dotnet` CLI is not installed (`dotnet: command not found`), so no automated build/tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b20233c08329842f77836aed5a31)