### PR TITLE
Refine Progress Review header hierarchy and spacing

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -85,12 +85,17 @@
 
 <div class="progress-review-shell" data-page-id="progress-review">
     <div class="pr-page">
-        <div class="progress-review__toolbar">
-            <div class="progress-review__title-block">
-                <p class="progress-review__eyebrow text-muted">Project office reports</p>
-                <h1 class="h4 mb-0">Progress Review</h1>
+        @* SECTION: Unified report header *@
+        <div class="pr-report-header">
+            <div class="pr-report-header__title-block">
+                <p class="pr-report-header__eyebrow mb-0">Project office reports</p>
+                <h1 class="pr-report-header__title">Progress Review</h1>
+                @if (vm is not null)
+                {
+                    <p class="pr-report-header__period mb-0">@vm.Range.From.ToString("dd MMM yyyy") – @vm.Range.To.ToString("dd MMM yyyy")</p>
+                }
             </div>
-            <div class="progress-review__toolbar-actions">
+            <div class="pr-report-header__actions">
                 <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#progress-review-range">Date range</button>
                 <button class="btn btn-primary btn-sm" type="button" data-action="print">
                     <i class="bi bi-printer me-1"></i>
@@ -108,22 +113,15 @@
         else
         {
             <article class="progress-review__canvas">
-                <header class="progress-review__document-header">
-                    <div>
-                        <p class="text-uppercase text-muted small fw-semibold mb-0">Reporting period</p>
-                        <h2 class="h6 mb-0">@vm.Range.From.ToString("dd MMM yyyy") – @vm.Range.To.ToString("dd MMM yyyy")</h2>
-                    </div>
-                </header>
-
                 @* SECTION: Project progress buckets *@
                 <section class="progress-review__section pr-section" id="project-progress">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label pr-section-label" aria-hidden="true">Section 01</span>
-                            <h2 class="progress-review__section-title pr-section-title">Ongoing projects progress</h2>
-                            <div class="pr-section-divider"></div>
+                    @* SECTION: Unified section heading *@
+                    <header class="pr-section-header" aria-label="Ongoing projects progress summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 01</span>
+                            <h2 class="pr-section-header__title">Ongoing projects progress</h2>
                         </div>
-                        <p class="progress-review__section-meta pr-meta">@vm.Projects.Review.Summary.ProjectsInScope projects in scope</p>
+                        <p class="pr-section-header__meta mb-0">@vm.Projects.Review.Summary.ProjectsInScope projects in scope</p>
                     </header>
 
                     @if (vm.Projects.Review.Summary.ProjectsInScope == 0)

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -29,40 +29,49 @@
     margin-inline: auto;
 }
 
-/* Toolbar at the top (title, range selector, print) */
-.progress-review__toolbar {
+/* =========================================================
+   SECTION: Unified report header
+   ========================================================= */
+
+.pr-report-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 0;
+    gap: 1.1rem;
+    padding: 0.5rem 0 0.65rem;
 }
 
-.progress-review__title-block {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
+.pr-report-header__title-block {
+    min-width: 0;
 }
 
-.progress-review__eyebrow {
-    font-size: 0.85rem;
-    letter-spacing: 0.04em;
+.pr-report-header__eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.045em;
     text-transform: uppercase;
-    margin-bottom: 0;
-    color: var(--pr-muted);
+    color: #6f7f92;
 }
 
-.progress-review__title {
-    font-size: 1.35rem;
-    font-weight: 600;
+.pr-report-header__title {
     margin: 0;
+    font-size: 2rem;
+    line-height: 1.1;
+    font-weight: 700;
     color: var(--pm-text-contrast);
 }
 
-.progress-review__toolbar-actions {
-    display: flex;
+.pr-report-header__period {
+    margin-top: 0.32rem;
+    font-size: 0.95rem;
+    color: #4f5f73;
+}
+
+.pr-report-header__actions {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.55rem;
+    flex-shrink: 0;
+    padding-top: 0.22rem;
 }
 
 /* Main report canvas card */
@@ -73,23 +82,6 @@
     padding: 1rem 1.2rem 1.15rem;
     box-shadow: 0 6px 16px rgba(15, 30, 65, 0.04);
 }
-
-/* Header with reporting period and any meta */
-.progress-review__document-header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.85rem;
-    border-bottom: 1px solid var(--pr-border);
-    padding-bottom: 0.55rem;
-    margin-bottom: 0.75rem;
-}
-
-    .progress-review__document-header h2 {
-        margin: 0;
-        font-size: 1rem;
-        font-weight: 600;
-    }
 
 .progress-review__section-label {
     display: block;
@@ -118,6 +110,11 @@
     color: var(--pr-muted);
 }
 
+.progress-review__section {
+    margin-top: 0.9rem;
+}
+
+
 .progress-review__section-header {
     display: flex;
     justify-content: space-between;
@@ -126,8 +123,9 @@
     margin-bottom: 0.65rem;
 }
 
-.progress-review__section {
-    margin-top: 1.25rem;
+.pr-section-divider {
+    border-top: 1px solid var(--pm-surface-haze);
+    margin-bottom: 10px;
 }
 
 .progress-review__stack {
@@ -167,7 +165,7 @@
    ========================================================= */
 
 .pr-section {
-    margin-top: 12px;
+    margin-top: 0;
 }
 
 .pr-section + .pr-section {
@@ -190,9 +188,46 @@
     margin-bottom: 6px;
 }
 
-.pr-section-divider {
-    border-top: 1px solid var(--pm-surface-haze);
-    margin-bottom: 10px;
+/* =========================================================
+   SECTION: Project section heading row
+   ========================================================= */
+
+.pr-section-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.65rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.pr-section-header__left {
+    min-width: 0;
+}
+
+.pr-section-header__eyebrow {
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #738195;
+    margin-bottom: 0.18rem;
+}
+
+.pr-section-header__title {
+    margin: 0;
+    font-size: 1.7rem;
+    line-height: 1.12;
+    font-weight: 650;
+    color: #0f172a;
+}
+
+.pr-section-header__meta {
+    font-size: 0.98rem;
+    color: #64748b;
+    white-space: nowrap;
 }
 
 /* =========================================================
@@ -423,10 +458,19 @@
    ========================================================= */
 
 @media (max-width: 991.98px) {
-    .progress-review__document-header,
-    .progress-review__section-header {
+    .pr-report-header,
+    .pr-section-header {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
+    }
+
+    .pr-report-header__actions {
+        justify-content: flex-start;
+        padding-top: 0;
+    }
+
+    .pr-section-header__meta {
+        white-space: normal;
     }
 
     .pr-page {
@@ -443,12 +487,7 @@
 }
 
 @media (max-width: 767.98px) {
-    .progress-review__toolbar {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .progress-review__toolbar-actions {
+    .pr-report-header__actions {
         width: 100%;
         justify-content: flex-start;
         flex-wrap: wrap;
@@ -486,7 +525,7 @@
     border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: 0.95rem;
     padding: 0.95rem 1.05rem 1.1rem;
-    margin-top: 0.45rem;
+    margin-top: 0.2rem;
     box-shadow: 0 8px 20px rgba(15, 30, 65, 0.04);
 }
 


### PR DESCRIPTION
### Motivation
- The top of the Progress Review page was visually fragmented into separate bands (title block, reporting period, actions, and section labels) and needed a single, intentional header composition. 
- The reporting period and section meta (`projects in scope`) read as overly dominant, creating stacked headings and loose spacing that weaken visual cohesion. 
- These changes are presentation-only and must preserve all existing report logic, movement-board behaviour, and print/date-range functionality.

### Description
- Replaced the split toolbar + document-period band with a unified header block by adding a `pr-report-header` markup block in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` that contains the eyebrow label, page title, inline reporting period and actions.  
- Flattened the previous `Reporting period` band from the canvas and moved period metadata into the new header while keeping conditional rendering when the view model is present.  
- Replaced the original section header with a composed `pr-section-header` row that pairs the `Ongoing projects progress` title and `@vm.Projects.Review.Summary.ProjectsInScope projects in scope`, and demoted `Section 01` to a subtle eyebrow.  
- Updated `wwwroot/css/progress-review.css` to add `.pr-report-header` and `.pr-section-header` styles, tighten top spacing and movement-board margins, reduce divider emphasis, and improve responsive stacking for header/actions and section meta.

### Testing
- Attempted an automated project build with `dotnet build`, but the command failed in this environment because `dotnet` is not available.  
- No automated browser/rendering tests were executed because the runtime lacks the browser/container tooling required to generate UI screenshots or run visual tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8313a53b08329ac34eed5073c3571)