### PR TITLE
Unify Progress Review content frame to fix right-rail alignment

### DIFF
--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -25,10 +25,11 @@
 
 /* Page-scoped wide container for desktop-heavy report content */
 .pr-page {
-    width: min(1680px, calc(100vw - 64px));
-    margin-inline: auto;
+    width: 100%;
+    max-width: none;
+    margin-inline: 0;
     box-sizing: border-box;
-    padding-inline: clamp(1rem, 1.5vw, 1.75rem);
+    padding-inline: 0;
 }
 
 /* =========================================================
@@ -476,8 +477,8 @@
     }
 
     .pr-page {
-        width: min(100%, calc(100vw - 24px));
-        padding-inline: 0.75rem;
+        width: 100%;
+        padding-inline: 0;
     }
 
     .progress-review__canvas {


### PR DESCRIPTION
### Motivation
- The Progress Review page showed a visible misaligned right rail because the page used an inner width/padding wrapper that produced a different right boundary for the header/actions and the cards/tables.
- The goal is to collapse the two horizontal constraints into a single content frame so header, actions, section metrics and report cards share the same right boundary without ad-hoc per-element offsets.

### Description
- Updated `wwwroot/css/progress-review.css` to change `.pr-page` to `width: 100%`, `max-width: none`, `margin-inline: 0`, and `padding-inline: 0` so the inner wrapper no longer creates a separate horizontal rail.
- Updated the responsive override for `.pr-page` (under the `max-width: 991.98px` media query) to use `width: 100%` and `padding-inline: 0` to avoid re-introducing a second rail at smaller breakpoints.
- No per-section `margin-right` fixes or ad-hoc adjustments were added and changes are scoped to the Progress Review CSS only.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln -c Debug`, which failed in this environment because the .NET SDK (`dotnet`) is not available, so no automated build/test completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88303fa388329b18fdd843362a7ba)