### PR TITLE
Role-based direct save for timeline plan edits (HoD/Admin)

### DIFF
--- a/Pages/Projects/Timeline/EditPlan.cshtml.cs
+++ b/Pages/Projects/Timeline/EditPlan.cshtml.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using ProjectManagement.Configuration;
 using ProjectManagement.Data;
 using ProjectManagement.Helpers;
 using ProjectManagement.Models;
@@ -75,8 +76,9 @@ public class EditPlanModel : PageModel
         }
 
         var principal = _userContext.User;
-        var isAdmin = principal.IsInRole("Admin");
-        var isHoD = principal.IsInRole("HoD");
+        var isAdmin = principal.IsInRole(RoleNames.Admin);
+        var isHoD = principal.IsInRole(RoleNames.HoD);
+        var canDirectApply = isAdmin || isHoD;
 
         var project = await _db.Projects
             .AsNoTracking()
@@ -100,10 +102,10 @@ public class EditPlanModel : PageModel
 
         if (string.Equals(Input.Mode, PlanEditorModes.Durations, StringComparison.OrdinalIgnoreCase))
         {
-            return await HandleDurationsAsync(id, userId, cancellationToken, workflowVersion);
+            return await HandleDurationsAsync(id, userId, cancellationToken, workflowVersion, canDirectApply);
         }
 
-        return await HandleExactAsync(id, userId, principal, cancellationToken, workflowVersion);
+        return await HandleExactAsync(id, userId, principal, cancellationToken, workflowVersion, canDirectApply);
     }
 
     public async Task<IActionResult> OnGetValidateAsync(int id, CancellationToken cancellationToken)
@@ -191,7 +193,7 @@ public class EditPlanModel : PageModel
         return RedirectToPage("/Projects/Overview", new { id });
     }
 
-    private async Task<IActionResult> HandleExactAsync(int id, string userId, ClaimsPrincipal principal, CancellationToken cancellationToken, string? workflowVersion)
+    private async Task<IActionResult> HandleExactAsync(int id, string userId, ClaimsPrincipal principal, CancellationToken cancellationToken, string? workflowVersion, bool canDirectApply)
     {
         var rows = Input.Rows ??= new List<PlanEditInputRow>();
 
@@ -216,6 +218,11 @@ public class EditPlanModel : PageModel
         }
 
         var action = NormalizeAction(Input.Action);
+        if (canDirectApply)
+        {
+            return await HandleExactDirectSaveAsync(id, userId, principal, rows, cancellationToken);
+        }
+
         var submitForApproval = string.Equals(action, PlanEditActions.Submit, StringComparison.OrdinalIgnoreCase);
 
         PlanVersion draft;
@@ -363,7 +370,7 @@ public class EditPlanModel : PageModel
         return RedirectToPage("/Projects/Overview", new { id });
     }
 
-    private async Task<IActionResult> HandleDurationsAsync(int id, string userId, CancellationToken ct, string? workflowVersion)
+    private async Task<IActionResult> HandleDurationsAsync(int id, string userId, CancellationToken ct, string? workflowVersion, bool canDirectApply)
     {
         var action = NormalizeAction(Input.Action);
         var calculateOnly = string.Equals(action, PlanEditActions.Calculate, StringComparison.OrdinalIgnoreCase);
@@ -504,6 +511,24 @@ public class EditPlanModel : PageModel
             id,
             _db.Database.GetConnectionString());
 
+        if (canDirectApply)
+        {
+            await EnsureProjectStagesExistAsync(id, rows.Select(r => r.Code), ct);
+            await _planGeneration.GenerateAsync(id, ct);
+
+            await _audit.LogAsync(
+                "Projects.PlanGeneratedFromDurations",
+                userId: userId,
+                data: new Dictionary<string, string?>
+                {
+                    ["ProjectId"] = id.ToString(CultureInfo.InvariantCulture),
+                    ["Action"] = PlanEditActions.SaveChanges
+                });
+
+            TempData["Flash"] = "Timeline plan updated.";
+            return RedirectToPage("/Projects/Overview", new { id });
+        }
+
         PlanVersion draft;
         try
         {
@@ -622,6 +647,150 @@ public class EditPlanModel : PageModel
     }
 
     private static string? FormatDate(DateOnly? value) => value?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    // SECTION: Direct-save helpers for HoD/Admin
+    private async Task<IActionResult> HandleExactDirectSaveAsync(
+        int projectId,
+        string userId,
+        ClaimsPrincipal principal,
+        IReadOnlyCollection<PlanEditInputRow> rows,
+        CancellationToken cancellationToken)
+    {
+        var stageRows = await _db.ProjectStages
+            .Where(stage => stage.ProjectId == projectId)
+            .ToListAsync(cancellationToken);
+
+        var stageLookup = stageRows
+            .Where(stage => !string.IsNullOrWhiteSpace(stage.StageCode))
+            .ToDictionary(stage => stage.StageCode!, StringComparer.OrdinalIgnoreCase);
+
+        var stageOrderLookup = ProcurementWorkflow.BuildOrderLookup(await _db.Projects
+            .AsNoTracking()
+            .Where(project => project.Id == projectId)
+            .Select(project => project.WorkflowVersion)
+            .SingleOrDefaultAsync(cancellationToken));
+
+        var nextSortOrder = stageRows.Count > 0
+            ? stageRows.Max(stage => stage.SortOrder) + 1
+            : stageOrderLookup.Count;
+
+        var changes = new List<StageChange>();
+
+        foreach (var row in rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Code))
+            {
+                continue;
+            }
+
+            if (!stageLookup.TryGetValue(row.Code, out var stage))
+            {
+                stage = new ProjectStage
+                {
+                    ProjectId = projectId,
+                    StageCode = row.Code,
+                    Status = StageStatus.NotStarted,
+                    SortOrder = StageOrder(row.Code, stageOrderLookup, ref nextSortOrder)
+                };
+                _db.ProjectStages.Add(stage);
+                stageLookup[row.Code] = stage;
+            }
+
+            var previousStart = stage.PlannedStart;
+            var previousDue = stage.PlannedDue;
+            if (previousStart == row.PlannedStart && previousDue == row.PlannedDue)
+            {
+                continue;
+            }
+
+            stage.PlannedStart = row.PlannedStart;
+            stage.PlannedDue = row.PlannedDue;
+            changes.Add(new StageChange(row.Code, row.Name, previousStart, previousDue, row.PlannedStart, row.PlannedDue));
+        }
+
+        if (changes.Count > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+            var userName = principal.Identity?.Name;
+
+            var data = new Dictionary<string, string?>
+            {
+                ["ProjectId"] = projectId.ToString(CultureInfo.InvariantCulture),
+                ["ChangedStages"] = string.Join(";", changes.Select(change => change.Code)),
+                ["SaveMode"] = "Direct"
+            };
+
+            for (var index = 0; index < changes.Count; index++)
+            {
+                var change = changes[index];
+                var prefix = $"Stage[{index}]";
+                data[$"{prefix}.Code"] = change.Code;
+                data[$"{prefix}.Name"] = change.Name;
+                data[$"{prefix}.Start.Before"] = FormatDate(change.PreviousStart);
+                data[$"{prefix}.Start.After"] = FormatDate(change.NewStart);
+                data[$"{prefix}.Due.Before"] = FormatDate(change.PreviousDue);
+                data[$"{prefix}.Due.After"] = FormatDate(change.NewDue);
+            }
+
+            await _audit.LogAsync(
+                "Projects.PlanUpdated",
+                userId: userId,
+                userName: userName,
+                data: data);
+        }
+
+        TempData["Flash"] = changes.Count > 0
+            ? "Timeline plan updated."
+            : "Planned dates saved successfully.";
+        return RedirectToPage("/Projects/Overview", new { id = projectId });
+    }
+
+    // SECTION: Ensure timeline stages exist for direct generation
+    private async Task EnsureProjectStagesExistAsync(int projectId, IEnumerable<string?> stageCodes, CancellationToken cancellationToken)
+    {
+        var codes = stageCodes
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Select(code => code!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (codes.Length == 0)
+        {
+            return;
+        }
+
+        var existingCodes = await _db.ProjectStages
+            .AsNoTracking()
+            .Where(stage => stage.ProjectId == projectId && stage.StageCode != null)
+            .Select(stage => stage.StageCode!)
+            .ToListAsync(cancellationToken);
+
+        var existingSet = new HashSet<string>(existingCodes, StringComparer.OrdinalIgnoreCase);
+        var stageOrderLookup = ProcurementWorkflow.BuildOrderLookup(await _db.Projects
+            .AsNoTracking()
+            .Where(project => project.Id == projectId)
+            .Select(project => project.WorkflowVersion)
+            .SingleOrDefaultAsync(cancellationToken));
+        var extraSortStart = stageOrderLookup.Count;
+
+        foreach (var code in codes)
+        {
+            if (existingSet.Contains(code))
+            {
+                continue;
+            }
+
+            _db.ProjectStages.Add(new ProjectStage
+            {
+                ProjectId = projectId,
+                StageCode = code,
+                SortOrder = StageOrder(code, stageOrderLookup, ref extraSortStart),
+                Status = StageStatus.NotStarted
+            });
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
 
     // SECTION: Stage ordering helpers
     private static int StageOrder(string stageCode, IReadOnlyDictionary<string, int> stageOrderLookup, ref int extraSortStart)

--- a/Pages/Projects/Timeline/_EditPlanForm.cshtml
+++ b/Pages/Projects/Timeline/_EditPlanForm.cshtml
@@ -1,13 +1,16 @@
 @model ProjectManagement.ViewModels.PlanEditorVm
+@using ProjectManagement.Configuration
 @using ProjectManagement.Models.Plans
 @using ProjectManagement.Models.Stages
 @using ProjectManagement.ViewModels
 @{ 
+    // SECTION: Role-sensitive action rendering
+    var isDirectSaveRole = User.IsInRole(RoleNames.Admin) || User.IsInRole(RoleNames.HoD);
     var activeMode = Model.ActiveMode ?? PlanEditorModes.Exact;
     var exactActive = string.Equals(activeMode, PlanEditorModes.Exact, StringComparison.OrdinalIgnoreCase);
     var durationsActive = string.Equals(activeMode, PlanEditorModes.Durations, StringComparison.OrdinalIgnoreCase);
     var state = Model.State ?? new PlanEditorStateVm();
-    var isLocked = state.IsLocked;
+    var isLocked = !isDirectSaveRole && state.IsLocked;
     var canSubmit = state.CanSubmit && !isLocked;
     var submitDisabledAttr = canSubmit ? null : "disabled";
     var disableAttr = isLocked ? "disabled" : null;
@@ -48,7 +51,7 @@
         </div>
     }
 
-    @if (!isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
+    @if (!isDirectSaveRole && !isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
     {
         <div class="alert alert-secondary mb-3" role="status">
             <div class="fw-semibold">Draft saved</div>
@@ -65,7 +68,7 @@
         </div>
     }
 
-    @if (!isLocked && state.HasPendingSubmission && !state.PendingOwnedByCurrentUser && !string.IsNullOrWhiteSpace(state.SubmissionBlockedReason))
+    @if (!isDirectSaveRole && !isLocked && state.HasPendingSubmission && !state.PendingOwnedByCurrentUser && !string.IsNullOrWhiteSpace(state.SubmissionBlockedReason))
     {
         <div class="alert alert-warning mb-3" role="status">
             <div class="fw-semibold">Submission blocked</div>
@@ -151,12 +154,19 @@
                 </div>
 
                 <div class="pt-3 mt-3 border-top d-flex justify-content-end gap-2">
-                    @if (!isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
+                    @if (!isDirectSaveRole && !isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
                     {
                         <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#discardDraftModal">Discard draft</button>
                     }
-                    <button class="btn btn-outline-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
-                    <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
+                    @if (isDirectSaveRole)
+                    {
+                        <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.SaveChanges" @(disableAttr)>Save changes</button>
+                    }
+                    else
+                    {
+                        <button class="btn btn-outline-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
+                        <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
+                    }
                 </div>
             </form>
         </div>
@@ -244,12 +254,19 @@
 
                 <div class="d-flex gap-2 justify-content-end mt-3 pt-3 border-top">
                     <button class="btn btn-outline-secondary" type="submit" name="Input.Action" value="@PlanEditActions.Calculate" @(disableAttr)>Calculate</button>
-                    @if (!isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
+                    @if (!isDirectSaveRole && !isLocked && state.HasMyDraft && state.Status == PlanVersionStatus.Draft)
                     {
                         <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#discardDraftModal">Discard draft</button>
                     }
-                    <button class="btn btn-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
-                    <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
+                    @if (isDirectSaveRole)
+                    {
+                        <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.SaveChanges" @(disableAttr)>Save changes</button>
+                    }
+                    else
+                    {
+                        <button class="btn btn-secondary" type="submit" name="Input.Action" value="@PlanEditActions.SaveDraft" @(disableAttr)>Save draft</button>
+                        <button class="btn btn-primary" type="submit" name="Input.Action" value="@PlanEditActions.Submit" @(submitDisabledAttr)>Save &amp; request approval</button>
+                    }
                 </div>
             </form>
         </div>

--- a/ViewModels/PlanEditActions.cs
+++ b/ViewModels/PlanEditActions.cs
@@ -4,5 +4,6 @@ public static class PlanEditActions
 {
     public const string Calculate = "Calculate";
     public const string SaveDraft = "SaveDraft";
+    public const string SaveChanges = "SaveChanges";
     public const string Submit = "Submit";
 }


### PR DESCRIPTION
### Motivation
- Make the Timeline "Edit plan" drawer role-sensitive so `HoD` and `Admin` users can apply planned dates immediately without going through the draft/approval workflow. 
- Ensure the change is enforced server-side so the behavior does not rely on front-end hiding of buttons and preserves auditability.

### Description
- UI: updated `Pages/Projects/Timeline/_EditPlanForm.cshtml` to detect direct-save roles (`RoleNames.Admin` or `RoleNames.HoD`), hide the `Save draft`/`Save & request approval` actions for those roles and show a single `Save changes` action instead, and adjusted lock/message rendering so HoD/Admin are not blocked by pending-draft UI state. 
- Constants: added `PlanEditActions.SaveChanges` in `ViewModels/PlanEditActions.cs` for the new direct-save action token. 
- Server: updated `Pages/Projects/Timeline/EditPlan.cshtml.cs` to resolve role membership via `RoleNames`, compute `canDirectApply`, and branch submission handling for both exact-date and durations modes. 
- Direct-save implementation: added `HandleExactDirectSaveAsync` which writes planned dates directly to `ProjectStages` (creating missing stage rows when needed), records detailed audit data, and returns immediate success feedback; added `EnsureProjectStagesExistAsync` and direct-duration handling to persist schedule settings/durations and call `PlanGenerationService.GenerateAsync` to update live planned dates without creating plan drafts or approval requests. 
- Preservation: existing draft creation, draft submission (`PlanDraftService` / `PlanApprovalService`) and approval flows remain unchanged for non-HoD/Admin roles.

### Testing
- Attempted to build with `dotnet build`, but it failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- No automated unit/integration tests were run in this container; code changes were committed (`git commit`) and diffs inspected locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ccc521883299baeb25b6d27e7a4)