### PR TITLE
Refine Progress Review content gutters and header alignment

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -103,9 +103,7 @@
                 </button>
             </div>
         </div>
-    </div>
 
-    <div class="pr-page">
         @if (vm is null)
         {
             <div class="alert alert-info">Unable to load progress data for the selected range.</div>

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -27,6 +27,8 @@
 .pr-page {
     width: min(1680px, calc(100vw - 64px));
     margin-inline: auto;
+    box-sizing: border-box;
+    padding-inline: clamp(1rem, 1.5vw, 1.75rem);
 }
 
 /* =========================================================
@@ -475,6 +477,7 @@
 
     .pr-page {
         width: min(100%, calc(100vw - 24px));
+        padding-inline: 0.75rem;
     }
 
     .progress-review__canvas {


### PR DESCRIPTION
### Motivation

- Fix the horizontal gutter imbalance so the header title block and action buttons are comfortably inset from the page edges and align to shared content rails.  
- Ensure the Progress Review header and all report sections share the same page-level frame so cards, tables and right-aligned metrics line up and the page feels balanced and professional.

### Description

- Add page-level inner gutters by updating `.pr-page` to use `box-sizing: border-box` and `padding-inline: clamp(1rem, 1.5vw, 1.75rem)` so content no longer hugs the edges.  
- Add a responsive mobile override (`padding-inline: 0.75rem`) for `.pr-page` inside the `(max-width: 991.98px)` media query to preserve consistent framing on small viewports.  
- Unify the markup so the report header and the report body share the same `.pr-page` wrapper (removed the duplicate wrapper) ensuring the header, action buttons, section headers, metrics, cards, and tables align to one content frame.  
- Keep changes layout-only, scoped to `wwwroot/css/progress-review.css` and `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml`, and do not add any inline scripts.

### Testing

- Attempted to run a build with `dotnet build`, but the environment does not have the .NET SDK installed so the build could not be executed (`dotnet: command not found`).  
- No automated unit or UI tests were run due to the unavailable build environment; changes were validated by inspecting the updated markup and stylesheet diffs to confirm the intended layout updates were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e845a27ef88329a909587264292ccb)