### PR TITLE
Harden ActionTask status transitions and submission authorization

### DIFF
--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -84,6 +84,12 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Invalid status transition.");
         }
 
+        // SECTION: Role-governed close transition
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && !_permission.CanClose(role))
+        {
+            throw new InvalidOperationException("You are not authorized to close this task.");
+        }
+
         var oldStatus = task.Status;
         task.Status = status;
         if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
@@ -102,6 +108,13 @@ public class ActionTaskService : IActionTaskService
     public async Task SubmitTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
     {
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+
+        // SECTION: Ownership and role authorization checks
+        if (!_permission.CanUpdateTask(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to submit this task.");
+        }
+
         if (!_permission.CanSubmit(role))
         {
             throw new InvalidOperationException("You are not authorized to submit this task.");


### PR DESCRIPTION
### Motivation

- Prevent role/permission bypasses that allowed non-authorized users to close or submit tasks via generic APIs.

### Description

- Added a guard in `UpdateStatusAsync` that blocks setting status to `Closed` unless `_permission.CanClose(role)` returns true.
- Added an ownership/authorization check in `SubmitTaskAsync` to require `_permission.CanUpdateTask(role, userId, task.AssignedToUserId)` before allowing a submit.
- Added section comments around the new checks for clarity and maintainability, and updated `Services/ActionTasks/ActionTaskService.cs` accordingly.

### Testing

- Attempted to run `dotnet build -nologo` but the .NET SDK is not available in this environment (`dotnet: command not found`).
- No automated unit tests were executed due to the missing SDK, but changes are localized to authorization guard clauses and simple non-breaking checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7cf555f08329b4070b6c6ba9e5b6)