### PR TITLE
Make photo uploads optional on New Visit page (remove false required validation)

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml
@@ -108,7 +108,7 @@ else
                     <div class="visit-form-card">
                         <div class="visit-form-card__header">
                             <h2 class="visit-form-card__title">Photo evidence</h2>
-                            <p class="visit-form-card__subtitle">Share crisp visuals from the visit. You can add more photos later from the edit screen.</p>
+                            <p class="visit-form-card__subtitle">Photos are optional at creation time. You can add or manage photos later from the edit screen.</p>
                         </div>
                         <div class="visit-form-grid visit-form-grid--single">
                             <div class="visit-form-grid__field">

--- a/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml.cs
@@ -49,7 +49,7 @@ public class NewModel : PageModel
     public int VisitPhotoMaxMb => Math.Max(1, (int)Math.Floor(VisitPhotoMaxBytes / 1024d / 1024d));
 
     public string VisitPhotoHelpText =>
-        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each. You can select up to {VisitPhotoMaxFiles} files.";
+        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each. You can select up to {VisitPhotoMaxFiles} files, or leave this empty and add photos later.";
 
     [BindProperty]
     public InputModel Input { get; set; } = new();
@@ -59,7 +59,7 @@ public class NewModel : PageModel
     public string? UploadCaption { get; set; }
 
     [BindProperty]
-    public List<IFormFile> Uploads { get; set; } = new();
+    public List<IFormFile>? Uploads { get; set; }
 
     public IReadOnlyList<SelectListItem> VisitTypeOptions { get; private set; } = Array.Empty<SelectListItem>();
 


### PR DESCRIPTION
### Motivation
- The New Visit form incorrectly conveyed that photo uploads were required, while server-side logic allowed creating visits with no photos, causing a misleading validation message.
- The UI, client-side metadata, and helper text must be aligned with the actual behavior so users can submit visits without photos.

### Description
- Change the uploads binding to a nullable list (`Uploads` from `List<IFormFile>` to `List<IFormFile>?`) so model metadata/client validation no longer treats the field as required (file: `Areas/ProjectOfficeReports/Pages/Visits/New.cshtml.cs`).
- Expand the photo help text to explicitly state photos are optional at creation and can be added later (string `VisitPhotoHelpText` updated in `New.cshtml.cs`).
- Update the Razor subtitle in the Photo evidence section to: “Photos are optional at creation time. You can add or manage photos later from the edit screen.” (file: `Areas/ProjectOfficeReports/Pages/Visits/New.cshtml`).
- Keep all server-side upload guardrails unchanged so valid upload errors (max count, zero-byte, file size) continue to be enforced during POST processing.

### Testing
- Attempted to run a build with `dotnet build`, but the CLI is not available in this environment and the command failed with `dotnet: command not found`.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2519e6d88329bffe8c7878ace238)