### PR TITLE
Refactor ActionTasks UI into modular partials and ERP-grade presentation

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -1,16 +1,8 @@
 @page
 @model ProjectManagement.Pages.ActionTasks.IndexModel
-@using ProjectManagement.Models
 @{
     ViewData["Title"] = "Task Tracker";
     ViewData["UseFullWidth"] = true;
-
-    int CountByStatus(string status) => Model.Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
-    var activeCount = Model.Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
-    var overdueCount = Model.Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
-    var submittedCount = CountByStatus(ActionTaskStatuses.Submitted);
-    var blockedCount = CountByStatus(ActionTaskStatuses.Blocked);
-    var closedCount = CountByStatus(ActionTaskStatuses.Closed);
 }
 
 @section Styles {
@@ -37,8 +29,8 @@
         @* SECTION: Shared page header and create-task trigger. *@
         <header class="at-header">
             <div>
-                <h1>@(Model.IsTaskListView ? "Command Task Register" : Model.IsMyTasksView ? "My Tasks" : "Command Task Dashboard")</h1>
-                <p>Command-level task tracking with role-governed access and audit integrity.</p>
+                <h1>@Model.PageHeading</h1>
+                <p>@Model.PageSubtitle</p>
             </div>
             @if (Model.CanCreate)
             {
@@ -46,397 +38,35 @@
             }
         </header>
 
-        @* SECTION: Create panel stays collapsed by default; opens for validation failures. *@
         @if (Model.CanCreate)
         {
-            <section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
-                <h2>Create Task</h2>
-                @if (!ViewData.ModelState.IsValid)
-                {
-                    <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
-                }
-                <form method="post" asp-page-handler="Create" class="row g-3">
-                    @* SECTION: Preserve selected view mode during postbacks. *@
-                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                    <div class="col-md-4">
-                        <label asp-for="Input.Title" class="form-label"></label>
-                        <input asp-for="Input.Title" class="form-control" />
-                        <span asp-validation-for="Input.Title" class="text-danger small"></span>
-                    </div>
-                    <div class="col-md-8">
-                        <label asp-for="Input.Description" class="form-label"></label>
-                        <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
-                        <span asp-validation-for="Input.Description" class="text-danger small"></span>
-                    </div>
-                    <div class="col-md-3">
-                        <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
-                        <select asp-for="Input.AssignedToUserId" class="form-select">
-                            <option value="">Select user</option>
-                            @foreach (var user in Model.AssignableUsers)
-                            {
-                                <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
-                            }
-                        </select>
-                        <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
-                    </div>
-                    <div class="col-md-2">
-                        <label asp-for="Input.Priority" class="form-label"></label>
-                        <select asp-for="Input.Priority" class="form-select">
-                            <option>Low</option>
-                            <option selected>Normal</option>
-                            <option>High</option>
-                            <option>Critical</option>
-                        </select>
-                        <span asp-validation-for="Input.Priority" class="text-danger small"></span>
-                    </div>
-                    <div class="col-md-2">
-                        <label asp-for="Input.DueDate" class="form-label"></label>
-                        <input asp-for="Input.DueDate" type="date" class="form-control" />
-                        <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
-                    </div>
-                    <div class="col-md-2 d-flex align-items-end">
-                        <button type="submit" class="btn btn-success w-100">Create Task</button>
-                    </div>
-                </form>
-            </section>
+            <partial name="_TaskCreatePanel" model="Model" />
         }
 
-        @* SECTION: View-specific rendering. *@
         @if (Model.IsDashboardView)
         {
-            <section class="at-kpis">
-                <article><h3>Active</h3><strong>@activeCount</strong></article>
-                <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
-                <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
-                <article><h3>Submitted</h3><strong>@submittedCount</strong></article>
-                <article><h3>Closed</h3><strong>@closedCount</strong></article>
-            </section>
-
-            <section class="at-card-grid">
-                <article class="at-panel">
-                    <h2>Critical Open Tasks</h2>
-                    <ul class="at-simple-list">
-                        @foreach (var task in Model.CriticalOpenTasks)
-                        {
-                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
-                        }
-                    </ul>
-                </article>
-                <article class="at-panel">
-                    <h2>Overdue Tasks</h2>
-                    <ul class="at-simple-list">
-                        @foreach (var task in Model.OverdueTasks)
-                        {
-                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
-                        }
-                    </ul>
-                </article>
-                <article class="at-panel">
-                    <h2>Recently Submitted</h2>
-                    <ul class="at-simple-list">
-                        @foreach (var task in Model.RecentlySubmittedTasks)
-                        {
-                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
-                        }
-                    </ul>
-                </article>
-                <article class="at-panel">
-                    <h2>Recently Updated</h2>
-                    <ul class="at-simple-list">
-                        @foreach (var task in Model.RecentlyUpdatedTasks)
-                        {
-                            <li><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id · @task.Title</a></li>
-                        }
-                    </ul>
-                </article>
-            </section>
+            <partial name="_TaskDashboard" model="Model" />
         }
         else if (Model.IsMyTasksView || Model.IsTaskListView)
         {
-            @if (Model.IsTaskListView)
-            {
-                <section class="at-panel mb-3">
-                    <h2>Task List Filters</h2>
-                    <form method="get" class="row g-2">
-                        <input type="hidden" name="viewMode" value="TaskList" />
-                        <div class="col-md-2">
-                            <label class="form-label">Status</label>
-                            <select class="form-select" name="FilterStatus">
-                                <option value="">All</option>
-                                @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
-                                {
-                                    @if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        <option value="@status" selected>@status</option>
-                                    }
-                                    else
-                                    {
-                                        <option value="@status">@status</option>
-                                    }
-                                }
-                            </select>
-                        </div>
-                        <div class="col-md-2">
-                            <label class="form-label">Priority</label>
-                            <select class="form-select" name="FilterPriority">
-                                <option value="">All</option>
-                                @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
-                                {
-                                    @if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        <option value="@priority" selected>@priority</option>
-                                    }
-                                    else
-                                    {
-                                        <option value="@priority">@priority</option>
-                                    }
-                                }
-                            </select>
-                        </div>
-                        <div class="col-md-3">
-                            <label class="form-label">Assignee</label>
-                            <select class="form-select" name="FilterAssigneeUserId">
-                                <option value="">All</option>
-                                @foreach (var assignee in Model.AssignableUsers)
-                                {
-                                    @if (string.Equals(Model.FilterAssigneeUserId, assignee.UserId, StringComparison.Ordinal))
-                                    {
-                                        <option value="@assignee.UserId" selected>@assignee.DisplayName (@assignee.Role)</option>
-                                    }
-                                    else
-                                    {
-                                        <option value="@assignee.UserId">@assignee.DisplayName (@assignee.Role)</option>
-                                    }
-                                }
-                            </select>
-                        </div>
-                        <div class="col-md-2">
-                            <label class="form-label">Due Date</label>
-                            <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
-                        </div>
-                        <div class="col-md-3">
-                            <label class="form-label">Search by title</label>
-                            <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" />
-                        </div>
-                        <div class="col-12 d-flex gap-2">
-                            <button type="submit" class="btn btn-primary btn-sm">Apply Filters</button>
-                            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
-                        </div>
-                    </form>
-                </section>
-            }
-
-            <section class="at-panel">
-                <h2>@(Model.IsMyTasksView ? "My Tasks" : "Task Register")</h2>
-                @if (!Model.Tasks.Any())
-                {
-                    <div class="at-empty-state">
-                        <div class="fw-semibold">No tasks available for this view.</div>
-                        <div class="text-muted">Try adjusting filters or create a task.</div>
-                    </div>
-                }
-                else
-                {
-                    <div class="table-responsive">
-                        <table class="table table-sm at-table">
-                            <thead>
-                                <tr>
-                                    <th>ID</th>
-                                    <th>Task</th>
-                                    <th>Assignee</th>
-                                    <th>Due Date</th>
-                                    <th>Status</th>
-                                    <th>Priority</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var task in Model.Tasks)
-                                {
-                                    <tr>
-                                        <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
-                                        <td>
-                                            <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
-                                            <div class="at-task-desc">@task.Description</div>
-                                        </td>
-                                        <td>
-                                            <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>
-                                            <div class="text-muted small">@task.AssignedToRole</div>
-                                        </td>
-                                        <td>@task.DueDate.ToString("dd MMM yyyy")</td>
-                                        <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
-                                        <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
-                                        <td class="at-actions">
-                                            <div class="at-actions-stack">
-                                                @if (Model.CanSubmitTask(task))
-                                                {
-                                                    <form method="post" asp-page-handler="Submit" class="at-inline-action-form">
-                                                        @* SECTION: Preserve list context while performing row actions. *@
-                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                                        <input type="hidden" name="id" value="@task.Id" />
-                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Submission remarks" maxlength="300" />
-                                                        <button type="submit" class="btn btn-outline-warning btn-sm">Submit</button>
-                                                    </form>
-                                                }
-                                                @if (Model.CanCloseTask(task))
-                                                {
-                                                    <form method="post" asp-page-handler="Close" class="at-inline-action-form">
-                                                        @* SECTION: Preserve list context while performing row actions. *@
-                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                                        <input type="hidden" name="id" value="@task.Id" />
-                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Closure remarks" maxlength="300" />
-                                                        <button type="submit" class="btn btn-outline-success btn-sm">Close</button>
-                                                    </form>
-                                                }
-                                                @if (Model.CanUpdateTaskStatus(task))
-                                                {
-                                                    <form method="post" asp-page-handler="UpdateStatus" class="at-status-form">
-                                                        @* SECTION: Preserve list context while performing row actions. *@
-                                                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                                        <input type="hidden" name="id" value="@task.Id" />
-                                                        <select name="status" class="form-select form-select-sm">
-                                                            @foreach (var status in Model.AllowedStatusOptions)
-                                                            {
-                                                                if (task.Status == status)
-                                                                {
-                                                                    <option value="@status" selected>@status</option>
-                                                                }
-                                                                else
-                                                                {
-                                                                    <option value="@status">@status</option>
-                                                                }
-                                                            }
-                                                        </select>
-                                                        <input name="remarks" class="form-control form-control-sm" placeholder="Remarks" maxlength="300" />
-                                                        <button type="submit" class="btn btn-outline-primary btn-sm">Update</button>
-                                                    </form>
-                                                }
-                                            </div>
-                                        </td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                }
-            </section>
+            <partial name="_TaskRegister" model="Model" />
         }
         else if (Model.IsKanbanView)
         {
-            <section class="at-board-grid">
-                <article class="at-panel at-board-column"><h2>Assigned</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanAssignedTasks)</article>
-                <article class="at-panel at-board-column"><h2>In Progress</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanInProgressTasks)</article>
-                <article class="at-panel at-board-column"><h2>Blocked</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanBlockedTasks)</article>
-                <article class="at-panel at-board-column"><h2>Submitted</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanSubmittedTasks)</article>
-                <article class="at-panel at-board-column"><h2>Closed</h2>@await Html.PartialAsync("_TaskCards", Model.KanbanClosedTasks)</article>
-            </section>
+            <partial name="_TaskKanban" model="Model" />
         }
         else if (Model.IsSprintBoardView)
         {
-            <section class="at-board-grid at-board-grid-sprint">
-                <article class="at-panel at-board-column"><h2>Due Today</h2>@await Html.PartialAsync("_TaskCards", Model.DueTodayTasks)</article>
-                <article class="at-panel at-board-column"><h2>Due This Week</h2>@await Html.PartialAsync("_TaskCards", Model.DueThisWeekTasks)</article>
-                <article class="at-panel at-board-column"><h2>Due Later</h2>@await Html.PartialAsync("_TaskCards", Model.DueLaterTasks)</article>
-                <article class="at-panel at-board-column"><h2>Overdue</h2>@await Html.PartialAsync("_TaskCards", Model.SprintOverdueTasks)</article>
-            </section>
+            <partial name="_TaskSprintBoard" model="Model" />
         }
         else if (Model.IsReportsView)
         {
-            <section class="at-kpis at-kpis-reports">
-                <article><h3>Total Active</h3><strong>@activeCount</strong></article>
-                <article><h3>Overdue</h3><strong>@overdueCount</strong></article>
-                <article><h3>Blocked</h3><strong>@blockedCount</strong></article>
-                <article><h3>Submitted Pending Closure</h3><strong>@submittedCount</strong></article>
-                <article><h3>Closed</h3><strong>@closedCount</strong></article>
-                <article><h3>Critical Open</h3><strong>@Model.CriticalOpenTasks.Count</strong></article>
-            </section>
-
-            <section class="at-card-grid">
-                <article class="at-panel">
-                    <h2>Assignee-wise Pending Tasks</h2>
-                    <table class="table table-sm at-table mb-0">
-                        <tbody>
-                            @foreach (var item in Model.AssigneePendingCounts)
-                            {
-                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                            }
-                        </tbody>
-                    </table>
-                </article>
-                <article class="at-panel">
-                    <h2>Priority-wise Task Count</h2>
-                    <table class="table table-sm at-table mb-0">
-                        <tbody>
-                            @foreach (var item in Model.PriorityCounts)
-                            {
-                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                            }
-                        </tbody>
-                    </table>
-                </article>
-                <article class="at-panel">
-                    <h2>Status-wise Task Count</h2>
-                    <table class="table table-sm at-table mb-0">
-                        <tbody>
-                            @foreach (var item in Model.StatusCounts)
-                            {
-                                <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                            }
-                        </tbody>
-                    </table>
-                </article>
-            </section>
+            <partial name="_TaskReports" model="Model" />
         }
 
-        @* SECTION: Audit trail is visible only for an explicitly selected task. *@
         @if (Model.TaskId.HasValue)
         {
-            <section class="at-panel mt-3">
-                <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
-                    <h2 class="mb-0">Task Details: AT-@Model.TaskId.Value</h2>
-                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Back to Task List</a>
-                </div>
-
-                @if (Model.SelectedTask is not null)
-                {
-                    <div class="at-task-details-grid mb-3">
-                        <div><span class="text-muted">Task ID</span><div class="fw-semibold">AT-@Model.SelectedTask.Id</div></div>
-                        <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
-                        <div><span class="text-muted">Description</span><div class="fw-semibold">@Model.SelectedTask.Description</div></div>
-                        <div><span class="text-muted">Assignee</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId) (@Model.SelectedTask.AssignedToRole)</div></div>
-                        <div><span class="text-muted">Priority</span><div class="fw-semibold">@Model.SelectedTask.Priority</div></div>
-                        <div><span class="text-muted">Status</span><div class="fw-semibold">@Model.SelectedTask.Status</div></div>
-                        <div><span class="text-muted">Due Date</span><div class="fw-semibold">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div></div>
-                        <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
-                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
-                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
-                    </div>
-                }
-
-                <h3 class="h5 mb-2">Task Audit Trail</h3>
-                <div class="at-audit-list">
-                    @foreach (var log in Model.SelectedTaskLogs)
-                    {
-                        <div class="at-audit-item">
-                            <div class="d-flex justify-content-between gap-2 flex-wrap">
-                                <div>
-                                    <strong>@log.ActionType</strong>
-                                    <span class="text-muted">by @log.PerformedByRole</span>
-                                </div>
-                                <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
-                            </div>
-                            @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
-                            {
-                                <div class="small text-muted">@log.OldValue → @log.NewValue</div>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(log.Remarks))
-                            {
-                                <div class="at-audit-remarks">@log.Remarks</div>
-                            }
-                        </div>
-                    }
-                </div>
-            </section>
+            <partial name="_TaskDetails" model="Model" />
         }
     </section>
 </div>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -87,6 +87,24 @@ public class IndexModel : PageModel
     public bool IsKanbanView => string.Equals(ResolvedViewMode, "Kanban", StringComparison.OrdinalIgnoreCase);
     public bool IsSprintBoardView => string.Equals(ResolvedViewMode, "Sprint", StringComparison.OrdinalIgnoreCase);
     public bool IsReportsView => string.Equals(ResolvedViewMode, "Reports", StringComparison.OrdinalIgnoreCase);
+    public string PageHeading => ResolvedViewMode switch
+    {
+        "MyTasks" => "My Tasks",
+        "Sprint" => "Due Window Board",
+        "Kanban" => "Task Kanban Board",
+        "TaskList" => "Command Task Register",
+        "Reports" => "Task Performance Summary",
+        _ => "Command Task Dashboard"
+    };
+    public string PageSubtitle => ResolvedViewMode switch
+    {
+        "MyTasks" => "Tasks assigned to the logged-in user.",
+        "Sprint" => "Tasks grouped by due date and urgency.",
+        "Kanban" => "Tasks grouped by current workflow status.",
+        "TaskList" => "Filterable register of all visible tasks.",
+        "Reports" => "Summary of pending, critical, blocked and closed tasks.",
+        _ => "Command-level visibility of active, delayed and critical tasks."
+    };
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => new[]
@@ -315,6 +333,54 @@ public class IndexModel : PageModel
             SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
         }
     }
+
+    // SECTION: Task display projections for richer UI cards and mini-lists.
+    public IReadOnlyList<TaskDisplayItem> CriticalOpenTaskDisplays =>
+        ToDisplayItems(CriticalOpenTasks);
+
+    public IReadOnlyList<TaskDisplayItem> OverdueTaskDisplays =>
+        ToDisplayItems(OverdueTasks);
+
+    public IReadOnlyList<TaskDisplayItem> RecentlySubmittedTaskDisplays =>
+        ToDisplayItems(RecentlySubmittedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> RecentlyUpdatedTaskDisplays =>
+        ToDisplayItems(RecentlyUpdatedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> KanbanAssignedTaskDisplays =>
+        ToDisplayItems(KanbanAssignedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> KanbanInProgressTaskDisplays =>
+        ToDisplayItems(KanbanInProgressTasks);
+
+    public IReadOnlyList<TaskDisplayItem> KanbanBlockedTaskDisplays =>
+        ToDisplayItems(KanbanBlockedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> KanbanSubmittedTaskDisplays =>
+        ToDisplayItems(KanbanSubmittedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> KanbanClosedTaskDisplays =>
+        ToDisplayItems(KanbanClosedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> DueTodayTaskDisplays =>
+        ToDisplayItems(DueTodayTasks);
+
+    public IReadOnlyList<TaskDisplayItem> DueThisWeekTaskDisplays =>
+        ToDisplayItems(DueThisWeekTasks);
+
+    public IReadOnlyList<TaskDisplayItem> DueLaterTaskDisplays =>
+        ToDisplayItems(DueLaterTasks);
+
+    public IReadOnlyList<TaskDisplayItem> SprintOverdueTaskDisplays =>
+        ToDisplayItems(SprintOverdueTasks);
+
+    // SECTION: KPI helpers for dashboard and reports.
+    public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
+    public int OverdueCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
+    public int SubmittedCount => CountByStatus(ActionTaskStatuses.Submitted);
+    public int BlockedCount => CountByStatus(ActionTaskStatuses.Blocked);
+    public int ClosedCount => CountByStatus(ActionTaskStatuses.Closed);
+    public int CriticalOpenCount => CriticalOpenTasks.Count;
 
     private IReadOnlyList<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks)
     {
@@ -555,4 +621,19 @@ public class IndexModel : PageModel
 
     public sealed record UserOption(string UserId, string DisplayName, string Role);
     public sealed record CountSummary(string Name, int Count);
+    public sealed class TaskDisplayItem
+    {
+        public ActionTaskItem Task { get; init; } = default!;
+        public string AssigneeName { get; init; } = string.Empty;
+    }
+
+    private int CountByStatus(string status) =>
+        Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
+
+    private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>
+        tasks.Select(task => new TaskDisplayItem
+        {
+            Task = task,
+            AssigneeName = ResolveAssigneeName(task.AssignedToUserId)
+        }).ToList();
 }

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -1,0 +1,53 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@* SECTION: Create panel stays collapsed by default; opens for validation failures. *@
+<section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
+    <h2>Create Task</h2>
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
+    }
+    <form method="post" asp-page-handler="Create" class="row g-3">
+        @* SECTION: Preserve selected view mode during postbacks. *@
+        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+        <div class="col-md-4">
+            <label asp-for="Input.Title" class="form-label"></label>
+            <input asp-for="Input.Title" class="form-control" />
+            <span asp-validation-for="Input.Title" class="text-danger small"></span>
+        </div>
+        <div class="col-md-8">
+            <label asp-for="Input.Description" class="form-label"></label>
+            <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+            <span asp-validation-for="Input.Description" class="text-danger small"></span>
+        </div>
+        <div class="col-md-3">
+            <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
+            <select asp-for="Input.AssignedToUserId" class="form-select">
+                <option value="">Select user</option>
+                @foreach (var user in Model.AssignableUsers)
+                {
+                    <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
+                }
+            </select>
+            <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
+        </div>
+        <div class="col-md-2">
+            <label asp-for="Input.Priority" class="form-label"></label>
+            <select asp-for="Input.Priority" class="form-select">
+                <option>Low</option>
+                <option selected>Normal</option>
+                <option>High</option>
+                <option>Critical</option>
+            </select>
+            <span asp-validation-for="Input.Priority" class="text-danger small"></span>
+        </div>
+        <div class="col-md-2">
+            <label asp-for="Input.DueDate" class="form-label"></label>
+            <input asp-for="Input.DueDate" type="date" class="form-control" />
+            <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <button type="submit" class="btn btn-success w-100">Create Task</button>
+        </div>
+    </form>
+</section>

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -1,0 +1,52 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@* SECTION: Command overview KPI strip. *@
+<section class="at-kpis">
+    <article><h3>Active</h3><strong>@Model.ActiveCount</strong></article>
+    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong></article>
+    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong></article>
+    <article><h3>Submitted</h3><strong>@Model.SubmittedCount</strong></article>
+    <article><h3>Closed</h3><strong>@Model.ClosedCount</strong></article>
+</section>
+
+@* SECTION: Attention-required panels with compact task rows. *@
+<section class="at-section-group">
+    <h2 class="at-section-title">Attention Required</h2>
+    <div class="at-card-grid">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Critical Open Tasks</h3>
+                <span class="at-count-chip">@Model.CriticalOpenTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CriticalOpenTaskDisplays, "No critical open tasks.")' />
+        </article>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Overdue Tasks</h3>
+                <span class="at-count-chip">@Model.OverdueTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.OverdueTaskDisplays, "No overdue tasks.")' />
+        </article>
+    </div>
+</section>
+
+@* SECTION: Recent activity panels with compact task rows. *@
+<section class="at-section-group">
+    <h2 class="at-section-title">Recent Activity</h2>
+    <div class="at-card-grid">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Recently Submitted</h3>
+                <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No tasks pending recent submission.")' />
+        </article>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Recently Updated</h3>
+                <span class="at-count-chip">@Model.RecentlyUpdatedTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlyUpdatedTaskDisplays, "No recently updated tasks.")' />
+        </article>
+    </div>
+</section>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -1,0 +1,58 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@* SECTION: Audit trail is visible only for an explicitly selected task. *@
+<section class="at-panel mt-3">
+    <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
+        <div class="at-detail-hero">
+            <div>
+                <div class="text-muted small">Task Details</div>
+                <h2>AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
+            </div>
+            @if (Model.SelectedTask is not null)
+            {
+                <div class="d-flex gap-2 flex-wrap">
+                    <span class="@Model.GetStatusBadgeClass(Model.SelectedTask.Status)">@Model.SelectedTask.Status</span>
+                    <span class="@Model.GetPriorityBadgeClass(Model.SelectedTask.Priority)">@Model.SelectedTask.Priority</span>
+                    <span class="at-detail-due">Due @Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</span>
+                </div>
+            }
+        </div>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Back to Task List</a>
+    </div>
+
+    @if (Model.SelectedTask is not null)
+    {
+        <div class="at-task-details-grid mb-3">
+            <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
+            <div><span class="text-muted">Assignee</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId) (@Model.SelectedTask.AssignedToRole)</div></div>
+            <div class="at-grid-span-2"><span class="text-muted">Description</span><div class="fw-semibold">@Model.SelectedTask.Description</div></div>
+            <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
+            <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+            <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+        </div>
+    }
+
+    <h3 class="h5 mb-2">Task Audit Trail</h3>
+    <div class="at-audit-list">
+        @foreach (var log in Model.SelectedTaskLogs)
+        {
+            <div class="at-audit-item">
+                <div class="d-flex justify-content-between gap-2 flex-wrap">
+                    <div>
+                        <strong>@log.ActionType</strong>
+                        <span class="text-muted">by @log.PerformedByRole</span>
+                    </div>
+                    <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
+                {
+                    <div class="small text-muted">@log.OldValue → @log.NewValue</div>
+                }
+                @if (!string.IsNullOrWhiteSpace(log.Remarks))
+                {
+                    <div class="at-audit-remarks">@log.Remarks</div>
+                }
+            </div>
+        }
+    </div>
+</section>

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -1,0 +1,24 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+<section class="at-board-grid">
+    <article class="at-panel at-board-column">
+        <h2>Assigned</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>In Progress</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No tasks in progress.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Blocked</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Submitted</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Closed</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks yet.")' />
+    </article>
+</section>

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -15,19 +15,20 @@
 }
 else
 {
-    <div class="at-task-cards">
+    <div class="at-mini-list">
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            <article class="at-task-card">
-                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">AT-@task.Id · @task.Title</a>
-                <div class="small text-muted">@item.AssigneeName · @task.AssignedToRole</div>
-                <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
-                <div class="d-flex gap-2 mt-2 flex-wrap">
+            <a class="at-mini-row" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">
+                <div class="at-mini-title">AT-@task.Id · @task.Title</div>
+                <div class="at-mini-meta">
+                    <span>@item.AssigneeName</span>
+                    <span>·</span>
+                    <span>Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                    <span>·</span>
                     <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                    <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
                 </div>
-            </article>
+            </a>
         }
     </div>
 }

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -1,0 +1,256 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+@using ProjectManagement.Models
+
+@* SECTION: Task-list specific filters. *@
+@if (Model.IsTaskListView)
+{
+    <section class="at-panel mb-3">
+        <h2>Task List Filters</h2>
+        <form method="get" class="row g-2">
+            <input type="hidden" name="viewMode" value="TaskList" />
+            <div class="col-md-2">
+                <label class="form-label">Status</label>
+                <select class="form-select" name="FilterStatus">
+                    <option value="">All</option>
+                    @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
+                    {
+                        @if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@status" selected>@status</option>
+                        }
+                        else
+                        {
+                            <option value="@status">@status</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Priority</label>
+                <select class="form-select" name="FilterPriority">
+                    <option value="">All</option>
+                    @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
+                    {
+                        @if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@priority" selected>@priority</option>
+                        }
+                        else
+                        {
+                            <option value="@priority">@priority</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Assignee</label>
+                <select class="form-select" name="FilterAssigneeUserId">
+                    <option value="">All</option>
+                    @foreach (var assignee in Model.AssignableUsers)
+                    {
+                        @if (string.Equals(Model.FilterAssigneeUserId, assignee.UserId, StringComparison.Ordinal))
+                        {
+                            <option value="@assignee.UserId" selected>@assignee.DisplayName (@assignee.Role)</option>
+                        }
+                        else
+                        {
+                            <option value="@assignee.UserId">@assignee.DisplayName (@assignee.Role)</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Due Date</label>
+                <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Search by title</label>
+                <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" />
+            </div>
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary btn-sm">Apply Filters</button>
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
+            </div>
+        </form>
+    </section>
+}
+
+@* SECTION: Shared register table for MyTasks and TaskList views. *@
+<section class="at-panel">
+    <h2>@(Model.IsMyTasksView ? "My Tasks" : "Task Register")</h2>
+    @if (!Model.Tasks.Any())
+    {
+        <div class="at-empty-state">
+            <div class="at-empty-icon">✓</div>
+            <div class="fw-semibold">No tasks in this section</div>
+            <div class="text-muted small">Try adjusting filters or create a task.</div>
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-sm at-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Task</th>
+                        <th>Assignee</th>
+                        <th>Due Date</th>
+                        <th>Status</th>
+                        <th>Priority</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var task in Model.Tasks)
+                    {
+                        var submitModalId = $"atSubmitModal_{task.Id}";
+                        var closeModalId = $"atCloseModal_{task.Id}";
+                        var updateModalId = $"atUpdateModal_{task.Id}";
+
+                        <tr>
+                            <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
+                            <td>
+                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
+                                <div class="at-task-desc">@task.Description</div>
+                            </td>
+                            <td>
+                                <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>
+                                <div class="text-muted small">@task.AssignedToRole</div>
+                            </td>
+                            <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                            <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
+                            <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
+                            <td class="at-actions-compact">
+                                @if (Model.CanUpdateTaskStatus(task))
+                                {
+                                    <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#@updateModalId">Update</button>
+                                }
+                                @if (Model.CanSubmitTask(task))
+                                {
+                                    <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#@submitModalId">Submit</button>
+                                }
+                                @if (Model.CanCloseTask(task))
+                                {
+                                    <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#@closeModalId">Close</button>
+                                }
+                                <a class="btn btn-outline-secondary btn-sm" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">Details</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        @* SECTION: Action modals are rendered outside table markup for valid structure. *@
+        @foreach (var task in Model.Tasks)
+        {
+            var submitModalId = $"atSubmitModal_{task.Id}";
+            var closeModalId = $"atCloseModal_{task.Id}";
+            var updateModalId = $"atUpdateModal_{task.Id}";
+
+            if (Model.CanUpdateTaskStatus(task))
+            {
+                <div class="modal fade" id="@updateModalId" tabindex="-1" aria-labelledby="@(updateModalId + "Label")" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <form method="post" asp-page-handler="UpdateStatus">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="@(updateModalId + "Label")">Update Task AT-@task.Id</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                    <input type="hidden" name="id" value="@task.Id" />
+                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
+                                    <div class="mb-3">
+                                        <label class="form-label">New Status</label>
+                                        <select name="status" class="form-select">
+                                            @foreach (var status in Model.AllowedStatusOptions)
+                                            {
+                                                if (task.Status == status)
+                                                {
+                                                    <option value="@status" selected>@status</option>
+                                                }
+                                                else
+                                                {
+                                                    <option value="@status">@status</option>
+                                                }
+                                            }
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="form-label">Remarks</label>
+                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add update remarks"></textarea>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-primary">Confirm Update</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            if (Model.CanSubmitTask(task))
+            {
+                <div class="modal fade" id="@submitModalId" tabindex="-1" aria-labelledby="@(submitModalId + "Label")" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <form method="post" asp-page-handler="Submit">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="@(submitModalId + "Label")">Submit Task AT-@task.Id</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                    <input type="hidden" name="id" value="@task.Id" />
+                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
+                                    <div>
+                                        <label class="form-label">Submission Remarks</label>
+                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add submission remarks"></textarea>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-warning">Confirm Submit</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            if (Model.CanCloseTask(task))
+            {
+                <div class="modal fade" id="@closeModalId" tabindex="-1" aria-labelledby="@(closeModalId + "Label")" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <form method="post" asp-page-handler="Close">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="@(closeModalId + "Label")">Close Task AT-@task.Id</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                    <input type="hidden" name="id" value="@task.Id" />
+                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
+                                    <div>
+                                        <label class="form-label">Closure Remarks</label>
+                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add closure remarks"></textarea>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-success">Confirm Close</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            }
+        }
+    }
+</section>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -1,0 +1,60 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@* SECTION: Reports KPI row. *@
+<section class="at-kpis at-kpis-reports">
+    <article><h3>Total Active</h3><strong>@Model.ActiveCount</strong><p>Pending tasks only.</p></article>
+    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Open tasks past due date.</p></article>
+    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Tasks requiring intervention.</p></article>
+    <article><h3>Submitted Pending Closure</h3><strong>@Model.SubmittedCount</strong><p>Awaiting command review.</p></article>
+    <article><h3>Closed</h3><strong>@Model.ClosedCount</strong><p>Completed and closed items.</p></article>
+    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>High-priority attention required.</p></article>
+</section>
+
+@* SECTION: Reports summary panels (no chart dependency). *@
+<section class="at-card-grid at-card-grid-reports">
+    <article class="at-panel">
+        <h2>Status Distribution</h2>
+        <p class="at-panel-note">Tasks by current workflow status.</p>
+        <table class="table table-sm at-table mb-0">
+            <tbody>
+                @foreach (var item in Model.StatusCounts)
+                {
+                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                }
+            </tbody>
+        </table>
+    </article>
+    <article class="at-panel">
+        <h2>Priority Distribution</h2>
+        <p class="at-panel-note">Open tasks by priority.</p>
+        <table class="table table-sm at-table mb-0">
+            <tbody>
+                @foreach (var item in Model.PriorityCounts)
+                {
+                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                }
+            </tbody>
+        </table>
+    </article>
+    <article class="at-panel">
+        <h2>Assignee Workload</h2>
+        <p class="at-panel-note">Pending tasks only.</p>
+        <table class="table table-sm at-table mb-0">
+            <tbody>
+                @foreach (var item in Model.AssigneePendingCounts)
+                {
+                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
+                }
+            </tbody>
+        </table>
+    </article>
+    <article class="at-panel">
+        <h2>Attention Required</h2>
+        <p class="at-panel-note">Critical, overdue and blocked tasks requiring command focus.</p>
+        <div class="at-attention-list">
+            <div><span>Critical Open</span><strong>@Model.CriticalOpenCount</strong></div>
+            <div><span>Overdue</span><strong>@Model.OverdueCount</strong></div>
+            <div><span>Blocked</span><strong>@Model.BlockedCount</strong></div>
+        </div>
+    </article>
+</section>

--- a/Pages/ActionTasks/_TaskSprintBoard.cshtml
+++ b/Pages/ActionTasks/_TaskSprintBoard.cshtml
@@ -1,0 +1,20 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+<section class="at-board-grid at-board-grid-sprint">
+    <article class="at-panel at-board-column">
+        <h2>Due Today</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Due This Week</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Due Later</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks in this due window.")' />
+    </article>
+    <article class="at-panel at-board-column">
+        <h2>Overdue</h2>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.")' />
+    </article>
+</section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1,40 +1,78 @@
+/* SECTION: Action Tracker design tokens */
+:root {
+    --at-navy: #0f2748;
+    --at-blue: #2563eb;
+    --at-surface: #ffffff;
+    --at-surface-soft: #f8fafc;
+    --at-border: #dbe4f0;
+    --at-text: #0f172a;
+    --at-muted: #64748b;
+    --at-danger: #dc2626;
+    --at-warning: #d97706;
+    --at-success: #16a34a;
+    --at-radius-lg: 18px;
+    --at-radius-md: 12px;
+    --at-shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
 /* SECTION: Action Tracker shell */
 .at-shell {
     display: grid;
-    grid-template-columns: 240px minmax(0, 1fr);
+    grid-template-columns: 230px minmax(0, 1fr);
     gap: 1rem;
     min-height: 70vh;
     width: 100%;
 }
 
 .at-sidebar {
-    background: #0e2445;
+    position: sticky;
+    top: 5rem;
+    align-self: start;
+    background: linear-gradient(180deg, #173663 0%, #112a4e 100%);
     color: #fff;
-    border-radius: 12px;
-    padding: 1rem;
+    border-radius: 1.25rem;
+    padding: 0.85rem;
+    box-shadow: var(--at-shadow-sm);
 }
 
-.at-brand { font-size: 1.9rem; font-weight: 800; }
-.at-module { opacity: .8; margin-bottom: 1rem; }
+.at-brand {
+    font-size: 1.45rem;
+    font-weight: 800;
+}
 
-.at-nav { display: grid; gap: .45rem; }
+.at-module {
+    opacity: .86;
+    margin-bottom: 0.8rem;
+}
+
+.at-nav {
+    display: grid;
+    gap: 0.3rem;
+}
+
 .at-nav a {
-    color: #c3d3ea;
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: #d2e1f7;
     text-decoration: none;
     border-radius: 10px;
-    padding: .55rem .75rem;
+    padding: .45rem .65rem;
+    font-weight: 600;
 }
+
 .at-nav a:hover,
 .at-nav a.active {
     color: #fff;
-    background: #1f4677;
+    background: rgba(37, 99, 235, 0.3);
 }
 
-/* SECTION: Header and cards */
+/* SECTION: Header and panels */
 .at-content {
     min-width: 0;
     padding-bottom: 1.5rem;
 }
+
 .at-header {
     display: flex;
     justify-content: space-between;
@@ -42,8 +80,69 @@
     gap: 1rem;
     margin-bottom: 1rem;
 }
-.at-header h1 { margin: 0; }
-.at-header p { margin: 0; color: #62718c; }
+
+.at-header h1 {
+    margin: 0;
+    color: var(--at-text);
+}
+
+.at-header p {
+    margin: 0;
+    color: var(--at-muted);
+}
+
+.at-panel {
+    background: var(--at-surface);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    box-shadow: var(--at-shadow-sm);
+    padding: 1rem;
+}
+
+.at-panel h2 {
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: var(--at-text);
+    margin-bottom: 0.85rem;
+}
+
+.at-panel-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 0.7rem;
+}
+
+.at-panel-heading h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 800;
+}
+
+.at-count-chip {
+    min-width: 2rem;
+    border-radius: 999px;
+    text-align: center;
+    background: #dbeafe;
+    color: #1d4ed8;
+    padding: 0.15rem 0.55rem;
+    font-weight: 700;
+    font-size: 0.8rem;
+}
+
+.at-section-group + .at-section-group {
+    margin-top: 0.85rem;
+}
+
+.at-section-title {
+    font-size: 0.87rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--at-muted);
+    font-weight: 800;
+    margin-bottom: 0.55rem;
+}
 
 .at-kpis {
     display: grid;
@@ -52,27 +151,36 @@
     margin-bottom: 1rem;
 }
 
-.at-kpis-reports {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.at-kpis article,
-.at-panel {
-    border: 1px solid #ccd8ea;
-    background: #fff;
-    border-radius: 12px;
-    padding: .9rem;
+.at-kpis article {
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    padding: 1rem;
+    box-shadow: var(--at-shadow-sm);
 }
 
 .at-kpis h3 {
+    font-size: 0.82rem;
+    color: var(--at-muted);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
     margin: 0;
-    font-size: 1rem;
-    color: #566a89;
 }
 
 .at-kpis strong {
-    font-size: 1.7rem;
-    color: #1f2e45;
+    font-size: 1.8rem;
+    color: var(--at-text);
+}
+
+.at-kpis p {
+    margin: 0.2rem 0 0;
+    font-size: 0.77rem;
+    color: var(--at-muted);
+}
+
+.at-kpis-reports {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .at-card-grid {
@@ -81,26 +189,62 @@
     gap: .75rem;
 }
 
-.at-simple-list {
-    margin: 0;
-    padding-left: 1rem;
+.at-card-grid-reports {
+    margin-top: 0.6rem;
 }
 
-/* SECTION: Table controls and styling */
+/* SECTION: Compact mini lists */
+.at-mini-list {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.at-mini-row {
+    display: block;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    padding: 0.6rem;
+    background: var(--at-surface-soft);
+    text-decoration: none;
+}
+
+.at-mini-title {
+    font-weight: 700;
+    color: var(--at-text);
+}
+
+.at-mini-meta {
+    margin-top: 0.2rem;
+    color: var(--at-muted);
+    font-size: 0.82rem;
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+/* SECTION: Table design and actions */
 .at-table {
+    border-collapse: separate;
+    border-spacing: 0;
     margin-bottom: 0;
 }
 
 .at-table thead th {
-    font-size: 0.82rem;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    color: #475569;
     background: #f8fafc;
+    color: #475569;
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--at-border);
 }
 
 .at-table td {
     vertical-align: middle;
+}
+
+.at-table tbody tr {
+    transition: background-color 0.15s ease;
 }
 
 .at-table tbody tr:hover {
@@ -108,59 +252,62 @@
 }
 
 .at-task-title {
-    font-weight: 700;
+    font-weight: 800;
+    color: var(--at-blue);
+    text-decoration: none;
+}
+
+.at-task-title:hover {
+    text-decoration: underline;
 }
 
 .at-task-desc {
-    color: #64748b;
+    color: var(--at-muted);
     font-size: 0.86rem;
 }
 
-.at-actions {
-    min-width: 420px;
-}
-
-.at-actions-stack {
+.at-actions-compact {
+    min-width: 250px;
     display: flex;
-    flex-direction: column;
-    gap: .45rem;
+    flex-wrap: wrap;
+    gap: 0.35rem;
 }
 
-.at-status-form,
-.at-inline-action-form {
+/* SECTION: Details dossier and audit */
+.at-detail-hero {
     display: flex;
-    gap: .4rem;
-    align-items: center;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    flex: 1;
 }
 
-.at-status-form select {
-    max-width: 150px;
+.at-detail-due {
+    border-radius: 999px;
+    background: #e2e8f0;
+    color: #334155;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.78rem;
+    font-weight: 700;
 }
 
-.at-status-form input,
-.at-inline-action-form input {
-    min-width: 180px;
-}
-
-.at-inline-action-form .btn,
-.at-status-form .btn {
-    white-space: nowrap;
-}
-
-/* SECTION: Selected task details and audit context */
 .at-task-details-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: .65rem 1rem;
-    border: 1px solid #e2e8f0;
-    border-radius: 10px;
-    background: #f8fafc;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    background: var(--at-surface-soft);
     padding: .9rem;
 }
 
+.at-grid-span-2 {
+    grid-column: span 2;
+}
+
 .at-audit-list {
-    border: 1px solid #e2e8f0;
-    border-radius: 10px;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
     overflow: hidden;
 }
 
@@ -231,7 +378,7 @@
     background: #fee2e2;
 }
 
-/* SECTION: Board and card layouts */
+/* SECTION: Board and reports */
 .at-board-grid {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -252,15 +399,30 @@
 }
 
 .at-task-card {
-    border: 1px solid #e2e8f0;
-    border-radius: 10px;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
     padding: .65rem;
-    background: #f8fafc;
+    background: var(--at-surface-soft);
 }
 
-.at-empty-column {
-    color: #64748b;
-    font-size: .9rem;
+.at-panel-note {
+    color: var(--at-muted);
+    font-size: 0.8rem;
+    margin-top: -0.35rem;
+}
+
+.at-attention-list {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.at-attention-list div {
+    display: flex;
+    justify-content: space-between;
+    border: 1px solid var(--at-border);
+    border-radius: 10px;
+    padding: 0.45rem 0.55rem;
+    background: var(--at-surface-soft);
 }
 
 /* SECTION: Empty states */
@@ -272,17 +434,45 @@
     color: #475569;
 }
 
+.at-empty-state-compact {
+    padding: 0.8rem;
+}
+
+.at-empty-icon {
+    width: 1.35rem;
+    height: 1.35rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 0.3rem;
+    color: var(--at-success);
+    background: #dcfce7;
+    font-weight: 800;
+}
+
 @media (max-width: 1399px) {
-    .at-board-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .at-board-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 @media (max-width: 1199px) {
-    .at-shell { grid-template-columns: 1fr; }
+    .at-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .at-sidebar {
+        position: static;
+    }
+
     .at-kpis,
     .at-kpis-reports,
     .at-card-grid,
     .at-board-grid,
-    .at-board-grid-sprint { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .at-board-grid-sprint {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 @media (max-width: 767px) {
@@ -290,9 +480,19 @@
     .at-kpis-reports,
     .at-card-grid,
     .at-board-grid,
-    .at-board-grid-sprint { grid-template-columns: 1fr; }
+    .at-board-grid-sprint {
+        grid-template-columns: 1fr;
+    }
 
     .at-task-details-grid {
         grid-template-columns: 1fr;
+    }
+
+    .at-grid-span-2 {
+        grid-column: span 1;
+    }
+
+    .at-actions-compact {
+        min-width: 0;
     }
 }


### PR DESCRIPTION
### Motivation
- The `Index.cshtml` had grown into a monolithic Razor page that mixed multiple view renderings and made the UI hard to maintain. 
- The visual presentation was prototype-grade and needed improved hierarchy, consistent tokens, and clearer compact interactions for a professional ERP look. 
- Task cards lacked assignee display names and the Task List exposed inline remark inputs on every row, making the table visually noisy. 
- Keep existing server-side workflow and handlers unchanged while improving maintainability, accessibility and CSP compliance.

### Description
- Split the large page into partials and replaced in-file view conditionals with `Index.cshtml` partial orchestration using `partial` calls for `_TaskCreatePanel`, `_TaskDashboard`, `_TaskRegister`, `_TaskKanban`, `_TaskSprintBoard`, `_TaskReports`, `_TaskDetails`, `_TaskCards`, and `_TaskMiniList`.
- Added contextual heading/subtitle properties `PageHeading` and `PageSubtitle` to `IndexModel` and introduced `TaskDisplayItem` plus projection helpers to supply `AssigneeName` for cards and mini-lists while preserving existing data/handlers.
- Reworked Task Register to use compact action buttons and Bootstrap modals (opened via attributes) for `Update`, `Submit`, and `Close` instead of persistent inline remark inputs, keeping interactions CSP-safe and server-side handlers (`OnPostSubmitAsync`, `OnPostCloseAsync`, `OnPostUpdateStatusAsync`) unchanged.
- Replaced and enhanced `wwwroot/css/action-tracker.css` with design tokens, improved card/table/sidebar/empty-state styles, and new classes for KPI strips, mini-lists, boards and dossier-style task details.

### Testing
- Ran `git diff --check` and it passed with no whitespace or diff-check issues. 
- Searched pages for inline script attributes and handlers (e.g. `rg -n "<script|onclick=|onchange=" Pages/ActionTasks`) and found no introduced inline scripting, confirming CSP-safe changes. 
- Attempted `dotnet build` for full compile validation but it failed in this environment because `dotnet` is not installed. 
- Changes were committed (`Refactor task tracker UI into polished partial-based views`) and a PR metadata entry was prepared for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c1e5d71083299030f4ff37a7ebb2)