### PR TITLE
Add year-wise completed-project board to Completed analytics tab

### DIFF
--- a/Models/Analytics/CompletedAnalyticsVm.cs
+++ b/Models/Analytics/CompletedAnalyticsVm.cs
@@ -7,8 +7,26 @@ public sealed class CompletedAnalyticsVm
     public required IReadOnlyList<AnalyticsCategoryCountPoint> ByTechnical { get; init; }
     public required IReadOnlyList<CompletedPerYearPoint> PerYear { get; init; }
     public required IReadOnlyList<CompletedPerYearByParentCategoryPoint> PerYearByParentCategory { get; init; }
+    public required IReadOnlyList<CompletedYearBoardItemVm> YearBoard { get; init; }
     public int TotalCompletedProjects { get; init; }
 }
+
+// SECTION: Completed year board DTOs
+public sealed record CompletedYearBoardProjectVm(
+    int ProjectId,
+    string ProjectName,
+    DateOnly? CompletedOn);
+
+public sealed record CompletedYearBoardCategoryVm(
+    string ParentCategoryName,
+    int CategoryCount,
+    IReadOnlyList<CompletedYearBoardProjectVm> Projects);
+
+public sealed record CompletedYearBoardItemVm(
+    int Year,
+    int YearCount,
+    IReadOnlyList<CompletedYearBoardCategoryVm> Categories);
+// END SECTION
 
 // SECTION: Shared analytics DTOs
 public sealed record AnalyticsCategoryCountPoint(string Name, int Count);

--- a/Pages/Analytics/Index.cshtml.cs
+++ b/Pages/Analytics/Index.cshtml.cs
@@ -207,6 +207,7 @@ namespace ProjectManagement.Pages.Analytics
             var perYearByParentCategory = await BuildCompletedPerYearByParentCategoryAsync(
                 completedQuery,
                 cancellationToken);
+            var yearBoard = await BuildCompletedYearBoardAsync(completedQuery, cancellationToken);
 
             // SECTION: Completed per-year aggregation
             var completionDates = await completedQuery
@@ -228,6 +229,7 @@ namespace ProjectManagement.Pages.Analytics
                 ByTechnical = byTechnical,
                 PerYear = perYear,
                 PerYearByParentCategory = perYearByParentCategory,
+                YearBoard = yearBoard,
                 TotalCompletedProjects = await completedQuery.CountAsync(cancellationToken)
             };
             // END SECTION
@@ -712,6 +714,68 @@ namespace ProjectManagement.Pages.Analytics
                 .ThenBy(point => point.CategoryName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
+
+        // SECTION: Completed analytics year board aggregation
+        private async Task<IReadOnlyList<CompletedYearBoardItemVm>> BuildCompletedYearBoardAsync(
+            IQueryable<Project> completedQuery,
+            CancellationToken cancellationToken)
+        {
+            var rows = await completedQuery
+                .Select(project => new
+                {
+                    project.Id,
+                    project.Name,
+                    project.CompletedOn,
+                    project.CompletedYear,
+                    ParentCategoryName = project.CategoryId.HasValue
+                        ? (project.Category!.Parent != null
+                            ? project.Category.Parent.Name
+                            : project.Category.Name)
+                        : null
+                })
+                .ToListAsync(cancellationToken);
+
+            var shapedRows = rows
+                .Select(row => new
+                {
+                    row.Id,
+                    ProjectName = string.IsNullOrWhiteSpace(row.Name)
+                        ? "Untitled project"
+                        : row.Name.Trim(),
+                    row.CompletedOn,
+                    EffectiveYear = row.CompletedYear ?? row.CompletedOn?.Year,
+                    ParentCategoryName = string.IsNullOrWhiteSpace(row.ParentCategoryName)
+                        ? "Unassigned"
+                        : row.ParentCategoryName.Trim()
+                })
+                .Where(row => row.EffectiveYear.HasValue)
+                .ToList();
+
+            return shapedRows
+                .GroupBy(row => row.EffectiveYear!.Value)
+                .OrderBy(group => group.Key)
+                .Select(yearGroup => new CompletedYearBoardItemVm(
+                    yearGroup.Key,
+                    yearGroup.Count(),
+                    yearGroup
+                        .GroupBy(project => project.ParentCategoryName)
+                        .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
+                        .Select(categoryGroup => new CompletedYearBoardCategoryVm(
+                            categoryGroup.Key,
+                            categoryGroup.Count(),
+                            categoryGroup
+                                .OrderByDescending(project => project.CompletedOn.HasValue)
+                                .ThenByDescending(project => project.CompletedOn)
+                                .ThenBy(project => project.ProjectName, StringComparer.OrdinalIgnoreCase)
+                                .Select(project => new CompletedYearBoardProjectVm(
+                                    project.Id,
+                                    project.ProjectName,
+                                    project.CompletedOn))
+                                .ToList()))
+                        .ToList()))
+                .ToList();
+        }
+        // END SECTION
 
         private async Task<IReadOnlyDictionary<int, string>> LoadCategoryNamesAsync(
             IEnumerable<CategoryAggregation> aggregations,

--- a/Pages/Analytics/Partials/_CompletedAnalytics.cshtml
+++ b/Pages/Analytics/Partials/_CompletedAnalytics.cshtml
@@ -39,6 +39,48 @@
                 <div class="analytics-chart-container">
                     <canvas id="completedPerYearChart" aria-label="Projects completed per year" role="img"></canvas>
                 </div>
+
+                @if (Model.YearBoard.Count == 0)
+                {
+                    <p class="analytics-card__empty-text analytics-completed-board__empty">
+                        No completed projects available for year-wise listing.
+                    </p>
+                }
+                else
+                {
+                    <section class="analytics-completed-board" aria-label="Completed projects grouped by year">
+                        @foreach (var yearItem in Model.YearBoard)
+                        {
+                            <article class="analytics-completed-board__year-column"
+                                     aria-label="@($"{yearItem.Year} with {yearItem.YearCount} completed projects")">
+                                <h3 class="analytics-completed-board__year-title">@yearItem.Year (@yearItem.YearCount)</h3>
+
+                                @foreach (var category in yearItem.Categories)
+                                {
+                                    <section class="analytics-completed-board__category-group"
+                                             aria-label="@($"{category.ParentCategoryName} with {category.CategoryCount} projects")">
+                                        <h4 class="analytics-completed-board__category-title">
+                                            <span class="analytics-completed-board__category-dot"
+                                                  data-category-name="@category.ParentCategoryName"
+                                                  aria-hidden="true"></span>
+                                            @category.ParentCategoryName (@category.CategoryCount)
+                                        </h4>
+
+                                        <ol class="analytics-completed-board__project-list">
+                                            @foreach (var project in category.Projects)
+                                            {
+                                                <li class="analytics-completed-board__project-item"
+                                                    title="@project.ProjectName">
+                                                    @project.ProjectName
+                                                </li>
+                                            }
+                                        </ol>
+                                    </section>
+                                }
+                            </article>
+                        }
+                    </section>
+                }
             </div>
         </article>
         <!-- END SECTION -->

--- a/wwwroot/css/analytics.css
+++ b/wwwroot/css/analytics.css
@@ -567,6 +567,73 @@
 }
 /* END SECTION */
 
+/* SECTION: Completed year board */
+.analytics-completed-board {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(250px, 1fr);
+  gap: 1rem;
+  margin-top: 1.25rem;
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+}
+
+.analytics-completed-board__year-column {
+  background: var(--pm-card);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+}
+
+.analytics-completed-board__year-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: var(--pm-text);
+}
+
+.analytics-completed-board__category-group + .analytics-completed-board__category-group {
+  margin-top: 0.8rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.analytics-completed-board__category-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0 0.35rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--pm-muted);
+}
+
+.analytics-completed-board__category-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #94a3b8;
+  flex: 0 0 auto;
+}
+
+.analytics-completed-board__project-list {
+  margin: 0;
+  padding-left: 1.05rem;
+}
+
+.analytics-completed-board__project-item {
+  margin: 0.12rem 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--pm-text);
+  overflow-wrap: anywhere;
+}
+
+.analytics-completed-board__empty {
+  margin-top: 1rem;
+}
+/* END SECTION */
+
 
 /* SECTION: Analytics roadmap / subcategory listing */
 .analytics-roadmap {

--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -412,7 +412,12 @@ function buildCategoryColorMapping(stackedPoints) {
 
 // SECTION: Ongoing stage board color sync
 function applyStageBoardCategoryColors(categoryColorMap = new Map()) {
-  const categoryDots = document.querySelectorAll('.analytics-stage-board__category-dot[data-category-name]');
+  applyCategoryDots('.analytics-stage-board__category-dot[data-category-name]', categoryColorMap);
+}
+
+// SECTION: Shared category dot color sync
+function applyCategoryDots(selector, categoryColorMap = new Map()) {
+  const categoryDots = document.querySelectorAll(selector);
   if (!categoryDots.length) {
     return;
   }
@@ -762,6 +767,8 @@ function initCompletedAnalytics() {
   if (perYearEl) {
     if (data.perYearByParentCategory?.length) {
       createCompletedPerYearStackedChart(perYearEl, data.perYearByParentCategory);
+      const { categoryColorMap } = buildCategoryColorMapping(data.perYearByParentCategory);
+      applyCategoryDots('.analytics-completed-board__category-dot[data-category-name]', categoryColorMap);
     } else if (data.perYear?.length) {
       createBarChart(perYearEl, {
         labels: data.perYear.map((point) => point.year?.toString() ?? ''),


### PR DESCRIPTION
### Motivation
- Provide a textual year-wise drill-down of completed projects under the existing "Projects completed per year" chart so users can see project names grouped by year and parent category. 
- Reuse the proven chart-plus-board pattern used by the ongoing tab and keep chart aggregates and board data consistent by sharing the same effective-year and parent-category resolution logic.

### Description
- Added a `YearBoard` property and new DTOs (`CompletedYearBoardItemVm`, `CompletedYearBoardCategoryVm`, `CompletedYearBoardProjectVm`) to `CompletedAnalyticsVm` to carry the board data separate from chart series (`Models/Analytics/CompletedAnalyticsVm.cs`).
- Implemented `BuildCompletedYearBoardAsync(...)` and wired it into `BuildCompletedAnalyticsAsync(...)` to populate the year board using the effective-year rule (`CompletedYear` fallback to `CompletedOn.Year`), resolving parent category names and excluding projects with no effective year (`Pages/Analytics/Index.cshtml.cs`).
- Rendered the horizontally scrollable year-wise project board below the existing completed-per-year chart with accessible labels and an empty state (`Pages/Analytics/Partials/_CompletedAnalytics.cshtml`).
- Added CSS for the completed-year board column layout and styles (`wwwroot/css/analytics.css`) and generalized category-dot color syncing in the analytics JS via `applyCategoryDots(...)`, applying the same category-colour mapping used by the stacked chart so category dots in the board match chart colours (`wwwroot/js/analytics-projects.js`).

### Testing
- Attempted `dotnet build` in this environment but it failed due to the .NET SDK not being available (`dotnet: command not found`).
- No other automated tests were runnable in this environment; UI/visual verification and integration validation should be performed in a local/dev environment where the app can be built and the browser assets executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3098c1f48329b9f463efd50d894d)