### PR TITLE
Make ActionTasks views mode-specific and polish task register UX

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -4,15 +4,14 @@
 @{
     ViewData["Title"] = "Task Tracker";
     ViewData["UseFullWidth"] = true;
-    var activeView = (Model.ViewMode ?? "Dashboard").Trim();
 
     int CountByStatus(string status) => Model.Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
-    var activeCount = Model.Tasks.Count(t => t.Status != ActionTaskStatuses.Closed);
-    var overdueCount = Model.Tasks.Count(t => t.Status != ActionTaskStatuses.Closed && t.DueDate < DateTime.UtcNow);
+    var activeCount = Model.Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
+    var overdueCount = Model.Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
     var submittedCount = CountByStatus(ActionTaskStatuses.Submitted);
     var blockedCount = CountByStatus(ActionTaskStatuses.Blocked);
     var closedCount = CountByStatus(ActionTaskStatuses.Closed);
-
+    var selectedTaskTitle = Model.SelectedTask?.Title ?? "Task";
 }
 
 @section Styles {
@@ -20,24 +19,26 @@
 }
 
 <div class="at-shell">
+    @* SECTION: Left navigation with standardized route values. *@
     <aside class="at-sidebar">
         <div class="at-brand">PRISM ERP</div>
         <div class="at-module">Task Tracker</div>
 
         <nav class="at-nav">
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(activeView == "Dashboard" ? "active" : string.Empty)">Dashboard</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(activeView == "MyTasks" ? "active" : string.Empty)">My Tasks</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="SprintBoard" class="@(activeView == "SprintBoard" ? "active" : string.Empty)">Sprint Board</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(activeView == "Kanban" ? "active" : string.Empty)">Kanban Board</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(activeView == "TaskList" ? "active" : string.Empty)">Task List</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(activeView == "Reports" ? "active" : string.Empty)">Reports</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(Model.IsDashboardView ? "active" : string.Empty)">Dashboard</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(Model.IsMyTasksView ? "active" : string.Empty)">My Tasks</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)">Sprint Board</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)">Kanban Board</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)">Task List</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)">Reports</a>
         </nav>
     </aside>
 
     <section class="at-content">
+        @* SECTION: Shared page header and create-task trigger. *@
         <header class="at-header">
             <div>
-                <h1>Command Task Dashboard</h1>
+                <h1>@(Model.IsTaskListView ? "Command Task Register" : Model.IsMyTasksView ? "My Tasks" : "Command Task Dashboard")</h1>
                 <p>Command-level task tracking with role-governed access and audit integrity.</p>
             </div>
             @if (Model.CanCreate)
@@ -46,6 +47,7 @@
             }
         </header>
 
+        @* SECTION: Create panel stays collapsed by default; opens for validation failures. *@
         @if (Model.CanCreate)
         {
             <section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
@@ -56,7 +58,7 @@
                 }
                 <form method="post" asp-page-handler="Create" class="row g-3">
                     @* SECTION: Preserve selected view mode during postbacks. *@
-                    <input type="hidden" name="ViewMode" value="@activeView" />
+                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                     <div class="col-md-4">
                         <label asp-for="Input.Title" class="form-label"></label>
                         <input asp-for="Input.Title" class="form-control" />
@@ -100,110 +102,298 @@
             </section>
         }
 
-        <section class="at-kpis">
-            <article><h3>Active</h3><strong>@activeCount</strong></article>
-            <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
-            <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
-            <article><h3>Submitted</h3><strong>@submittedCount</strong></article>
-            <article><h3>Closed</h3><strong>@closedCount</strong></article>
-        </section>
+        @* SECTION: View-specific rendering. *@
+        @if (Model.IsDashboardView)
+        {
+            <section class="at-kpis">
+                <article><h3>Active</h3><strong>@activeCount</strong></article>
+                <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
+                <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
+                <article><h3>Submitted</h3><strong>@submittedCount</strong></article>
+                <article><h3>Closed</h3><strong>@closedCount</strong></article>
+            </section>
 
-        <section class="at-panel">
-            <h2>@(activeView == "MyTasks" ? "My Tasks" : "Task Register")</h2>
-            @if (!Model.Tasks.Any())
-            {
-                <div class="at-empty-state">
-                    <div class="fw-semibold">No tasks have been created yet.</div>
-                    <div class="text-muted">Use New Task to create the first task.</div>
-                </div>
-            }
-            else
-            {
-            <div class="table-responsive">
-                <table class="table table-sm align-middle">
-                    <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Task</th>
-                            <th>Assignee</th>
-                            <th>Due Date</th>
-                            <th>Status</th>
-                            <th>Priority</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var task in Model.Tasks)
+            <section class="at-card-grid">
+                <article class="at-panel">
+                    <h2>Critical Open Tasks</h2>
+                    <ul class="at-simple-list">
+                        @foreach (var task in Model.CriticalOpenTasks)
                         {
-                            <tr>
-                                <td>AT-@task.Id</td>
-                                <td>
-                                    <a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@activeView">@task.Title</a>
-                                    <div class="small text-muted">@task.Description</div>
-                                </td>
-                                <td>
-                                    <div class="fw-semibold">@(Model.TaskAssigneeNames.TryGetValue(task.AssignedToUserId, out var assigneeName) ? assigneeName : "User")</div>
-                                    <div class="text-muted small">@task.AssignedToRole</div>
-                                </td>
-                                <td>@task.DueDate.ToString("dd MMM yyyy")</td>
-                                <td>@task.Status</td>
-                                <td>@task.Priority</td>
-                                <td class="at-actions">
-                                    <div class="at-actions-stack">
-                                        @if (Model.CanSubmitTask(task))
-                                        {
-                                            <form method="post" asp-page-handler="Submit">
-                                                @* SECTION: Preserve list context while performing row actions. *@
-                                                <input type="hidden" name="ViewMode" value="@activeView" />
-                                                <input type="hidden" name="id" value="@task.Id" />
-                                                <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
-                                            </form>
-                                        }
-                                        @if (Model.CanCloseTask(task))
-                                        {
-                                            <form method="post" asp-page-handler="Close">
-                                                @* SECTION: Preserve list context while performing row actions. *@
-                                                <input type="hidden" name="ViewMode" value="@activeView" />
-                                                <input type="hidden" name="id" value="@task.Id" />
-                                                <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
-                                            </form>
-                                        }
-                                        @if (Model.CanUpdateTaskStatus(task))
-                                        {
-                                            <form method="post" asp-page-handler="UpdateStatus" class="at-status-form">
-                                                @* SECTION: Preserve list context while performing row actions. *@
-                                                <input type="hidden" name="ViewMode" value="@activeView" />
-                                                <input type="hidden" name="id" value="@task.Id" />
-                                                <select name="status" class="form-select form-select-sm">
-                                                    @foreach (var status in Model.AllowedStatusOptions)
-                                                    {
-                                                        if (task.Status == status)
-                                                        {
-                                                            <option value="@status" selected>@status</option>
-                                                        }
-                                                        else
-                                                        {
-                                                            <option value="@status">@status</option>
-                                                        }
-                                                    }
-                                                </select>
-                                                <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
-                                            </form>
-                                        }
-                                    </div>
-                                </td>
-                            </tr>
+                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
                         }
-                    </tbody>
-                </table>
-            </div>
+                    </ul>
+                </article>
+                <article class="at-panel">
+                    <h2>Overdue Tasks</h2>
+                    <ul class="at-simple-list">
+                        @foreach (var task in Model.OverdueTasks)
+                        {
+                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
+                        }
+                    </ul>
+                </article>
+                <article class="at-panel">
+                    <h2>Recently Submitted</h2>
+                    <ul class="at-simple-list">
+                        @foreach (var task in Model.RecentlySubmittedTasks)
+                        {
+                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
+                        }
+                    </ul>
+                </article>
+                <article class="at-panel">
+                    <h2>Recently Updated</h2>
+                    <ul class="at-simple-list">
+                        @foreach (var task in Model.RecentlyUpdatedTasks)
+                        {
+                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
+                        }
+                    </ul>
+                </article>
+            </section>
+        }
+        else if (Model.IsMyTasksView || Model.IsTaskListView)
+        {
+            @if (Model.IsTaskListView)
+            {
+                <section class="at-panel mb-3">
+                    <h2>Task List Filters</h2>
+                    <form method="get" class="row g-2">
+                        <input type="hidden" name="viewMode" value="TaskList" />
+                        <div class="col-md-2">
+                            <label class="form-label">Status</label>
+                            <select class="form-select" name="FilterStatus">
+                                <option value="">All</option>
+                                @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
+                                {
+                                    @if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <option value="@status" selected>@status</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@status">@status</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">Priority</label>
+                            <select class="form-select" name="FilterPriority">
+                                <option value="">All</option>
+                                @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
+                                {
+                                    @if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <option value="@priority" selected>@priority</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@priority">@priority</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Assignee</label>
+                            <select class="form-select" name="FilterAssigneeUserId">
+                                <option value="">All</option>
+                                @foreach (var assignee in Model.AssignableUsers)
+                                {
+                                    @if (string.Equals(Model.FilterAssigneeUserId, assignee.UserId, StringComparison.Ordinal))
+                                    {
+                                        <option value="@assignee.UserId" selected>@assignee.DisplayName (@assignee.Role)</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@assignee.UserId">@assignee.DisplayName (@assignee.Role)</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label">Due Date</label>
+                            <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Search by title</label>
+                            <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" />
+                        </div>
+                        <div class="col-12 d-flex gap-2">
+                            <button type="submit" class="btn btn-primary btn-sm">Apply Filters</button>
+                            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
+                        </div>
+                    </form>
+                </section>
             }
-        </section>
 
+            <section class="at-panel">
+                <h2>@(Model.IsMyTasksView ? "My Tasks" : "Task Register")</h2>
+                @if (!Model.Tasks.Any())
+                {
+                    <div class="at-empty-state">
+                        <div class="fw-semibold">No tasks available for this view.</div>
+                        <div class="text-muted">Try adjusting filters or create a task.</div>
+                    </div>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-sm at-table">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Task</th>
+                                    <th>Assignee</th>
+                                    <th>Due Date</th>
+                                    <th>Status</th>
+                                    <th>Priority</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var task in Model.Tasks)
+                                {
+                                    <tr>
+                                        <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
+                                        <td>
+                                            <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
+                                            <div class="at-task-desc">@task.Description</div>
+                                        </td>
+                                        <td>
+                                            <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>
+                                            <div class="text-muted small">@task.AssignedToRole</div>
+                                        </td>
+                                        <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                                        <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
+                                        <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
+                                        <td class="at-actions">
+                                            <div class="at-actions-stack">
+                                                @if (Model.CanSubmitTask(task))
+                                                {
+                                                    <form method="post" asp-page-handler="Submit">
+                                                        @* SECTION: Preserve list context while performing row actions. *@
+                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                                        <input type="hidden" name="id" value="@task.Id" />
+                                                        <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
+                                                    </form>
+                                                }
+                                                @if (Model.CanCloseTask(task))
+                                                {
+                                                    <form method="post" asp-page-handler="Close">
+                                                        @* SECTION: Preserve list context while performing row actions. *@
+                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                                        <input type="hidden" name="id" value="@task.Id" />
+                                                        <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
+                                                    </form>
+                                                }
+                                                @if (Model.CanUpdateTaskStatus(task))
+                                                {
+                                                    <form method="post" asp-page-handler="UpdateStatus" class="at-status-form">
+                                                        @* SECTION: Preserve list context while performing row actions. *@
+                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                                        <input type="hidden" name="id" value="@task.Id" />
+                                                        <select name="status" class="form-select form-select-sm">
+                                                            @foreach (var status in Model.AllowedStatusOptions)
+                                                            {
+                                                                if (task.Status == status)
+                                                                {
+                                                                    <option value="@status" selected>@status</option>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <option value="@status">@status</option>
+                                                                }
+                                                            }
+                                                        </select>
+                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
+                                                    </form>
+                                                }
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </section>
+        }
+        else if (Model.IsKanbanView)
+        {
+            <section class="at-board-grid">
+                <article class="at-panel at-board-column"><h2>Assigned</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanAssignedTasks)</article>
+                <article class="at-panel at-board-column"><h2>In Progress</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanInProgressTasks)</article>
+                <article class="at-panel at-board-column"><h2>Blocked</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanBlockedTasks)</article>
+                <article class="at-panel at-board-column"><h2>Submitted</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanSubmittedTasks)</article>
+                <article class="at-panel at-board-column"><h2>Closed</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanClosedTasks)</article>
+            </section>
+        }
+        else if (Model.IsSprintBoardView)
+        {
+            <section class="at-board-grid at-board-grid-sprint">
+                <article class="at-panel at-board-column"><h2>Due Today</h2>@await Html.PartialAsync("_TaskCards", Model.DueTodayTasks)</article>
+                <article class="at-panel at-board-column"><h2>Due This Week</h2>@await Html.PartialAsync("_TaskCards", Model.DueThisWeekTasks)</article>
+                <article class="at-panel at-board-column"><h2>Due Later</h2>@await Html.PartialAsync("_TaskCards", Model.DueLaterTasks)</article>
+                <article class="at-panel at-board-column"><h2>Overdue</h2>@await Html.PartialAsync("_TaskCards", Model.SprintOverdueTasks)</article>
+            </section>
+        }
+        else if (Model.IsReportsView)
+        {
+            <section class="at-kpis at-kpis-reports">
+                <article><h3>Total Active</h3><strong>@activeCount</strong></article>
+                <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
+                <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
+                <article><h3>Submitted Pending Closure</h3><strong>@submittedCount</strong></article>
+                <article><h3>Closed</h3><strong>@closedCount</strong></article>
+                <article><h3>Critical Open</h3><strong>@Model.CriticalOpenTasks.Count</strong></article>
+            </section>
+
+            <section class="at-card-grid">
+                <article class="at-panel">
+                    <h2>Assignee-wise Pending Tasks</h2>
+                    <table class="table table-sm at-table mb-0">
+                        <tbody>
+                            @foreach (var item in Model.AssigneePendingCounts)
+                            {
+                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                </article>
+                <article class="at-panel">
+                    <h2>Priority-wise Task Count</h2>
+                    <table class="table table-sm at-table mb-0">
+                        <tbody>
+                            @foreach (var item in Model.PriorityCounts)
+                            {
+                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                </article>
+                <article class="at-panel">
+                    <h2>Status-wise Task Count</h2>
+                    <table class="table table-sm at-table mb-0">
+                        <tbody>
+                            @foreach (var item in Model.StatusCounts)
+                            {
+                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                </article>
+            </section>
+        }
+
+        @* SECTION: Audit trail is visible only for an explicitly selected task. *@
         @if (Model.TaskId.HasValue)
         {
             <section class="at-panel mt-3">
-                <h2>Task Audit Trail (AT-@Model.TaskId.Value)</h2>
+                <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
+                    <h2 class="mb-0">Task Audit Trail: AT-@Model.TaskId.Value - @selectedTaskTitle</h2>
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Back to Task List</a>
+                </div>
                 <ul class="list-group list-group-flush">
                     @foreach (var log in Model.SelectedTaskLogs)
                     {

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
 
@@ -29,9 +28,25 @@ public class IndexModel : PageModel
     }
 
     public IReadOnlyList<ActionTaskItem> Tasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> OverdueTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> RecentlySubmittedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> RecentlyUpdatedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> KanbanAssignedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> KanbanInProgressTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> KanbanBlockedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> KanbanSubmittedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> KanbanClosedTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> DueTodayTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> DueThisWeekTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> DueLaterTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> SprintOverdueTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
     public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public IReadOnlyList<CountSummary> AssigneePendingCounts { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> PriorityCounts { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> StatusCounts { get; private set; } = Array.Empty<CountSummary>();
 
     [BindProperty(SupportsGet = true)]
     public string? ViewMode { get; set; } = "Dashboard";
@@ -39,9 +54,25 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public int? TaskId { get; set; }
 
+    [BindProperty(SupportsGet = true)]
+    public string? FilterStatus { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? FilterPriority { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? FilterAssigneeUserId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public DateTime? FilterDueDate { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? FilterSearch { get; set; }
+
     public string CurrentRole { get; private set; } = string.Empty;
     public string CurrentUserId { get; private set; } = string.Empty;
     public bool ShowCreatePanel { get; private set; }
+    public ActionTaskItem? SelectedTask { get; private set; }
 
     [BindProperty]
     public CreateTaskInput Input { get; set; } = new();
@@ -49,6 +80,14 @@ public class IndexModel : PageModel
     // SECTION: UI state projections
     public bool CanCreate => _permission.CanCreate(CurrentRole);
     public bool CanClose => _permission.CanClose(CurrentRole);
+    public string ResolvedViewMode => ResolveViewMode();
+    public bool IsDashboardView => string.Equals(ResolvedViewMode, "Dashboard", StringComparison.OrdinalIgnoreCase);
+    public bool IsMyTasksView => string.Equals(ResolvedViewMode, "MyTasks", StringComparison.OrdinalIgnoreCase);
+    public bool IsTaskListView => string.Equals(ResolvedViewMode, "TaskList", StringComparison.OrdinalIgnoreCase);
+    public bool IsKanbanView => string.Equals(ResolvedViewMode, "Kanban", StringComparison.OrdinalIgnoreCase);
+    public bool IsSprintBoardView => string.Equals(ResolvedViewMode, "Sprint", StringComparison.OrdinalIgnoreCase);
+    public bool IsReportsView => string.Equals(ResolvedViewMode, "Reports", StringComparison.OrdinalIgnoreCase);
+
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => new[]
     {
@@ -76,6 +115,53 @@ public class IndexModel : PageModel
     {
         return !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
             && (_permission.CanViewAll(CurrentRole) || string.Equals(task.AssignedToUserId, CurrentUserId, StringComparison.Ordinal));
+    }
+
+    public string GetStatusBadgeClass(string status)
+    {
+        if (string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-status-progress";
+        }
+
+        if (string.Equals(status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-status-blocked";
+        }
+
+        if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-status-submitted";
+        }
+
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-status-closed";
+        }
+
+        return "at-badge at-badge-status-assigned";
+    }
+
+    public string GetPriorityBadgeClass(string priority)
+    {
+        if (string.Equals(priority, "Critical", StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-priority-critical";
+        }
+
+        if (string.Equals(priority, "High", StringComparison.OrdinalIgnoreCase))
+        {
+            return "at-badge at-badge-priority-high";
+        }
+
+        return "at-badge at-badge-priority-normal";
+    }
+
+    public string ResolveAssigneeName(string assignedToUserId)
+    {
+        return TaskAssigneeNames.TryGetValue(assignedToUserId, out var assigneeName)
+            ? assigneeName
+            : "User";
     }
 
     public async Task OnGetAsync()
@@ -200,17 +286,160 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
 
         var tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
-        Tasks = IsMyTasksView()
-            ? tasks.Where(t => string.Equals(t.AssignedToUserId, CurrentUserId, StringComparison.Ordinal)).ToList()
-            : tasks;
+
+        // SECTION: Apply view-specific filtering
+        if (IsMyTasksView)
+        {
+            tasks = tasks
+                .Where(t => string.Equals(t.AssignedToUserId, CurrentUserId, StringComparison.Ordinal))
+                .ToList();
+        }
 
         AssignableUsers = await LoadAssignableUsersAsync();
-        TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(Tasks);
+        TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(tasks);
+
+        // SECTION: Populate overview and grouping collections
+        BuildDashboardCollections(tasks);
+        BuildKanbanCollections(tasks);
+        BuildSprintCollections(tasks);
+        BuildReportCollections(tasks);
+
+        // SECTION: Apply task-list filters only in task list mode
+        Tasks = IsTaskListView
+            ? ApplyTaskListFilters(tasks)
+            : tasks;
 
         if (TaskId.HasValue)
         {
+            SelectedTask = tasks.FirstOrDefault(t => t.Id == TaskId.Value);
             SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
         }
+    }
+
+    private IReadOnlyList<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var query = tasks.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(FilterStatus))
+        {
+            query = query.Where(t => string.Equals(t.Status, FilterStatus, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(FilterPriority))
+        {
+            query = query.Where(t => string.Equals(t.Priority, FilterPriority, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(FilterAssigneeUserId))
+        {
+            query = query.Where(t => string.Equals(t.AssignedToUserId, FilterAssigneeUserId, StringComparison.Ordinal));
+        }
+
+        if (FilterDueDate.HasValue)
+        {
+            var dueDate = FilterDueDate.Value.Date;
+            query = query.Where(t => t.DueDate.Date == dueDate);
+        }
+
+        if (!string.IsNullOrWhiteSpace(FilterSearch))
+        {
+            var search = FilterSearch.Trim();
+            query = query.Where(t => t.Title.Contains(search, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
+    private void BuildDashboardCollections(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var utcNow = DateTime.UtcNow;
+
+        CriticalOpenTasks = tasks
+            .Where(t => string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase)
+                        && !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .Take(5)
+            .ToList();
+
+        OverdueTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                        && t.DueDate.Date < utcNow.Date)
+            .OrderBy(t => t.DueDate)
+            .Take(5)
+            .ToList();
+
+        RecentlySubmittedTasks = tasks
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue)
+            .Take(5)
+            .ToList();
+
+        RecentlyUpdatedTasks = tasks
+            .OrderByDescending(t => t.SubmittedOn ?? t.AssignedOn)
+            .Take(5)
+            .ToList();
+    }
+
+    private void BuildKanbanCollections(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        KanbanAssignedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)).ToList();
+        KanbanInProgressTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)).ToList();
+        KanbanBlockedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
+        KanbanSubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
+        KanbanClosedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    private void BuildSprintCollections(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var utcToday = DateTime.UtcNow.Date;
+        var endOfWeek = utcToday.AddDays(7);
+
+        SprintOverdueTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                        && t.DueDate.Date < utcToday)
+            .OrderBy(t => t.DueDate)
+            .ToList();
+
+        DueTodayTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                        && t.DueDate.Date == utcToday)
+            .OrderBy(t => t.DueDate)
+            .ToList();
+
+        DueThisWeekTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                        && t.DueDate.Date > utcToday
+                        && t.DueDate.Date <= endOfWeek)
+            .OrderBy(t => t.DueDate)
+            .ToList();
+
+        DueLaterTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                        && t.DueDate.Date > endOfWeek)
+            .OrderBy(t => t.DueDate)
+            .ToList();
+    }
+
+    private void BuildReportCollections(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        AssigneePendingCounts = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+            .GroupBy(t => ResolveAssigneeName(t.AssignedToUserId))
+            .OrderByDescending(group => group.Count())
+            .Select(group => new CountSummary(group.Key, group.Count()))
+            .ToList();
+
+        PriorityCounts = tasks
+            .GroupBy(t => t.Priority)
+            .OrderByDescending(group => group.Count())
+            .Select(group => new CountSummary(group.Key, group.Count()))
+            .ToList();
+
+        StatusCounts = tasks
+            .GroupBy(t => t.Status)
+            .OrderByDescending(group => group.Count())
+            .Select(group => new CountSummary(group.Key, group.Count()))
+            .ToList();
     }
 
     private async Task ResolveIdentityAsync()
@@ -271,15 +500,26 @@ public class IndexModel : PageModel
             StringComparer.Ordinal);
     }
 
-    // SECTION: Normalize and evaluate selected view mode
-    private bool IsMyTasksView() =>
-        string.Equals(ResolveViewMode(), "MyTasks", StringComparison.OrdinalIgnoreCase);
-
-    // SECTION: Resolve a safe view mode value for postback and redirects
+    // SECTION: Resolve a safe, standardized view mode value for postback and redirects
     private string ResolveViewMode()
     {
         var normalized = (ViewMode ?? string.Empty).Trim();
-        return string.IsNullOrWhiteSpace(normalized) ? "Dashboard" : normalized;
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return "Dashboard";
+        }
+
+        if (string.Equals(normalized, "SprintBoard", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Sprint";
+        }
+
+        if (string.Equals(normalized, "My Tasks", StringComparison.OrdinalIgnoreCase))
+        {
+            return "MyTasks";
+        }
+
+        return normalized;
     }
 
     public sealed class CreateTaskInput
@@ -304,4 +544,5 @@ public class IndexModel : PageModel
     }
 
     public sealed record UserOption(string UserId, string DisplayName, string Role);
+    public sealed record CountSummary(string Name, int Count);
 }

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -1,0 +1,41 @@
+@model IReadOnlyList<ProjectManagement.Models.ActionTaskItem>
+@using ProjectManagement.Models
+@{
+    string StatusClass(string status)
+    {
+        if (string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-progress";
+        if (string.Equals(status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-blocked";
+        if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-submitted";
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-closed";
+        return "at-badge at-badge-status-assigned";
+    }
+
+    string PriorityClass(string priority)
+    {
+        if (string.Equals(priority, "Critical", StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-priority-critical";
+        if (string.Equals(priority, "High", StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-priority-high";
+        return "at-badge at-badge-priority-normal";
+    }
+}
+
+@if (!Model.Any())
+{
+    <div class="at-empty-column">No tasks</div>
+}
+else
+{
+    <div class="at-task-cards">
+        @foreach (var task in Model)
+        {
+            <article class="at-task-card">
+                <div class="fw-semibold">AT-@task.Id · @task.Title</div>
+                <div class="small text-muted">Assignee Role: @task.AssignedToRole</div>
+                <div class="small text-muted">Due: @task.DueDate.ToString("dd MMM yyyy")</div>
+                <div class="d-flex gap-2 mt-2 flex-wrap">
+                    <span class="@PriorityClass(task.Priority)">@task.Priority</span>
+                    <span class="@StatusClass(task.Status)">@task.Status</span>
+                </div>
+            </article>
+        }
+    </div>
+}

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -52,6 +52,10 @@
     margin-bottom: 1rem;
 }
 
+.at-kpis-reports {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .at-kpis article,
 .at-panel {
     border: 1px solid #ccd8ea;
@@ -71,7 +75,47 @@
     color: #1f2e45;
 }
 
-/* SECTION: Table controls */
+.at-card-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .75rem;
+}
+
+.at-simple-list {
+    margin: 0;
+    padding-left: 1rem;
+}
+
+/* SECTION: Table controls and styling */
+.at-table {
+    margin-bottom: 0;
+}
+
+.at-table thead th {
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #475569;
+    background: #f8fafc;
+}
+
+.at-table td {
+    vertical-align: middle;
+}
+
+.at-table tbody tr:hover {
+    background: #f8fafc;
+}
+
+.at-task-title {
+    font-weight: 700;
+}
+
+.at-task-desc {
+    color: #64748b;
+    font-size: 0.86rem;
+}
+
 .at-actions {
     min-width: 300px;
 }
@@ -90,6 +134,87 @@
     min-width: 220px;
 }
 
+/* SECTION: Badge system */
+.at-badge {
+    border-radius: 999px;
+    padding: 0.25rem 0.55rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    border: 1px solid transparent;
+}
+
+.at-badge-status-assigned {
+    color: #1f2937;
+    background: #e5e7eb;
+}
+
+.at-badge-status-progress {
+    color: #1e3a8a;
+    background: #dbeafe;
+}
+
+.at-badge-status-blocked {
+    color: #991b1b;
+    background: #fee2e2;
+}
+
+.at-badge-status-submitted {
+    color: #92400e;
+    background: #fef3c7;
+}
+
+.at-badge-status-closed {
+    color: #166534;
+    background: #dcfce7;
+}
+
+.at-badge-priority-normal {
+    color: #334155;
+    background: #e2e8f0;
+}
+
+.at-badge-priority-high {
+    color: #92400e;
+    background: #fef3c7;
+}
+
+.at-badge-priority-critical {
+    color: #991b1b;
+    background: #fee2e2;
+}
+
+/* SECTION: Board and card layouts */
+.at-board-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: .75rem;
+}
+
+.at-board-grid-sprint {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.at-board-column h2 {
+    font-size: 1rem;
+}
+
+.at-task-cards {
+    display: grid;
+    gap: .55rem;
+}
+
+.at-task-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: .65rem;
+    background: #f8fafc;
+}
+
+.at-empty-column {
+    color: #64748b;
+    font-size: .9rem;
+}
+
 /* SECTION: Empty states */
 .at-empty-state {
     border: 1px dashed #cbd5e1;
@@ -99,7 +224,23 @@
     color: #475569;
 }
 
+@media (max-width: 1399px) {
+    .at-board-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
 @media (max-width: 1199px) {
     .at-shell { grid-template-columns: 1fr; }
-    .at-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .at-kpis,
+    .at-kpis-reports,
+    .at-card-grid,
+    .at-board-grid,
+    .at-board-grid-sprint { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 767px) {
+    .at-kpis,
+    .at-kpis-reports,
+    .at-card-grid,
+    .at-board-grid,
+    .at-board-grid-sprint { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- The page previously rendered create, register and audit content together regardless of left-nav selection, making the Dashboard and other views crowded and confusing. 
- The goal is to make each left-hand view mode (`Dashboard`, `MyTasks`, `Sprint`, `Kanban`, `TaskList`, `Reports`) show only relevant content and improve register readability without changing core task/workflow logic.

### Description
- Added view-mode-specific rendering and navigation by updating `Pages/ActionTasks/Index.cshtml` to render distinct sections for Dashboard, My Tasks, Task List, Kanban, Sprint and Reports and standardised route values to `Dashboard`, `MyTasks`, `Sprint`, `Kanban`, `TaskList`, and `Reports`.
- Extended the page model `Pages/ActionTasks/Index.cshtml.cs` with helper properties (`ResolvedViewMode`, `IsDashboardView`, `IsMyTasksView`, etc.), view-specific data projections (dashboard lists, kanban groups, sprint buckets, report summaries), strict personal filtering for My Tasks (`AssignedToUserId == CurrentUserId`), and server-side Task List filters (`FilterStatus`, `FilterPriority`, `FilterAssigneeUserId`, `FilterDueDate`, `FilterSearch`).
- Kept existing create/submit/update/close/audit flows intact while improving UX: the Create panel is collapsed by default and only shown on validation failure, both task ID and title are clickable to open detail/audit, the audit trail is rendered only when a task is explicitly selected with clearer heading and a back link, and status/priority display uses badge CSS classes instead of plain text.
- Added a reusable partial `Pages/ActionTasks/_TaskCards.cshtml` for board card rendering and updated `wwwroot/css/action-tracker.css` with badge styles, table polish, board/card layouts, hover/vertical alignment and responsive rules; no database or schema changes were introduced.

### Testing
- Attempted an automated build with `dotnet build` in the container, but the .NET SDK is not installed and the command failed with `dotnet: command not found` (build not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b137af748329a2ff7578e274e8dc)