### PR TITLE
Harden Action Task workflow and tighten row action permissions

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -50,7 +50,10 @@
         {
             <section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
                 <h2>Create Task</h2>
-                <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
+                @if (!ViewData.ModelState.IsValid)
+                {
+                    <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
+                }
                 <form method="post" asp-page-handler="Create" class="row g-3">
                     @* SECTION: Preserve selected view mode during postbacks. *@
                     <input type="hidden" name="ViewMode" value="@activeView" />
@@ -146,46 +149,48 @@
                                 <td>@task.Status</td>
                                 <td>@task.Priority</td>
                                 <td class="at-actions">
-                                    @if (task.Status != ActionTaskStatuses.Submitted && task.Status != ActionTaskStatuses.Closed)
-                                    {
-                                        <form method="post" asp-page-handler="Submit">
-                                            @* SECTION: Preserve list context while performing row actions. *@
-                                            <input type="hidden" name="ViewMode" value="@activeView" />
-                                            <input type="hidden" name="id" value="@task.Id" />
-                                            <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
-                                        </form>
-                                    }
-                                    @if (Model.CanClose && task.Status != ActionTaskStatuses.Closed)
-                                    {
-                                        <form method="post" asp-page-handler="Close">
-                                            @* SECTION: Preserve list context while performing row actions. *@
-                                            <input type="hidden" name="ViewMode" value="@activeView" />
-                                            <input type="hidden" name="id" value="@task.Id" />
-                                            <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
-                                        </form>
-                                    }
-                                    @if (task.Status != ActionTaskStatuses.Closed)
-                                    {
-                                        <form method="post" asp-page-handler="UpdateStatus" class="d-flex gap-1">
-                                            @* SECTION: Preserve list context while performing row actions. *@
-                                            <input type="hidden" name="ViewMode" value="@activeView" />
-                                            <input type="hidden" name="id" value="@task.Id" />
-                                            <select name="status" class="form-select form-select-sm">
-                                                @foreach (var status in Model.AllowedStatusOptions)
-                                                {
-                                                    if (task.Status == status)
+                                    <div class="at-actions-stack">
+                                        @if (Model.CanSubmitTask(task))
+                                        {
+                                            <form method="post" asp-page-handler="Submit">
+                                                @* SECTION: Preserve list context while performing row actions. *@
+                                                <input type="hidden" name="ViewMode" value="@activeView" />
+                                                <input type="hidden" name="id" value="@task.Id" />
+                                                <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
+                                            </form>
+                                        }
+                                        @if (Model.CanCloseTask(task))
+                                        {
+                                            <form method="post" asp-page-handler="Close">
+                                                @* SECTION: Preserve list context while performing row actions. *@
+                                                <input type="hidden" name="ViewMode" value="@activeView" />
+                                                <input type="hidden" name="id" value="@task.Id" />
+                                                <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
+                                            </form>
+                                        }
+                                        @if (Model.CanUpdateTaskStatus(task))
+                                        {
+                                            <form method="post" asp-page-handler="UpdateStatus" class="at-status-form">
+                                                @* SECTION: Preserve list context while performing row actions. *@
+                                                <input type="hidden" name="ViewMode" value="@activeView" />
+                                                <input type="hidden" name="id" value="@task.Id" />
+                                                <select name="status" class="form-select form-select-sm">
+                                                    @foreach (var status in Model.AllowedStatusOptions)
                                                     {
-                                                        <option value="@status" selected>@status</option>
+                                                        if (task.Status == status)
+                                                        {
+                                                            <option value="@status" selected>@status</option>
+                                                        }
+                                                        else
+                                                        {
+                                                            <option value="@status">@status</option>
+                                                        }
                                                     }
-                                                    else
-                                                    {
-                                                        <option value="@status">@status</option>
-                                                    }
-                                                }
-                                            </select>
-                                            <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
-                                        </form>
-                                    }
+                                                </select>
+                                                <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
+                                            </form>
+                                        }
+                                    </div>
                                 </td>
                             </tr>
                         }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -50,9 +50,33 @@ public class IndexModel : PageModel
     public bool CanCreate => _permission.CanCreate(CurrentRole);
     public bool CanClose => _permission.CanClose(CurrentRole);
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
-    public IReadOnlyList<string> AllowedStatusOptions => CanClose
-        ? ActionTaskStatuses.All
-        : new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted };
+    public IReadOnlyList<string> AllowedStatusOptions => new[]
+    {
+        ActionTaskStatuses.Assigned,
+        ActionTaskStatuses.InProgress,
+        ActionTaskStatuses.Blocked,
+        ActionTaskStatuses.Submitted
+    };
+
+    // SECTION: Per-task action visibility helpers
+    public bool CanSubmitTask(ActionTaskItem task)
+    {
+        return !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(task.AssignedToUserId, CurrentUserId, StringComparison.Ordinal);
+    }
+
+    public bool CanCloseTask(ActionTaskItem task)
+    {
+        return CanClose
+            && string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool CanUpdateTaskStatus(ActionTaskItem task)
+    {
+        return !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            && (_permission.CanViewAll(CurrentRole) || string.Equals(task.AssignedToUserId, CurrentUserId, StringComparison.Ordinal));
+    }
 
     public async Task OnGetAsync()
     {
@@ -123,8 +147,16 @@ public class IndexModel : PageModel
     public async Task<IActionResult> OnPostSubmitAsync(int id)
     {
         await ResolveIdentityAsync();
-        await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, "Submitted by assignee/workflow actor.");
-        TempData["ToastMessage"] = "Task submitted.";
+        try
+        {
+            await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, "Submitted by assignee/workflow actor.");
+            TempData["ToastMessage"] = "Task submitted.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
@@ -132,8 +164,16 @@ public class IndexModel : PageModel
     public async Task<IActionResult> OnPostCloseAsync(int id)
     {
         await ResolveIdentityAsync();
-        await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, "Closed by command authority.");
-        TempData["ToastMessage"] = "Task closed.";
+        try
+        {
+            await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, "Closed by command authority.");
+            TempData["ToastMessage"] = "Task closed.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
@@ -141,8 +181,16 @@ public class IndexModel : PageModel
     public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string status)
     {
         await ResolveIdentityAsync();
-        await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole);
-        TempData["ToastMessage"] = "Task status updated.";
+        try
+        {
+            await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task status updated.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
@@ -236,15 +284,18 @@ public class IndexModel : PageModel
 
     public sealed class CreateTaskInput
     {
+        [Display(Name = "Task Title")]
         [Required, StringLength(200)]
         public string Title { get; set; } = string.Empty;
 
+        [Display(Name = "Description / Instructions")]
         [Required, StringLength(4000)]
         public string Description { get; set; } = string.Empty;
 
         [Required]
         public string AssignedToUserId { get; set; } = string.Empty;
 
+        [Display(Name = "Due Date")]
         [Required]
         public DateTime DueDate { get; set; } = DateTime.UtcNow.Date.AddDays(7);
 

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -84,10 +84,16 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Invalid status transition.");
         }
 
-        // SECTION: Role-governed close transition
-        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && !_permission.CanClose(role))
+        // SECTION: Enforce dedicated close action
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
         {
-            throw new InvalidOperationException("Only HoD/Comdt can close tasks.");
+            throw new InvalidOperationException("Use the close action to close a task.");
+        }
+
+        // SECTION: Enforce lifecycle transitions
+        if (!IsAllowedTransition(task.Status, status))
+        {
+            throw new InvalidOperationException($"Invalid status transition from {task.Status} to {status}.");
         }
 
         var oldStatus = task.Status;
@@ -110,15 +116,19 @@ public class ActionTaskService : IActionTaskService
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
 
         // SECTION: Ownership and role authorization checks
-        if (!_permission.CanViewAll(role) &&
-            !string.Equals(task.AssignedToUserId, userId, StringComparison.Ordinal))
+        if (!string.Equals(task.AssignedToUserId, userId, StringComparison.Ordinal))
         {
-            throw new InvalidOperationException("Unauthorized access.");
+            throw new InvalidOperationException("Only the assigned user can submit this task.");
         }
 
         if (!_permission.CanSubmit(role))
         {
             throw new InvalidOperationException("You are not authorized to submit this task.");
+        }
+
+        if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Closed tasks cannot be submitted.");
         }
 
         var oldStatus = task.Status;
@@ -137,6 +147,10 @@ public class ActionTaskService : IActionTaskService
         }
 
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Only submitted tasks can be closed.");
+        }
 
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Closed;
@@ -162,5 +176,33 @@ public class ActionTaskService : IActionTaskService
         });
 
         await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    // SECTION: Workflow transition guard
+    private static bool IsAllowedTransition(string currentStatus, string nextStatus)
+    {
+        if (string.Equals(currentStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(nextStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(currentStatus, nextStatus, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return currentStatus switch
+        {
+            ActionTaskStatuses.Assigned => nextStatus is ActionTaskStatuses.InProgress or ActionTaskStatuses.Blocked or ActionTaskStatuses.Submitted,
+            ActionTaskStatuses.InProgress => nextStatus is ActionTaskStatuses.Blocked or ActionTaskStatuses.Submitted,
+            ActionTaskStatuses.Blocked => nextStatus is ActionTaskStatuses.InProgress or ActionTaskStatuses.Submitted,
+            ActionTaskStatuses.Submitted => nextStatus is ActionTaskStatuses.InProgress or ActionTaskStatuses.Blocked,
+            _ => false
+        };
     }
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -73,8 +73,21 @@
 
 /* SECTION: Table controls */
 .at-actions {
-    display: grid;
+    min-width: 300px;
+}
+
+.at-actions-stack {
+    display: flex;
+    flex-wrap: wrap;
     gap: .4rem;
+    align-items: center;
+}
+
+.at-status-form {
+    display: flex;
+    gap: .35rem;
+    align-items: center;
+    min-width: 220px;
 }
 
 /* SECTION: Empty states */


### PR DESCRIPTION
### Motivation

- Fix UX and workflow correctness by removing a persistent empty validation alert, making action buttons role- and task-aware, and preventing improper status/close transitions so the Task Tracker enforces a predictable lifecycle.

### Description

- Render the create-task validation summary only when the model is invalid by changing `Index.cshtml` to conditionally show the `asp-validation-summary` block. (Pages/ActionTasks/Index.cshtml)
- Add per-task visibility helpers `CanSubmitTask`, `CanCloseTask` and `CanUpdateTaskStatus` and restrict `AllowedStatusOptions` to non-`Closed` states, and add display labels to `CreateTaskInput` (`Task Title`, `Description / Instructions`, `Due Date`). (Pages/ActionTasks/Index.cshtml.cs)
- Replace row-action rendering to use the new helpers and a compact action group layout (`Submit`, `Close`, status dropdown + `Update`) and add minimal CSS classes for the group and status form. (Pages/ActionTasks/Index.cshtml, wwwroot/css/action-tracker.css)
- Wrap `OnPostSubmitAsync`, `OnPostCloseAsync`, and `OnPostUpdateStatusAsync` handlers in `try/catch` to capture `InvalidOperationException` and surface messages in `TempData["ToastError"]`. (Pages/ActionTasks/Index.cshtml.cs)
- Enforce service-layer workflow rules in `ActionTaskService`: prevent setting `Closed` via `UpdateStatusAsync`, require only the assignee to `SubmitTaskAsync`, block submitting closed tasks, require tasks to be `Submitted` before `CloseTaskAsync`, and add `IsAllowedTransition` to guard allowed lifecycle transitions. (Services/ActionTasks/ActionTaskService.cs)

### Testing

- Attempted a build with `dotnet build` in this environment and the command failed because `dotnet` is not available here, so no compilation or automated unit tests were executed; changes have been smoke-reviewed via file inspection commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01893bf00832993df252f16de8593)