### PR TITLE
Fix completed analytics stacked-chart category color mismatch

### DIFF
--- a/wwwroot/js/analytics-projects.js
+++ b/wwwroot/js/analytics-projects.js
@@ -531,7 +531,12 @@ function getCompletedAnalyticsData() {
 }
 
 // SECTION: Completed analytics chart builders
-function createCompletedPerYearStackedChart(canvas, points) {
+function createCompletedPerYearStackedChart(
+  canvas,
+  points,
+  categoryColorMap = new Map(),
+  categoryOrder = []
+) {
   if (!canvas || !window.Chart || !Array.isArray(points) || !points.length) {
     return null;
   }
@@ -545,9 +550,18 @@ function createCompletedPerYearStackedChart(canvas, points) {
     (first, second) => first - second
   );
 
-  const categories = Array.from(
-    new Set(points.map((point) => point.categoryName))
-  ).sort((first, second) => first.localeCompare(second));
+  const detectedCategories = Array.from(
+    new Set(points.map((point) => point.categoryName ?? 'Unassigned'))
+  );
+  let categories = detectedCategories.sort((first, second) => first.localeCompare(second));
+
+  if (Array.isArray(categoryOrder) && categoryOrder.length) {
+    const orderedSet = categoryOrder.filter((category) => detectedCategories.includes(category));
+    const remainingCategories = detectedCategories.filter(
+      (category) => !orderedSet.includes(category)
+    );
+    categories = [...orderedSet, ...remainingCategories];
+  }
 
   const palette = getPalette();
   const accentColors = palette.accents && palette.accents.length ? palette.accents : paletteFallback;
@@ -556,11 +570,11 @@ function createCompletedPerYearStackedChart(canvas, points) {
     label: category,
     data: years.map((year) => {
       const match = points.find(
-        (point) => point.year === year && point.categoryName === category
+        (point) => point.year === year && (point.categoryName ?? 'Unassigned') === category
       );
       return ensureNumber(match?.count);
     }),
-    backgroundColor: accentColors[index % accentColors.length],
+    backgroundColor: categoryColorMap.get(category) ?? accentColors[index % accentColors.length],
     borderWidth: 1
   }));
 
@@ -766,8 +780,13 @@ function initCompletedAnalytics() {
 
   if (perYearEl) {
     if (data.perYearByParentCategory?.length) {
-      createCompletedPerYearStackedChart(perYearEl, data.perYearByParentCategory);
-      const { categoryColorMap } = buildCategoryColorMapping(data.perYearByParentCategory);
+      const { categoryColorMap, rankedCategories } = buildCategoryColorMapping(data.perYearByParentCategory);
+      createCompletedPerYearStackedChart(
+        perYearEl,
+        data.perYearByParentCategory,
+        categoryColorMap,
+        rankedCategories
+      );
       applyCategoryDots('.analytics-completed-board__category-dot[data-category-name]', categoryColorMap);
     } else if (data.perYear?.length) {
       createBarChart(perYearEl, {


### PR DESCRIPTION
### Motivation
- The completed per-year stacked chart could show bar segment colors that didn’t match the category legend/dots, and categories with missing names were not consistently grouped.
- The change aims to ensure the chart and board use the same category color mapping and ordering so visual cues remain consistent.

### Description
- Updated `createCompletedPerYearStackedChart` signature to accept `categoryColorMap` and `categoryOrder` and use them when building datasets.
- Normalized missing `categoryName` values to `Unassigned` when detecting categories and when matching points to dataset buckets.
- Applied `categoryColorMap.get(category)` as the dataset `backgroundColor` fallbacking to palette accents when missing, and applied `categoryOrder` to preserve preferred ordering.
- Modified `initCompletedAnalytics` to build the color mapping via `buildCategoryColorMapping` and pass both `categoryColorMap` and `rankedCategories` into the stacked chart builder before calling `applyCategoryDots`.

### Testing
- Ran `npm test`, which completed successfully (all JS tests passed).
- Attempted `dotnet test` for the .NET test project, but it could not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3404d058832989d67014095e6a17)