### PR TITLE
Inspector-first premium UI for Action Tasks (rail, modal, cleaner rows, reports)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -13,12 +13,13 @@
     @* SECTION: Compact left rail navigation. *@
     <aside class="at-rail" aria-label="Task tracker navigation">
         <nav class="at-nav">
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(Model.IsDashboardView ? "active" : string.Empty)">Dashboard</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(Model.IsMyTasksView ? "active" : string.Empty)">My Tasks</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)">Due</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)">Kanban</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)">Register</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)">Reports</a>
+            @* SECTION: Icon-led rail links for compact enterprise navigation. *@
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(Model.IsDashboardView ? "active" : string.Empty)"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Dashboard</span></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(Model.IsMyTasksView ? "active" : string.Empty)"><i class="bi bi-check2-circle" aria-hidden="true"></i><span>My Tasks</span></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)"><i class="bi bi-calendar2-week" aria-hidden="true"></i><span>Due</span></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)"><i class="bi bi-columns-gap" aria-hidden="true"></i><span>Kanban</span></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)"><i class="bi bi-list-task" aria-hidden="true"></i><span>Register</span></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)"><i class="bi bi-bar-chart" aria-hidden="true"></i><span>Reports</span></a>
         </nav>
     </aside>
 
@@ -31,7 +32,7 @@
             </div>
             @if (Model.CanCreate)
             {
-                <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#createTaskPanel" aria-expanded="false" aria-controls="createTaskPanel">Create Task</button>
+                <button class="btn btn-primary at-create-trigger" type="button" data-bs-toggle="modal" data-bs-target="#createTaskModal"><i class="bi bi-plus-lg" aria-hidden="true"></i><span>Create Task</span></button>
             }
         </header>
 
@@ -62,18 +63,11 @@
         }
     </section>
 
-    @* SECTION: Persistent task inspector drawer host. *@
-    <aside class="at-drawer-host @(Model.TaskId.HasValue ? "is-open" : string.Empty)">
-        @if (Model.TaskId.HasValue)
-        {
+    @* SECTION: Task inspector renders only when a task is selected. *@
+    @if (Model.TaskId.HasValue)
+    {
+        <aside class="at-drawer-host is-open">
             <partial name="_TaskDetails" model="Model" />
-        }
-        else
-        {
-            <section class="at-panel at-drawer-empty" aria-live="polite">
-                <h2>Task Inspector</h2>
-                <p>Select a task from any view to inspect summary, metadata, actions, and audit trail.</p>
-            </section>
-        }
-    </aside>
+        </aside>
+    }
 </div>

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -47,6 +47,8 @@ public class IndexModel : PageModel
     public IReadOnlyList<CountSummary> AssigneePendingCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> PriorityCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> StatusCounts { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
 
     [BindProperty(SupportsGet = true)]
     public string? ViewMode { get; set; } = "Dashboard";
@@ -387,6 +389,15 @@ public class IndexModel : PageModel
     public int BlockedCount => CountByStatus(ActionTaskStatuses.Blocked);
     public int ClosedCount => CountByStatus(ActionTaskStatuses.Closed);
     public int CriticalOpenCount => CriticalOpenTasks.Count;
+    public int StatusCountsMax => StatusCounts.Count == 0 ? 0 : StatusCounts.Max(x => x.Count);
+    public int PriorityCountsMax => PriorityCounts.Count == 0 ? 0 : PriorityCounts.Max(x => x.Count);
+    public int AssigneePendingCountsMax => AssigneePendingCounts.Count == 0 ? 0 : AssigneePendingCounts.Max(x => x.Count);
+    public int OpenAgeingBucketsMax => OpenAgeingBuckets.Count == 0 ? 0 : OpenAgeingBuckets.Max(x => x.Count);
+    public int OverdueAgeingBucketsMax => OverdueAgeingBuckets.Count == 0 ? 0 : OverdueAgeingBuckets.Max(x => x.Count);
+
+    // SECTION: Percentage helper for CSS bar-width calculations.
+    public int ToPercent(int value, int max) =>
+        max <= 0 ? 0 : (int)Math.Round((double)value / max * 100);
 
     private IReadOnlyList<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks)
     {
@@ -494,6 +505,11 @@ public class IndexModel : PageModel
 
     private void BuildReportCollections(IReadOnlyList<ActionTaskItem> tasks)
     {
+        var utcToday = DateTime.UtcNow.Date;
+        var openTasks = tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
         AssigneePendingCounts = tasks
             .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
             .GroupBy(t => ResolveAssigneeName(t.AssignedToUserId))
@@ -512,6 +528,23 @@ public class IndexModel : PageModel
             .OrderByDescending(group => group.Count())
             .Select(group => new CountSummary(group.Key, group.Count()))
             .ToList();
+
+        // SECTION: Open-task ageing buckets for command trend analysis.
+        OpenAgeingBuckets = new[]
+        {
+            new CountSummary("0 to 3 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)),
+            new CountSummary("4 to 7 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)),
+            new CountSummary("8 to 14 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)),
+            new CountSummary("15+ days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15))
+        };
+
+        // SECTION: Overdue ageing buckets for late-task exposure.
+        OverdueAgeingBuckets = new[]
+        {
+            new CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)),
+            new CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)),
+            new CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8))
+        };
     }
 
     private async Task ResolveIdentityAsync()

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -7,11 +7,7 @@
 
 @if (!tasks.Any())
 {
-    <div class="at-empty-state at-empty-state-compact">
-        <div class="at-empty-icon">✓</div>
-        <div class="fw-semibold">@emptyMessage</div>
-        <div class="text-muted small">Tasks will appear here when available.</div>
-    </div>
+    <p class="at-empty-inline">@emptyMessage</p>
 }
 else
 {
@@ -20,11 +16,14 @@ else
         {
             var task = item.Task;
             <article class="at-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                <a class="at-card-title-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-fragment="task-details">AT-@task.Id · @task.Title</a>
-                <div class="small text-muted">@item.AssigneeName · @task.AssignedToRole</div>
-                <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
-                <div class="d-flex gap-2 mt-2 flex-wrap">
+                <div class="d-flex justify-content-between align-items-start gap-2">
+                    <a class="at-card-title-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">AT-@task.Id</a>
                     <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                </div>
+                <a class="at-card-subject" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">@task.Title</a>
+                <div class="small text-muted">@item.AssigneeName · @task.AssignedToRole</div>
+                <div class="d-flex justify-content-between align-items-center gap-2 mt-1">
+                    <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
                     <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
                 </div>
             </article>

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -1,53 +1,65 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Create panel stays collapsed by default; opens for validation failures. *@
-<section id="createTaskPanel" class="collapse @(Model.ShowCreatePanel ? "show" : string.Empty) at-panel mb-3">
-    <h2>Create Task</h2>
-    @if (!ViewData.ModelState.IsValid)
-    {
-        <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
-    }
-    <form method="post" asp-page-handler="Create" class="row g-3">
-        @* SECTION: Preserve selected view mode during postbacks. *@
-        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-        <div class="col-md-4">
-            <label asp-for="Input.Title" class="form-label"></label>
-            <input asp-for="Input.Title" class="form-control" />
-            <span asp-validation-for="Input.Title" class="text-danger small"></span>
+@* SECTION: Create-task modal for focused task capture workflow. *@
+<div class="modal fade @(Model.ShowCreatePanel ? "show" : string.Empty)" id="createTaskModal" tabindex="-1" aria-labelledby="createTaskModalLabel" aria-hidden="@(Model.ShowCreatePanel ? "false" : "true")" data-bs-backdrop="static" style="@(Model.ShowCreatePanel ? "display:block;" : null)">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <form method="post" asp-page-handler="Create">
+                <div class="modal-header">
+                    <h2 class="modal-title h5 mb-0" id="createTaskModalLabel">Create Task</h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    @if (!ViewData.ModelState.IsValid)
+                    {
+                        <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
+                    }
+                    @* SECTION: Preserve selected view mode during postbacks. *@
+                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                    <div class="row g-3">
+                        <div class="col-md-5">
+                            <label asp-for="Input.Title" class="form-label"></label>
+                            <input asp-for="Input.Title" class="form-control" />
+                            <span asp-validation-for="Input.Title" class="text-danger small"></span>
+                        </div>
+                        <div class="col-md-7">
+                            <label asp-for="Input.Description" class="form-label"></label>
+                            <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+                            <span asp-validation-for="Input.Description" class="text-danger small"></span>
+                        </div>
+                        <div class="col-md-5">
+                            <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
+                            <select asp-for="Input.AssignedToUserId" class="form-select">
+                                <option value="">Select user</option>
+                                @foreach (var user in Model.AssignableUsers)
+                                {
+                                    <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
+                                }
+                            </select>
+                            <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
+                        </div>
+                        <div class="col-md-3">
+                            <label asp-for="Input.Priority" class="form-label"></label>
+                            <select asp-for="Input.Priority" class="form-select">
+                                <option>Low</option>
+                                <option selected>Normal</option>
+                                <option>High</option>
+                                <option>Critical</option>
+                            </select>
+                            <span asp-validation-for="Input.Priority" class="text-danger small"></span>
+                        </div>
+                        <div class="col-md-4">
+                            <label asp-for="Input.DueDate" class="form-label"></label>
+                            <input asp-for="Input.DueDate" type="date" class="form-control" />
+                            <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create Task</button>
+                </div>
+            </form>
         </div>
-        <div class="col-md-8">
-            <label asp-for="Input.Description" class="form-label"></label>
-            <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
-            <span asp-validation-for="Input.Description" class="text-danger small"></span>
-        </div>
-        <div class="col-md-3">
-            <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
-            <select asp-for="Input.AssignedToUserId" class="form-select">
-                <option value="">Select user</option>
-                @foreach (var user in Model.AssignableUsers)
-                {
-                    <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
-                }
-            </select>
-            <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
-        </div>
-        <div class="col-md-2">
-            <label asp-for="Input.Priority" class="form-label"></label>
-            <select asp-for="Input.Priority" class="form-select">
-                <option>Low</option>
-                <option selected>Normal</option>
-                <option>High</option>
-                <option>Critical</option>
-            </select>
-            <span asp-validation-for="Input.Priority" class="text-danger small"></span>
-        </div>
-        <div class="col-md-2">
-            <label asp-for="Input.DueDate" class="form-label"></label>
-            <input asp-for="Input.DueDate" type="date" class="form-control" />
-            <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
-        </div>
-        <div class="col-md-2 d-flex align-items-end">
-            <button type="submit" class="btn btn-success w-100">Create Task</button>
-        </div>
-    </form>
-</section>
+    </div>
+</div>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -2,12 +2,11 @@
 
 @* SECTION: Right-side task inspector drawer content. *@
 <section id="task-details" class="at-panel at-task-details-panel" tabindex="-1">
-    <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2">
+    @* SECTION: Inspector header with compact identity and close action. *@
+    <div class="at-inspector-header">
         <div class="at-detail-hero">
-            <div>
-                <div class="text-muted small">Task Details</div>
-                <h2>AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
-            </div>
+            <div class="at-section-eyebrow">Task Inspector</div>
+            <h2 class="at-panel-title mb-1">AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
             @if (Model.SelectedTask is not null)
             {
                 <div class="d-flex gap-2 flex-wrap">
@@ -17,11 +16,84 @@
                 </div>
             }
         </div>
-        <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" class="btn btn-outline-secondary btn-sm">Close</a>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
     </div>
 
     @if (Model.SelectedTask is not null)
     {
+        @* SECTION: Context-valid task actions rendered inside inspector only. *@
+        <div class="at-inspector-actions">
+            @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
+            {
+                <form method="post" asp-page-handler="UpdateStatus" class="at-inline-form">
+                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                    <div class="at-inline-grid">
+                        <div>
+                            <label class="form-label at-small">Update Status</label>
+                            <select name="status" class="form-select form-select-sm">
+                                @foreach (var status in Model.AllowedStatusOptions)
+                                {
+                                    if (Model.SelectedTask.Status == status)
+                                    {
+                                        <option value="@status" selected>@status</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@status">@status</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                        <div>
+                            <label class="form-label at-small">Remarks</label>
+                            <input name="remarks" class="form-control form-control-sm" maxlength="300" placeholder="Status update remarks" />
+                        </div>
+                        <div class="d-flex align-items-end">
+                            <button type="submit" class="btn btn-primary btn-sm w-100">Save Update</button>
+                        </div>
+                    </div>
+                </form>
+            }
+
+            @if (Model.CanSubmitTask(Model.SelectedTask))
+            {
+                <form method="post" asp-page-handler="Submit" class="at-inline-form">
+                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                    <div class="at-inline-grid at-inline-grid-submit">
+                        <div class="at-grid-span-2">
+                            <label class="form-label at-small">Submission Remarks</label>
+                            <input name="remarks" class="form-control form-control-sm" maxlength="300" placeholder="Add submission notes" />
+                        </div>
+                        <div class="d-flex align-items-end">
+                            <button type="submit" class="btn btn-warning btn-sm w-100">Submit</button>
+                        </div>
+                    </div>
+                </form>
+            }
+
+            @if (Model.CanCloseTask(Model.SelectedTask))
+            {
+                <form method="post" asp-page-handler="Close" class="at-inline-form">
+                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                    <div class="at-inline-grid at-inline-grid-submit">
+                        <div class="at-grid-span-2">
+                            <label class="form-label at-small">Closure Remarks</label>
+                            <input name="remarks" class="form-control form-control-sm" maxlength="300" placeholder="Add closure notes" />
+                        </div>
+                        <div class="d-flex align-items-end">
+                            <button type="submit" class="btn btn-success btn-sm w-100">Close Task</button>
+                        </div>
+                    </div>
+                </form>
+            }
+        </div>
+
         <div class="at-task-details-grid mb-3">
             <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
             <div><span class="text-muted">Assignee</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId) (@Model.SelectedTask.AssignedToRole)</div></div>

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -4,23 +4,23 @@
 <section class="at-board-scroll" aria-label="Kanban board">
     <div class="at-board-grid is-kanban">
         <article class="at-panel at-board-column">
-            <h2>Assigned</h2>
+            <div class="at-panel-heading"><h2>Assigned</h2><span class="at-count-chip">@Model.KanbanAssignedTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>In Progress</h2>
+            <div class="at-panel-heading"><h2>In Progress</h2><span class="at-count-chip">@Model.KanbanInProgressTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No tasks in progress.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Blocked</h2>
+            <div class="at-panel-heading"><h2>Blocked</h2><span class="at-count-chip">@Model.KanbanBlockedTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Submitted</h2>
+            <div class="at-panel-heading"><h2>Submitted</h2><span class="at-count-chip">@Model.KanbanSubmittedTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Closed</h2>
+            <div class="at-panel-heading"><h2>Closed</h2><span class="at-count-chip">@Model.KanbanClosedTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks yet.")' />
         </article>
     </div>

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -8,7 +8,7 @@
 @if (!tasks.Any())
 {
     <div class="at-empty-state at-empty-state-compact">
-        <div class="at-empty-icon">✓</div>
+        <div class="at-empty-icon"><i class="bi bi-inbox" aria-hidden="true"></i></div>
         <div class="fw-semibold">@emptyMessage</div>
         <div class="text-muted small">Tasks will appear here when available.</div>
     </div>
@@ -19,7 +19,7 @@ else
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-fragment="task-details">
+            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">
                 <div class="at-mini-title">AT-@task.Id · @task.Title</div>
                 <div class="at-mini-meta">
                     <span>@item.AssigneeName</span>

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -81,7 +81,7 @@
     @if (!Model.Tasks.Any())
     {
         <div class="at-empty-state">
-            <div class="at-empty-icon">✓</div>
+            <div class="at-empty-icon"><i class="bi bi-inbox" aria-hidden="true"></i></div>
             <div class="fw-semibold">No tasks in this section</div>
             <div class="text-muted small">Try adjusting filters or create a task.</div>
         </div>
@@ -98,20 +98,15 @@
                         <th>Due Date</th>
                         <th>Status</th>
                         <th>Priority</th>
-                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
                     @foreach (var task in Model.Tasks)
                     {
-                        var submitModalId = $"atSubmitModal_{task.Id}";
-                        var closeModalId = $"atCloseModal_{task.Id}";
-                        var updateModalId = $"atUpdateModal_{task.Id}";
-
                         <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                            <td><a asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">AT-@task.Id</a></td>
+                            <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
                             <td>
-                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">@task.Title</a>
+                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
                                 <div class="at-task-desc">@task.Description</div>
                             </td>
                             <td>
@@ -121,136 +116,10 @@
                             <td>@task.DueDate.ToString("dd MMM yyyy")</td>
                             <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
                             <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
-                            <td class="at-actions-compact">
-                                @if (Model.CanUpdateTaskStatus(task))
-                                {
-                                    <button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#@updateModalId">Update</button>
-                                }
-                                @if (Model.CanSubmitTask(task))
-                                {
-                                    <button type="button" class="btn btn-outline-warning btn-sm" data-bs-toggle="modal" data-bs-target="#@submitModalId">Submit</button>
-                                }
-                                @if (Model.CanCloseTask(task))
-                                {
-                                    <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#@closeModalId">Close</button>
-                                }
-                                <a class="btn btn-outline-secondary btn-sm" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode" asp-fragment="task-details">Details</a>
-                            </td>
                         </tr>
                     }
                 </tbody>
             </table>
         </div>
-
-        @* SECTION: Action modals are rendered outside table markup for valid structure. *@
-        @foreach (var task in Model.Tasks)
-        {
-            var submitModalId = $"atSubmitModal_{task.Id}";
-            var closeModalId = $"atCloseModal_{task.Id}";
-            var updateModalId = $"atUpdateModal_{task.Id}";
-
-            if (Model.CanUpdateTaskStatus(task))
-            {
-                <div class="modal fade" id="@updateModalId" tabindex="-1" aria-labelledby="@(updateModalId + "Label")" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered">
-                        <div class="modal-content">
-                            <form method="post" asp-page-handler="UpdateStatus">
-                                <div class="modal-header">
-                                    <h5 class="modal-title" id="@(updateModalId + "Label")">Update Task AT-@task.Id</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <div class="modal-body">
-                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                    <input type="hidden" name="id" value="@task.Id" />
-                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
-                                    <div class="mb-3">
-                                        <label class="form-label">New Status</label>
-                                        <select name="status" class="form-select">
-                                            @foreach (var status in Model.AllowedStatusOptions)
-                                            {
-                                                if (task.Status == status)
-                                                {
-                                                    <option value="@status" selected>@status</option>
-                                                }
-                                                else
-                                                {
-                                                    <option value="@status">@status</option>
-                                                }
-                                            }
-                                        </select>
-                                    </div>
-                                    <div>
-                                        <label class="form-label">Remarks</label>
-                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add update remarks"></textarea>
-                                    </div>
-                                </div>
-                                <div class="modal-footer">
-                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-                                    <button type="submit" class="btn btn-primary">Confirm Update</button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            }
-
-            if (Model.CanSubmitTask(task))
-            {
-                <div class="modal fade" id="@submitModalId" tabindex="-1" aria-labelledby="@(submitModalId + "Label")" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered">
-                        <div class="modal-content">
-                            <form method="post" asp-page-handler="Submit">
-                                <div class="modal-header">
-                                    <h5 class="modal-title" id="@(submitModalId + "Label")">Submit Task AT-@task.Id</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <div class="modal-body">
-                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                    <input type="hidden" name="id" value="@task.Id" />
-                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
-                                    <div>
-                                        <label class="form-label">Submission Remarks</label>
-                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add submission remarks"></textarea>
-                                    </div>
-                                </div>
-                                <div class="modal-footer">
-                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-                                    <button type="submit" class="btn btn-warning">Confirm Submit</button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            }
-
-            if (Model.CanCloseTask(task))
-            {
-                <div class="modal fade" id="@closeModalId" tabindex="-1" aria-labelledby="@(closeModalId + "Label")" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered">
-                        <div class="modal-content">
-                            <form method="post" asp-page-handler="Close">
-                                <div class="modal-header">
-                                    <h5 class="modal-title" id="@(closeModalId + "Label")">Close Task AT-@task.Id</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <div class="modal-body">
-                                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                                    <input type="hidden" name="id" value="@task.Id" />
-                                    <div class="mb-2 small text-muted">Current Status: @task.Status</div>
-                                    <div>
-                                        <label class="form-label">Closure Remarks</label>
-                                        <textarea name="remarks" class="form-control" rows="3" maxlength="300" placeholder="Add closure remarks"></textarea>
-                                    </div>
-                                </div>
-                                <div class="modal-footer">
-                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-                                    <button type="submit" class="btn btn-success">Confirm Close</button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            }
-        }
     }
 </section>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -1,60 +1,99 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Reports KPI row. *@
+@* SECTION: Command-attention KPI strip. *@
 <section class="at-kpis at-kpis-reports">
-    <article><h3>Total Active</h3><strong>@Model.ActiveCount</strong><p>Pending tasks only.</p></article>
+    <article><h3>Active</h3><strong>@Model.ActiveCount</strong><p>All open workflow tasks.</p></article>
+    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Urgent open tasks.</p></article>
     <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Open tasks past due date.</p></article>
     <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Tasks requiring intervention.</p></article>
-    <article><h3>Submitted Pending Closure</h3><strong>@Model.SubmittedCount</strong><p>Awaiting command review.</p></article>
-    <article><h3>Closed</h3><strong>@Model.ClosedCount</strong><p>Completed and closed items.</p></article>
-    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>High-priority attention required.</p></article>
+    <article><h3>Submitted</h3><strong>@Model.SubmittedCount</strong><p>Pending command closure.</p></article>
+    <article><h3>Closed</h3><strong>@Model.ClosedCount</strong><p>Completed outcomes.</p></article>
 </section>
 
-@* SECTION: Reports summary panels (no chart dependency). *@
+@* SECTION: Reports analysis panels with lightweight proportional bars. *@
 <section class="at-card-grid at-card-grid-reports">
     <article class="at-panel">
-        <h2>Status Distribution</h2>
-        <p class="at-panel-note">Tasks by current workflow status.</p>
-        <table class="table table-sm at-table mb-0">
-            <tbody>
-                @foreach (var item in Model.StatusCounts)
-                {
-                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                }
-            </tbody>
-        </table>
-    </article>
-    <article class="at-panel">
-        <h2>Priority Distribution</h2>
-        <p class="at-panel-note">Open tasks by priority.</p>
-        <table class="table table-sm at-table mb-0">
-            <tbody>
-                @foreach (var item in Model.PriorityCounts)
-                {
-                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                }
-            </tbody>
-        </table>
-    </article>
-    <article class="at-panel">
-        <h2>Assignee Workload</h2>
-        <p class="at-panel-note">Pending tasks only.</p>
-        <table class="table table-sm at-table mb-0">
-            <tbody>
-                @foreach (var item in Model.AssigneePendingCounts)
-                {
-                    <tr><td>@item.Name</td><td class="text-end">@item.Count</td></tr>
-                }
-            </tbody>
-        </table>
-    </article>
-    <article class="at-panel">
-        <h2>Attention Required</h2>
-        <p class="at-panel-note">Critical, overdue and blocked tasks requiring command focus.</p>
+        <h2>Command Attention</h2>
+        <p class="at-panel-note">What requires command focus now.</p>
         <div class="at-attention-list">
             <div><span>Critical Open</span><strong>@Model.CriticalOpenCount</strong></div>
             <div><span>Overdue</span><strong>@Model.OverdueCount</strong></div>
             <div><span>Blocked</span><strong>@Model.BlockedCount</strong></div>
+            <div><span>Submitted Pending Closure</span><strong>@Model.SubmittedCount</strong></div>
+        </div>
+    </article>
+    <article class="at-panel">
+        <h2>Workflow Health</h2>
+        <p class="at-panel-note">Tasks by current stage of completion.</p>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.StatusCounts)
+            {
+                <div class="at-metric-row">
+                    <span>@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
+        </div>
+    </article>
+    <article class="at-panel">
+        <h2>Ageing Analysis</h2>
+        <p class="at-panel-note">Open and overdue ageing buckets.</p>
+        <div class="at-ageing-grid">
+            <div>
+                <h3 class="at-small at-section-eyebrow">Open Tasks Ageing</h3>
+                <div class="at-metric-bars">
+                    @foreach (var item in Model.OpenAgeingBuckets)
+                    {
+                        <div class="at-metric-row">
+                            <span>@item.Name</span>
+                            <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.OpenAgeingBucketsMax)%"></div></div>
+                            <strong>@item.Count</strong>
+                        </div>
+                    }
+                </div>
+            </div>
+            <div>
+                <h3 class="at-small at-section-eyebrow">Overdue Ageing</h3>
+                <div class="at-metric-bars">
+                    @foreach (var item in Model.OverdueAgeingBuckets)
+                    {
+                        <div class="at-metric-row">
+                            <span>@item.Name</span>
+                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.OverdueAgeingBucketsMax)%"></div></div>
+                            <strong>@item.Count</strong>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    </article>
+    <article class="at-panel">
+        <h2>Workload Distribution</h2>
+        <p class="at-panel-note">Pending tasks grouped by assignee.</p>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.AssigneePendingCounts)
+            {
+                <div class="at-metric-row">
+                    <span>@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.AssigneePendingCountsMax)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
+        </div>
+    </article>
+    <article class="at-panel">
+        <h2>Closure Performance</h2>
+        <p class="at-panel-note">Priority exposure across open tasks.</p>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.PriorityCounts)
+            {
+                <div class="at-metric-row">
+                    <span>@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.PriorityCountsMax)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
         </div>
     </article>
 </section>

--- a/Pages/ActionTasks/_TaskSprintBoard.cshtml
+++ b/Pages/ActionTasks/_TaskSprintBoard.cshtml
@@ -4,19 +4,19 @@
 <section class="at-board-scroll" aria-label="Due board">
     <div class="at-board-grid at-board-grid-sprint">
         <article class="at-panel at-board-column">
-            <h2>Due Today</h2>
+            <div class="at-panel-heading"><h2>Due Today</h2><span class="at-count-chip">@Model.DueTodayTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Due This Week</h2>
+            <div class="at-panel-heading"><h2>Due This Week</h2><span class="at-count-chip">@Model.DueThisWeekTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Due Later</h2>
+            <div class="at-panel-heading"><h2>Due Later</h2><span class="at-count-chip">@Model.DueLaterTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks in this due window.")' />
         </article>
         <article class="at-panel at-board-column">
-            <h2>Overdue</h2>
+            <div class="at-panel-heading"><h2>Overdue</h2><span class="at-count-chip">@Model.SprintOverdueTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.")' />
         </article>
     </div>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -22,10 +22,14 @@ html {
 
 .at-shell {
     display: grid;
-    grid-template-columns: 88px minmax(0, 1fr) minmax(320px, 30vw);
+    grid-template-columns: 88px minmax(0, 1fr);
     gap: 1rem;
     min-height: 70vh;
     width: 100%;
+}
+
+.at-shell.has-selection {
+    grid-template-columns: 88px minmax(0, 1fr) minmax(320px, 30vw);
 }
 
 .at-rail {
@@ -46,8 +50,10 @@ html {
 
 .at-nav a {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
     text-align: center;
     color: #334155;
     text-decoration: none;
@@ -57,13 +63,27 @@ html {
     font-weight: 700;
     line-height: 1.2;
     border: 1px solid transparent;
+    transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+
+.at-nav a i {
+    font-size: 0.95rem;
+}
+
+.at-nav a span {
+    font-size: 0.72rem;
+    font-weight: 700;
 }
 
 .at-nav a:hover,
 .at-nav a.active {
     color: #1d4ed8;
-    background: #eff6ff;
-    border-color: #bfdbfe;
+    background: #f8fbff;
+    border-color: #cfe0fb;
+}
+
+.at-nav a:hover {
+    transform: translateY(-1px);
 }
 
 .at-drawer-host {
@@ -91,11 +111,15 @@ html {
 .at-header h1 {
     margin: 0;
     color: var(--at-text);
+    font-size: 1.55rem;
+    font-weight: 760;
+    letter-spacing: -0.025em;
 }
 
 .at-header p {
     margin: 0;
     color: var(--at-muted);
+    font-size: 0.92rem;
 }
 
 .at-panel {
@@ -107,10 +131,27 @@ html {
 }
 
 .at-panel h2 {
-    font-size: 1.05rem;
-    font-weight: 800;
+    font-size: 1rem;
+    font-weight: 760;
     color: var(--at-text);
     margin-bottom: 0.85rem;
+}
+
+.at-section-eyebrow {
+    font-size: 0.72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--at-muted);
+}
+
+.at-panel-title {
+    font-size: 1rem;
+    font-weight: 760;
+}
+
+.at-small {
+    font-size: 0.78rem;
 }
 
 
@@ -274,6 +315,11 @@ html {
     text-decoration: none;
 }
 
+.at-task-id-link {
+    font-weight: 700;
+    text-decoration: none;
+}
+
 .at-task-title:hover {
     text-decoration: underline;
 }
@@ -283,20 +329,23 @@ html {
     font-size: 0.86rem;
 }
 
-.at-actions-compact {
-    min-width: 250px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-}
-
 /* SECTION: Details dossier and audit */
 .at-detail-hero {
+    display: grid;
+    gap: 0.35rem;
+    flex: 1;
+}
+
+.at-inspector-header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: start;
     gap: 0.75rem;
-    flex: 1;
+    margin-bottom: 0.8rem;
+}
+
+.at-inspector-close {
+    border-color: transparent;
 }
 
 .at-detail-due {
@@ -306,6 +355,29 @@ html {
     padding: 0.2rem 0.55rem;
     font-size: 0.78rem;
     font-weight: 700;
+}
+
+.at-inspector-actions {
+    display: grid;
+    gap: 0.55rem;
+    margin-bottom: 0.8rem;
+}
+
+.at-inline-form {
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    background: var(--at-surface-soft);
+    padding: 0.7rem;
+}
+
+.at-inline-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.6rem;
+}
+
+.at-inline-grid-submit {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .at-task-details-grid {
@@ -418,7 +490,8 @@ html {
 }
 
 .at-board-column h2 {
-    font-size: 1rem;
+    font-size: 0.95rem;
+    margin-bottom: 0;
 }
 
 .at-task-cards {
@@ -431,6 +504,11 @@ html {
     border-radius: var(--at-radius-md);
     padding: .65rem;
     background: var(--at-surface-soft);
+    transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+
+.at-task-card:hover {
+    transform: translateY(-1px);
 }
 
 .at-card-title-link {
@@ -443,16 +521,32 @@ html {
     text-decoration: underline;
 }
 
+.at-card-subject {
+    display: block;
+    text-decoration: none;
+    color: var(--at-text);
+    font-weight: 700;
+    margin: 0.2rem 0 0.3rem;
+}
+
 .at-task-card.is-selected,
 .at-mini-row.is-selected,
 .at-table tbody tr.is-selected {
-    border-color: rgba(37, 99, 235, 0.55);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
-    background: #eff6ff;
+    background: #f8fbff;
+    box-shadow: none;
+}
+
+.at-task-card.is-selected,
+.at-mini-row.is-selected {
+    border-left: 4px solid var(--at-blue);
 }
 
 .at-table tbody tr.is-selected td {
-    background: #eff6ff;
+    background: #f8fbff;
+}
+
+.at-table tbody tr.is-selected td:first-child {
+    border-left: 4px solid var(--at-blue);
 }
 
 .at-panel-note {
@@ -475,6 +569,46 @@ html {
     background: var(--at-surface-soft);
 }
 
+/* SECTION: Reports metric bars */
+.at-metric-bars {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.at-metric-row {
+    display: grid;
+    grid-template-columns: minmax(100px, auto) 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.84rem;
+}
+
+.at-metric-track {
+    height: 0.5rem;
+    background: #e2e8f0;
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.at-metric-fill {
+    height: 100%;
+    background: #2563eb;
+}
+
+.at-metric-fill-danger {
+    background: #dc2626;
+}
+
+.at-metric-fill-amber {
+    background: #d97706;
+}
+
+.at-ageing-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.7rem;
+}
+
 /* SECTION: Empty states */
 .at-empty-state {
     border: 1px dashed #cbd5e1;
@@ -486,6 +620,7 @@ html {
 
 .at-empty-state-compact {
     padding: 0.8rem;
+    min-height: auto;
 }
 
 .at-empty-icon {
@@ -496,9 +631,21 @@ html {
     align-items: center;
     justify-content: center;
     margin-bottom: 0.3rem;
-    color: var(--at-success);
-    background: #dcfce7;
+    color: var(--at-muted);
+    background: #e2e8f0;
     font-weight: 800;
+}
+
+.at-empty-inline {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--at-muted);
+}
+
+.at-create-trigger {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
 }
 
 @media (max-width: 1399px) {
@@ -537,6 +684,11 @@ html {
     .at-kpis-reports,
     .at-card-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-inline-grid,
+    .at-inline-grid-submit {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -578,7 +730,8 @@ html {
         grid-column: span 1;
     }
 
-    .at-actions-compact {
-        min-width: 0;
+    .at-metric-row {
+        grid-template-columns: 1fr;
+        gap: 0.2rem;
     }
 }


### PR DESCRIPTION
### Motivation
- Move the workspace to an inspector-first command surface so the main workspace uses full width until a task is selected and the inspector is only visible when needed.
- Reduce row-level action clutter so rows remain a clean register and all workflow operations are performed in the inspector.
- Improve navigation, hierarchy, and visual discipline (compact icon rail, disciplined typography, restrained selected states) to raise the UI to a professional ERP-grade command workspace.
- Upgrade analytical usefulness of Reports by adding ageing buckets, workload distribution and lightweight visual bars for decision making.

### Description
- Render the right inspector only when a task is selected by changing `Pages/ActionTasks/Index.cshtml` to conditionally include the drawer and updating layout CSS in `wwwroot/css/action-tracker.css` so `.at-shell` uses full width until selection.
- Replace the text-heavy rail with icon-led compact links (uses Bootstrap Icons) in `Pages/ActionTasks/Index.cshtml` and add refined hover/active micro-interactions in the CSS.
- Remove row-level workflow controls and `Details` fragment links from `Pages/ActionTasks/_TaskRegister.cshtml` and make the task ID/title links open the inspector instead, while moving `Update/Submit/Close` forms into the inspector (`Pages/ActionTasks/_TaskDetails.cshtml`) with contextual inline forms and remark inputs.
- Convert task creation from a collapsed inline panel into a focused modal flow in `Pages/ActionTasks/_TaskCreatePanel.cshtml` that preserves `ViewMode` during postbacks and supports validation, and improve board cards/columns (counts, compact empties) in `Pages/ActionTasks/_TaskCards.cshtml`, `_TaskKanban.cshtml` and `_TaskSprintBoard.cshtml`.
- Expand reports into analytical panels in `Pages/ActionTasks/_TaskReports.cshtml` and add ageing bucket calculations and helper methods in `Pages/ActionTasks/Index.cshtml.cs` (new properties `OpenAgeingBuckets`, `OverdueAgeingBuckets`, `ToPercent`, and max helpers) together with lightweight CSS bars in `wwwroot/css/action-tracker.css`.
- Apply visual polish across `wwwroot/css/action-tracker.css` including typography adjustments, compact empty states, new selected-state (tint + left accent), card hover lifts, and small interaction transitions.

### Testing
- Attempted an automated project build with `dotnet build ProjectManagement.csproj -nologo`, which failed due to the environment missing the .NET SDK (`dotnet: command not found`).
- Ran codebase checks with ripgrep to verify removal of legacy row-level action markers and `asp-fragment="task-details"` usages and confirmed templates now rely on ID/title links to open the inspector (`rg` checks completed successfully).
- Verified file changes and template outputs by inspecting the updated Razor pages and CSS files (`nl`/`sed` outputs) to ensure the new modal, inspector forms, board counts, and report metric sections render from the server model (static verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d121cef0832997022582d22dccc1)