### PR TITLE
Fix ActionTask timestamp error and nullability warnings

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -407,7 +407,7 @@
                         <div><span class="text-muted">Priority</span><div class="fw-semibold">@Model.SelectedTask.Priority</div></div>
                         <div><span class="text-muted">Status</span><div class="fw-semibold">@Model.SelectedTask.Status</div></div>
                         <div><span class="text-muted">Due Date</span><div class="fw-semibold">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div></div>
-                        <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.CreatedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
+                        <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
                         <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
                         <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
                     </div>

--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -550,7 +550,6 @@ else
                                 var internalRemarksExpandedOnly = item.RecentInternalRemarks.Skip(collapsedInternalCount).ToList();
                                 var hasExpandableInternalRemarks = internalRemarksExpandedOnly.Count > 0;
                                 var latestExternalRemark = item.LatestExternalRemark;
-                                var hasExternalRemark = !string.IsNullOrWhiteSpace(latestExternalRemark?.Body);
                             }
 
                             <!-- SECTION: Remarks panel heading and toggle -->
@@ -622,13 +621,13 @@ else
                                 <!-- SECTION: Latest external remark (30%) -->
                                 <div class="ongoing-remarks__column ongoing-remarks__column--external">
                                     <h3 class="ongoing-remarks__column-title">Latest external remark</h3>
-                                    @if (!hasExternalRemark)
+                                    @if (latestExternalRemark is not { Body: { Length: > 0 } })
                                     {
                                         <p class="small text-muted mb-0">No external remarks.</p>
                                     }
                                     else
                                     {
-                                        var externalRemark = latestExternalRemark!;
+                                        var externalRemark = latestExternalRemark;
                                         <article class="ongoing-remarks__item">
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
                                                 @Html.Raw(RenderRemark(externalRemark.Body))

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1886,10 +1886,19 @@ public sealed class ProgressReviewService : IProgressReviewService
             return new Dictionary<int, string?>();
         }
 
-        return await _db.Projects
+        var workflowVersionLookup = await _db.Projects
             .AsNoTracking()
             .Where(project => projectIds.Contains(project.Id))
-            .ToDictionaryAsync(project => project.Id, project => (string?)project.WorkflowVersion, cancellationToken);
+            .Select(project => new
+            {
+                project.Id,
+                WorkflowVersion = (string?)project.WorkflowVersion
+            })
+            .ToListAsync(cancellationToken);
+
+        return workflowVersionLookup.ToDictionary(
+            project => project.Id,
+            project => project.WorkflowVersion);
     }
 
     private string? BuildAttachmentUrl(string? storageKey)


### PR DESCRIPTION
### Motivation
- Resolve a build error caused by referencing a non-existent property on `ActionTaskItem` and eliminate related nullability warnings noticed during code analysis.
- Ensure appearance of remark data in the Ongoing Projects UI is rendered safely without possible null dereferences.
- Keep dictionary value typing consistent (`string?`) when building lookups from EF query results to avoid nullability mismatch warnings.

### Description
- Updated `Pages/ActionTasks/Index.cshtml` to use `AssignedOn` instead of the non-existent `CreatedOn` on `ActionTaskItem` when showing the task "Created On" timestamp (`@Model.SelectedTask.AssignedOn`).
- Changed `Services/Reports/ProgressReview/ProgressReviewService.cs` lookup logic to materialize a projection with `WorkflowVersion` first via `Select(...).ToListAsync(...)` and then call `.ToDictionary(...)` to produce an `IReadOnlyDictionary<int, string?>` and avoid the nullability mismatch.
- Tightened null handling in `Pages/Projects/Ongoing/Index.cshtml` by replacing the previous `HasExternalRemark` check with a property pattern check (`latestExternalRemark is not { Body: { Length: > 0 } }`) and using the narrowed `externalRemark` safely in the `else` branch.
- Changes touch the following files: `Pages/ActionTasks/Index.cshtml`, `Services/Reports/ProgressReview/ProgressReviewService.cs`, and `Pages/Projects/Ongoing/Index.cshtml`.

### Testing
- Attempted to run `dotnet build` in this environment to validate the changes, but the build could not be executed because the .NET SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bbf2e03c832989bb5165b05ac947)