### PR TITLE
Fix whitespace-only external remark handling in Ongoing projects view

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -621,13 +621,13 @@ else
                                 <!-- SECTION: Latest external remark (30%) -->
                                 <div class="ongoing-remarks__column ongoing-remarks__column--external">
                                     <h3 class="ongoing-remarks__column-title">Latest external remark</h3>
-                                    @if (latestExternalRemark is not { Body: { Length: > 0 } })
+                                    @if (string.IsNullOrWhiteSpace(latestExternalRemark?.Body))
                                     {
                                         <p class="small text-muted mb-0">No external remarks.</p>
                                     }
                                     else
                                     {
-                                        var externalRemark = latestExternalRemark;
+                                        var externalRemark = latestExternalRemark!;
                                         <article class="ongoing-remarks__item">
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
                                                 @Html.Raw(RenderRemark(externalRemark.Body))


### PR DESCRIPTION
### Motivation
- Restore whitespace-aware detection for the latest external remark so whitespace/newline-only bodies are treated as empty and the UI shows `No external remarks.` instead of rendering an empty remark block.

### Description
- In `Pages/Projects/Ongoing/Index.cshtml` replace `@if (latestExternalRemark is not { Body: { Length: > 0 } })` with `@if (string.IsNullOrWhiteSpace(latestExternalRemark?.Body))` and use `latestExternalRemark!` in the guarded `else` branch to preserve nullability assumptions.

### Testing
- Attempted `dotnet build ProjectManagement.sln -v minimal`, which failed because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bd2abae08329b622f5a5a10f73e7)