### PR TITLE
Align Projects.WorkflowVersion column length with model via explicit EF migration

### DIFF
--- a/Migrations/20261125140000_FixProjectWorkflowVersionColumnLength.cs
+++ b/Migrations/20261125140000_FixProjectWorkflowVersionColumnLength.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125140000_FixProjectWorkflowVersionColumnLength")]
+    public partial class FixProjectWorkflowVersionColumnLength : Migration
+    {
+        // SECTION: Apply schema changes
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "WorkflowVersion",
+                table: "Projects",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "SDD-1.0",
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32,
+                oldDefaultValue: "SDD-1.0");
+        }
+
+        // SECTION: Revert schema changes
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                UPDATE \"Projects\"
+                SET \"WorkflowVersion\" = LEFT(\"WorkflowVersion\", 32)
+                WHERE length(\"WorkflowVersion\") > 32;
+                """);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "WorkflowVersion",
+                table: "Projects",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "SDD-1.0",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldDefaultValue: "SDD-1.0");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The database schema for `Projects.WorkflowVersion` was created as `character varying(32)` while the current model and snapshot expect `character varying(64)`, causing migration drift and repeated alter-column diffs. 
- An explicit migration is required to bring the persisted schema in line with the model to stabilise future scaffolding and deployments.

### Description
- Added a new EF Core migration file `Migrations/20261125140000_FixProjectWorkflowVersionColumnLength.cs` that alters `Projects.WorkflowVersion` to `character varying(64)` with `maxLength: 64` and a default of `"SDD-1.0"` in `Up()`.
- Implemented a defensive `Down()` that first truncates any values longer than 32 characters using a SQL `UPDATE` and then alters the column back to `character varying(32)` to ensure rollbacks do not fail due to data length.
- Kept clear section comments in the migration file (`// SECTION: Apply schema changes` and `// SECTION: Revert schema changes`) to make the change easy to review and maintain.

### Testing
- Verified the presence of the model/snapshot discrepancy via searches showing the original migration used `character varying(32)` and the snapshot/model expect `character varying(64)`, which succeeded.
- Confirmed the new migration file was created at `Migrations/20261125140000_FixProjectWorkflowVersionColumnLength.cs` and inspected its contents, which succeeded.
- Attempted to run `dotnet ef` checks in this environment but they failed because `dotnet` is not available in PATH, so runtime migration application was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8512f6d48329a1635396b351acc3)