### PR TITLE
Compact left rail, persistent right-side task inspector, and horizontal board scrolling

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -9,24 +9,21 @@
     <link rel="stylesheet" href="~/css/action-tracker.css" asp-append-version="true" />
 }
 
-<div class="at-shell">
-    @* SECTION: Left navigation with standardized route values. *@
-    <aside class="at-sidebar">
-        <div class="at-brand">PRISM ERP</div>
-        <div class="at-module">Task Tracker</div>
-
+<div class="at-shell @(Model.TaskId.HasValue ? "has-selection" : string.Empty)">
+    @* SECTION: Compact left rail navigation. *@
+    <aside class="at-rail" aria-label="Task tracker navigation">
         <nav class="at-nav">
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(Model.IsDashboardView ? "active" : string.Empty)">Dashboard</a>
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(Model.IsMyTasksView ? "active" : string.Empty)">My Tasks</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)">Sprint Board</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)">Kanban Board</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)">Task List</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)">Due</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)">Kanban</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)">Register</a>
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)">Reports</a>
         </nav>
     </aside>
 
-    <section class="at-content">
-        @* SECTION: Shared page header and create-task trigger. *@
+    @* SECTION: Main workspace column. *@
+    <section class="at-workspace">
         <header class="at-header">
             <div>
                 <h1>@Model.PageHeading</h1>
@@ -34,7 +31,7 @@
             </div>
             @if (Model.CanCreate)
             {
-                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createTaskPanel" aria-expanded="false" aria-controls="createTaskPanel">New Task</button>
+                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createTaskPanel" aria-expanded="false" aria-controls="createTaskPanel">Create Task</button>
             }
         </header>
 
@@ -63,10 +60,20 @@
         {
             <partial name="_TaskReports" model="Model" />
         }
+    </section>
 
+    @* SECTION: Persistent task inspector drawer host. *@
+    <aside class="at-drawer-host @(Model.TaskId.HasValue ? "is-open" : string.Empty)">
         @if (Model.TaskId.HasValue)
         {
             <partial name="_TaskDetails" model="Model" />
         }
-    </section>
+        else
+        {
+            <section class="at-panel at-drawer-empty" aria-live="polite">
+                <h2>Task Inspector</h2>
+                <p>Select a task from any view to inspect summary, metadata, actions, and audit trail.</p>
+            </section>
+        }
+    </aside>
 </div>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -115,6 +115,12 @@ public class IndexModel : PageModel
         ActionTaskStatuses.Submitted
     };
 
+    // SECTION: Selected-task projection helper
+    public bool IsSelectedTask(ActionTaskItem task)
+    {
+        return TaskId.HasValue && TaskId.Value == task.Id;
+    }
+
     // SECTION: Per-task action visibility helpers
     public bool CanSubmitTask(ActionTaskItem task)
     {

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -19,8 +19,8 @@ else
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            <article class="at-task-card">
-                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">AT-@task.Id · @task.Title</a>
+            <article class="at-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                <a class="at-card-title-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-fragment="task-details">AT-@task.Id · @task.Title</a>
                 <div class="small text-muted">@item.AssigneeName · @task.AssignedToRole</div>
                 <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
                 <div class="d-flex gap-2 mt-2 flex-wrap">

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -1,7 +1,7 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Audit trail is visible only for an explicitly selected task. *@
-<section class="at-panel mt-3">
+@* SECTION: Right-side task inspector drawer content. *@
+<section id="task-details" class="at-panel at-task-details-panel" tabindex="-1">
     <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
         <div class="at-detail-hero">
             <div>
@@ -17,7 +17,7 @@
                 </div>
             }
         </div>
-        <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Back to Task List</a>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" class="btn btn-outline-secondary btn-sm">Close</a>
     </div>
 
     @if (Model.SelectedTask is not null)

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -1,24 +1,27 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-<section class="at-board-grid">
-    <article class="at-panel at-board-column">
-        <h2>Assigned</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>In Progress</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No tasks in progress.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Blocked</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Submitted</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Closed</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks yet.")' />
-    </article>
+@* SECTION: Horizontally scrollable Kanban workspace to preserve professional card widths. *@
+<section class="at-board-scroll" aria-label="Kanban board">
+    <div class="at-board-grid is-kanban">
+        <article class="at-panel at-board-column">
+            <h2>Assigned</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>In Progress</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No tasks in progress.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Blocked</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Submitted</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Closed</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks yet.")' />
+        </article>
+    </div>
 </section>

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -19,7 +19,7 @@ else
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            <a class="at-mini-row" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">
+            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-fragment="task-details">
                 <div class="at-mini-title">AT-@task.Id · @task.Title</div>
                 <div class="at-mini-meta">
                     <span>@item.AssigneeName</span>

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -108,10 +108,10 @@
                         var closeModalId = $"atCloseModal_{task.Id}";
                         var updateModalId = $"atUpdateModal_{task.Id}";
 
-                        <tr>
-                            <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
+                        <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                            <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">AT-@task.Id</a></td>
                             <td>
-                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
+                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">@task.Title</a>
                                 <div class="at-task-desc">@task.Description</div>
                             </td>
                             <td>
@@ -134,7 +134,7 @@
                                 {
                                     <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#@closeModalId">Close</button>
                                 }
-                                <a class="btn btn-outline-secondary btn-sm" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">Details</a>
+                                <a class="btn btn-outline-secondary btn-sm" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">Details</a>
                             </td>
                         </tr>
                     }

--- a/Pages/ActionTasks/_TaskSprintBoard.cshtml
+++ b/Pages/ActionTasks/_TaskSprintBoard.cshtml
@@ -1,20 +1,23 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-<section class="at-board-grid at-board-grid-sprint">
-    <article class="at-panel at-board-column">
-        <h2>Due Today</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Due This Week</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Due Later</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks in this due window.")' />
-    </article>
-    <article class="at-panel at-board-column">
-        <h2>Overdue</h2>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.")' />
-    </article>
+@* SECTION: Horizontally scrollable due-board workspace to preserve column readability. *@
+<section class="at-board-scroll" aria-label="Due board">
+    <div class="at-board-grid at-board-grid-sprint">
+        <article class="at-panel at-board-column">
+            <h2>Due Today</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Due This Week</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Due Later</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks in this due window.")' />
+        </article>
+        <article class="at-panel at-board-column">
+            <h2>Overdue</h2>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.")' />
+        </article>
+    </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -16,59 +16,66 @@
 }
 
 /* SECTION: Action Tracker shell */
+html {
+    scroll-behavior: smooth;
+}
+
 .at-shell {
     display: grid;
-    grid-template-columns: 230px minmax(0, 1fr);
+    grid-template-columns: 88px minmax(0, 1fr) minmax(320px, 30vw);
     gap: 1rem;
     min-height: 70vh;
     width: 100%;
 }
 
-.at-sidebar {
+.at-rail {
     position: sticky;
     top: 5rem;
     align-self: start;
-    background: linear-gradient(180deg, #173663 0%, #112a4e 100%);
-    color: #fff;
-    border-radius: 1.25rem;
-    padding: 0.85rem;
+    background: #ffffff;
+    border: 1px solid var(--at-border);
+    border-radius: 1rem;
+    padding: 0.65rem 0.5rem;
     box-shadow: var(--at-shadow-sm);
-}
-
-.at-brand {
-    font-size: 1.45rem;
-    font-weight: 800;
-}
-
-.at-module {
-    opacity: .86;
-    margin-bottom: 0.8rem;
 }
 
 .at-nav {
     display: grid;
-    gap: 0.3rem;
+    gap: 0.45rem;
 }
 
 .at-nav a {
     display: flex;
+    justify-content: center;
     align-items: center;
-    gap: 0.55rem;
-    color: #d2e1f7;
+    text-align: center;
+    color: #334155;
     text-decoration: none;
     border-radius: 10px;
-    padding: .45rem .65rem;
-    font-weight: 600;
+    padding: 0.55rem 0.35rem;
+    font-size: 0.76rem;
+    font-weight: 700;
+    line-height: 1.2;
+    border: 1px solid transparent;
 }
 
 .at-nav a:hover,
 .at-nav a.active {
-    color: #fff;
-    background: rgba(37, 99, 235, 0.3);
+    color: #1d4ed8;
+    background: #eff6ff;
+    border-color: #bfdbfe;
 }
 
+.at-drawer-host {
+    min-width: 0;
+}
+
+.at-drawer-empty p {
+    margin-bottom: 0;
+    color: var(--at-muted);
+}
 /* SECTION: Header and panels */
-.at-content {
+.at-workspace {
     min-width: 0;
     padding-bottom: 1.5rem;
 }
@@ -104,6 +111,16 @@
     font-weight: 800;
     color: var(--at-text);
     margin-bottom: 0.85rem;
+}
+
+
+.at-task-details-panel {
+    scroll-margin-top: 6rem;
+}
+
+.at-task-details-panel:focus {
+    outline: 3px solid rgba(37, 99, 235, 0.25);
+    outline-offset: 4px;
 }
 
 .at-panel-heading {
@@ -379,14 +396,25 @@
 }
 
 /* SECTION: Board and reports */
-.at-board-grid {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: .75rem;
+.at-board-scroll {
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
 }
 
-.at-board-grid-sprint {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+.at-board-grid {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(280px, 1fr);
+    gap: 1rem;
+    min-width: max-content;
+}
+
+.at-board-grid.at-board-grid-sprint {
+    grid-template-columns: repeat(4, minmax(260px, 1fr));
+}
+
+.at-board-grid.is-kanban {
+    grid-template-columns: repeat(5, minmax(260px, 1fr));
 }
 
 .at-board-column h2 {
@@ -403,6 +431,28 @@
     border-radius: var(--at-radius-md);
     padding: .65rem;
     background: var(--at-surface-soft);
+}
+
+.at-card-title-link {
+    font-weight: 800;
+    color: var(--at-blue);
+    text-decoration: none;
+}
+
+.at-card-title-link:hover {
+    text-decoration: underline;
+}
+
+.at-task-card.is-selected,
+.at-mini-row.is-selected,
+.at-table tbody tr.is-selected {
+    border-color: rgba(37, 99, 235, 0.55);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+    background: #eff6ff;
+}
+
+.at-table tbody tr.is-selected td {
+    background: #eff6ff;
 }
 
 .at-panel-note {
@@ -452,35 +502,71 @@
 }
 
 @media (max-width: 1399px) {
-    .at-board-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+    .at-shell {
+        grid-template-columns: 88px minmax(0, 1fr);
+    }
+
+    .at-drawer-host {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(460px, 90vw);
+        padding: 5rem 1rem 1rem;
+        background: rgba(15, 23, 42, 0.2);
+        backdrop-filter: blur(2px);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+        overflow-y: auto;
+        z-index: 1030;
+    }
+
+    .at-drawer-host .at-panel {
+        background: var(--at-surface);
+    }
+
+    .at-drawer-host.is-open {
+        opacity: 1;
+        pointer-events: auto;
     }
 }
 
 @media (max-width: 1199px) {
-    .at-shell {
-        grid-template-columns: 1fr;
-    }
-
-    .at-sidebar {
-        position: static;
-    }
-
     .at-kpis,
     .at-kpis-reports,
-    .at-card-grid,
-    .at-board-grid,
-    .at-board-grid-sprint {
+    .at-card-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 
 @media (max-width: 767px) {
+    .at-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .at-rail {
+        position: static;
+    }
+
+    .at-nav {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .at-drawer-host {
+        width: 100vw;
+        padding: 0;
+    }
+
+    .at-drawer-host .at-panel {
+        min-height: 100vh;
+        border-radius: 0;
+        border: none;
+    }
+
     .at-kpis,
     .at-kpis-reports,
-    .at-card-grid,
-    .at-board-grid,
-    .at-board-grid-sprint {
+    .at-card-grid {
         grid-template-columns: 1fr;
     }
 


### PR DESCRIPTION
### Motivation
- Move Task Tracker to a professional 3-column workspace with a compact left rail and a consistent right-side task inspector so task inspection is visible without changing modal behaviour.
- Ensure clicking any task selects it, highlights the source row/card, and opens the inspector consistently across Dashboard, My Tasks, Due Board, Kanban and Register views.
- Preserve readable Kanban/Due board column widths by enabling a horizontally scrollable board container instead of compressing columns.

### Description
- Replaced the large left sidebar with a compact rail and updated labels in `Pages/ActionTasks/Index.cshtml`, and introduced a persistent drawer host (`.at-drawer-host`) that renders the task inspector when `TaskId` is present.
- Moved/updated the task detail partial to a drawer-friendly layout with a stable anchor and focus target (`id="task-details"`, `tabindex="-1"`) in `Pages/ActionTasks/_TaskDetails.cshtml`, and changed the close action to preserve `viewMode`.
- Added a selected-task projection helper `IsSelectedTask(ActionTaskItem)` to `Pages/ActionTasks/Index.cshtml.cs` and applied `is-selected` styling in cards, mini-list items and register rows so the selected task is visibly highlighted (`Pages/ActionTasks/_TaskCards.cshtml`, `Pages/ActionTasks/_TaskMiniList.cshtml`, `Pages/ActionTasks/_TaskRegister.cshtml`).
- Updated task links to preserve `viewMode` and add the `#task-details` fragment via `asp-fragment="task-details"` to allow anchor-based navigation to the inspector from all entry points.
- Converted Kanban and Sprint/Due board partials to horizontally scrollable containers (`.at-board-scroll` + `.at-board-grid`) so columns keep a professional minimum width and the board can scroll when the drawer is open (`Pages/ActionTasks/_TaskKanban.cshtml`, `Pages/ActionTasks/_TaskSprintBoard.cshtml`).
- Extended `wwwroot/css/action-tracker.css` to add `scroll-behavior: smooth`, new grid shell (`rail | workspace | drawer`), drawer host styles and responsive behavior (desktop third-column, medium overlay, small full-screen), board scrolling rules and selected-item visual styles; preserved use of modals for action workflows only.

### Testing
- Attempted an automated build with `dotnet build`, but the `dotnet` CLI is not available in this execution environment so a full build/compile verification could not be performed (build was not run successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c9a41fa48329aaebba9527a94186)