### PR TITLE
Widen Progress Review layout and flatten visual hierarchy

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -84,7 +84,7 @@
 }
 
 <div class="progress-review-shell" data-page-id="progress-review">
-    <div class="container-xxl">
+    <div class="pr-page">
         <div class="progress-review__toolbar">
             <div class="progress-review__title-block">
                 <p class="progress-review__eyebrow text-muted">Project office reports</p>
@@ -100,7 +100,7 @@
         </div>
     </div>
 
-    <div class="container-xxl">
+    <div class="pr-page">
         @if (vm is null)
         {
             <div class="alert alert-info">Unable to load progress data for the selected range.</div>
@@ -137,7 +137,7 @@
                         <div class="pr-review-band">
                             <div class="pr-review-band__head">
                                 <div>
-                                    <div class="pr-review-band__title">Ongoing projects progress</div>
+                                    <div class="pr-review-band__title">Executive summary</div>
                                     <div class="pr-review-band__period">
                                         Review window: @vm.Range.From.ToString("dd MMM yyyy") to @vm.Range.To.ToString("dd MMM yyyy")
                                     </div>
@@ -160,7 +160,7 @@
                         @if (vm.Projects.Review.Highlights.Any())
                         {
                             <section class="pr-highlights" aria-label="Highlights this period">
-                                <h3 class="h6 mb-2">Highlights this period</h3>
+                                <h3 class="h6 mb-1">Highlights this period</h3>
                                 <ul class="pr-highlight-list list-unstyled mb-0">
                                     @foreach (var highlight in vm.Projects.Review.Highlights)
                                     {
@@ -267,7 +267,7 @@
 
                         @* SECTION: Projects active in this period without stage advancement *@
                         <section class="pr-activity-table" aria-label="Projects active in this period without stage advancement">
-                            <h3 class="h6 mb-2">Projects active in this period without stage advancement</h3>
+                            <h3 class="h6 mb-1">Projects active in this period without stage advancement</h3>
                             @if (!vm.Projects.Review.ActiveWithoutAdvancement.Any())
                             {
                                 <p class="pr-meta mb-0">No projects were active-by-remark without stage movement.</p>
@@ -298,7 +298,7 @@
 
                         @* SECTION: Projects requiring attention *@
                         <section class="pr-attention-table" aria-label="Projects requiring attention">
-                            <h3 class="h6 mb-2">Projects requiring attention</h3>
+                            <h3 class="h6 mb-1">Projects requiring attention</h3>
                             @if (!vm.Projects.Review.Attention.Any())
                             {
                                 <p class="pr-meta mb-0">No projects currently in the attention bucket.</p>

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -20,7 +20,13 @@
 
 .progress-review-shell {
     background: var(--pr-background);
-    padding: 1.5rem 0 3rem;
+    padding: 1.25rem 0 2.5rem;
+}
+
+/* Page-scoped wide container for desktop-heavy report content */
+.pr-page {
+    width: min(1680px, calc(100vw - 64px));
+    margin-inline: auto;
 }
 
 /* Toolbar at the top (title, range selector, print) */
@@ -62,10 +68,10 @@
 /* Main report canvas card */
 .progress-review__canvas {
     background: var(--pr-surface);
-    border: 1px solid var(--pr-border);
-    border-radius: 1rem;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 20px 50px rgba(15, 30, 65, 0.08);
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    border-radius: 0.9rem;
+    padding: 1.15rem 1.3rem 1.25rem;
+    box-shadow: 0 10px 24px rgba(15, 30, 65, 0.05);
 }
 
 /* Header with reporting period and any meta */
@@ -73,10 +79,10 @@
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 0.85rem;
     border-bottom: 1px solid var(--pr-border);
-    padding-bottom: 0.75rem;
-    margin-bottom: 1.25rem;
+    padding-bottom: 0.65rem;
+    margin-bottom: 1rem;
 }
 
     .progress-review__document-header h2 {
@@ -116,12 +122,12 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
+    gap: 0.85rem;
+    margin-bottom: 0.65rem;
 }
 
 .progress-review__section {
-    margin-top: 1.75rem;
+    margin-top: 1.25rem;
 }
 
 .progress-review__stack {
@@ -161,7 +167,11 @@
    ========================================================= */
 
 .pr-section {
-    margin-top: 20px;
+    margin-top: 16px;
+}
+
+.pr-section + .pr-section {
+    margin-top: 1rem;
 }
 
 .pr-section-label {
@@ -419,8 +429,12 @@
         align-items: flex-start;
     }
 
+    .pr-page {
+        width: min(100%, calc(100vw - 24px));
+    }
+
     .progress-review__canvas {
-        padding: 1.25rem 1.25rem;
+        padding: 1.05rem 1rem 1.15rem;
     }
 
     .pr-project-row {
@@ -455,11 +469,11 @@
    ========================================================= */
 
 .pr-review-band {
-    border: 1px solid var(--pm-surface-silver);
-    border-radius: 12px;
-    padding: 0.9rem 1rem;
-    background: var(--pm-surface-mist);
-    margin-bottom: 0.9rem;
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    border-radius: 10px;
+    padding: 0.75rem 0.9rem;
+    background: #f8fafc;
+    margin-bottom: 0.7rem;
 }
 
 .pr-review-band__head {
@@ -469,43 +483,48 @@
     gap: 1rem;
 }
 
-.pr-review-band__title { font-weight: 600; color: var(--pm-text-contrast); }
+.pr-review-band__title { font-weight: 600; color: var(--pm-text-contrast); font-size: 0.92rem; }
 .pr-review-band__period,
 .pr-review-band__scope { font-size: 0.82rem; color: var(--pr-muted); }
 
 .pr-review-metrics {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.55rem;
-    margin-top: 0.8rem;
+    gap: 0.45rem;
+    margin-top: 0.65rem;
 }
 
 .pr-review-metric {
-    background: var(--pm-card);
-    border: 1px solid var(--pm-surface-silver);
-    border-radius: 10px;
-    padding: 0.45rem 0.55rem;
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 8px;
+    padding: 0.35rem 0.5rem;
     display: flex;
     justify-content: space-between;
-    gap: 0.5rem;
+    gap: 0.45rem;
 }
 
 .pr-review-metric__label { font-size: 0.8rem; color: var(--pr-muted); }
 .pr-review-metric__value { font-weight: 600; color: var(--pm-text-contrast); }
-.pr-review-band__insight { margin: 0.75rem 0 0; font-size: 0.88rem; }
+.pr-review-band__insight { margin: 0.6rem 0 0; font-size: 0.86rem; }
 
 .pr-highlights,
 .pr-activity-table,
 .pr-attention-table {
-    border: 1px solid var(--pm-surface-silver);
-    border-radius: 12px;
-    background: var(--pm-card);
-    padding: 0.85rem 1rem;
-    margin-top: 0.8rem;
+    border: 1px solid rgba(15, 23, 42, 0.05);
+    border-radius: 10px;
+    background: #fff;
+    padding: 0.75rem 0.9rem;
+    margin-top: 0.7rem;
 }
 
-.pr-highlight-list { display: grid; gap: 0.45rem; }
-.pr-highlight-item { font-size: 0.88rem; }
+.pr-activity-table,
+.pr-attention-table {
+    border-color: rgba(15, 23, 42, 0.08);
+}
+
+.pr-highlight-list { display: grid; gap: 0.35rem; }
+.pr-highlight-item { font-size: 0.86rem; }
 
 /* =========================================================
    SECTION: Project movement board
@@ -513,18 +532,19 @@
 
 .pr-movement-board {
     background: var(--pm-card);
-    border: 1px solid var(--pr-border);
+    border: 1px solid rgba(15, 23, 42, 0.1);
     border-radius: 0.95rem;
-    padding: 1rem 1.1rem 1.15rem;
-    margin-top: 0.8rem;
+    padding: 0.9rem 1rem 1rem;
+    margin-top: 0.75rem;
+    box-shadow: 0 10px 26px rgba(15, 30, 65, 0.05);
 }
 
 .pr-movement-board__header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 0.9rem;
+    gap: 0.85rem;
+    margin-bottom: 0.7rem;
 }
 
 .pr-movement-board__count {
@@ -543,7 +563,7 @@
 .pr-movement-table__head,
 .pr-movement-table__row {
     display: grid;
-    grid-template-columns: minmax(220px, 1.4fr) minmax(120px, 0.7fr) minmax(440px, 2.8fr) 72px 120px 160px;
+    grid-template-columns: minmax(240px, 1.35fr) minmax(130px, 0.7fr) minmax(620px, 3.3fr) 72px 130px 170px;
     align-items: start;
     gap: 0.85rem;
 }
@@ -551,14 +571,14 @@
 .pr-movement-table__head {
     background: var(--pm-surface-mist);
     border-bottom: 1px solid var(--pm-surface-ice);
-    padding: 0.85rem 1rem;
-    font-size: 0.78rem;
+    padding: 0.75rem 0.9rem;
+    font-size: 0.76rem;
     font-weight: 600;
     color: var(--pm-text-gray-soft);
 }
 
 .pr-movement-table__row {
-    padding: 0.95rem 1rem;
+    padding: 0.78rem 0.9rem;
     border-top: 1px solid var(--pm-surface-ice);
 }
 


### PR DESCRIPTION
### Motivation
- Provide a wider, denser, report-style layout for the Progress Review page so the movement board has more horizontal breathing room and the page reads as a report rather than stacked cards.
- Reduce nested card weight and excessive vertical spacing so supporting blocks (summary/highlights) are lighter and the movement board becomes the primary operational surface.
- Achieve the above without changing any reporting/business logic or movement-board data semantics.

### Description
- Introduced a page-scoped wide container by adding `.pr-page` and replacing the page-level `container-xxl` wrappers in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` to scope the width change to this page only.
- Adjusted `wwwroot/css/progress-review.css` to flatten the outer canvas (lighter border/shadow, reduced padding), tighten section/header spacing, and reduce stacked-card visual weight for summary/highlights (subtler borders, reduced padding).
- Promoted the movement board visually by increasing its emphasis (adjusted border/shadow/padding) and updated the grid column distribution for `.pr-movement-table__head` / `__row` to `minmax(240px, 1.35fr) minmax(130px, 0.7fr) minmax(620px, 3.3fr) 72px 130px 170px` so the stage movement column gets more room.
- Minor markup/spacing tweaks: reduced heading bottom margins (`h3` changed to `mb-1`), tightened review band metrics and renamed the review band title to `Executive summary` to reflect its demoted visual weight.
- No changes were made to data models, business rules, or movement-board semantics; changes are purely presentational.

### Testing
- Attempted `dotnet build ProjectManagement.sln`, but the build could not run in this environment because `dotnet` is not installed (`dotnet: command not found`). (failed)
- Verified repository changes with `git status` and `git diff` and committed the edits; commit recorded the layout/CSS updates. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e823371e208329b841310d827cb6c7)