### PR TITLE
Add Action Tracker module with role-governed tasks and audit trail

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -49,6 +49,8 @@ namespace ProjectManagement.Data
         public DbSet<ProjectTechStatus> ProjectTechStatuses => Set<ProjectTechStatus>();
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
         public DbSet<TodoItem> TodoItems => Set<TodoItem>();
+        public DbSet<ActionTaskItem> ActionTasks => Set<ActionTaskItem>();
+        public DbSet<ActionTaskAuditLog> ActionTaskAuditLogs => Set<ActionTaskAuditLog>();
         public DbSet<Celebration> Celebrations => Set<Celebration>();
         public DbSet<AuthEvent> AuthEvents => Set<AuthEvent>();
         public DbSet<DailyLoginStat> DailyLoginStats => Set<DailyLoginStat>();
@@ -1803,6 +1805,32 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Status).HasDefaultValue(TodoStatus.Open);
                 e.Property(x => x.IsPinned).HasDefaultValue(false);
                 e.Property(x => x.OrderIndex).HasDefaultValue(0);
+            });
+
+            builder.Entity<ActionTaskItem>(e =>
+            {
+                e.HasIndex(x => new { x.AssignedToUserId, x.Status });
+                e.HasIndex(x => new { x.DueDate, x.Status });
+                e.HasIndex(x => x.IsDeleted);
+                e.Property(x => x.Title).IsRequired().HasMaxLength(200);
+                e.Property(x => x.Description).IsRequired().HasMaxLength(4000);
+                e.Property(x => x.CreatedByUserId).IsRequired().HasMaxLength(450);
+                e.Property(x => x.AssignedToUserId).IsRequired().HasMaxLength(450);
+                e.Property(x => x.CreatedByRole).IsRequired().HasMaxLength(64);
+                e.Property(x => x.AssignedToRole).IsRequired().HasMaxLength(64);
+                e.Property(x => x.Priority).IsRequired().HasMaxLength(24);
+                e.Property(x => x.Status).IsRequired().HasMaxLength(32);
+                e.Property(x => x.IsDeleted).HasDefaultValue(false);
+            });
+
+            builder.Entity<ActionTaskAuditLog>(e =>
+            {
+                e.HasIndex(x => new { x.TaskId, x.PerformedAt });
+                e.HasIndex(x => x.PerformedByUserId);
+                e.Property(x => x.ActionType).IsRequired().HasMaxLength(64);
+                e.Property(x => x.PerformedByUserId).IsRequired().HasMaxLength(450);
+                e.Property(x => x.PerformedByRole).IsRequired().HasMaxLength(64);
+                e.Property(x => x.Remarks).HasMaxLength(2000);
             });
 
             builder.Entity<Celebration>(e =>

--- a/Migrations/20261125140000_AddActionTasks.cs
+++ b/Migrations/20261125140000_AddActionTasks.cs
@@ -1,0 +1,95 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125140000_AddActionTasks")]
+    public class AddActionTasks : Migration
+    {
+        // SECTION: Apply Action Tracker schema
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ActionTasks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    AssignedToUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    CreatedByRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    AssignedToRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    AssignedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DueDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Priority = table.Column<string>(type: "character varying(24)", maxLength: 24, nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SubmittedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ClosedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionTasks", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ActionTaskAuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TaskId = table.Column<int>(type: "integer", nullable: false),
+                    ActionType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    PerformedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    PerformedByRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    PerformedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    OldValue = table.Column<string>(type: "text", nullable: true),
+                    NewValue = table.Column<string>(type: "text", nullable: true),
+                    Remarks = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionTaskAuditLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTaskAuditLogs_PerformedByUserId",
+                table: "ActionTaskAuditLogs",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTaskAuditLogs_TaskId_PerformedAt",
+                table: "ActionTaskAuditLogs",
+                columns: new[] { "TaskId", "PerformedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTasks_AssignedToUserId_Status",
+                table: "ActionTasks",
+                columns: new[] { "AssignedToUserId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTasks_DueDate_Status",
+                table: "ActionTasks",
+                columns: new[] { "DueDate", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTasks_IsDeleted",
+                table: "ActionTasks",
+                column: "IsDeleted");
+        }
+
+        // SECTION: Revert Action Tracker schema
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "ActionTaskAuditLogs");
+            migrationBuilder.DropTable(name: "ActionTasks");
+        }
+    }
+}

--- a/Models/ActionTaskAuditLog.cs
+++ b/Models/ActionTaskAuditLog.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class ActionTaskAuditLog
+{
+    [Key]
+    public int Id { get; set; }
+
+    public int TaskId { get; set; }
+
+    [Required, StringLength(64)]
+    public string ActionType { get; set; } = string.Empty;
+
+    [Required, StringLength(450)]
+    public string PerformedByUserId { get; set; } = string.Empty;
+
+    [Required, StringLength(64)]
+    public string PerformedByRole { get; set; } = string.Empty;
+
+    public DateTime PerformedAt { get; set; }
+
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+
+    [StringLength(2000)]
+    public string? Remarks { get; set; }
+}

--- a/Models/ActionTaskItem.cs
+++ b/Models/ActionTaskItem.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public static class ActionTaskStatuses
+{
+    public const string Assigned = "Assigned";
+    public const string InProgress = "In Progress";
+    public const string Submitted = "Submitted";
+    public const string Closed = "Closed";
+    public const string Blocked = "Blocked";
+
+    public static readonly string[] All =
+    {
+        Assigned,
+        InProgress,
+        Submitted,
+        Closed,
+        Blocked
+    };
+}
+
+public class ActionTaskItem
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required, StringLength(200)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required, StringLength(4000)]
+    public string Description { get; set; } = string.Empty;
+
+    [Required, StringLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    [Required, StringLength(450)]
+    public string AssignedToUserId { get; set; } = string.Empty;
+
+    [Required, StringLength(64)]
+    public string CreatedByRole { get; set; } = string.Empty;
+
+    [Required, StringLength(64)]
+    public string AssignedToRole { get; set; } = string.Empty;
+
+    public DateTime AssignedOn { get; set; }
+    public DateTime DueDate { get; set; }
+
+    [Required, StringLength(24)]
+    public string Priority { get; set; } = "Normal";
+
+    [Required, StringLength(32)]
+    public string Status { get; set; } = ActionTaskStatuses.Assigned;
+
+    public DateTime? SubmittedOn { get; set; }
+    public DateTime? ClosedOn { get; set; }
+
+    public bool IsDeleted { get; set; }
+}

--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -1,0 +1,199 @@
+@page
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+@using ProjectManagement.Models
+@{
+    ViewData["Title"] = "Action Tracker";
+    var activeView = (Model.ViewMode ?? "Dashboard").Trim();
+
+    int CountByStatus(string status) => Model.Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
+    var activeCount = Model.Tasks.Count(t => t.Status != ActionTaskStatuses.Closed);
+    var overdueCount = Model.Tasks.Count(t => t.Status != ActionTaskStatuses.Closed && t.DueDate < DateTime.UtcNow);
+    var submittedCount = CountByStatus(ActionTaskStatuses.Submitted);
+    var blockedCount = CountByStatus(ActionTaskStatuses.Blocked);
+    var closedCount = CountByStatus(ActionTaskStatuses.Closed);
+
+    var grouped = Model.Tasks.GroupBy(x => x.Status).OrderBy(g => g.Key).ToList();
+}
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/action-tracker.css" asp-append-version="true" />
+}
+
+<div class="at-shell">
+    <aside class="at-sidebar">
+        <div class="at-brand">PRISM ERP</div>
+        <div class="at-module">Action Tracker</div>
+
+        <nav class="at-nav">
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(activeView == "Dashboard" ? "active" : string.Empty)">Dashboard</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(activeView == "MyTasks" ? "active" : string.Empty)">My Tasks</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="SprintBoard" class="@(activeView == "SprintBoard" ? "active" : string.Empty)">Sprint Board</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(activeView == "Kanban" ? "active" : string.Empty)">Kanban Board</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(activeView == "TaskList" ? "active" : string.Empty)">Task List</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(activeView == "Reports" ? "active" : string.Empty)">Reports</a>
+        </nav>
+    </aside>
+
+    <section class="at-content">
+        <header class="at-header">
+            <div>
+                <h1>Task Command Dashboard</h1>
+                <p>Command-level action tracking with role-governed access and audit integrity.</p>
+            </div>
+            @if (Model.CanCreate)
+            {
+                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createActionTaskPanel" aria-expanded="false" aria-controls="createActionTaskPanel">New Task</button>
+            }
+        </header>
+
+        @if (Model.CanCreate)
+        {
+            <section id="createActionTaskPanel" class="collapse at-panel mb-3">
+                <h2>Create Action Task</h2>
+                <form method="post" asp-page-handler="Create" class="row g-3">
+                    <div class="col-md-4">
+                        <label asp-for="Input.Title" class="form-label"></label>
+                        <input asp-for="Input.Title" class="form-control" />
+                    </div>
+                    <div class="col-md-8">
+                        <label asp-for="Input.Description" class="form-label"></label>
+                        <input asp-for="Input.Description" class="form-control" />
+                    </div>
+                    <div class="col-md-3">
+                        <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
+                        <select asp-for="Input.AssignedToUserId" class="form-select">
+                            <option value="">Select user</option>
+                            @foreach (var user in Model.AssignableUsers)
+                            {
+                                <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label asp-for="Input.AssignedToRole" class="form-label"></label>
+                        <select asp-for="Input.AssignedToRole" class="form-select">
+                            @foreach (var role in Model.AssignmentRoles)
+                            {
+                                <option value="@role">@role</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-md-2">
+                        <label asp-for="Input.Priority" class="form-label"></label>
+                        <select asp-for="Input.Priority" class="form-select">
+                            <option>Low</option>
+                            <option selected>Normal</option>
+                            <option>High</option>
+                            <option>Critical</option>
+                        </select>
+                    </div>
+                    <div class="col-md-2">
+                        <label asp-for="Input.DueDate" class="form-label"></label>
+                        <input asp-for="Input.DueDate" type="date" class="form-control" />
+                    </div>
+                    <div class="col-md-2 d-flex align-items-end">
+                        <button type="submit" class="btn btn-success w-100">Create</button>
+                    </div>
+                </form>
+            </section>
+        }
+
+        <section class="at-kpis">
+            <article><h3>Active</h3><strong>@activeCount</strong></article>
+            <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
+            <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
+            <article><h3>Submitted</h3><strong>@submittedCount</strong></article>
+            <article><h3>Closed</h3><strong>@closedCount</strong></article>
+        </section>
+
+        <section class="at-panel">
+            <h2>@(activeView == "MyTasks" ? "My Action Tasks" : "Action Task Register")</h2>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Task</th>
+                            <th>Assignee Role</th>
+                            <th>Due Date</th>
+                            <th>Status</th>
+                            <th>Priority</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var task in Model.Tasks)
+                        {
+                            <tr>
+                                <td>AT-@task.Id</td>
+                                <td>
+                                    <a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@activeView">@task.Title</a>
+                                    <div class="small text-muted">@task.Description</div>
+                                </td>
+                                <td>@task.AssignedToRole</td>
+                                <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                                <td>@task.Status</td>
+                                <td>@task.Priority</td>
+                                <td class="at-actions">
+                                    @if (task.Status != ActionTaskStatuses.Submitted && task.Status != ActionTaskStatuses.Closed)
+                                    {
+                                        <form method="post" asp-page-handler="Submit">
+                                            <input type="hidden" name="id" value="@task.Id" />
+                                            <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
+                                        </form>
+                                    }
+                                    @if (Model.CanClose && task.Status != ActionTaskStatuses.Closed)
+                                    {
+                                        <form method="post" asp-page-handler="Close">
+                                            <input type="hidden" name="id" value="@task.Id" />
+                                            <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
+                                        </form>
+                                    }
+                                    @if (task.Status != ActionTaskStatuses.Closed)
+                                    {
+                                        <form method="post" asp-page-handler="UpdateStatus" class="d-flex gap-1">
+                                            <input type="hidden" name="id" value="@task.Id" />
+                                            <select name="status" class="form-select form-select-sm">
+                                                @foreach (var status in ActionTaskStatuses.All)
+                                                {
+                                                    if (task.Status == status)
+                                                    {
+                                                        <option value="@status" selected>@status</option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@status">@status</option>
+                                                    }
+                                                }
+                                            </select>
+                                            <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
+                                        </form>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        @if (Model.TaskId.HasValue)
+        {
+            <section class="at-panel mt-3">
+                <h2>Task Audit Trail (AT-@Model.TaskId.Value)</h2>
+                <ul class="list-group list-group-flush">
+                    @foreach (var log in Model.SelectedTaskLogs)
+                    {
+                        <li class="list-group-item">
+                            <strong>@log.ActionType</strong> by @log.PerformedByRole on @log.PerformedAt.ToString("dd MMM yyyy HH:mm")
+                            @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
+                            {
+                                <div class="small text-muted">@log.OldValue → @log.NewValue</div>
+                            }
+                        </li>
+                    }
+                </ul>
+            </section>
+        }
+    </section>
+</div>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Configuration;
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Pages.ActionTasks;
+
+[Authorize(Policy = "ActionTracker.Access")]
+public class IndexModel : PageModel
+{
+    private readonly IActionTaskService _service;
+    private readonly ActionTaskPermissionService _permission;
+    private readonly UserManager<ApplicationUser> _users;
+
+    public IndexModel(IActionTaskService service, ActionTaskPermissionService permission, UserManager<ApplicationUser> users)
+    {
+        _service = service;
+        _permission = permission;
+        _users = users;
+    }
+
+    public IReadOnlyList<ActionTaskItem> Tasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
+    public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
+
+    [BindProperty(SupportsGet = true)]
+    public string ViewMode { get; set; } = "Dashboard";
+
+    [BindProperty(SupportsGet = true)]
+    public int? TaskId { get; set; }
+
+    public string CurrentRole { get; private set; } = string.Empty;
+    public string CurrentUserId { get; private set; } = string.Empty;
+
+    [BindProperty]
+    public CreateTaskInput Input { get; set; } = new();
+
+    // SECTION: UI state projections
+    public bool CanCreate => _permission.CanCreate(CurrentRole);
+    public bool CanClose => _permission.CanClose(CurrentRole);
+    public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
+
+    public async Task OnGetAsync()
+    {
+        await LoadDataAsync();
+    }
+
+    // SECTION: Create action task
+    public async Task<IActionResult> OnPostCreateAsync()
+    {
+        await ResolveIdentityAsync();
+
+        if (!_permission.CanCreate(CurrentRole))
+        {
+            return Forbid();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            await LoadDataAsync();
+            return Page();
+        }
+
+        var assignedUser = await _users.FindByIdAsync(Input.AssignedToUserId);
+        if (assignedUser is null)
+        {
+            ModelState.AddModelError(string.Empty, "Assigned user was not found.");
+            await LoadDataAsync();
+            return Page();
+        }
+
+        var assignedRoles = await _users.GetRolesAsync(assignedUser);
+        var assignedRole = assignedRoles.FirstOrDefault(r => string.Equals(r, Input.AssignedToRole, StringComparison.OrdinalIgnoreCase));
+        if (assignedRole is null || !_permission.CanAssign(CurrentRole, assignedRole))
+        {
+            ModelState.AddModelError(string.Empty, "Invalid assignment target selected.");
+            await LoadDataAsync();
+            return Page();
+        }
+
+        await _service.CreateTaskAsync(new ActionTaskItem
+        {
+            Title = Input.Title.Trim(),
+            Description = Input.Description.Trim(),
+            CreatedByUserId = CurrentUserId,
+            AssignedToUserId = Input.AssignedToUserId,
+            CreatedByRole = CurrentRole,
+            AssignedToRole = assignedRole,
+            DueDate = Input.DueDate,
+            Priority = Input.Priority
+        });
+
+        TempData["ToastMessage"] = "Action task created.";
+        return RedirectToPage(new { ViewMode });
+    }
+
+    // SECTION: Submit task for closure review
+    public async Task<IActionResult> OnPostSubmitAsync(int id)
+    {
+        await ResolveIdentityAsync();
+        await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, "Submitted by assignee/workflow actor.");
+        TempData["ToastMessage"] = "Task submitted.";
+        return RedirectToPage(new { ViewMode, TaskId = id });
+    }
+
+    // SECTION: Close task by command role
+    public async Task<IActionResult> OnPostCloseAsync(int id)
+    {
+        await ResolveIdentityAsync();
+        await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, "Closed by command authority.");
+        TempData["ToastMessage"] = "Task closed.";
+        return RedirectToPage(new { ViewMode, TaskId = id });
+    }
+
+    // SECTION: Update in-flight status
+    public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string status)
+    {
+        await ResolveIdentityAsync();
+        await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole);
+        TempData["ToastMessage"] = "Task status updated.";
+        return RedirectToPage(new { ViewMode, TaskId = id });
+    }
+
+    // SECTION: Shared data loading
+    private async Task LoadDataAsync()
+    {
+        await ResolveIdentityAsync();
+
+        Tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
+        AssignableUsers = await LoadAssignableUsersAsync();
+
+        if (TaskId.HasValue)
+        {
+            SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
+        }
+    }
+
+    private async Task ResolveIdentityAsync()
+    {
+        CurrentUserId = _users.GetUserId(User) ?? string.Empty;
+        CurrentRole = ActionTaskRoleResolver.Resolve(User) ?? string.Empty;
+
+        await Task.CompletedTask;
+    }
+
+    private async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync()
+    {
+        var targets = AssignmentRoles;
+        var list = new List<UserOption>();
+        foreach (var user in _users.Users.OrderBy(x => x.UserName).Take(200))
+        {
+            var roles = await _users.GetRolesAsync(user);
+            var matchedRole = roles.FirstOrDefault(r => targets.Contains(r));
+            if (matchedRole is null)
+            {
+                continue;
+            }
+
+            list.Add(new UserOption(user.Id, user.UserName ?? user.Email ?? "User", matchedRole));
+        }
+
+        return list;
+    }
+
+    public sealed class CreateTaskInput
+    {
+        [Required, StringLength(200)]
+        public string Title { get; set; } = string.Empty;
+
+        [Required, StringLength(4000)]
+        public string Description { get; set; } = string.Empty;
+
+        [Required]
+        public string AssignedToUserId { get; set; } = string.Empty;
+
+        [Required]
+        public string AssignedToRole { get; set; } = RoleNames.ProjectOfficer;
+
+        [Required]
+        public DateTime DueDate { get; set; } = DateTime.UtcNow.Date.AddDays(7);
+
+        [Required, StringLength(24)]
+        public string Priority { get; set; } = "Normal";
+    }
+
+    public sealed record UserOption(string UserId, string DisplayName, string Role);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -49,6 +49,7 @@ using ProjectManagement.Models.Stages;
 using ProjectManagement.Services;
 using ProjectManagement.Services.Activities;
 using ProjectManagement.Services.Analytics;
+using ProjectManagement.Services.ActionTasks;
 using ProjectManagement.Services.Dashboard;
 using ProjectManagement.Services.DocRepo;
 using ProjectManagement.Services.Documents;
@@ -217,6 +218,10 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("DocRepo.Purge", policy =>
         policy.RequireRole(RoleNames.Admin));
 
+    // SECTION: Action tracker authorization policy
+    options.AddPolicy("ActionTracker.Access", policy =>
+        policy.RequireRole(RoleNames.Comdt, RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta));
+
 
 });
 
@@ -378,6 +383,8 @@ builder.Services.AddScoped<IUserLifecycleService, UserLifecycleService>();
 builder.Services.AddHostedService<UserPurgeWorker>();
 builder.Services.AddSingleton<IClock, SystemClock>();
 builder.Services.AddScoped<ITodoService, TodoService>();
+builder.Services.AddScoped<ActionTaskPermissionService>();
+builder.Services.AddScoped<IActionTaskService, ActionTaskService>();
 builder.Services.Configure<TodoOptions>(
     builder.Configuration.GetSection("Todo"));
 builder.Services.AddScoped<ILoginAnalyticsService, LoginAnalyticsService>();

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using ProjectManagement.Configuration;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public class ActionTaskPermissionService
+{
+    private static readonly string[] AssignmentTargets =
+    {
+        RoleNames.HoD,
+        RoleNames.ProjectOfficer,
+        RoleNames.Mco,
+        RoleNames.Ta
+    };
+
+    // SECTION: Role capability checks
+    public bool CanCreate(string role)
+        => role == RoleNames.Comdt || role == RoleNames.HoD;
+
+    public bool CanAssign(string assignerRole, string assigneeRole)
+    {
+        if (assignerRole != RoleNames.Comdt && assignerRole != RoleNames.HoD)
+        {
+            return false;
+        }
+
+        return AssignmentTargets.Contains(assigneeRole, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool CanClose(string role)
+        => role == RoleNames.Comdt || role == RoleNames.HoD;
+
+    public bool CanViewAll(string role)
+        => role == RoleNames.Comdt || role == RoleNames.HoD;
+
+    public bool CanViewLogs(string role, string currentUserId, string ownerUserId)
+        => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
+
+    public bool CanUpdateTask(string role, string currentUserId, string ownerUserId)
+        => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
+
+    public bool CanSubmit(string role)
+        => role is RoleNames.Comdt or RoleNames.HoD or RoleNames.ProjectOfficer or RoleNames.Mco or RoleNames.Ta;
+}

--- a/Services/ActionTasks/ActionTaskRoleResolver.cs
+++ b/Services/ActionTasks/ActionTaskRoleResolver.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using ProjectManagement.Configuration;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public static class ActionTaskRoleResolver
+{
+    private static readonly string[] Precedence =
+    {
+        RoleNames.Comdt,
+        RoleNames.HoD,
+        RoleNames.ProjectOfficer,
+        RoleNames.Mco,
+        RoleNames.Ta
+    };
+
+    // SECTION: Resolve highest-precedence action-tracker role
+    public static string? Resolve(ClaimsPrincipal user)
+    {
+        foreach (var role in Precedence)
+        {
+            if (user.IsInRole(role))
+            {
+                return role;
+            }
+        }
+
+        return null;
+    }
+
+    public static IReadOnlyList<string> AllowedAssignmentRoles()
+        => new[] { RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta };
+}

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public class ActionTaskService : IActionTaskService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ActionTaskPermissionService _permission;
+
+    public ActionTaskService(ApplicationDbContext context, ActionTaskPermissionService permission)
+    {
+        _context = context;
+        _permission = permission;
+    }
+
+    // SECTION: Task read APIs
+    public async Task<List<ActionTaskItem>> GetTasksAsync(string userId, string role, CancellationToken cancellationToken = default)
+    {
+        var query = _context.ActionTasks
+            .AsNoTracking()
+            .Where(x => !x.IsDeleted);
+
+        if (!_permission.CanViewAll(role))
+        {
+            query = query.Where(x => x.AssignedToUserId == userId);
+        }
+
+        return await query
+            .OrderByDescending(x => x.DueDate)
+            .ThenBy(x => x.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default)
+        => _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken);
+
+    public async Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to view logs for this task.");
+        }
+
+        return await _context.ActionTaskAuditLogs
+            .AsNoTracking()
+            .Where(x => x.TaskId == taskId)
+            .OrderByDescending(x => x.PerformedAt)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    // SECTION: Task mutation APIs
+    public async Task<ActionTaskItem> CreateTaskAsync(ActionTaskItem task, CancellationToken cancellationToken = default)
+    {
+        task.AssignedOn = DateTime.UtcNow;
+        task.Status = ActionTaskStatuses.Assigned;
+
+        _context.ActionTasks.Add(task);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        await Log(task.Id, "TaskCreated", task.CreatedByUserId, task.CreatedByRole, null, task.Status, null, cancellationToken);
+
+        return task;
+    }
+
+    public async Task UpdateStatusAsync(int taskId, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    {
+        var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanUpdateTask(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to update this task.");
+        }
+
+        if (!ActionTaskStatuses.All.Contains(status, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Invalid status transition.");
+        }
+
+        var oldStatus = task.Status;
+        task.Status = status;
+        if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        {
+            task.SubmittedOn = DateTime.UtcNow;
+        }
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            task.ClosedOn = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        await Log(taskId, "StatusUpdated", userId, role, oldStatus, task.Status, remarks, cancellationToken);
+    }
+
+    public async Task SubmitTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    {
+        var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanSubmit(role))
+        {
+            throw new InvalidOperationException("You are not authorized to submit this task.");
+        }
+
+        var oldStatus = task.Status;
+        task.Status = ActionTaskStatuses.Submitted;
+        task.SubmittedOn = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync(cancellationToken);
+        await Log(taskId, "Submitted", userId, role, oldStatus, task.Status, remarks, cancellationToken);
+    }
+
+    public async Task CloseTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    {
+        if (!_permission.CanClose(role))
+        {
+            throw new InvalidOperationException("You are not authorized to close this task.");
+        }
+
+        var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+
+        var oldStatus = task.Status;
+        task.Status = ActionTaskStatuses.Closed;
+        task.ClosedOn = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync(cancellationToken);
+        await Log(taskId, "Closed", userId, role, oldStatus, task.Status, remarks, cancellationToken);
+    }
+
+    // SECTION: Audit logging
+    private async Task Log(int taskId, string action, string userId, string role, string? oldValue, string? newValue, string? remarks, CancellationToken cancellationToken)
+    {
+        _context.ActionTaskAuditLogs.Add(new ActionTaskAuditLog
+        {
+            TaskId = taskId,
+            ActionType = action,
+            PerformedByUserId = userId,
+            PerformedByRole = role,
+            PerformedAt = DateTime.UtcNow,
+            OldValue = oldValue,
+            NewValue = newValue,
+            Remarks = remarks
+        });
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Services/ActionTasks/IActionTaskService.cs
+++ b/Services/ActionTasks/IActionTaskService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public interface IActionTaskService
+{
+    Task<List<ActionTaskItem>> GetTasksAsync(string userId, string role, CancellationToken cancellationToken = default);
+    Task<ActionTaskItem> CreateTaskAsync(ActionTaskItem task, CancellationToken cancellationToken = default);
+    Task UpdateStatusAsync(int taskId, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task SubmitTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task CloseTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default);
+    Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
+}

--- a/Services/Navigation/RoleBasedNavigationProvider.cs
+++ b/Services/Navigation/RoleBasedNavigationProvider.cs
@@ -71,6 +71,13 @@ public class RoleBasedNavigationProvider : INavigationProvider
             },
             new()
             {
+                Text = "Action tracker",
+                Page = "/ActionTasks/Index",
+                AuthorizationPolicy = "ActionTracker.Access",
+                Icon = "bi-list-task"
+            },
+            new()
+            {
                 Text = "Proliferation compendium",
                 Page = "/Projects/Compendium/Index",
                 Icon = "bi-file-earmark-pdf"

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1,0 +1,79 @@
+/* SECTION: Action Tracker shell */
+.at-shell {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 1rem;
+    min-height: 70vh;
+}
+
+.at-sidebar {
+    background: #0e2445;
+    color: #fff;
+    border-radius: 12px;
+    padding: 1rem;
+}
+
+.at-brand { font-size: 1.9rem; font-weight: 800; }
+.at-module { opacity: .8; margin-bottom: 1rem; }
+
+.at-nav { display: grid; gap: .45rem; }
+.at-nav a {
+    color: #c3d3ea;
+    text-decoration: none;
+    border-radius: 10px;
+    padding: .55rem .75rem;
+}
+.at-nav a:hover,
+.at-nav a.active {
+    color: #fff;
+    background: #1f4677;
+}
+
+/* SECTION: Header and cards */
+.at-content { padding-bottom: 1.5rem; }
+.at-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.at-header h1 { margin: 0; }
+.at-header p { margin: 0; color: #62718c; }
+
+.at-kpis {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: .75rem;
+    margin-bottom: 1rem;
+}
+
+.at-kpis article,
+.at-panel {
+    border: 1px solid #ccd8ea;
+    background: #fff;
+    border-radius: 12px;
+    padding: .9rem;
+}
+
+.at-kpis h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: #566a89;
+}
+
+.at-kpis strong {
+    font-size: 1.7rem;
+    color: #1f2e45;
+}
+
+/* SECTION: Table controls */
+.at-actions {
+    display: grid;
+    gap: .4rem;
+}
+
+@media (max-width: 1199px) {
+    .at-shell { grid-template-columns: 1fr; }
+    .at-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}


### PR DESCRIPTION
### Motivation
- Add a command-level, role-governed action tracking system separate from the existing personal `/Tasks` area to support controlled assignment, sprint-style monitoring, and auditable state transitions. 
- Enforce the finalized role model (Comdt, HoD, Project Officer, MCO, TA) and the permission matrix so only authorized roles can create/assign/close tasks while execution roles can own and submit tasks. 
- Maintain full, queryable audit logs for every important state change to preserve command/audit integrity. 
- Keep the existing `/Tasks` feature unchanged and avoid inline scripts to respect CSP and offline deployment constraints.

### Description
- Added domain models `ActionTaskItem` and `ActionTaskAuditLog` and status constants in `Models/ActionTaskItem.cs` and `Models/ActionTaskAuditLog.cs` to represent tasks and audit entries. 
- Implemented centralized permission and role helpers in `Services/ActionTasks/ActionTaskPermissionService.cs` and `Services/ActionTasks/ActionTaskRoleResolver.cs` and a service layer API via `IActionTaskService` and `ActionTaskService` in `Services/ActionTasks/` that provide create, role-scoped listing, status updates, submit, close, and audit logging. 
- Wired EF integration by adding `DbSet<ActionTaskItem>` and `DbSet<ActionTaskAuditLog>` and entity configuration/indexes to `Data/ApplicationDbContext.cs` and added a migration file `Migrations/20261125140000_AddActionTasks.cs` to create the tables and indexes. 
- Added a Razor Pages UI at `/ActionTasks/Index` with role-aware actions and KPI panel (`Pages/ActionTasks/Index.cshtml` and `Pages/ActionTasks/Index.cshtml.cs`) and a dedicated stylesheet `wwwroot/css/action-tracker.css`. 
- Registered DI and authorization wiring in `Program.cs` by adding the `ActionTracker.Access` policy and registering `ActionTaskPermissionService` and `IActionTaskService`/`ActionTaskService`, and added a navigation entry in `Services/Navigation/RoleBasedNavigationProvider.cs`.

### Testing
- Verified code references and wiring with repository searches using `rg` to confirm the policy, DI registrations, DbSet additions, service implementations, page, and migration are present, and those checks succeeded. 
- Attempted to run EF tooling with `dotnet ef migrations add AddActionTasks` but the `dotnet` CLI was not available in this environment, so migrations could not be executed against a database here. 
- Created the migration file manually (`Migrations/20261125140000_AddActionTasks.cs`) to reflect required schema changes and validated the SQL schema and indexes in the generated migration file. 
- No runtime/integration tests were executed because the .NET SDK/CLI and application runtime were not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef764f52c48329bad60c8b1b9f1eb3)