### PR TITLE
Simplify Progress Review opening and streamline movement board

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -113,7 +113,6 @@
                         <p class="text-uppercase text-muted small fw-semibold mb-0">Reporting period</p>
                         <h2 class="h6 mb-0">@vm.Range.From.ToString("dd MMM yyyy") – @vm.Range.To.ToString("dd MMM yyyy")</h2>
                     </div>
-                    
                 </header>
 
                 @* SECTION: Project progress buckets *@
@@ -133,55 +132,13 @@
                     }
                     else
                     {
-                        @* SECTION: Executive review band *@
-                        <div class="pr-review-band">
-                            <div class="pr-review-band__head">
-                                <div>
-                                    <div class="pr-review-band__title">Executive summary</div>
-                                    <div class="pr-review-band__period">
-                                        Review window: @vm.Range.From.ToString("dd MMM yyyy") to @vm.Range.To.ToString("dd MMM yyyy")
-                                    </div>
-                                </div>
-                                <div class="pr-review-band__scope">@vm.Projects.Review.Summary.ProjectsInScope in scope</div>
-                            </div>
-                            <div class="pr-review-metrics">
-                                <div class="pr-review-metric"><span class="pr-review-metric__label">Advanced</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.AdvancedCount</span></div>
-                                <div class="pr-review-metric"><span class="pr-review-metric__label">Active, no advancement</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.ActiveWithoutAdvancementCount</span></div>
-                                <div class="pr-review-metric"><span class="pr-review-metric__label">No movement</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.NoMovementCount</span></div>
-                                <div class="pr-review-metric"><span class="pr-review-metric__label">Attention</span><span class="pr-review-metric__value">@vm.Projects.Review.Summary.AttentionCount</span></div>
-                            </div>
-                            @if (!string.IsNullOrWhiteSpace(vm.Projects.Review.Summary.InterpretiveSummaryText))
-                            {
-                                <p class="pr-review-band__insight">@vm.Projects.Review.Summary.InterpretiveSummaryText</p>
-                            }
-                        </div>
-
-                        @* SECTION: Highlights this period *@
-                        @if (vm.Projects.Review.Highlights.Any())
-                        {
-                            <section class="pr-highlights" aria-label="Highlights this period">
-                                <h3 class="h6 mb-1">Highlights this period</h3>
-                                <ul class="pr-highlight-list list-unstyled mb-0">
-                                    @foreach (var highlight in vm.Projects.Review.Highlights)
-                                    {
-                                        var projectDetailsUrl = Url.Page("/Projects/Overview", new { id = highlight.ProjectId });
-                                        <li class="pr-highlight-item">
-                                            <a class="progress-review__link" href="@projectDetailsUrl">@highlight.ProjectName</a>
-                                            <span class="pr-body"> — @highlight.HighlightText</span>
-                                        </li>
-                                    }
-                                </ul>
-                            </section>
-                        }
-
                         @* SECTION: Project movement in this period *@
                         <section class="pr-movement-board" aria-label="Project movement in this period">
                             <div class="pr-movement-board__header">
                                 <div>
                                     <h3 class="h6 mb-1">Project movement in this period</h3>
                                     <p class="pr-meta mb-0">
-                                        Projects that moved from one stage to another between
-                                        @vm.Range.From.ToString("dd MMM yyyy") and @vm.Range.To.ToString("dd MMM yyyy").
+                                        Projects that advanced through workflow stages in the selected period.
                                     </p>
                                 </div>
                                 <div class="pr-movement-board__count">@vm.Projects.MovementBoard.TotalMovedProjects moved projects</div>
@@ -199,8 +156,6 @@
                                         <div>Category</div>
                                         <div>Stage movement during period</div>
                                         <div>Moves</div>
-                                        <div>First movement</div>
-                                        <div>Current stage</div>
                                     </div>
 
                                     @foreach (var row in vm.Projects.MovementBoard.Rows)
@@ -246,19 +201,6 @@
                                             </div>
 
                                             <div class="pr-movement-table__moves">@row.MovementCount</div>
-                                            <div class="pr-movement-table__first">
-                                                @(row.FirstMovementDate.HasValue ? row.FirstMovementDate.Value.ToString("dd MMM yyyy") : "—")
-                                            </div>
-                                            <div class="pr-movement-table__current">
-                                                @if (string.IsNullOrWhiteSpace(row.CurrentStageName))
-                                                {
-                                                    <span class="pr-stage-badge">Stage pending</span>
-                                                }
-                                                else
-                                                {
-                                                    <span class="pr-stage-badge">@row.CurrentStageName</span>
-                                                }
-                                            </div>
                                         </article>
                                     }
                                 </div>

--- a/Services/Reports/ProgressReview/IProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/IProgressReviewService.cs
@@ -150,9 +150,7 @@ public sealed record ProjectMovementRowVm(
     string ProjectName,
     string? ProjectCategoryName,
     IReadOnlyList<ProjectMovementStepVm> Steps,
-    int MovementCount,
-    DateOnly? FirstMovementDate,
-    string? CurrentStageName
+    int MovementCount
 );
 
 public sealed record ProjectMovementStepVm(

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1525,27 +1525,15 @@ public sealed class ProgressReviewService : IProgressReviewService
                         i == includedStages.Count - 1));
                 }
 
-                var firstMovementDate = movementSteps
-                    .Where(step =>
-                        string.Equals(step.ResolutionKind, "ActualCompletion", StringComparison.OrdinalIgnoreCase)
-                        || string.Equals(step.ResolutionKind, "ActualStart", StringComparison.OrdinalIgnoreCase))
-                    .Select(step => step.DisplayDate)
-                    .Where(date => date.HasValue)
-                    .OrderBy(date => date)
-                    .FirstOrDefault();
-
                 return new ProjectMovementRowVm(
                     row.ProjectId,
                     row.ProjectName,
                     row.ProjectCategoryName,
                     movementSteps,
-                    row.MovementCountInRange,
-                    firstMovementDate,
-                    row.PresentStage.CurrentStageName);
+                    row.MovementCountInRange);
             })
             .Where(row => row.Steps.Count > 0)
             .OrderByDescending(r => r.MovementCount)
-            .ThenByDescending(r => r.FirstMovementDate)
             .ThenBy(r => r.ProjectName)
             .ToList();
 

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -20,7 +20,7 @@
 
 .progress-review-shell {
     background: var(--pr-background);
-    padding: 1.25rem 0 2.5rem;
+    padding: 1rem 0 2rem;
 }
 
 /* Page-scoped wide container for desktop-heavy report content */
@@ -68,10 +68,10 @@
 /* Main report canvas card */
 .progress-review__canvas {
     background: var(--pr-surface);
-    border: 1px solid rgba(15, 23, 42, 0.06);
+    border: 1px solid rgba(15, 23, 42, 0.05);
     border-radius: 0.9rem;
-    padding: 1.15rem 1.3rem 1.25rem;
-    box-shadow: 0 10px 24px rgba(15, 30, 65, 0.05);
+    padding: 1rem 1.2rem 1.15rem;
+    box-shadow: 0 6px 16px rgba(15, 30, 65, 0.04);
 }
 
 /* Header with reporting period and any meta */
@@ -81,8 +81,8 @@
     justify-content: space-between;
     gap: 0.85rem;
     border-bottom: 1px solid var(--pr-border);
-    padding-bottom: 0.65rem;
-    margin-bottom: 1rem;
+    padding-bottom: 0.55rem;
+    margin-bottom: 0.75rem;
 }
 
     .progress-review__document-header h2 {
@@ -167,7 +167,7 @@
    ========================================================= */
 
 .pr-section {
-    margin-top: 16px;
+    margin-top: 12px;
 }
 
 .pr-section + .pr-section {
@@ -465,66 +465,17 @@
 }
 
 /* =========================================================
-   SECTION: Section 01 executive review redesign
+   SECTION: Section 01 supporting tables
    ========================================================= */
 
-.pr-review-band {
-    border: 1px solid rgba(15, 23, 42, 0.06);
-    border-radius: 10px;
-    padding: 0.75rem 0.9rem;
-    background: #f8fafc;
-    margin-bottom: 0.7rem;
-}
-
-.pr-review-band__head {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-}
-
-.pr-review-band__title { font-weight: 600; color: var(--pm-text-contrast); font-size: 0.92rem; }
-.pr-review-band__period,
-.pr-review-band__scope { font-size: 0.82rem; color: var(--pr-muted); }
-
-.pr-review-metrics {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.45rem;
-    margin-top: 0.65rem;
-}
-
-.pr-review-metric {
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    border-radius: 8px;
-    padding: 0.35rem 0.5rem;
-    display: flex;
-    justify-content: space-between;
-    gap: 0.45rem;
-}
-
-.pr-review-metric__label { font-size: 0.8rem; color: var(--pr-muted); }
-.pr-review-metric__value { font-weight: 600; color: var(--pm-text-contrast); }
-.pr-review-band__insight { margin: 0.6rem 0 0; font-size: 0.86rem; }
-
-.pr-highlights,
 .pr-activity-table,
 .pr-attention-table {
-    border: 1px solid rgba(15, 23, 42, 0.05);
+    border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: 10px;
     background: #fff;
     padding: 0.75rem 0.9rem;
     margin-top: 0.7rem;
 }
-
-.pr-activity-table,
-.pr-attention-table {
-    border-color: rgba(15, 23, 42, 0.08);
-}
-
-.pr-highlight-list { display: grid; gap: 0.35rem; }
-.pr-highlight-item { font-size: 0.86rem; }
 
 /* =========================================================
    SECTION: Project movement board
@@ -532,11 +483,11 @@
 
 .pr-movement-board {
     background: var(--pm-card);
-    border: 1px solid rgba(15, 23, 42, 0.1);
+    border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: 0.95rem;
-    padding: 0.9rem 1rem 1rem;
-    margin-top: 0.75rem;
-    box-shadow: 0 10px 26px rgba(15, 30, 65, 0.05);
+    padding: 0.95rem 1.05rem 1.1rem;
+    margin-top: 0.45rem;
+    box-shadow: 0 8px 20px rgba(15, 30, 65, 0.04);
 }
 
 .pr-movement-board__header {
@@ -563,7 +514,7 @@
 .pr-movement-table__head,
 .pr-movement-table__row {
     display: grid;
-    grid-template-columns: minmax(240px, 1.35fr) minmax(130px, 0.7fr) minmax(620px, 3.3fr) 72px 130px 170px;
+    grid-template-columns: minmax(260px, 1.45fr) minmax(150px, 0.8fr) minmax(760px, 4.2fr) 72px;
     align-items: start;
     gap: 0.85rem;
 }
@@ -588,15 +539,12 @@
 
 .pr-movement-table__project,
 .pr-movement-table__category,
-.pr-movement-table__moves,
-.pr-movement-table__first,
-.pr-movement-table__current {
+.pr-movement-table__moves {
     padding-top: 0.15rem;
 }
 
 .pr-movement-table__category,
-.pr-movement-table__moves,
-.pr-movement-table__first {
+.pr-movement-table__moves {
     font-size: 0.86rem;
     color: var(--pm-text-secondary);
 }
@@ -685,17 +633,6 @@
     margin-right: 0.18rem;
 }
 
-.pr-stage-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.32rem 0.65rem;
-    border-radius: 0.7rem;
-    background: var(--pm-surface-mist);
-    color: var(--pm-primary);
-    font-size: 0.78rem;
-    font-weight: 600;
-}
-
 @media (max-width: 1199.98px) {
     .pr-movement-table {
         overflow-x: auto;
@@ -703,7 +640,7 @@
 
     .pr-movement-table__head,
     .pr-movement-table__row {
-        min-width: 1100px;
+        min-width: 980px;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Reduce visual clutter at the top of the Progress Review so users land directly on the operational movement board.  
- Remove redundant summary gestures and right-hand columns that duplicate information already visible in the movement path.  
- Reclaim horizontal space for the movement path so long stage flows render more clearly.  

### Description

- Removed the `Executive summary` band and the `Highlights this period` block from `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` so the movement board becomes the first main section under the report header.  
- Deleted the `First movement` and `Current stage` columns from the movement board header and rows in `Index.cshtml` and tightened the movement-board subtitle wording.  
- Simplified the movement row view model by removing the `FirstMovementDate` and `CurrentStageName` fields in `Services/Reports/ProgressReview/IProgressReviewService.cs`.  
- Updated `BuildProjectMovementBoard(...)` in `Services/Reports/ProgressReview/ProgressReviewService.cs` to stop computing/assigning `firstMovementDate` and to adjust row ordering accordingly.  
- Rebalanced and cleaned CSS in `wwwroot/css/progress-review.css`: tightened shell/canvas spacing, removed unused styles for the deleted blocks/columns, added a small section for supporting tables, and changed the movement table grid to a 4-column layout so the movement-path column gets more width.  

### Testing

- Performed repository searches for removed identifiers (`pr-review-band`, `pr-highlights`, `pr-movement-table__first`, `pr-movement-table__current`, `pr-stage-badge`, `FirstMovementDate`, `CurrentStageName`) and confirmed no remaining references in the modified files.  
- Attempted to run `dotnet build ProjectManagement.sln` but the environment lacks the .NET SDK/CLI (`dotnet: command not found`), so a full compile/test could not be executed here.  
- Changes were committed locally with the message: "Simplify progress review opening and movement board columns."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82e1985f883298e9ef76d7f5b8c73)