### PR TITLE
Unify Progress Review spacing rails and card insets

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml
@@ -129,7 +129,7 @@
                     else
                     {
                         @* SECTION: Project movement in this period *@
-                        <section class="pr-movement-board" aria-label="Project movement in this period">
+                        <section class="pr-movement-board pr-card pr-card--hero" aria-label="Project movement in this period">
                             <div class="pr-movement-board__header">
                                 <div>
                                     <h3 class="h6 mb-1">Project movement in this period</h3>
@@ -204,7 +204,7 @@
                         </section>
 
                         @* SECTION: Projects active in this period without stage advancement *@
-                        <section class="pr-activity-table" aria-label="Projects active in this period without stage advancement">
+                        <section class="pr-activity-table pr-card pr-card--standard" aria-label="Projects active in this period without stage advancement">
                             <h3 class="h6 mb-1">Projects active in this period without stage advancement</h3>
                             @if (!vm.Projects.Review.ActiveWithoutAdvancement.Any())
                             {
@@ -235,7 +235,7 @@
                         </section>
 
                         @* SECTION: Projects requiring attention *@
-                        <section class="pr-attention-table" aria-label="Projects requiring attention">
+                        <section class="pr-attention-table pr-card pr-card--standard" aria-label="Projects requiring attention">
                             <h3 class="h6 mb-1">Projects requiring attention</h3>
                             @if (!vm.Projects.Review.Attention.Any())
                             {
@@ -277,16 +277,16 @@
 
                 @* SECTION: Visits and Social media outreach *@
                 <section class="progress-review__section pr-section" id="field-engagement">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label pr-section-label" aria-hidden="true">Section 02</span>
-                            <h2 class="progress-review__section-title pr-section-title">Visits to SDD & social media outreach</h2>
+                    <header class="pr-section-header" aria-label="Visits to SDD and social media outreach summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 02</span>
+                            <h2 class="pr-section-header__title">Visits to SDD & social media outreach</h2>
                             <p class="progress-review__section-subtitle pr-meta">Visits to SDD and social narratives captured for documentation.</p>
-                            <div class="pr-section-divider"></div>
                         </div>
+                        <p class="pr-section-header__meta mb-0">@((vm.Visits.TotalCount + vm.SocialMedia.TotalCount)) records</p>
                     </header>
                     <div class="pr-category-stack">
-                        <section class="pr-category-block" aria-label="Visits log">
+                        <section class="pr-category-block pr-card pr-card--standard" aria-label="Visits log">
                             <div class="pr-category-header">
                                 <span>Visits log</span>
                                 <span class="pr-category-count">@vm.Visits.TotalCount entries</span>
@@ -338,7 +338,7 @@
                                 }
                             }
                         </section>
-                        <section class="pr-category-block" aria-label="Social media">
+                        <section class="pr-category-block pr-card pr-card--standard" aria-label="Social media">
                             <div class="pr-category-header">
                                 <span>Social media</span>
                                 <span class="pr-category-count">@vm.SocialMedia.TotalCount posts</span>
@@ -395,15 +395,15 @@
 
                 @* SECTION: Technology transfer & IPR *@
                 <section class="progress-review__section pr-section" id="tech-transfer">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label pr-section-label" aria-hidden="true">Section 03</span>
-                            <h2 class="progress-review__section-title pr-section-title">Transfer of technology & Patent/ Copyrights</h2>
-                            <div class="pr-section-divider"></div>
+                    <header class="pr-section-header" aria-label="Transfer of technology and Patent/Copyright summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 03</span>
+                            <h2 class="pr-section-header__title">Transfer of technology & Patent/ Copyrights</h2>
                         </div>
+                        <p class="pr-section-header__meta mb-0">@((vm.Tot.StageChanges.Count + vm.Tot.Remarks.Count + vm.Ipr.StatusChanges.Count + vm.Ipr.Remarks.Count)) records</p>
                     </header>
                     <div class="progress-review__stack">
-                        <div class="progress-review__block">
+                        <div class="progress-review__block pr-card pr-card--standard">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h3 class="progress-review__subheading mb-0">Transfer of Technology</h3>
                                 <span class="text-muted small">@vm.Tot.StageChanges.Count stage changes</span>
@@ -456,7 +456,7 @@
                                 }
                             </div>
                         </div>
-                        <div class="progress-review__block mt-3">
+                        <div class="progress-review__block pr-card pr-card--standard mt-3">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h3 class="progress-review__subheading mb-0">Patents/ Copyrights updates</h3>
                                 <span class="text-muted small">@vm.Ipr.StatusChanges.Count status changes</span>
@@ -518,16 +518,16 @@
 
                 @* SECTION: Training *@
                 <section class="progress-review__section pr-section" id="training">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label pr-section-label" aria-hidden="true">Section 04</span>
-                            <h2 class="progress-review__section-title pr-section-title">Training conducted by SDD</h2>
+                    <header class="pr-section-header" aria-label="Training conducted by SDD summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 04</span>
+                            <h2 class="pr-section-header__title">Training conducted by SDD</h2>
                             <p class="progress-review__section-subtitle pr-meta">Simulator and drone training efforts for the period.</p>
-                            <div class="pr-section-divider"></div>
                         </div>
+                        <p class="pr-section-header__meta mb-0">@((vm.Training.Simulator.Rows.Count + vm.Training.Drone.Rows.Count)) sessions</p>
                     </header>
                     <div class="progress-review__stack">
-                        <div class="progress-review__block">
+                        <div class="progress-review__block pr-card pr-card--standard">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h3 class="progress-review__subheading mb-0">Simulator training (@vm.Training.Simulator.TotalPersons participants)</h3>
                                 <span class="text-muted small">@vm.Training.Simulator.Rows.Count sessions</span>
@@ -566,7 +566,7 @@
                                 }
                             </div>
                         </div>
-                        <div class="progress-review__block mt-3">
+                        <div class="progress-review__block pr-card pr-card--standard mt-3">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h3 class="progress-review__subheading mb-0">Drone training (@vm.Training.Drone.TotalPersons participants)</h3>
                                 <span class="text-muted small">@vm.Training.Drone.Rows.Count sessions</span>
@@ -610,14 +610,15 @@
 
                 @* SECTION: Proliferation *@
                 <section class="progress-review__section" id="proliferation">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label" aria-hidden="true">Section 05</span>
-                            <h2 class="progress-review__section-title">Proliferation</h2>
+                    <header class="pr-section-header" aria-label="Proliferation summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 05</span>
+                            <h2 class="pr-section-header__title">Proliferation</h2>
                         </div>
+                        <p class="pr-section-header__meta mb-0">@vm.Proliferation.Rows.Count entries</p>
                     </header>
                     <div class="progress-review__stack">
-                        <div class="progress-review__block">
+                        <div class="progress-review__block pr-card pr-card--standard">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h3 class="progress-review__subheading mb-0">Proliferation (@vm.Proliferation.Rows.Count records)</h3>
                                 <span class="text-muted small">@vm.Proliferation.Rows.Count entries</span>
@@ -664,13 +665,13 @@
 
                 @* SECTION: Miscellaneous activities *@
                 <section class="progress-review__section" id="miscellaneous">
-                    <header class="progress-review__section-header">
-                        <div>
-                            <span class="progress-review__section-label" aria-hidden="true">Section 06</span>
-                            <h2 class="progress-review__section-title">Miscellaneous activities</h2>
+                    <header class="pr-section-header" aria-label="Miscellaneous activities summary">
+                        <div class="pr-section-header__left">
+                            <span class="pr-section-header__eyebrow" aria-hidden="true">Section 06</span>
+                            <h2 class="pr-section-header__title">Miscellaneous activities</h2>
                             <p class="progress-review__section-subtitle">Additional highlights requiring documentation.</p>
                         </div>
-                        <p class="progress-review__section-meta text-muted">@vm.Misc.Rows.Count activities</p>
+                        <p class="pr-section-header__meta mb-0">@vm.Misc.Rows.Count activities</p>
                     </header>
                     @if (!vm.Misc.Rows.Any())
                     {
@@ -679,7 +680,7 @@
                     else
                     {
                         var miscLimit = 10;
-                        <div class="progress-review__stack">
+                        <div class="progress-review__block pr-card pr-card--standard">
                             @foreach (var act in vm.Misc.Rows.Take(miscLimit))
                             {
                                 var photoUrl = BuildActivityPhotoUrl(act.ActivityId, act.DisplayPhotoId) ?? act.PhotoUrl;

--- a/wwwroot/css/progress-review.css
+++ b/wwwroot/css/progress-review.css
@@ -16,6 +16,13 @@
     --pr-background: var(--pm-surface-bg);
     /* Accent text when we need emphasis */
     --pr-accent: var(--pm-text-contrast);
+    /* Unified horizontal rail and panel inset system */
+    --pr-page-max-width: 1680px;
+    --pr-page-gutter: 1.5rem;
+    --pr-card-pad-hero-y: 1.125rem;
+    --pr-card-pad-hero-x: 1.25rem;
+    --pr-card-pad-standard-y: 1rem;
+    --pr-card-pad-standard-x: 1.125rem;
 }
 
 .progress-review-shell {
@@ -25,11 +32,10 @@
 
 /* Page-scoped wide container for desktop-heavy report content */
 .pr-page {
-    width: 100%;
-    max-width: none;
-    margin-inline: 0;
+    width: min(var(--pr-page-max-width), 100%);
+    margin-inline: auto;
     box-sizing: border-box;
-    padding-inline: 0;
+    padding-inline: var(--pr-page-gutter);
 }
 
 /* =========================================================
@@ -41,7 +47,9 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 1.1rem;
-    padding: 0.5rem 0 0.65rem;
+    padding: 0.5rem 0 0.75rem;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    margin-bottom: 0.75rem;
 }
 
 .pr-report-header__title-block {
@@ -114,22 +122,9 @@
 }
 
 .progress-review__section {
-    margin-top: 0.9rem;
+    margin-top: 1rem;
 }
 
-
-.progress-review__section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.85rem;
-    margin-bottom: 0.65rem;
-}
-
-.pr-section-divider {
-    border-top: 1px solid var(--pm-surface-haze);
-    margin-bottom: 10px;
-}
 
 .progress-review__stack {
     display: flex;
@@ -200,8 +195,8 @@
     align-items: flex-end;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 0.65rem;
-    padding-bottom: 0.35rem;
+    margin-bottom: 0.7rem;
+    padding-bottom: 0.45rem;
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
@@ -231,6 +226,8 @@
     font-size: 0.98rem;
     color: #64748b;
     white-space: nowrap;
+    text-align: right;
+    margin-left: auto;
 }
 
 /* =========================================================
@@ -247,14 +244,14 @@
     background: var(--pm-card);
     border: 1px solid var(--pm-surface-silver);
     border-radius: 10px;
-    overflow: hidden;
+    overflow: clip;
     box-shadow: inset 0 0 0 1px rgba(35, 43, 59, 0.02);
 }
 
 .pr-category-header {
     background: var(--pm-surface-mist);
     border-left: 3px solid var(--pm-text-gray-soft);
-    padding: 6px 10px;
+    padding: 0.55rem var(--pr-card-pad-standard-x);
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -340,7 +337,7 @@
 .pr-media-item {
     display: flex;
     gap: 0.75rem;
-    padding: 0.6rem 0;
+    padding: 0.65rem 0;
     border-top: 1px solid var(--pm-surface-ice);
 }
 
@@ -428,7 +425,7 @@
 .progress-review__mini-section {
     background: var(--pm-surface-plain);
     border-radius: 0.75rem;
-    padding: 0.75rem 0.9rem;
+    padding: 0.75rem 0.95rem;
     border: 1px solid var(--pm-surface-ice);
 }
 
@@ -477,8 +474,7 @@
     }
 
     .pr-page {
-        width: 100%;
-        padding-inline: 0;
+        padding-inline: 0.875rem;
     }
 
     .progress-review__canvas {
@@ -516,7 +512,7 @@
     border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: 10px;
     background: #fff;
-    padding: 0.75rem 0.9rem;
+    padding: var(--pr-card-pad-standard-y) var(--pr-card-pad-standard-x);
     margin-top: 0.7rem;
 }
 
@@ -528,7 +524,7 @@
     background: var(--pm-card);
     border: 1px solid rgba(15, 23, 42, 0.08);
     border-radius: 0.95rem;
-    padding: 0.95rem 1.05rem 1.1rem;
+    padding: var(--pr-card-pad-hero-y) var(--pr-card-pad-hero-x);
     margin-top: 0.2rem;
     box-shadow: 0 8px 20px rgba(15, 30, 65, 0.04);
 }
@@ -565,14 +561,14 @@
 .pr-movement-table__head {
     background: var(--pm-surface-mist);
     border-bottom: 1px solid var(--pm-surface-ice);
-    padding: 0.75rem 0.9rem;
+    padding: 0.75rem 1rem;
     font-size: 0.76rem;
     font-weight: 600;
     color: var(--pm-text-gray-soft);
 }
 
 .pr-movement-table__row {
-    padding: 0.78rem 0.9rem;
+    padding: 0.8rem 1rem;
     border-top: 1px solid var(--pm-surface-ice);
 }
 
@@ -702,3 +698,42 @@
 .pr-status-pill.is-watch { border-color: #8d8d8d; }
 .pr-status-pill.is-delayed { border-color: #6f6f6f; font-weight: 600; }
 .pr-status-pill.is-long-pending { border-color: #4f4f4f; font-weight: 700; }
+
+/* =========================================================
+   SECTION: Unified card rail & metadata alignment
+   ========================================================= */
+
+.pr-card {
+    width: 100%;
+}
+
+.pr-card--hero {
+    padding: var(--pr-card-pad-hero-y) var(--pr-card-pad-hero-x);
+}
+
+.pr-card--standard {
+    padding: var(--pr-card-pad-standard-y) var(--pr-card-pad-standard-x);
+}
+
+.progress-review__block {
+    padding: var(--pr-card-pad-standard-y) var(--pr-card-pad-standard-x);
+}
+
+.progress-review__block .table-responsive,
+.pr-activity-table .table-responsive,
+.pr-attention-table .table-responsive {
+    margin-inline: 0;
+}
+
+.pr-activity-table .table > :not(caption) > * > *,
+.pr-attention-table .table > :not(caption) > * > *,
+.progress-review__block .table > :not(caption) > * > * {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+
+.pr-category-block > .list-unstyled,
+.pr-category-block > p.pr-meta {
+    padding-left: var(--pr-card-pad-standard-x) !important;
+    padding-right: var(--pr-card-pad-standard-x) !important;
+}


### PR DESCRIPTION
### Motivation
- Create one strict outer content rail so header, actions, sections, cards, tables and footer share the same centered frame and gutter. 
- Tighten the right-alignment rail so section-level counters and card metadata terminate on a single visual boundary. 
- Standardize card padding and table/list insets so the page uses a small fixed set of panel padding patterns (hero vs standard) instead of many near-duplicate values. 

### Description
- Added page-scoped layout tokens and enforced an outer content wrapper via `.pr-page` with `--pr-page-max-width` and `--pr-page-gutter` to establish the true content rail. 
- Introduced unified card classes (`.pr-card`, `.pr-card--hero`, `.pr-card--standard`) and corresponding CSS tokens (`--pr-card-pad-*`) and applied them to movement board, activity/attention tables, category blocks, training/proliferation blocks, and miscellaneous activities. 
- Replaced several section header patterns with a shared `pr-section-header` structure and migrated Sections 02–06 to use `pr-section-header__left` + `pr-section-header__meta` so right-side metadata aligns to the same right rail. 
- Normalized inner insets for tables and media lists by standardizing table cell horizontal padding and category list insets, and tightened small spacing tweaks (e.g. header bottom border, minor padding adjustments) in `wwwroot/css/progress-review.css` and markup updates in `Areas/ProjectOfficeReports/Pages/ProgressReview/Index.cshtml`. 

### Testing
- Attempted to run `dotnet build ProjectManagement.sln -c Debug` but the build could not be executed in this environment because `dotnet` is not installed (build failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b4270cec832986311ba23e9f0b33)