### PR TITLE
Fix Npgsql command-in-progress error on ActionTasks page load

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
@@ -153,12 +154,19 @@ public class IndexModel : PageModel
 
     private async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync()
     {
-        var targets = AssignmentRoles;
+        // SECTION: Stabilize user snapshot to avoid overlapping data-reader operations
+        var targets = new HashSet<string>(AssignmentRoles, StringComparer.OrdinalIgnoreCase);
+        var users = await _users.Users
+            .OrderBy(x => x.UserName)
+            .Take(200)
+            .ToListAsync();
+
+        // SECTION: Resolve assignable users with role checks
         var list = new List<UserOption>();
-        foreach (var user in _users.Users.OrderBy(x => x.UserName).Take(200))
+        foreach (var user in users)
         {
             var roles = await _users.GetRolesAsync(user);
-            var matchedRole = roles.FirstOrDefault(r => targets.Contains(r));
+            var matchedRole = roles.FirstOrDefault(targets.Contains);
             if (matchedRole is null)
             {
                 continue;


### PR DESCRIPTION
### Motivation
- Prevent intermittent `NpgsqlOperationInProgressException` that occurred when enumerating `_users.Users` and calling `GetRolesAsync` while the underlying EF Core data reader was still streaming. 
- Stabilize the assignable-user loading path to make role lookups safe and deterministic while keeping UI behavior unchanged.

### Description
- Import `Microsoft.EntityFrameworkCore` and materialize the candidate user query with `ToListAsync()` before iterating to avoid overlapping DB reader operations. 
- Replace direct enumeration of `_users.Users.OrderBy(...).Take(200)` with a captured `users` list and iterate that snapshot. 
- Normalize assignment-role matching by using a case-insensitive `HashSet<string>` and simplify the `FirstOrDefault` check to use `targets.Contains`. 
- Add section comments to clarify the stabilization and resolution steps and keep the implementation modular and readable.

### Testing
- Attempted to run `dotnet build /workspace/ProjectManagement/ProjectManagement.csproj -v minimal` but the build could not run in this environment because `dotnet` is not installed, so no successful automated build/test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef97736e908329b0184d9ec881b436)