### PR TITLE
Rename Progress Review Section 05 heading to "Proliferation" and remove subtitle

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -610,13 +610,12 @@
                     </div>
                 </section>
 
-                @* SECTION: Proliferation & FFC *@
+                @* SECTION: Proliferation *@
                 <section class="progress-review__section" id="proliferation">
                     <header class="progress-review__section-header">
                         <div>
                             <span class="progress-review__section-label" aria-hidden="true">Section 05</span>
-                            <h2 class="progress-review__section-title">Proliferation & FFC simulators</h2>
-                            <p class="progress-review__section-subtitle">Proloferation of simulators to units and to friendly foreign counteries.</p>
+                            <h2 class="progress-review__section-title">Proliferation</h2>
                         </div>
                     </header>
                     <div class="progress-review__stack">


### PR DESCRIPTION
### Motivation

- Align the Progress Review UI with the requested text change by renaming Section 05 heading and removing its supporting subtitle as a presentation-only update.

### Description

- Updated `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` to change the section comment and replace the header `h2` text with `Proliferation`.
- Removed the `<p class="progress-review__section-subtitle">` subtitle so no descriptive subtitle is rendered for Section 05.
- Left all data rendering, table markup and the `@vm.Proliferation.Rows.Count` bindings unchanged.

### Testing

- Ran `rg -n "Proliferation & FFC simulators|Proloferation of simulators to units and to friendly foreign counteries\." Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml` to verify the old heading/subtitle strings are no longer present, and the search returned no matches.
- Inspected the updated lines with `nl -ba Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml | sed -n '610,635p'` and confirmed the `h2` now reads `Proliferation` and the subtitle paragraph is absent.
- Generated a file diff for the modified file and confirmed only presentation header lines were changed and no table/data logic was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e832997a788329a079a687bb534fec)