### PR TITLE
Normalize Progress Review movement board stage resolution

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -225,7 +225,14 @@
                                                                 @step.StageCode
                                                             </span>
                                                             <span class="pr-stage-flow__date">
-                                                                @(step.EventDate.HasValue ? FormatDay(step.EventDate.Value) : "—")
+                                                                @if (step.EventDate.HasValue)
+                                                                {
+                                                                    @FormatDay(step.EventDate.Value)
+                                                                }
+                                                                else
+                                                                {
+                                                                    @:Unresolved
+                                                                }
                                                             </span>
                                                         </div>
 

--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -159,7 +159,8 @@ public sealed record ProjectMovementStepVm(
     string StageCode,
     string StageName,
     DateOnly? EventDate,
-    bool IsTerminal
+    bool IsTerminal,
+    string ResolutionKind
 );
 
 public sealed record ProjectResolvedStageVm(
@@ -169,7 +170,9 @@ public sealed record ProjectResolvedStageVm(
     int StageOrder,
     DateOnly? StartedOn,
     DateOnly? CompletedOn,
-    bool IsCurrent
+    string? Status,
+    bool IsCurrent,
+    bool RequiresBackfill
 );
 
 public sealed record ProjectCategoryGroupVm(

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1277,19 +1277,80 @@ public sealed class ProgressReviewService : IProgressReviewService
         return movement.CompletedOn ?? movement.StartedOn;
     }
 
-    private static DateOnly? ResolveMovementBoardDate(ProjectResolvedStageVm stage)
+    private static ProjectMovementStepVm ResolveMovementBoardStep(
+        ProjectResolvedStageVm stage,
+        ProjectResolvedStageVm? previousStage,
+        ProjectResolvedStageVm? nextStage,
+        bool isTerminal)
     {
+        // SECTION: Actual event dates on resolved stage
         if (stage.CompletedOn.HasValue)
         {
-            return stage.CompletedOn.Value;
+            return new ProjectMovementStepVm(
+                stage.StageCode,
+                stage.StageName,
+                stage.CompletedOn.Value,
+                isTerminal,
+                "ActualCompletion");
         }
 
         if (stage.IsCurrent && stage.StartedOn.HasValue)
         {
-            return stage.StartedOn.Value;
+            return new ProjectMovementStepVm(
+                stage.StageCode,
+                stage.StageName,
+                stage.StartedOn.Value,
+                isTerminal,
+                "ActualStart");
         }
 
-        return null;
+        // SECTION: Inference for skipped/completed-undated stages
+        var status = (stage.Status ?? string.Empty).Trim();
+        var isSkipped = string.Equals(status, nameof(StageStatus.Skipped), StringComparison.OrdinalIgnoreCase);
+        var isCompleted = string.Equals(status, nameof(StageStatus.Completed), StringComparison.OrdinalIgnoreCase);
+
+        if (isSkipped || isCompleted)
+        {
+            if (previousStage?.CompletedOn is DateOnly previousCompleted)
+            {
+                return new ProjectMovementStepVm(
+                    stage.StageCode,
+                    stage.StageName,
+                    previousCompleted,
+                    isTerminal,
+                    "InferredFromPreviousCompletion");
+            }
+
+            var nextAnchor = nextStage?.StartedOn ?? nextStage?.CompletedOn;
+            if (nextAnchor.HasValue)
+            {
+                return new ProjectMovementStepVm(
+                    stage.StageCode,
+                    stage.StageName,
+                    nextAnchor.Value,
+                    isTerminal,
+                    "InferredFromNextAnchor");
+            }
+        }
+
+        // SECTION: Inference for current stage without actual start date
+        if (stage.IsCurrent && previousStage?.CompletedOn is DateOnly currentFallbackDate)
+        {
+            return new ProjectMovementStepVm(
+                stage.StageCode,
+                stage.StageName,
+                currentFallbackDate,
+                isTerminal,
+                "InferredFromPreviousCompletion");
+        }
+
+        // SECTION: Unresolved reporting date
+        return new ProjectMovementStepVm(
+            stage.StageCode,
+            stage.StageName,
+            null,
+            isTerminal,
+            "Unresolved");
     }
 
     // -----------------------------------------------------------------
@@ -1435,17 +1496,28 @@ public sealed class ProgressReviewService : IProgressReviewService
                 var includedStages = projectStages
                     .Where(stage =>
                         (stage.CompletedOn.HasValue && stage.CompletedOn.Value >= rangeFrom && stage.CompletedOn.Value <= rangeTo)
-                        || (stage.IsCurrent && stage.StartedOn.HasValue && stage.StartedOn.Value >= rangeFrom && stage.StartedOn.Value <= rangeTo))
+                        || (stage.IsCurrent && stage.StartedOn.HasValue && stage.StartedOn.Value >= rangeFrom && stage.StartedOn.Value <= rangeTo)
+                        || string.Equals(stage.Status, nameof(StageStatus.Skipped), StringComparison.OrdinalIgnoreCase)
+                        || (string.Equals(stage.Status, nameof(StageStatus.Completed), StringComparison.OrdinalIgnoreCase)
+                            && !stage.CompletedOn.HasValue
+                            && stage.RequiresBackfill))
                     .OrderBy(stage => stage.StageOrder)
                     .ToList();
 
-                var movementSteps = includedStages
-                    .Select((stage, index) => new ProjectMovementStepVm(
-                        stage.StageCode,
-                        stage.StageName,
-                        ResolveMovementBoardDate(stage),
-                        index == includedStages.Count - 1))
-                    .ToList();
+                // SECTION: Resolve authoritative movement path steps with adjacency inference
+                var movementSteps = new List<ProjectMovementStepVm>(includedStages.Count);
+                for (var i = 0; i < includedStages.Count; i++)
+                {
+                    var stage = includedStages[i];
+                    var previousStage = i > 0 ? includedStages[i - 1] : null;
+                    var nextStage = i < includedStages.Count - 1 ? includedStages[i + 1] : null;
+
+                    movementSteps.Add(ResolveMovementBoardStep(
+                        stage,
+                        previousStage,
+                        nextStage,
+                        i == includedStages.Count - 1));
+                }
 
                 var firstMovementDate = movementSteps
                     .Select(step => step.EventDate)
@@ -1497,11 +1569,12 @@ public sealed class ProgressReviewService : IProgressReviewService
                 stage.SortOrder,
                 stage.ActualStart,
                 stage.CompletedOn,
-                stage.Status
+                stage.Status,
+                stage.RequiresBackfill
             })
             .ToListAsync(cancellationToken);
 
-        return rows
+        var resolvedStages = rows
             .Select(stage =>
             {
                 workflowVersions.TryGetValue(stage.ProjectId, out var workflowVersion);
@@ -1514,8 +1587,33 @@ public sealed class ProgressReviewService : IProgressReviewService
                     stage.SortOrder,
                     stage.ActualStart,
                     stage.CompletedOn,
-                    stage.Status == StageStatus.InProgress);
+                    stage.Status.ToString(),
+                    stage.Status == StageStatus.InProgress,
+                    stage.RequiresBackfill);
             })
+            .ToList();
+
+        return NormalizeResolvedStages(resolvedStages);
+    }
+
+    private static IReadOnlyList<ProjectResolvedStageVm> NormalizeResolvedStages(
+        IReadOnlyList<ProjectResolvedStageVm> stages)
+    {
+        // SECTION: One authoritative stage row per project + stage code
+        return stages
+            .GroupBy(stage => new
+            {
+                stage.ProjectId,
+                StageCode = (stage.StageCode ?? string.Empty).Trim().ToUpperInvariant()
+            })
+            .Select(group => group
+                .OrderByDescending(x => x.CompletedOn.HasValue)
+                .ThenByDescending(x => x.StartedOn.HasValue)
+                .ThenByDescending(x => x.IsCurrent)
+                .ThenBy(x => x.StageOrder)
+                .First())
+            .OrderBy(stage => stage.ProjectId)
+            .ThenBy(stage => stage.StageOrder)
             .ToList();
     }
 


### PR DESCRIPTION
### Motivation
- The movement board was rendering duplicate stage rows and using raw stage-row dates, causing repeated stages and semantically-incorrect or missing dates in the UI. 
- Skipped stages and completed-but-undated stages were often dropped instead of being represented with a safe inferred date or marked unresolved. 
- The builder assumed incoming stage rows were authoritative, so there was no normalization to guarantee one entry per `ProjectId + StageCode`.

### Description
- Extended movement DTOs by adding `ResolutionKind` to `ProjectMovementStepVm` and adding `Status` and `RequiresBackfill` to `ProjectResolvedStageVm` in `Services/Reports/ProgressReview/IProgressReviewService.cs`.
- Replaced the simple `ResolveMovementBoardDate` with `ResolveMovementBoardStep(...)` in `Services/Reports/ProgressReview/ProgressReviewService.cs` which returns actual, inferred (from previous completion or next anchor), or `Unresolved` resolution kinds without using audit timestamps.
- Updated `LoadResolvedProjectStagesAsync(...)` to include `RequiresBackfill` and `Status`, emit `ProjectResolvedStageVm` with the new fields, and normalize rows with `NormalizeResolvedStages(...)` to enforce a single authoritative row per project-stage.
- Updated `BuildProjectMovementBoard(...)` to include skipped and completed-undated/backfill stages in the candidate set and to resolve each step using adjacency (previous/next) via the new resolver; updated UI `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` to render `Unresolved` when `EventDate` is null.

### Testing
- Attempted a local build with `dotnet build`, which failed in this environment because `dotnet` is not installed (build could not be verified here).
- No unit/integration test runs were executed in this environment; change surface covered by code edit and manual inspection of touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81bc4fd308329a770fa279b81b885)