### PR TITLE
Refine Task Tracker UI and assignment workflow (derive assignee role server-side)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -2,7 +2,8 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 @{
-    ViewData["Title"] = "Action Tracker";
+    ViewData["Title"] = "Task Tracker";
+    ViewData["UseFullWidth"] = true;
     var activeView = (Model.ViewMode ?? "Dashboard").Trim();
 
     int CountByStatus(string status) => Model.Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
@@ -12,7 +13,6 @@
     var blockedCount = CountByStatus(ActionTaskStatuses.Blocked);
     var closedCount = CountByStatus(ActionTaskStatuses.Closed);
 
-    var grouped = Model.Tasks.GroupBy(x => x.Status).OrderBy(g => g.Key).ToList();
 }
 
 @section Styles {
@@ -22,7 +22,7 @@
 <div class="at-shell">
     <aside class="at-sidebar">
         <div class="at-brand">PRISM ERP</div>
-        <div class="at-module">Action Tracker</div>
+        <div class="at-module">Task Tracker</div>
 
         <nav class="at-nav">
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(activeView == "Dashboard" ? "active" : string.Empty)">Dashboard</a>
@@ -37,19 +37,19 @@
     <section class="at-content">
         <header class="at-header">
             <div>
-                <h1>Task Command Dashboard</h1>
-                <p>Command-level action tracking with role-governed access and audit integrity.</p>
+                <h1>Command Task Dashboard</h1>
+                <p>Command-level task tracking with role-governed access and audit integrity.</p>
             </div>
             @if (Model.CanCreate)
             {
-                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createActionTaskPanel" aria-expanded="false" aria-controls="createActionTaskPanel">New Task</button>
+                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createTaskPanel" aria-expanded="false" aria-controls="createTaskPanel">New Task</button>
             }
         </header>
 
         @if (Model.CanCreate)
         {
-            <section id="createActionTaskPanel" class="collapse at-panel mb-3">
-                <h2>Create Action Task</h2>
+            <section id="createTaskPanel" class="collapse at-panel mb-3">
+                <h2>Create Task</h2>
                 <form method="post" asp-page-handler="Create" class="row g-3">
                     <div class="col-md-4">
                         <label asp-for="Input.Title" class="form-label"></label>
@@ -57,7 +57,7 @@
                     </div>
                     <div class="col-md-8">
                         <label asp-for="Input.Description" class="form-label"></label>
-                        <input asp-for="Input.Description" class="form-control" />
+                        <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
                     </div>
                     <div class="col-md-3">
                         <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
@@ -66,15 +66,6 @@
                             @foreach (var user in Model.AssignableUsers)
                             {
                                 <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
-                            }
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label asp-for="Input.AssignedToRole" class="form-label"></label>
-                        <select asp-for="Input.AssignedToRole" class="form-select">
-                            @foreach (var role in Model.AssignmentRoles)
-                            {
-                                <option value="@role">@role</option>
                             }
                         </select>
                     </div>
@@ -92,7 +83,7 @@
                         <input asp-for="Input.DueDate" type="date" class="form-control" />
                     </div>
                     <div class="col-md-2 d-flex align-items-end">
-                        <button type="submit" class="btn btn-success w-100">Create</button>
+                        <button type="submit" class="btn btn-success w-100">Create Task</button>
                     </div>
                 </form>
             </section>
@@ -107,14 +98,23 @@
         </section>
 
         <section class="at-panel">
-            <h2>@(activeView == "MyTasks" ? "My Action Tasks" : "Action Task Register")</h2>
+            <h2>@(activeView == "MyTasks" ? "My Tasks" : "Task Register")</h2>
+            @if (!Model.Tasks.Any())
+            {
+                <div class="at-empty-state">
+                    <div class="fw-semibold">No tasks have been created yet.</div>
+                    <div class="text-muted">Use New Task to create the first task.</div>
+                </div>
+            }
+            else
+            {
             <div class="table-responsive">
                 <table class="table table-sm align-middle">
                     <thead>
                         <tr>
                             <th>ID</th>
                             <th>Task</th>
-                            <th>Assignee Role</th>
+                            <th>Assignee</th>
                             <th>Due Date</th>
                             <th>Status</th>
                             <th>Priority</th>
@@ -130,7 +130,10 @@
                                     <a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@activeView">@task.Title</a>
                                     <div class="small text-muted">@task.Description</div>
                                 </td>
-                                <td>@task.AssignedToRole</td>
+                                <td>
+                                    <div class="fw-semibold">@(Model.TaskAssigneeNames.TryGetValue(task.AssignedToUserId, out var assigneeName) ? assigneeName : "User")</div>
+                                    <div class="text-muted small">@task.AssignedToRole</div>
+                                </td>
                                 <td>@task.DueDate.ToString("dd MMM yyyy")</td>
                                 <td>@task.Status</td>
                                 <td>@task.Priority</td>
@@ -154,7 +157,7 @@
                                         <form method="post" asp-page-handler="UpdateStatus" class="d-flex gap-1">
                                             <input type="hidden" name="id" value="@task.Id" />
                                             <select name="status" class="form-select form-select-sm">
-                                                @foreach (var status in ActionTaskStatuses.All)
+                                                @foreach (var status in Model.AllowedStatusOptions)
                                                 {
                                                     if (task.Status == status)
                                                     {
@@ -175,6 +178,7 @@
                     </tbody>
                 </table>
             </div>
+            }
         </section>
 
         @if (Model.TaskId.HasValue)

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -31,6 +31,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<ActionTaskItem> Tasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
+    public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
     [BindProperty(SupportsGet = true)]
     public string ViewMode { get; set; } = "Dashboard";
@@ -48,6 +49,9 @@ public class IndexModel : PageModel
     public bool CanCreate => _permission.CanCreate(CurrentRole);
     public bool CanClose => _permission.CanClose(CurrentRole);
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
+    public IReadOnlyList<string> AllowedStatusOptions => CanClose
+        ? ActionTaskStatuses.All
+        : new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted };
 
     public async Task OnGetAsync()
     {
@@ -79,10 +83,10 @@ public class IndexModel : PageModel
         }
 
         var assignedRoles = await _users.GetRolesAsync(assignedUser);
-        var assignedRole = assignedRoles.FirstOrDefault(r => string.Equals(r, Input.AssignedToRole, StringComparison.OrdinalIgnoreCase));
+        var assignedRole = ActionTaskRoleResolver.ResolveFromRoles(assignedRoles);
         if (assignedRole is null || !_permission.CanAssign(CurrentRole, assignedRole))
         {
-            ModelState.AddModelError(string.Empty, "Invalid assignment target selected.");
+            ModelState.AddModelError(string.Empty, "Selected user is not eligible for task assignment.");
             await LoadDataAsync();
             return Page();
         }
@@ -99,7 +103,7 @@ public class IndexModel : PageModel
             Priority = Input.Priority
         });
 
-        TempData["ToastMessage"] = "Action task created.";
+        TempData["ToastMessage"] = "Task created.";
         return RedirectToPage(new { ViewMode });
     }
 
@@ -135,8 +139,13 @@ public class IndexModel : PageModel
     {
         await ResolveIdentityAsync();
 
-        Tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
+        var tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
+        Tasks = IsMyTasksView()
+            ? tasks.Where(t => string.Equals(t.AssignedToUserId, CurrentUserId, StringComparison.Ordinal)).ToList()
+            : tasks;
+
         AssignableUsers = await LoadAssignableUsersAsync();
+        TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(Tasks);
 
         if (TaskId.HasValue)
         {
@@ -178,6 +187,35 @@ public class IndexModel : PageModel
         return list;
     }
 
+    // SECTION: Resolve assignee display names for task register rendering
+    private async Task<IReadOnlyDictionary<string, string>> LoadTaskAssigneeNamesAsync(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var userIds = tasks
+            .Select(t => t.AssignedToUserId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var users = await _users.Users
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.UserName, u.Email })
+            .ToListAsync();
+
+        return users.ToDictionary(
+            u => u.Id,
+            u => string.IsNullOrWhiteSpace(u.UserName) ? (u.Email ?? "User") : u.UserName!,
+            StringComparer.Ordinal);
+    }
+
+    // SECTION: Normalize and evaluate selected view mode
+    private bool IsMyTasksView() =>
+        string.Equals((ViewMode ?? string.Empty).Trim(), "MyTasks", StringComparison.OrdinalIgnoreCase);
+
     public sealed class CreateTaskInput
     {
         [Required, StringLength(200)]
@@ -188,9 +226,6 @@ public class IndexModel : PageModel
 
         [Required]
         public string AssignedToUserId { get; set; } = string.Empty;
-
-        [Required]
-        public string AssignedToRole { get; set; } = RoleNames.ProjectOfficer;
 
         [Required]
         public DateTime DueDate { get; set; } = DateTime.UtcNow.Date.AddDays(7);

--- a/Services/ActionTasks/ActionTaskRoleResolver.cs
+++ b/Services/ActionTasks/ActionTaskRoleResolver.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using ProjectManagement.Configuration;
 
@@ -31,4 +33,11 @@ public static class ActionTaskRoleResolver
 
     public static IReadOnlyList<string> AllowedAssignmentRoles()
         => new[] { RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta };
+
+    // SECTION: Resolve highest-precedence tracker role from user role list
+    public static string? ResolveFromRoles(IEnumerable<string> roles)
+    {
+        var roleSet = new HashSet<string>(roles, StringComparer.OrdinalIgnoreCase);
+        return Precedence.FirstOrDefault(roleSet.Contains);
+    }
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1,9 +1,10 @@
 /* SECTION: Action Tracker shell */
 .at-shell {
     display: grid;
-    grid-template-columns: 220px 1fr;
+    grid-template-columns: 240px minmax(0, 1fr);
     gap: 1rem;
     min-height: 70vh;
+    width: 100%;
 }
 
 .at-sidebar {
@@ -30,7 +31,10 @@
 }
 
 /* SECTION: Header and cards */
-.at-content { padding-bottom: 1.5rem; }
+.at-content {
+    min-width: 0;
+    padding-bottom: 1.5rem;
+}
 .at-header {
     display: flex;
     justify-content: space-between;
@@ -71,6 +75,15 @@
 .at-actions {
     display: grid;
     gap: .4rem;
+}
+
+/* SECTION: Empty states */
+.at-empty-state {
+    border: 1px dashed #cbd5e1;
+    border-radius: 14px;
+    padding: 1.25rem;
+    background: #f8fafc;
+    color: #475569;
 }
 
 @media (max-width: 1199px) {


### PR DESCRIPTION
### Motivation
- Clarify user-facing terminology by renaming the Action Tracker UI to Task Tracker and make the page layout more usable for dashboard/board views.
- Remove redundant and error-prone `AssignedToRole` user input so the system derives the assignee’s tracker role from their actual Identity roles instead of trusting form input.
- Improve register, create form and empty-state UX so the page reads like a tasking interface (assignee name first, role as secondary text, multiline description, full-width layout).

### Description
- UI changes in `Pages/ActionTasks/Index.cshtml`: updated visible labels to Task Tracker/Command Task Dashboard/Task Register/Create Task, enabled full-width rendering with `ViewData["UseFullWidth"] = true`, replaced description `input` with a `textarea`, removed the `AssignedToRole` selector, added an empty-state block, changed the create button label to `Create Task`, and switched the register to show Assignee name with muted role and use `Model.AllowedStatusOptions` for status dropdown rendering.
- Server-side changes in `Pages/ActionTasks/Index.cshtml.cs`: removed `AssignedToRole` from the bound input model, derive the assignee role using `ActionTaskRoleResolver.ResolveFromRoles(...)` when creating tasks and persist that value to the existing `AssignedToRole` column, added `AllowedStatusOptions` (UI-only restriction for non-closing roles), implemented `MyTasks` view-level narrowing so the My Tasks view shows only tasks assigned to the current user, and added `LoadTaskAssigneeNamesAsync` to project assignee display names for the register.
- Service helper in `Services/ActionTasks/ActionTaskRoleResolver.cs`: added `ResolveFromRoles(IEnumerable<string>)` to pick the highest-precedence tracker role from a user’s roles (preserves precedence ordering used elsewhere).
- CSS updates in `wwwroot/css/action-tracker.css`: set shell grid to `240px minmax(0, 1fr)`, added `min-width: 0` to `.at-content`, and added `.at-empty-state` styles to present a clean empty register UI.
- Non-functional: database schema and backend entity names remain unchanged (the `AssignedToRole` column and `ActionTaskItem` model are still persisted to keep historical snapshots and avoid migrations), no inline scripts were added and changes remain CSP- and offline-friendly.

### Testing
- Attempted build verification with `dotnet build`, but the environment does not have the .NET SDK installed so the build could not be run (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00b6021a08329b75675760793c9d2)