### PR TITLE
Flatten Progress Review canvas by removing outer report slab styling

### DIFF
--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -4,7 +4,7 @@
 
 /* Tokens just for the Progress Review page */
 :root {
-    /* Main report surface (the big white card) */
+    /* Main report surface token for section-level cards */
     --pr-surface: var(--pm-surface-elevated, var(--pm-card));
     /* Muted text for meta and helper labels */
     --pr-muted: var(--pm-text-tertiary);
@@ -74,13 +74,13 @@
     padding-top: 0.22rem;
 }
 
-/* Main report canvas card */
+/* Main report canvas wrapper (no outer sheet surface) */
 .progress-review__canvas {
-    background: var(--pr-surface);
-    border: 1px solid rgba(15, 23, 42, 0.05);
-    border-radius: 0.9rem;
-    padding: 1rem 1.2rem 1.15rem;
-    box-shadow: 0 6px 16px rgba(15, 30, 65, 0.04);
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    box-shadow: none;
 }
 
 .progress-review__section-label {
@@ -478,7 +478,7 @@
     }
 
     .progress-review__canvas {
-        padding: 1.05rem 1rem 1.15rem;
+        padding: 0;
     }
 
     .pr-project-row {


### PR DESCRIPTION
### Motivation
- The Progress Review page used a large white “report slab” behind all content which made the report feel like a pasted sheet rather than a unified app canvas, so the goal is to adopt a single page canvas and let section panels provide the visual surfaces.

### Description
- Updated `wwwroot/css/progress-review.css` to make `.progress-review__canvas` transparent and remove border, radius, shadow, and outer padding so the page uses the shared app canvas instead of a full-page card.
- Preserved section-level card styling (e.g. `.pr-movement-board`, `.pr-activity-table`, `.pr-attention-table`) so panels remain the primary visual hierarchy for content.
- Adjusted the responsive override so `.progress-review__canvas` uses `padding: 0` at the mobile breakpoint to keep layout consistent after removing the outer wrapper padding.
- Clarified a `:root` comment to reflect that `--pr-surface` is intended for section-level cards.

### Testing
- No automated tests were executed for this CSS-only visual change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83486c5d0832992e49363b0a69202)