### PR TITLE
Fix Progress Review print CSS after section-header class rename

### DIFF
--- a/wwwroot/css/progress-review.print.css
+++ b/wwwroot/css/progress-review.print.css
@@ -45,6 +45,7 @@
     .btn,
     .date-range-button,
     .progress-review__section-meta,
+    .pr-section-header__meta,
     .progress-review__section-subtitle {
         display: none !important;
     }
@@ -71,7 +72,8 @@
         break-inside: auto;
     }
 
-    .progress-review__section-header {
+    .progress-review__section-header,
+    .pr-section-header {
         page-break-after: avoid;
         break-after: avoid;
     }


### PR DESCRIPTION
### Motivation
- Print stylesheet needed updating after header classes were renamed so section metadata stays hidden and headers do not get orphaned from following content when printing/PDFing reports.

### Description
- Updated `wwwroot/css/progress-review.print.css` to add `.pr-section-header__meta` to the print-hide selector list and to include `.pr-section-header` alongside `.progress-review__section-header` for page-break rules.

### Testing
- Verified selector coverage with `rg` against the relevant files, reviewed the `git diff` to confirm the exact edits to `wwwroot/css/progress-review.print.css`, and committed the change with `git status` showing the commit; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9db60a2308329a300f9fcfc0c6ced)