### PR TITLE
Ensure ActionTasks viewMode falls back to Dashboard for unsupported values

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -509,17 +509,27 @@ public class IndexModel : PageModel
             return "Dashboard";
         }
 
+        // SECTION: Normalize known aliases first so legacy links remain valid.
         if (string.Equals(normalized, "SprintBoard", StringComparison.OrdinalIgnoreCase))
         {
-            return "Sprint";
+            normalized = "Sprint";
         }
-
-        if (string.Equals(normalized, "My Tasks", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(normalized, "My Tasks", StringComparison.OrdinalIgnoreCase))
         {
-            return "MyTasks";
+            normalized = "MyTasks";
         }
 
-        return normalized;
+        // SECTION: Explicitly whitelist supported view modes and default unsupported inputs.
+        return normalized switch
+        {
+            _ when string.Equals(normalized, "Dashboard", StringComparison.OrdinalIgnoreCase) => "Dashboard",
+            _ when string.Equals(normalized, "MyTasks", StringComparison.OrdinalIgnoreCase) => "MyTasks",
+            _ when string.Equals(normalized, "TaskList", StringComparison.OrdinalIgnoreCase) => "TaskList",
+            _ when string.Equals(normalized, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
+            _ when string.Equals(normalized, "Sprint", StringComparison.OrdinalIgnoreCase) => "Sprint",
+            _ when string.Equals(normalized, "Reports", StringComparison.OrdinalIgnoreCase) => "Reports",
+            _ => "Dashboard"
+        };
     }
 
     public sealed class CreateTaskInput


### PR DESCRIPTION
### Motivation
- Prevent stale or malformed `viewMode` query values from bypassing view branches and rendering an effectively blank main content area while preserving legacy aliases.

### Description
- Update `ResolveViewMode()` in `Pages/ActionTasks/Index.cshtml.cs` to normalize legacy aliases (`SprintBoard` → `Sprint`, `My Tasks` → `MyTasks`) and explicitly whitelist supported modes (`Dashboard`, `MyTasks`, `TaskList`, `Kanban`, `Sprint`, `Reports`), defaulting unknown values to `Dashboard`.
- Add section comments and replace the prior passthrough with a concise whitelist (`switch`) to make the logic clearer and maintainable.

### Testing
- Attempted to run `dotnet build` but the CLI is unavailable in this environment (`dotnet: command not found`), so no automated build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b8912494832982c03883219d6082)