### PR TITLE
Require and persist remarks on key task actions; add task detail panel and audit remarks UI

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -11,7 +11,6 @@
     var submittedCount = CountByStatus(ActionTaskStatuses.Submitted);
     var blockedCount = CountByStatus(ActionTaskStatuses.Blocked);
     var closedCount = CountByStatus(ActionTaskStatuses.Closed);
-    var selectedTaskTitle = Model.SelectedTask?.Title ?? "Task";
 }
 
 @section Styles {
@@ -271,19 +270,21 @@
                                             <div class="at-actions-stack">
                                                 @if (Model.CanSubmitTask(task))
                                                 {
-                                                    <form method="post" asp-page-handler="Submit">
+                                                    <form method="post" asp-page-handler="Submit" class="at-inline-action-form">
                                                         @* SECTION: Preserve list context while performing row actions. *@
                                                         <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                                         <input type="hidden" name="id" value="@task.Id" />
+                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Submission remarks" maxlength="300" />
                                                         <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
                                                     </form>
                                                 }
                                                 @if (Model.CanCloseTask(task))
                                                 {
-                                                    <form method="post" asp-page-handler="Close">
+                                                    <form method="post" asp-page-handler="Close" class="at-inline-action-form">
                                                         @* SECTION: Preserve list context while performing row actions. *@
                                                         <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                                         <input type="hidden" name="id" value="@task.Id" />
+                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Closure remarks" maxlength="300" />
                                                         <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
                                                     </form>
                                                 }
@@ -306,6 +307,7 @@
                                                                 }
                                                             }
                                                         </select>
+                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Remarks" maxlength="300" />
                                                         <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
                                                     </form>
                                                 }
@@ -391,21 +393,49 @@
         {
             <section class="at-panel mt-3">
                 <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
-                    <h2 class="mb-0">Task Audit Trail: AT-@Model.TaskId.Value - @selectedTaskTitle</h2>
+                    <h2 class="mb-0">Task Details: AT-@Model.TaskId.Value</h2>
                     <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Back to Task List</a>
                 </div>
-                <ul class="list-group list-group-flush">
+
+                @if (Model.SelectedTask is not null)
+                {
+                    <div class="at-task-details-grid mb-3">
+                        <div><span class="text-muted">Task ID</span><div class="fw-semibold">AT-@Model.SelectedTask.Id</div></div>
+                        <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
+                        <div><span class="text-muted">Description</span><div class="fw-semibold">@Model.SelectedTask.Description</div></div>
+                        <div><span class="text-muted">Assignee</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId) (@Model.SelectedTask.AssignedToRole)</div></div>
+                        <div><span class="text-muted">Priority</span><div class="fw-semibold">@Model.SelectedTask.Priority</div></div>
+                        <div><span class="text-muted">Status</span><div class="fw-semibold">@Model.SelectedTask.Status</div></div>
+                        <div><span class="text-muted">Due Date</span><div class="fw-semibold">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div></div>
+                        <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.CreatedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
+                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+                    </div>
+                }
+
+                <h3 class="h5 mb-2">Task Audit Trail</h3>
+                <div class="at-audit-list">
                     @foreach (var log in Model.SelectedTaskLogs)
                     {
-                        <li class="list-group-item">
-                            <strong>@log.ActionType</strong> by @log.PerformedByRole on @log.PerformedAt.ToString("dd MMM yyyy HH:mm")
+                        <div class="at-audit-item">
+                            <div class="d-flex justify-content-between gap-2 flex-wrap">
+                                <div>
+                                    <strong>@log.ActionType</strong>
+                                    <span class="text-muted">by @log.PerformedByRole</span>
+                                </div>
+                                <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
+                            </div>
                             @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
                             {
                                 <div class="small text-muted">@log.OldValue → @log.NewValue</div>
                             }
-                        </li>
+                            @if (!string.IsNullOrWhiteSpace(log.Remarks))
+                            {
+                                <div class="at-audit-remarks">@log.Remarks</div>
+                            }
+                        </div>
                     }
-                </ul>
+                </div>
             </section>
         }
     </section>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -230,12 +230,12 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Submit task for closure review
-    public async Task<IActionResult> OnPostSubmitAsync(int id)
+    public async Task<IActionResult> OnPostSubmitAsync(int id, string? remarks)
     {
         await ResolveIdentityAsync();
         try
         {
-            await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, "Submitted by assignee/workflow actor.");
+            await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task submitted.";
         }
         catch (InvalidOperationException ex)
@@ -247,12 +247,12 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Close task by command role
-    public async Task<IActionResult> OnPostCloseAsync(int id)
+    public async Task<IActionResult> OnPostCloseAsync(int id, string? remarks)
     {
         await ResolveIdentityAsync();
         try
         {
-            await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, "Closed by command authority.");
+            await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task closed.";
         }
         catch (InvalidOperationException ex)
@@ -264,12 +264,12 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Update in-flight status
-    public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string status)
+    public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string status, string? remarks)
     {
         await ResolveIdentityAsync();
         try
         {
-            await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole);
+            await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task status updated.";
         }
         catch (InvalidOperationException ex)

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -96,6 +96,9 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException($"Invalid status transition from {task.Status} to {status}.");
         }
 
+        // SECTION: Remarks validation for key transitions
+        ValidateRemarksForStatusTransition(task.Status, status, remarks);
+
         var oldStatus = task.Status;
         task.Status = status;
         if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
@@ -131,6 +134,12 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Closed tasks cannot be submitted.");
         }
 
+        // SECTION: Remarks validation for submit action
+        if (IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when submitting a task.");
+        }
+
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Submitted;
         task.SubmittedOn = DateTime.UtcNow;
@@ -150,6 +159,12 @@ public class ActionTaskService : IActionTaskService
         if (!string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException("Only submitted tasks can be closed.");
+        }
+
+        // SECTION: Remarks validation for close action
+        if (IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Closure remarks are required.");
         }
 
         var oldStatus = task.Status;
@@ -177,6 +192,29 @@ public class ActionTaskService : IActionTaskService
 
         await _context.SaveChangesAsync(cancellationToken);
     }
+
+    // SECTION: Remarks rule helpers
+    private static void ValidateRemarksForStatusTransition(string currentStatus, string nextStatus, string? remarks)
+    {
+        if (string.Equals(nextStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when marking a task as blocked.");
+        }
+
+        if (string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when submitting a task.");
+        }
+
+        if (string.Equals(currentStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when returning a submitted task for further action.");
+        }
+    }
+
+    private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
 
     // SECTION: Workflow transition guard
     private static bool IsAllowedTransition(string currentStatus, string nextStatus)

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -117,21 +117,69 @@
 }
 
 .at-actions {
-    min-width: 300px;
+    min-width: 420px;
 }
 
 .at-actions-stack {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: .45rem;
+}
+
+.at-status-form,
+.at-inline-action-form {
+    display: flex;
     gap: .4rem;
     align-items: center;
 }
 
-.at-status-form {
-    display: flex;
-    gap: .35rem;
-    align-items: center;
-    min-width: 220px;
+.at-status-form select {
+    max-width: 150px;
+}
+
+.at-status-form input,
+.at-inline-action-form input {
+    min-width: 180px;
+}
+
+.at-inline-action-form .btn,
+.at-status-form .btn {
+    white-space: nowrap;
+}
+
+/* SECTION: Selected task details and audit context */
+.at-task-details-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: .65rem 1rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #f8fafc;
+    padding: .9rem;
+}
+
+.at-audit-list {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.at-audit-item {
+    padding: .85rem 1rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.at-audit-item:last-child {
+    border-bottom: none;
+}
+
+.at-audit-remarks {
+    margin-top: .45rem;
+    padding: .55rem .7rem;
+    border-left: 3px solid #94a3b8;
+    background: #f8fafc;
+    color: #334155;
+    border-radius: .35rem;
 }
 
 /* SECTION: Badge system */
@@ -243,4 +291,8 @@
     .at-card-grid,
     .at-board-grid,
     .at-board-grid-sprint { grid-template-columns: 1fr; }
+
+    .at-task-details-grid {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
### Motivation
- Capture operational context for meaningful task transitions so audit trails show why changes occurred.  
- Enforce mandatory explanations for high-value transitions (blocked, submitted, closed, and returning submitted tasks).  
- Surface remarks in the UI and provide a compact task summary to make selected-task views actionable without breaking existing workflows.

### Description
- Enforced remarks validation in `ActionTaskService` for status transitions and added helpers `ValidateRemarksForStatusTransition` and `IsBlank`, and ensured the `Log` call persists `remarks`.  
- Changed service call signatures to accept remarks (already present in the interface) and updated page handlers to forward remarks: `OnPostUpdateStatusAsync`, `OnPostSubmitAsync`, and `OnPostCloseAsync`.  
- Updated `Pages/ActionTasks/Index.cshtml` to add compact `remarks` inputs for row actions (Update/Submit/Close), and replaced the selected-task audit list with a detail summary plus an improved audit trail rendering that highlights remarks.  
- Adjusted CSS in `wwwroot/css/action-tracker.css` for wider action column, stacked action rows, and new styles for the task details and audit remarks; no model/migration changes were required because `ActionTaskAuditLog.Remarks` already exists.

### Testing
- Attempted to run `dotnet build` in the environment but it failed because the `dotnet` SDK is not available (`dotnet: command not found`).  
- No other automated tests (unit/integration) were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ba532f208329be4577e1ed1309f8)