### PR TITLE
Fix silent ActionTasks create failures and assignment role resolution

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -48,16 +48,19 @@
 
         @if (Model.CanCreate)
         {
-            <section id="createTaskPanel" class="collapse at-panel mb-3">
+            <section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
                 <h2>Create Task</h2>
+                <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
                 <form method="post" asp-page-handler="Create" class="row g-3">
                     <div class="col-md-4">
                         <label asp-for="Input.Title" class="form-label"></label>
                         <input asp-for="Input.Title" class="form-control" />
+                        <span asp-validation-for="Input.Title" class="text-danger small"></span>
                     </div>
                     <div class="col-md-8">
                         <label asp-for="Input.Description" class="form-label"></label>
                         <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+                        <span asp-validation-for="Input.Description" class="text-danger small"></span>
                     </div>
                     <div class="col-md-3">
                         <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
@@ -68,6 +71,7 @@
                                 <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
                             }
                         </select>
+                        <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
                     </div>
                     <div class="col-md-2">
                         <label asp-for="Input.Priority" class="form-label"></label>
@@ -77,10 +81,12 @@
                             <option>High</option>
                             <option>Critical</option>
                         </select>
+                        <span asp-validation-for="Input.Priority" class="text-danger small"></span>
                     </div>
                     <div class="col-md-2">
                         <label asp-for="Input.DueDate" class="form-label"></label>
                         <input asp-for="Input.DueDate" type="date" class="form-control" />
+                        <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
                     </div>
                     <div class="col-md-2 d-flex align-items-end">
                         <button type="submit" class="btn btn-success w-100">Create Task</button>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -41,6 +41,7 @@ public class IndexModel : PageModel
 
     public string CurrentRole { get; private set; } = string.Empty;
     public string CurrentUserId { get; private set; } = string.Empty;
+    public bool ShowCreatePanel { get; private set; }
 
     [BindProperty]
     public CreateTaskInput Input { get; set; } = new();
@@ -70,6 +71,7 @@ public class IndexModel : PageModel
 
         if (!ModelState.IsValid)
         {
+            ShowCreatePanel = true;
             await LoadDataAsync();
             return Page();
         }
@@ -78,15 +80,25 @@ public class IndexModel : PageModel
         if (assignedUser is null)
         {
             ModelState.AddModelError(string.Empty, "Assigned user was not found.");
+            ShowCreatePanel = true;
             await LoadDataAsync();
             return Page();
         }
 
         var assignedRoles = await _users.GetRolesAsync(assignedUser);
-        var assignedRole = ActionTaskRoleResolver.ResolveFromRoles(assignedRoles);
-        if (assignedRole is null || !_permission.CanAssign(CurrentRole, assignedRole))
+        var assignedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(assignedRoles);
+        if (assignedRole is null)
         {
-            ModelState.AddModelError(string.Empty, "Selected user is not eligible for task assignment.");
+            ModelState.AddModelError(string.Empty, "Selected user does not have an assignable Task Tracker role.");
+            ShowCreatePanel = true;
+            await LoadDataAsync();
+            return Page();
+        }
+
+        if (!_permission.CanAssign(CurrentRole, assignedRole))
+        {
+            ModelState.AddModelError(string.Empty, $"Current role is not permitted to assign tasks to {assignedRole}.");
+            ShowCreatePanel = true;
             await LoadDataAsync();
             return Page();
         }
@@ -104,7 +116,7 @@ public class IndexModel : PageModel
         });
 
         TempData["ToastMessage"] = "Task created.";
-        return RedirectToPage(new { ViewMode });
+        return RedirectToPage("/ActionTasks/Index", new { viewMode = ViewMode });
     }
 
     // SECTION: Submit task for closure review
@@ -164,7 +176,6 @@ public class IndexModel : PageModel
     private async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync()
     {
         // SECTION: Stabilize user snapshot to avoid overlapping data-reader operations
-        var targets = new HashSet<string>(AssignmentRoles, StringComparer.OrdinalIgnoreCase);
         var users = await _users.Users
             .OrderBy(x => x.UserName)
             .Take(200)
@@ -175,8 +186,8 @@ public class IndexModel : PageModel
         foreach (var user in users)
         {
             var roles = await _users.GetRolesAsync(user);
-            var matchedRole = roles.FirstOrDefault(targets.Contains);
-            if (matchedRole is null)
+            var matchedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(roles);
+            if (matchedRole is null || !_permission.CanAssign(CurrentRole, matchedRole))
             {
                 continue;
             }

--- a/Services/ActionTasks/ActionTaskRoleResolver.cs
+++ b/Services/ActionTasks/ActionTaskRoleResolver.cs
@@ -40,4 +40,11 @@ public static class ActionTaskRoleResolver
         var roleSet = new HashSet<string>(roles, StringComparer.OrdinalIgnoreCase);
         return Precedence.FirstOrDefault(roleSet.Contains);
     }
+
+    // SECTION: Resolve highest-precedence assignable tracker role from user role list
+    public static string? ResolveAssignableRoleFromRoles(IEnumerable<string> roles)
+    {
+        var roleSet = new HashSet<string>(roles, StringComparer.OrdinalIgnoreCase);
+        return AllowedAssignmentRoles().FirstOrDefault(roleSet.Contains);
+    }
 }


### PR DESCRIPTION
### Motivation
- The Create POST returned the same page (`?handler=Create`) without visible errors when server-side eligibility checks failed, causing silent failures and browser "Confirm Form Resubmission" prompts.  
- Multi-role users could be resolved to a non-assignable role during creation, making the UI dropdown and backend inconsistent for assignment eligibility.  

### Description
- Add `ResolveAssignableRoleFromRoles(...)` to `Services/ActionTasks/ActionTaskRoleResolver.cs` to resolve only assignable tracker roles.  
- Update the create flow in `Pages/ActionTasks/Index.cshtml.cs` to use the assignable-role resolver, return clearer `ModelState` messages, keep the create panel open on validation failures via `ShowCreatePanel`, and redirect explicitly to `/ActionTasks/Index` on success.  
- Make `LoadAssignableUsersAsync()` use the same assignable-role resolver and filter users by `_permission.CanAssign(...)` so the dropdown lists only valid assignees.  
- Update the create form `Pages/ActionTasks/Index.cshtml` to show server-side errors with a validation summary and field-level messages and to preserve the expanded panel state on error.  

### Testing
- Attempted to run `dotnet build` in this environment, but it failed because the runtime is not available (`dotnet: command not found`).  
- No automated build/test run succeeded in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00fdd2f808329aacf557896146ff3)