### PR TITLE
Fix Progress Review movement board date semantics

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -221,17 +221,18 @@
                                                     {
                                                         var step = row.Steps[i];
                                                         <div class="pr-stage-flow__step">
-                                                            <span class="pr-stage-chip @MovementStageTone(step.StageCode) @(step.IsTerminal ? "is-terminal" : "")">
+                                                            <span class="pr-stage-chip @MovementStageTone(step.StageCode) @(step.IsTerminal ? "is-terminal" : "")"
+                                                                  title="@step.ResolutionKind">
                                                                 @step.StageCode
                                                             </span>
                                                             <span class="pr-stage-flow__date">
-                                                                @if (step.EventDate.HasValue)
+                                                                @if (step.DisplayDate.HasValue && !string.IsNullOrWhiteSpace(step.DisplayDateKind))
                                                                 {
-                                                                    @FormatDay(step.EventDate.Value)
+                                                                    <span class="pr-stage-flow__date-kind">@step.DisplayDateKind[0]:</span>@FormatDay(step.DisplayDate.Value)
                                                                 }
                                                                 else
                                                                 {
-                                                                    @:Unresolved
+                                                                    @:&nbsp;
                                                                 }
                                                             </span>
                                                         </div>

--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -158,7 +158,8 @@ public sealed record ProjectMovementRowVm(
 public sealed record ProjectMovementStepVm(
     string StageCode,
     string StageName,
-    DateOnly? EventDate,
+    DateOnly? DisplayDate,
+    string? DisplayDateKind,
     bool IsTerminal,
     string ResolutionKind
 );

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1290,6 +1290,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 stage.StageCode,
                 stage.StageName,
                 stage.CompletedOn.Value,
+                "Completed",
                 isTerminal,
                 "ActualCompletion");
         }
@@ -1300,6 +1301,7 @@ public sealed class ProgressReviewService : IProgressReviewService
                 stage.StageCode,
                 stage.StageName,
                 stage.StartedOn.Value,
+                "Started",
                 isTerminal,
                 "ActualStart");
         }
@@ -1316,30 +1318,33 @@ public sealed class ProgressReviewService : IProgressReviewService
                 return new ProjectMovementStepVm(
                     stage.StageCode,
                     stage.StageName,
-                    previousCompleted,
+                    null,
+                    null,
                     isTerminal,
                     "InferredFromPreviousCompletion");
             }
 
-            var nextAnchor = nextStage?.StartedOn ?? nextStage?.CompletedOn;
+            var nextAnchor = nextStage?.CompletedOn ?? nextStage?.StartedOn;
             if (nextAnchor.HasValue)
             {
                 return new ProjectMovementStepVm(
                     stage.StageCode,
                     stage.StageName,
-                    nextAnchor.Value,
+                    null,
+                    null,
                     isTerminal,
                     "InferredFromNextAnchor");
             }
         }
 
         // SECTION: Inference for current stage without actual start date
-        if (stage.IsCurrent && previousStage?.CompletedOn is DateOnly currentFallbackDate)
+        if (stage.IsCurrent && previousStage?.CompletedOn is DateOnly)
         {
             return new ProjectMovementStepVm(
                 stage.StageCode,
                 stage.StageName,
-                currentFallbackDate,
+                null,
+                null,
                 isTerminal,
                 "InferredFromPreviousCompletion");
         }
@@ -1348,6 +1353,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         return new ProjectMovementStepVm(
             stage.StageCode,
             stage.StageName,
+            null,
             null,
             isTerminal,
             "Unresolved");
@@ -1520,7 +1526,10 @@ public sealed class ProgressReviewService : IProgressReviewService
                 }
 
                 var firstMovementDate = movementSteps
-                    .Select(step => step.EventDate)
+                    .Where(step =>
+                        string.Equals(step.ResolutionKind, "ActualCompletion", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(step.ResolutionKind, "ActualStart", StringComparison.OrdinalIgnoreCase))
+                    .Select(step => step.DisplayDate)
                     .Where(date => date.HasValue)
                     .OrderBy(date => date)
                     .FirstOrDefault();

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -656,6 +656,13 @@
     font-size: 0.72rem;
     color: var(--pr-muted);
     line-height: 1.1;
+    min-height: 1em;
+}
+
+.pr-stage-flow__date-kind {
+    font-weight: 600;
+    color: #5f6b7a;
+    margin-right: 0.18rem;
 }
 
 .pr-stage-badge {


### PR DESCRIPTION
### Motivation

- Prevent inferred/inferred-anchor dates from being shown on the "Project movement in this period" board so the UI doesn't imply a false movement date. 
- Distinguish actual start vs completion dates in the UI so users can tell whether a displayed date is a `Started` or `Completed` event. 
- Ensure the row-level `FirstMovementDate` is computed only from real dated movements (actual starts/completions) and not from inferred anchors.

### Description

- Replaced the ambiguous `EventDate` on `ProjectMovementStepVm` with explicit display semantics: `DisplayDate` and `DisplayDateKind` (`Services/Reports/ProgressReview/IProgressReviewService.cs`).
- Updated the resolver `ResolveMovementBoardStep(...)` so only true `CompletedOn` and `StartedOn` produce a `DisplayDate` with `DisplayDateKind` set to `"Completed"` or `"Started"`, while inferred or unresolved steps are included for path membership but have `DisplayDate == null` and `DisplayDateKind == null` (`Services/Reports/ProgressReview/ProgressReviewService.cs`).
- Changed inference anchor preference to use `nextStage?.CompletedOn ?? nextStage?.StartedOn` for safer inclusion anchoring while still suppressing inferred display dates (`Services/Reports/ProgressReview/ProgressReviewService.cs`).
- Made `FirstMovementDate` actual-only by filtering movement steps to resolution kinds `ActualCompletion` or `ActualStart` and selecting `DisplayDate` values only (`Services/Reports/ProgressReview/ProgressReviewService.cs`).
- Updated Razor rendering to show a compact `S:` / `C:` prefix for actual displayed dates, suppress dates for inferred/unresolved steps (render blank), and added a `title` attribute to stage chips containing `ResolutionKind` to surface inclusion metadata (`Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml`).
- Added CSS for aligned empty date rows and styling for the date-kind prefix (`wwwroot/css/progress-review.css`).

### Testing

- Attempted to build the solution with `dotnet build ProjectManagement.sln`, but the environment does not have the .NET SDK installed so the build could not be executed (`dotnet: command not found`).
- Performed code inspection and local grep/grep-sed checks to confirm updated symbols (`DisplayDate`, `DisplayDateKind`, `ResolutionKind`) are wired into rendering and first-movement calculation; no compile/runtime verification was possible in this environment due to missing `dotnet`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81f873c308329b5e5b86b962b56c6)