### PR TITLE
Align movement-board Moves count with displayed stage steps

### DIFF
--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1516,12 +1516,15 @@ public sealed class ProgressReviewService : IProgressReviewService
                         i == includedStages.Count - 1));
                 }
 
+                // SECTION: Board-local moves count aligned with rendered steps
+                var boardMovesCount = movementSteps.Count;
+
                 return new ProjectMovementRowVm(
                     row.ProjectId,
                     row.ProjectName,
                     row.ProjectCategoryName,
                     movementSteps,
-                    row.MovementCountInRange);
+                    boardMovesCount);
             })
             .Where(row => row.Steps.Count > 0)
             .OrderByDescending(r => r.MovementCount)


### PR DESCRIPTION
### Motivation
- Fix a UI inconsistency where the movement-board rendered stage chips come from resolved/included stages but the numeric `Moves` value was taken from a separate stage-history lookup, producing mismatched counts.

### Description
- In `Services/Reports/ProgressReview/ProgressReviewService.cs` inside `BuildProjectMovementBoard` compute `boardMovesCount = movementSteps.Count` and pass that into `ProjectMovementRowVm` instead of using `row.MovementCountInRange`, so the row `Moves` is derived from the same `movementSteps` collection that is rendered.

### Testing
- Attempted an automated validation with `dotnet build ProjectManagement.sln -c Release`, but the environment is missing the .NET SDK (`dotnet: command not found`) so the build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee46c0d3bc8329ad6eb953850902c5)