### PR TITLE
Fix nullable warnings in ongoing projects view and workflow lookup

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -628,16 +628,17 @@ else
                                     }
                                     else
                                     {
+                                        var externalRemark = latestExternalRemark!;
                                         <article class="ongoing-remarks__item">
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
-                                                @Html.Raw(RenderRemark(latestExternalRemark.Body))
+                                                @Html.Raw(RenderRemark(externalRemark.Body))
                                             </div>
                                             <div class="ongoing-remarks__meta">
-                                                <span class="ongoing-remarks__author">@latestExternalRemark!.AuthorDisplayName</span>
+                                                <span class="ongoing-remarks__author">@externalRemark.AuthorDisplayName</span>
                                                 <span class="ongoing-remarks__meta-sep">·</span>
-                                                <span>@latestExternalRemark.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")</span>
+                                                <span>@externalRemark.CreatedAtUtc.ToLocalTime().ToString("dd-MMM-yyyy HH:mm")</span>
                                                 <span class="ongoing-remarks__meta-sep">·</span>
-                                                <span>Event: @latestExternalRemark.EventDate.ToString("dd-MMM-yyyy")</span>
+                                                <span>Event: @externalRemark.EventDate.ToString("dd-MMM-yyyy")</span>
                                             </div>
                                         </article>
                                     }

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1889,7 +1889,7 @@ public sealed class ProgressReviewService : IProgressReviewService
         return await _db.Projects
             .AsNoTracking()
             .Where(project => projectIds.Contains(project.Id))
-            .ToDictionaryAsync(project => project.Id, project => project.WorkflowVersion, cancellationToken);
+            .ToDictionaryAsync(project => project.Id, project => (string?)project.WorkflowVersion, cancellationToken);
     }
 
     private string? BuildAttachmentUrl(string? storageKey)


### PR DESCRIPTION
### Motivation
- Eliminate nullability warnings reported by the compiler: avoid a possible null dereference in the Ongoing Projects Razor view (CS8602) and make the workflow-version lookup projection match the method return type (CS8619).
- The migration warning about a lower-cased migration file (CS8981) could not be addressed because the referenced migration file was not found in the repository snapshot.

### Description
- In `Pages/Projects/Ongoing/Index.cshtml` capture `latestExternalRemark` into a local non-null variable `externalRemark` inside the `hasExternalRemark` guarded block and use it consistently for rendering the remark body and metadata to prevent nullable dereference.
- In `Services/Reports/ProgressReview/ProgressReviewService.cs` cast the selector in `ToDictionaryAsync` to `(string?)project.WorkflowVersion` so the produced dictionary value type matches `IReadOnlyDictionary<int, string?>`.
- Modified files: `Pages/Projects/Ongoing/Index.cshtml` and `Services/Reports/ProgressReview/ProgressReviewService.cs`.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln -v minimal` but the .NET SDK is not available in this environment, so the build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7bbf77a08329b6546a392681b84f)