### PR TITLE
Final Task Tracker polish: responsible person naming, multiline rendering, reports & filters

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -44,6 +44,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
     public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> TaskActorNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
     public IReadOnlyList<CountSummary> AssigneePendingCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> PriorityCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> StatusCounts { get; private set; } = Array.Empty<CountSummary>();
@@ -187,6 +188,13 @@ public class IndexModel : PageModel
     {
         return TaskAssigneeNames.TryGetValue(assignedToUserId, out var assigneeName)
             ? assigneeName
+            : "User";
+    }
+
+    public string ResolveActorName(string performedByUserId)
+    {
+        return TaskActorNames.TryGetValue(performedByUserId, out var actorName)
+            ? actorName
             : "User";
     }
 
@@ -339,6 +347,7 @@ public class IndexModel : PageModel
         {
             SelectedTask = tasks.FirstOrDefault(t => t.Id == TaskId.Value);
             SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
+            TaskActorNames = await LoadTaskActorNamesAsync(SelectedTaskLogs);
         }
     }
 
@@ -394,6 +403,44 @@ public class IndexModel : PageModel
     public int AssigneePendingCountsMax => AssigneePendingCounts.Count == 0 ? 0 : AssigneePendingCounts.Max(x => x.Count);
     public int OpenAgeingBucketsMax => OpenAgeingBuckets.Count == 0 ? 0 : OpenAgeingBuckets.Max(x => x.Count);
     public int OverdueAgeingBucketsMax => OverdueAgeingBuckets.Count == 0 ? 0 : OverdueAgeingBuckets.Max(x => x.Count);
+    public int ActiveCriticalCount => Tasks.Count(t =>
+        !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
+
+    public int SubmittedPendingClosureCount => Tasks.Count(t =>
+        string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase));
+
+    public bool HasActiveFilters =>
+        IsTaskListView &&
+        (!string.IsNullOrWhiteSpace(FilterStatus)
+         || !string.IsNullOrWhiteSpace(FilterPriority)
+         || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
+         || FilterDueDate.HasValue
+         || !string.IsNullOrWhiteSpace(FilterSearch));
+
+    public string CommandSummary
+    {
+        get
+        {
+            var activeTasksText = $"There {(ActiveCount == 1 ? "is" : "are")} {ActiveCount} active {(ActiveCount == 1 ? "task" : "tasks")}";
+            var criticalText = $", including {ActiveCriticalCount} critical {(ActiveCriticalCount == 1 ? "task" : "tasks")}.";
+            var overdueText = OverdueCount switch
+            {
+                0 => "No tasks are overdue.",
+                1 => "1 task is overdue.",
+                _ => $"{OverdueCount} tasks are overdue."
+            };
+
+            var submittedPendingText = SubmittedPendingClosureCount switch
+            {
+                0 => "No submitted task is pending closure.",
+                1 => "1 submitted task is pending closure.",
+                _ => $"{SubmittedPendingClosureCount} submitted tasks are pending closure."
+            };
+
+            return $"{activeTasksText}{criticalText} {overdueText} {submittedPendingText}";
+        }
+    }
 
     // SECTION: Percentage helper for CSS bar-width calculations.
     public int ToPercent(int value, int max) =>
@@ -559,7 +606,8 @@ public class IndexModel : PageModel
     {
         // SECTION: Stabilize user snapshot to avoid overlapping data-reader operations
         var users = await _users.Users
-            .OrderBy(x => x.UserName)
+            .OrderBy(x => x.FullName)
+            .ThenBy(x => x.UserName)
             .Take(200)
             .ToListAsync();
 
@@ -574,7 +622,7 @@ public class IndexModel : PageModel
                 continue;
             }
 
-            list.Add(new UserOption(user.Id, user.UserName ?? user.Email ?? "User", matchedRole));
+            list.Add(new UserOption(user.Id, BuildPersonDisplayName(user), matchedRole));
         }
 
         return list;
@@ -596,13 +644,66 @@ public class IndexModel : PageModel
 
         var users = await _users.Users
             .Where(u => userIds.Contains(u.Id))
-            .Select(u => new { u.Id, u.UserName, u.Email })
+            .Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email })
             .ToListAsync();
 
         return users.ToDictionary(
             u => u.Id,
-            u => string.IsNullOrWhiteSpace(u.UserName) ? (u.Email ?? "User") : u.UserName!,
+            u => BuildPersonDisplayName(u.Rank, u.FullName, u.UserName, u.Email),
             StringComparer.Ordinal);
+    }
+
+    // SECTION: Resolve inspector actor names for audit visibility.
+    private async Task<IReadOnlyDictionary<string, string>> LoadTaskActorNamesAsync(IReadOnlyList<ActionTaskAuditLog> logs)
+    {
+        var actorIds = logs
+            .Select(log => log.PerformedByUserId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (actorIds.Count == 0)
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var users = await _users.Users
+            .Where(u => actorIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email })
+            .ToListAsync();
+
+        return users.ToDictionary(
+            u => u.Id,
+            u => BuildPersonDisplayName(u.Rank, u.FullName, u.UserName, u.Email),
+            StringComparer.Ordinal);
+    }
+
+    // SECTION: Person display helper for rank and full-name-first rendering.
+    private static string BuildPersonDisplayName(ApplicationUser user) =>
+        BuildPersonDisplayName(user.Rank, user.FullName, user.UserName, user.Email);
+
+    // SECTION: Person display helper for query projections.
+    private static string BuildPersonDisplayName(string? rank, string? fullName, string? userName, string? email)
+    {
+        var trimmedRank = rank?.Trim();
+        var trimmedFullName = fullName?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(trimmedRank) && !string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return $"{trimmedRank} {trimmedFullName}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return trimmedFullName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(userName))
+        {
+            return userName;
+        }
+
+        return string.IsNullOrWhiteSpace(email) ? "User" : email;
     }
 
     // SECTION: Resolve a safe, standardized view mode value for postback and redirects

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -21,7 +21,7 @@ else
                     <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                 </div>
                 <a class="at-card-subject" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">@task.Title</a>
-                <div class="small text-muted">@item.AssigneeName · @task.AssignedToRole</div>
+                <div class="small text-muted">@item.AssigneeName</div>
                 <div class="at-card-footer">
                     <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
                     <div class="small at-card-status">@task.Status</div>

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -24,16 +24,19 @@
                         </div>
                         <div class="col-md-7">
                             <label asp-for="Input.Description" class="form-label">Description / Instructions</label>
-                            <textarea asp-for="Input.Description" class="form-control" rows="3"></textarea>
+                            <textarea asp-for="Input.Description"
+                                      class="form-control"
+                                      rows="4"
+                                      placeholder="Enter task instructions, background and expected output"></textarea>
                             <span asp-validation-for="Input.Description" class="text-danger small"></span>
                         </div>
-                        <div class="col-md-5">
+                        <div class="col-12">
                             <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
                             <select asp-for="Input.AssignedToUserId" class="form-select">
                                 <option value="">Select user</option>
                                 @foreach (var user in Model.AssignableUsers)
                                 {
-                                    <option value="@user.UserId">@user.DisplayName (@user.Role)</option>
+                                    <option value="@user.UserId">@user.DisplayName</option>
                                 }
                             </select>
                             <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -50,7 +50,7 @@
                     </div>
                     <div class="mb-2">
                         <label class="form-label at-small">Remarks</label>
-                        <textarea name="remarks" rows="2" class="form-control form-control-sm" maxlength="300" placeholder="Status update remarks"></textarea>
+                        <textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Status update remarks"></textarea>
                     </div>
                     <button type="submit" class="btn btn-primary btn-sm">Update Status</button>
                 </form>
@@ -65,7 +65,7 @@
                     <div class="at-action-title">Submit Task</div>
                     <div class="mb-2">
                         <label class="form-label at-small">Submission Remarks</label>
-                        <textarea name="remarks" rows="2" class="form-control form-control-sm" maxlength="300" placeholder="Add submission notes"></textarea>
+                        <textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add submission notes"></textarea>
                     </div>
                     <button type="submit" class="btn btn-warning btn-sm">Submit Task</button>
                 </form>
@@ -80,7 +80,7 @@
                     <div class="at-action-title">Close Task</div>
                     <div class="mb-2">
                         <label class="form-label at-small">Closure Remarks</label>
-                        <textarea name="remarks" rows="2" class="form-control form-control-sm" maxlength="300" placeholder="Add closure notes"></textarea>
+                        <textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add closure notes"></textarea>
                     </div>
                     <button type="submit" class="btn btn-success btn-sm">Close Task</button>
                 </form>
@@ -92,8 +92,8 @@
             <h3>Task Information</h3>
             <div class="at-task-details-grid">
                 <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
-                <div><span class="text-muted">Assignee</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId) (@Model.SelectedTask.AssignedToRole)</div></div>
-                <div class="at-grid-span-2"><span class="text-muted">Description</span><div class="fw-semibold">@Model.SelectedTask.Description</div></div>
+                <div><span class="text-muted">Responsible Person</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div></div>
+                <div class="at-grid-span-2"><span class="text-muted">Description</span><div class="fw-semibold at-description-text">@Model.SelectedTask.Description</div></div>
                 <div><span class="text-muted">Created On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
                 <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
                 <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
@@ -109,7 +109,7 @@
                 <div class="d-flex justify-content-between gap-2 flex-wrap">
                     <div>
                         <strong>@log.ActionType</strong>
-                        <span class="text-muted">by @log.PerformedByRole</span>
+                        <span class="text-muted">by @Model.ResolveActorName(log.PerformedByUserId)</span>
                     </div>
                     <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
                 </div>
@@ -119,7 +119,7 @@
                 }
                 @if (!string.IsNullOrWhiteSpace(log.Remarks))
                 {
-                    <div class="at-audit-remarks">@log.Remarks</div>
+                    <div class="at-audit-remarks at-remarks-text">@log.Remarks</div>
                 }
             </div>
         }

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -26,6 +26,8 @@ else
                     <span>·</span>
                     <span>Due @task.DueDate.ToString("dd MMM yyyy")</span>
                     <span>·</span>
+                    <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                    <span>·</span>
                     <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                 </div>
             </a>

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -43,18 +43,18 @@
                 </select>
             </div>
             <div class="col-md-3">
-                <label class="form-label">Assignee</label>
+                <label class="form-label">Responsible Person</label>
                 <select class="form-select" name="FilterAssigneeUserId">
                     <option value="">All</option>
                     @foreach (var assignee in Model.AssignableUsers)
                     {
                         @if (string.Equals(Model.FilterAssigneeUserId, assignee.UserId, StringComparison.Ordinal))
                         {
-                            <option value="@assignee.UserId" selected>@assignee.DisplayName (@assignee.Role)</option>
+                            <option value="@assignee.UserId" selected>@assignee.DisplayName</option>
                         }
                         else
                         {
-                            <option value="@assignee.UserId">@assignee.DisplayName (@assignee.Role)</option>
+                            <option value="@assignee.UserId">@assignee.DisplayName</option>
                         }
                     }
                 </select>
@@ -72,6 +72,33 @@
                 <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
             </div>
         </form>
+
+        @if (Model.HasActiveFilters)
+        {
+            <div class="at-active-filters" aria-label="Active filters">
+                @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
+                {
+                    <span class="at-filter-chip">Status: @Model.FilterStatus</span>
+                }
+                @if (!string.IsNullOrWhiteSpace(Model.FilterPriority))
+                {
+                    <span class="at-filter-chip">Priority: @Model.FilterPriority</span>
+                }
+                @if (!string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId))
+                {
+                    <span class="at-filter-chip">Responsible Person: @Model.ResolveAssigneeName(Model.FilterAssigneeUserId)</span>
+                }
+                @if (Model.FilterDueDate.HasValue)
+                {
+                    <span class="at-filter-chip">Due: @Model.FilterDueDate.Value.ToString("dd MMM yyyy")</span>
+                }
+                @if (!string.IsNullOrWhiteSpace(Model.FilterSearch))
+                {
+                    <span class="at-filter-chip">Search: @Model.FilterSearch</span>
+                }
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="at-filter-clear">Clear all</a>
+            </div>
+        }
     </section>
 }
 
@@ -94,7 +121,7 @@
                     <tr>
                         <th>ID</th>
                         <th>Task</th>
-                        <th>Assignee</th>
+                        <th>Responsible Person</th>
                         <th>Due Date</th>
                         <th>Status</th>
                         <th>Priority</th>
@@ -107,11 +134,10 @@
                             <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">AT-@task.Id</a></td>
                             <td>
                                 <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
-                                <div class="at-task-desc">@task.Description</div>
+                                <div class="at-task-desc-preview">@task.Description</div>
                             </td>
                             <td>
                                 <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>
-                                <div class="text-muted small">@task.AssignedToRole</div>
                             </td>
                             <td>@task.DueDate.ToString("dd MMM yyyy")</td>
                             <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -13,6 +13,14 @@
     </section>
 </section>
 
+@* SECTION: Command summary card with rule-based grammar. *@
+<section class="at-section-group">
+    <article class="at-panel">
+        <h2>Command Summary</h2>
+        <p class="at-panel-note">@Model.CommandSummary</p>
+    </article>
+</section>
+
 @* SECTION: Reports analysis panels with lightweight proportional bars. *@
 <section class="at-card-grid at-card-grid-reports">
     <article class="at-panel">
@@ -72,8 +80,8 @@
         </div>
     </article>
     <article class="at-panel">
-        <h2>Workload Distribution</h2>
-        <p class="at-panel-note">Pending tasks grouped by assignee.</p>
+        <h2>Responsible Person Workload</h2>
+        <p class="at-panel-note">Pending tasks grouped by responsible person.</p>
         <div class="at-metric-bars">
             @foreach (var item in Model.AssigneePendingCounts)
             {

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -90,6 +90,12 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Use the close action to close a task.");
         }
 
+        // SECTION: Ignore no-op updates and avoid redundant audit logs.
+        if (string.Equals(task.Status, status, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
         // SECTION: Enforce lifecycle transitions
         if (!IsAllowedTransition(task.Status, status))
         {

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -329,6 +329,31 @@ html {
     font-size: 0.86rem;
 }
 
+.at-preline {
+    white-space: pre-line;
+}
+
+.at-description-text {
+    white-space: pre-line;
+    line-height: 1.45;
+}
+
+.at-remarks-text {
+    white-space: pre-line;
+    line-height: 1.45;
+}
+
+.at-task-desc-preview {
+    color: var(--at-muted);
+    font-size: 0.82rem;
+    line-height: 1.35;
+    white-space: pre-line;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
 /* SECTION: Details dossier and audit */
 .at-detail-hero {
     display: grid;
@@ -418,10 +443,43 @@ html {
 .at-audit-remarks {
     margin-top: .45rem;
     padding: .55rem .7rem;
-    border-left: 3px solid #94a3b8;
+    border-left: 3px solid var(--at-border-strong, #94a3b8);
     background: #f8fafc;
-    color: #334155;
+    color: var(--at-text);
     border-radius: .35rem;
+    white-space: pre-line;
+    line-height: 1.45;
+}
+
+.at-active-filters {
+    margin-top: 0.8rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    align-items: center;
+}
+
+.at-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--at-border);
+    background: #eff6ff;
+    color: #1e3a8a;
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.at-filter-clear {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #1d4ed8;
+    text-decoration: none;
+}
+
+.at-filter-clear:hover {
+    text-decoration: underline;
 }
 
 /* SECTION: Badge system */


### PR DESCRIPTION
### Motivation

- Remove username/role as the primary person display and present operational identities as `Rank FullName` across the Task Tracker UI.  
- Preserve user-entered multiline text for descriptions and remarks to improve readability and avoid `Html.Raw()` usage.  
- Improve Create modal, register/table wording and filters, inspector UX, and report usefulness without changing backend role schema.  

### Description

- Implemented rank + full-name-first display logic with helper `BuildPersonDisplayName(...)` and wired it into assignable user options, assignee name maps and audit actor resolution (`Pages/ActionTasks/Index.cshtml.cs`).  
- Updated Create modal to keep label `Assign To`, make the field full-width, use textarea for `Description`, and show only the person display (no role) in the dropdown (`Pages/ActionTasks/_TaskCreatePanel.cshtml`).  
- Replaced visible role displays across register, cards and inspector: renamed column/labels to `Responsible Person`, removed role text in UI elements, added active filter chips and a compact multiline preview class (`Pages/ActionTasks/_TaskRegister.cshtml`, `_TaskCards.cshtml`, `_TaskMiniList.cshtml`).  
- Preserved multiline rendering by adding CSS classes `.at-description-text`, `.at-remarks-text`, `.at-task-desc-preview` and `.at-preline` and applied them to inspector description/audit remarks and register previews (`wwwroot/css/action-tracker.css`, `Pages/ActionTasks/_TaskDetails.cshtml`).  
- Upgraded inspector remarks inputs to `textarea` (larger rows, higher maxlength) and switched audit attribution to resolve person display names instead of showing roles (`Pages/ActionTasks/_TaskDetails.cshtml`).  
- Added a rule-based `Command Summary` card and renamed the workload panel to `Responsible Person Workload` in reports (`Pages/ActionTasks/_TaskReports.cshtml`) and added helper properties such as `CommandSummary`, `HasActiveFilters` in the page model.  
- Prevented no-op status updates from creating audit entries by short-circuiting when the requested status equals the current one in `UpdateStatusAsync` (`Services/ActionTasks/ActionTaskService.cs`).  

### Testing

- Ran project file inspections and local diffs to verify template and service changes were applied; committed changes successfully.  
- Attempted `dotnet build ProjectManagement.sln` to validate compilation, but the environment lacks the .NET SDK (`dotnet: command not found`), so a full automated build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e1e7b9748329b66c34f5c7c5399f)