### PR TITLE
Exclude inactive users from Task Tracker assignments and add server-side validation

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -223,7 +223,23 @@ public class IndexModel : PageModel
         var assignedUser = await _users.FindByIdAsync(Input.AssignedToUserId);
         if (assignedUser is null)
         {
-            ModelState.AddModelError(string.Empty, "Assigned user was not found.");
+            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user was not found.");
+            ShowCreateModal = true;
+            await LoadDataAsync();
+            return Page();
+        }
+
+        if (assignedUser.IsDisabled || assignedUser.PendingDeletion)
+        {
+            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user is inactive and cannot be assigned a task.");
+            ShowCreateModal = true;
+            await LoadDataAsync();
+            return Page();
+        }
+
+        if (assignedUser.LockoutEnd.HasValue && assignedUser.LockoutEnd > DateTimeOffset.UtcNow)
+        {
+            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user is locked and cannot be assigned a task.");
             ShowCreateModal = true;
             await LoadDataAsync();
             return Page();
@@ -605,9 +621,14 @@ public class IndexModel : PageModel
     private async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync()
     {
         // SECTION: Stabilize user snapshot to avoid overlapping data-reader operations
+        var utcNow = DateTimeOffset.UtcNow;
         var users = await _users.Users
-            .OrderBy(x => x.FullName)
-            .ThenBy(x => x.UserName)
+            .Where(u => !u.IsDisabled)
+            .Where(u => !u.PendingDeletion)
+            .Where(u => !u.LockoutEnd.HasValue || u.LockoutEnd <= utcNow)
+            .OrderBy(u => u.Rank)
+            .ThenBy(u => u.FullName)
+            .ThenBy(u => u.UserName)
             .Take(200)
             .ToListAsync();
 


### PR DESCRIPTION
### Motivation
- Prevent disabled, pending-deletion, or locked-out accounts from appearing in assignable user lists and from being assigned tasks via tampered form posts.
- Ensure visible person names use Rank + Full Name where available while preserving historical display for already-assigned tasks.
- Strengthen form feedback by attaching validation messages to the assigned-user input field.

### Description
- Filter `LoadAssignableUsersAsync()` to exclude `IsDisabled`, `PendingDeletion`, and currently locked-out users and order results by `Rank`, `FullName`, then `UserName` before role permission checks. (file: `Pages/ActionTasks/Index.cshtml.cs`)
- Add server-side guards in `OnPostCreateAsync()` to validate the posted assignee and reject missing, disabled, pending-deletion, or locked users with `ModelState` errors targeted at `Input.AssignedToUserId`. (file: `Pages/ActionTasks/Index.cshtml.cs`)
- Continue to resolve display names for existing tasks via `LoadTaskAssigneeNamesAsync()` using the existing `BuildPersonDisplayName` helpers so historical assignees still render correctly. (file: `Pages/ActionTasks/Index.cshtml.cs`)
- No UI template changes were required because the CSHTML already uses the `DisplayName` projection; role-based assignment logic remains unchanged.

### Testing
- Attempted an automated build with `dotnet build` in the environment and it failed because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`), so no further automated compilation or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15e6e7d40832989473330934a2bc5)