### PR TITLE
Prevent skipped stages from becoming movement anchors

### DIFF
--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1615,6 +1615,12 @@ public sealed class ProgressReviewService : IProgressReviewService
 
     private static bool IsInRangeAnchor(ProjectResolvedStageVm stage, DateOnly rangeFrom, DateOnly rangeTo)
     {
+        // SECTION: Skipped stages are never eligible as movement anchors
+        if (IsSkipped(stage))
+        {
+            return false;
+        }
+
         // SECTION: Authoritative anchors that establish in-period movement
         return (stage.CompletedOn.HasValue && stage.CompletedOn.Value >= rangeFrom && stage.CompletedOn.Value <= rangeTo)
             || (stage.IsCurrent && stage.StartedOn.HasValue && stage.StartedOn.Value >= rangeFrom && stage.StartedOn.Value <= rangeTo);


### PR DESCRIPTION
### Motivation
- Prevent stages marked `Skipped` from being treated as movement-board anchors when determining in-period project movement, because skipped stages should never establish movement boundaries even if they have retained dates.

### Description
- Added an explicit guard at the top of `IsInRangeAnchor` in `Services/Reports/ProgressReview/ProgressReviewService.cs` to return `false` for any stage where `IsSkipped(stage)` is `true`, preserving the existing date-based anchor checks for non-skipped stages.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --nologo`, but the test run could not be executed in this environment because the `dotnet` CLI is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2af388008329a340ff8afec2198b)