### PR TITLE
Fix ActionTasks create postback view mode binding

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -52,6 +52,8 @@
                 <h2>Create Task</h2>
                 <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
                 <form method="post" asp-page-handler="Create" class="row g-3">
+                    @* SECTION: Preserve selected view mode during postbacks. *@
+                    <input type="hidden" name="ViewMode" value="@activeView" />
                     <div class="col-md-4">
                         <label asp-for="Input.Title" class="form-label"></label>
                         <input asp-for="Input.Title" class="form-control" />
@@ -147,6 +149,8 @@
                                     @if (task.Status != ActionTaskStatuses.Submitted && task.Status != ActionTaskStatuses.Closed)
                                     {
                                         <form method="post" asp-page-handler="Submit">
+                                            @* SECTION: Preserve list context while performing row actions. *@
+                                            <input type="hidden" name="ViewMode" value="@activeView" />
                                             <input type="hidden" name="id" value="@task.Id" />
                                             <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
                                         </form>
@@ -154,6 +158,8 @@
                                     @if (Model.CanClose && task.Status != ActionTaskStatuses.Closed)
                                     {
                                         <form method="post" asp-page-handler="Close">
+                                            @* SECTION: Preserve list context while performing row actions. *@
+                                            <input type="hidden" name="ViewMode" value="@activeView" />
                                             <input type="hidden" name="id" value="@task.Id" />
                                             <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
                                         </form>
@@ -161,6 +167,8 @@
                                     @if (task.Status != ActionTaskStatuses.Closed)
                                     {
                                         <form method="post" asp-page-handler="UpdateStatus" class="d-flex gap-1">
+                                            @* SECTION: Preserve list context while performing row actions. *@
+                                            <input type="hidden" name="ViewMode" value="@activeView" />
                                             <input type="hidden" name="id" value="@task.Id" />
                                             <select name="status" class="form-select form-select-sm">
                                                 @foreach (var status in Model.AllowedStatusOptions)

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -34,7 +34,7 @@ public class IndexModel : PageModel
     public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
 
     [BindProperty(SupportsGet = true)]
-    public string ViewMode { get; set; } = "Dashboard";
+    public string? ViewMode { get; set; } = "Dashboard";
 
     [BindProperty(SupportsGet = true)]
     public int? TaskId { get; set; }
@@ -116,7 +116,7 @@ public class IndexModel : PageModel
         });
 
         TempData["ToastMessage"] = "Task created.";
-        return RedirectToPage("/ActionTasks/Index", new { viewMode = ViewMode });
+        return RedirectToPage("/ActionTasks/Index", new { viewMode = ResolveViewMode() });
     }
 
     // SECTION: Submit task for closure review
@@ -125,7 +125,7 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
         await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, "Submitted by assignee/workflow actor.");
         TempData["ToastMessage"] = "Task submitted.";
-        return RedirectToPage(new { ViewMode, TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
     // SECTION: Close task by command role
@@ -134,7 +134,7 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
         await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, "Closed by command authority.");
         TempData["ToastMessage"] = "Task closed.";
-        return RedirectToPage(new { ViewMode, TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
     // SECTION: Update in-flight status
@@ -143,7 +143,7 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
         await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole);
         TempData["ToastMessage"] = "Task status updated.";
-        return RedirectToPage(new { ViewMode, TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
     // SECTION: Shared data loading
@@ -225,7 +225,14 @@ public class IndexModel : PageModel
 
     // SECTION: Normalize and evaluate selected view mode
     private bool IsMyTasksView() =>
-        string.Equals((ViewMode ?? string.Empty).Trim(), "MyTasks", StringComparison.OrdinalIgnoreCase);
+        string.Equals(ResolveViewMode(), "MyTasks", StringComparison.OrdinalIgnoreCase);
+
+    // SECTION: Resolve a safe view mode value for postback and redirects
+    private string ResolveViewMode()
+    {
+        var normalized = (ViewMode ?? string.Empty).Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? "Dashboard" : normalized;
+    }
 
     public sealed class CreateTaskInput
     {


### PR DESCRIPTION
### Motivation
- Postbacks to the ActionTasks page could fail model validation and abort task creation because `ViewMode` was a non-nullable bound property but the create/row-action forms did not include it.
- Preserve the current list view context across postbacks so users remain on the same view (Dashboard/MyTasks/etc.) after create/submit/close/update actions.

### Description
- Changed the page model property to `public string? ViewMode { get; set; } = "Dashboard";` to avoid nullable-reference validation errors when the field is not posted.
- Added a `ResolveViewMode()` helper that normalizes `ViewMode` and falls back to `"Dashboard"`, and replaced redirects and `IsMyTasksView()` checks to use `ResolveViewMode()`.
- Updated `Pages/ActionTasks/Index.cshtml` to include hidden inputs (`<input name="ViewMode" .../>`) on the create form and all row-action forms to preserve UI context across postbacks.
- Updated all post handlers to use `ResolveViewMode()` for deterministic redirect behavior after actions.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~TasksPageTests"`, but the command failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f013405e44832984ac80e4bac48387)