### PR TITLE
Mature Action Tasks UX: filter chips, searchable assignee pickers, inspector guard, sorting, and reports insights

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -71,6 +71,10 @@ public class IndexModel : PageModel
 
     [BindProperty(SupportsGet = true)]
     public string? FilterSearch { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? SortBy { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? SortDir { get; set; }
 
     public string CurrentRole { get; private set; } = string.Empty;
     public string CurrentUserId { get; private set; } = string.Empty;
@@ -433,6 +437,10 @@ public class IndexModel : PageModel
          || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
          || FilterDueDate.HasValue
          || !string.IsNullOrWhiteSpace(FilterSearch));
+    public string DashboardCommandFocusSummary =>
+        $"{ActiveCount} active tasks. {CriticalOpenCount} critical. {OverdueCount} overdue. {InProgressCount} in progress. {SubmittedCount} pending closure.";
+    public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<TaskDisplayItem> TopAttentionTaskDisplays => BuildTopAttentionItems();
 
     public string CommandSummary
     {
@@ -492,8 +500,40 @@ public class IndexModel : PageModel
             var search = FilterSearch.Trim();
             query = query.Where(t => t.Title.Contains(search, StringComparison.OrdinalIgnoreCase));
         }
-
-        return query.ToList();
+        return ApplyTaskListSorting(query).ToList();
+    }
+    // SECTION: Task list sorting after filters.
+    private IEnumerable<ActionTaskItem> ApplyTaskListSorting(IEnumerable<ActionTaskItem> query)
+    {
+        var sortBy = (SortBy ?? "due").Trim().ToLowerInvariant();
+        var descending = string.Equals(SortDir, "desc", StringComparison.OrdinalIgnoreCase);
+        Func<ActionTaskItem, int> statusOrder = task => task.Status switch
+        {
+            ActionTaskStatuses.Assigned => 1,
+            ActionTaskStatuses.InProgress => 2,
+            ActionTaskStatuses.Blocked => 3,
+            ActionTaskStatuses.Submitted => 4,
+            ActionTaskStatuses.Closed => 5,
+            _ => 99
+        };
+        Func<ActionTaskItem, int> priorityOrder = task => task.Priority switch
+        {
+            "Critical" => 1,
+            "High" => 2,
+            "Normal" => 3,
+            "Low" => 4,
+            _ => 99
+        };
+        var ordered = sortBy switch
+        {
+            "title" => descending ? query.OrderByDescending(t => t.Title) : query.OrderBy(t => t.Title),
+            "assignee" => descending ? query.OrderByDescending(t => ResolveAssigneeName(t.AssignedToUserId)) : query.OrderBy(t => ResolveAssigneeName(t.AssignedToUserId)),
+            "status" => descending ? query.OrderByDescending(statusOrder).ThenBy(t => t.DueDate) : query.OrderBy(statusOrder).ThenBy(t => t.DueDate),
+            "priority" => descending ? query.OrderByDescending(priorityOrder).ThenBy(t => t.DueDate) : query.OrderBy(priorityOrder).ThenBy(t => t.DueDate),
+            "id" => descending ? query.OrderByDescending(t => t.Id) : query.OrderBy(t => t.Id),
+            _ => descending ? query.OrderByDescending(t => t.DueDate) : query.OrderBy(t => t.DueDate)
+        };
+        return ordered.ThenBy(t => t.Id);
     }
 
     private void BuildDashboardCollections(IReadOnlyList<ActionTaskItem> tasks)
@@ -608,6 +648,44 @@ public class IndexModel : PageModel
             new CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)),
             new CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8))
         };
+        var submittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
+        SubmittedPendingClosureAgeingBuckets = new[]
+        {
+            new CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)),
+            new CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)),
+            new CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4))
+        };
+    }
+    // SECTION: Report top-attention prioritization.
+    private IReadOnlyList<TaskDisplayItem> BuildTopAttentionItems()
+    {
+        var today = DateTime.UtcNow.Date;
+        var top = Tasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+            .Select(t => new
+            {
+                Task = t,
+                Score = GetAttentionScore(t, today)
+            })
+            .OrderBy(x => x.Score)
+            .ThenBy(x => x.Task.DueDate)
+            .ThenBy(x => x.Task.Id)
+            .Take(3)
+            .Where(x => x.Score < 99)
+            .Select(x => x.Task)
+            .ToList();
+        return ToDisplayItems(top);
+    }
+    private static int GetAttentionScore(ActionTaskItem task, DateTime today)
+    {
+        var isOverdue = task.DueDate.Date < today;
+        var isCritical = string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
+        if (isOverdue && isCritical) return 1;
+        if (isOverdue) return 2;
+        if (string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && isCritical) return 3;
+        if (isCritical) return 4;
+        if (string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)) return 5;
+        return 99;
     }
 
     private async Task ResolveIdentityAsync()

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -32,7 +32,7 @@
                         </div>
                         <div class="col-12">
                             <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
-                            <select asp-for="Input.AssignedToUserId" class="form-select">
+                            <select asp-for="Input.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person">
                                 <option value="">Select user</option>
                                 @foreach (var user in Model.AssignableUsers)
                                 {

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -8,6 +8,9 @@
     <article><h3>Submitted</h3><strong>@Model.SubmittedCount</strong></article>
     <article><h3>Closed</h3><strong>@Model.ClosedCount</strong></article>
 </section>
+<section class="at-panel at-command-focus-strip mb-3">
+    <strong>Command Focus:</strong> @Model.DashboardCommandFocusSummary
+</section>
 
 @* SECTION: Attention-required panels with compact task rows. *@
 <section class="at-section-group">
@@ -39,7 +42,7 @@
                 <h3>Recently Submitted</h3>
                 <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
             </div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No tasks pending recent submission.")' />
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No submitted tasks awaiting closure.")' />
         </article>
         <article class="at-panel">
             <div class="at-panel-heading">

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -34,7 +34,7 @@
                     <div class="at-action-title">Update Status</div>
                     <div class="mb-2">
                         <label class="form-label at-small">Change Status</label>
-                        <select name="status" class="form-select form-select-sm">
+                        <select name="status" class="form-select form-select-sm" data-at-status-select data-current-status="@Model.SelectedTask.Status">
                             @foreach (var status in Model.AllowedStatusOptions)
                             {
                                 if (Model.SelectedTask.Status == status)
@@ -52,7 +52,7 @@
                         <label class="form-label at-small">Remarks</label>
                         <textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Status update remarks"></textarea>
                     </div>
-                    <button type="submit" class="btn btn-primary btn-sm">Update Status</button>
+                    <button type="submit" class="btn btn-primary btn-sm" data-at-status-submit>Update Status</button>
                 </form>
             }
 
@@ -102,10 +102,18 @@
     }
 
     <h3 class="h5 mb-2">Audit Trail</h3>
-    <div class="at-audit-list">
-        @foreach (var log in Model.SelectedTaskLogs)
-        {
-            <div class="at-audit-item">
+    @if (!Model.SelectedTaskLogs.Any())
+    {
+        <div class="at-empty-state">
+            <div class="fw-semibold">No audit logs recorded for this task yet.</div>
+        </div>
+    }
+    else
+    {
+        <div class="at-audit-list">
+            @foreach (var log in Model.SelectedTaskLogs)
+            {
+                <div class="at-audit-item">
                 <div class="d-flex justify-content-between gap-2 flex-wrap">
                     <div>
                         <strong>@log.ActionType</strong>
@@ -121,7 +129,8 @@
                 {
                     <div class="at-audit-remarks at-remarks-text">@log.Remarks</div>
                 }
-            </div>
-        }
-    </div>
+                </div>
+            }
+        </div>
+    }
 </section>

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -7,11 +7,7 @@
 
 @if (!tasks.Any())
 {
-    <div class="at-empty-state at-empty-state-compact">
-        <div class="at-empty-icon"><i class="bi bi-inbox" aria-hidden="true"></i></div>
-        <div class="fw-semibold">@emptyMessage</div>
-        <div class="text-muted small">Tasks will appear here when available.</div>
-    </div>
+    <div class="at-empty-inline">@emptyMessage</div>
 }
 else
 {

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -44,7 +44,7 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Responsible Person</label>
-                <select class="form-select" name="FilterAssigneeUserId">
+                <select class="form-select at-searchable-select" name="FilterAssigneeUserId" data-at-searchable-select="true" data-at-placeholder="All Responsible Persons">
                     <option value="">All</option>
                     @foreach (var assignee in Model.AssignableUsers)
                     {
@@ -107,11 +107,9 @@
     <h2>@(Model.IsMyTasksView ? "My Tasks" : "Task Register")</h2>
     @if (!Model.Tasks.Any())
     {
-        <div class="at-empty-state">
-            <div class="at-empty-icon"><i class="bi bi-inbox" aria-hidden="true"></i></div>
-            <div class="fw-semibold">No tasks in this section</div>
-            <div class="text-muted small">Try adjusting filters or create a task.</div>
-        </div>
+            <div class="at-empty-state">
+                <div class="fw-semibold">No tasks found for the current filters.</div>
+            </div>
     }
     else
     {
@@ -119,12 +117,12 @@
             <table class="table table-sm at-table">
                 <thead>
                     <tr>
-                        <th>ID</th>
-                        <th>Task</th>
-                        <th>Responsible Person</th>
-                        <th>Due Date</th>
-                        <th>Status</th>
-                        <th>Priority</th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID</a></th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task</a></th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person</a></th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due Date</a></th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status</a></th>
+                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority</a></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -80,6 +80,20 @@
         </div>
     </article>
     <article class="at-panel">
+        <h2>Submitted Pending Closure Ageing</h2>
+        <p class="at-panel-note">Ageing buckets for submitted tasks awaiting closure.</p>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+            {
+                <div class="at-metric-row">
+                    <span>@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedCount == 0 ? 1 : Model.SubmittedCount)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
+        </div>
+    </article>
+    <article class="at-panel">
         <h2>Responsible Person Workload</h2>
         <p class="at-panel-note">Pending tasks grouped by responsible person.</p>
         <div class="at-metric-bars">
@@ -106,5 +120,10 @@
                 </div>
             }
         </div>
+    </article>
+    <article class="at-panel">
+        <h2>Top Attention Items</h2>
+        <p class="at-panel-note">Top 3 tasks requiring command attention now.</p>
+        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.TopAttentionTaskDisplays, "No urgent attention items.")' />
     </article>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -141,7 +141,7 @@ html {
     font-size: 0.72rem;
     font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
     color: var(--at-muted);
 }
 
@@ -196,7 +196,7 @@ html {
 .at-section-title {
     font-size: 0.87rem;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.045em;
     color: var(--at-muted);
     font-weight: 800;
     margin-bottom: 0.55rem;
@@ -293,12 +293,14 @@ html {
     color: #475569;
     font-size: 0.72rem;
     text-transform: uppercase;
-    letter-spacing: 0.045em;
+    letter-spacing: 0.03em;
     border-bottom: 1px solid var(--at-border);
 }
 
 .at-table td {
     vertical-align: middle;
+    padding-top: 0.42rem;
+    padding-bottom: 0.42rem;
 }
 
 .at-table tbody tr {
@@ -344,7 +346,7 @@ html {
 }
 
 .at-task-desc-preview {
-    color: var(--at-muted);
+    color: #7a8798;
     font-size: 0.82rem;
     line-height: 1.35;
     white-space: pre-line;
@@ -399,14 +401,14 @@ html {
     border: 1px solid var(--at-border);
     border-radius: 14px;
     background: #f8fafc;
-    padding: 0.85rem;
+    padding: 0.8rem;
 }
 
 .at-action-title {
     font-size: 0.78rem;
     font-weight: 800;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.04em;
     color: var(--at-muted);
     margin-bottom: 0.5rem;
 }
@@ -463,8 +465,8 @@ html {
     display: inline-flex;
     align-items: center;
     border: 1px solid var(--at-border);
-    background: #eff6ff;
-    color: #1e3a8a;
+    background: #f8fafc;
+    color: #334155;
     border-radius: 999px;
     padding: 0.2rem 0.6rem;
     font-size: 0.78rem;
@@ -473,8 +475,8 @@ html {
 
 .at-filter-clear {
     font-size: 0.8rem;
-    font-weight: 700;
-    color: #1d4ed8;
+    font-weight: 600;
+    color: #64748b;
     text-decoration: none;
 }
 
@@ -610,9 +612,24 @@ html {
 }
 
 .at-card-status {
-    color: #334155;
-    font-weight: 700;
+    color: #64748b;
+    font-weight: 600;
 }
+.at-card-footer span {
+    color: #7a8798;
+}
+.at-sort-link {
+    color: inherit;
+    text-decoration: none;
+}
+.at-sort-link:hover { text-decoration: underline; }
+.at-command-focus-strip {
+    padding: 0.65rem 0.9rem;
+    font-size: 0.84rem;
+    color: #334155;
+}
+.at-select-search-wrap { display: grid; gap: 0.35rem; }
+.at-select-search-input { font-size: 0.78rem; }
 
 .at-task-card.is-selected,
 .at-mini-row.is-selected,

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -17,6 +17,51 @@
         const modal = window.bootstrap.Modal.getOrCreateInstance(modalElement);
         modal.show();
     }
+    // SECTION: Lightweight searchable-select enhancement for offline deployment.
+    function initSearchableSelects() {
+        const selects = document.querySelectorAll("select[data-at-searchable-select='true']");
+        selects.forEach((select) => {
+            if (select.dataset.atSearchReady === "true") {
+                return;
+            }
+            const wrapper = document.createElement("div");
+            wrapper.className = "at-select-search-wrap";
+            select.parentNode.insertBefore(wrapper, select);
+            wrapper.appendChild(select);
+            const input = document.createElement("input");
+            input.type = "search";
+            input.className = "form-control form-control-sm at-select-search-input";
+            input.placeholder = select.dataset.atPlaceholder || "Search...";
+            wrapper.insertBefore(input, select);
+            input.addEventListener("input", () => {
+                const term = input.value.trim().toLowerCase();
+                Array.from(select.options).forEach((option, index) => {
+                    if (index === 0) { option.hidden = false; return; }
+                    option.hidden = !option.text.toLowerCase().includes(term);
+                });
+            });
+            select.dataset.atSearchReady = "true";
+        });
+    }
+    // SECTION: Disable status update when selected value does not change status.
+    function initStatusUpdateGuard() {
+        const select = document.querySelector("[data-at-status-select]");
+        const button = document.querySelector("[data-at-status-submit]");
+        if (!select || !button) {
+            return;
+        }
+        const sync = () => {
+            const current = (select.dataset.currentStatus || "").toLowerCase();
+            const selected = (select.value || "").toLowerCase();
+            button.disabled = current === selected;
+        };
+        select.addEventListener("change", sync);
+        sync();
+    }
 
-    document.addEventListener("DOMContentLoaded", openCreateTaskModalOnLoad);
+    document.addEventListener("DOMContentLoaded", function () {
+        openCreateTaskModalOnLoad();
+        initSearchableSelects();
+        initStatusUpdateGuard();
+    });
 })();


### PR DESCRIPTION
### Motivation
- Improve Task Tracker product maturity by adding clearer active-filter feedback, searchable assignee selection, inspector action refinement, server-side register sorting, and richer dashboard/reports insights while preserving the existing layout and behaviour.
- Reduce operational friction for command users by surfacing a concise command-focus summary and top-attention items and by making common controls (assignee pickers, status updates) easier and safer to use.

### Description
- Added GET-bound `SortBy` and `SortDir` and implemented `ApplyTaskListSorting(...)` in `Pages/ActionTasks/Index.cshtml.cs` with business ordering for `status` and `priority`, and ensured sorting applies after filters and persists in the query string.
- Introduced `DashboardCommandFocusSummary`, `SubmittedPendingClosureAgeingBuckets`, `TopAttentionTaskDisplays` and `GetAttentionScore(...)` in `Index.cshtml.cs` and wired them into reports and dashboard partials for the new insights.
- Finalized active filter chips and clear-all behaviour in `Pages/ActionTasks/_TaskRegister.cshtml`, added clickable sort links to column headers that preserve current filter state, and ensured `ResolveAssigneeName(...)` is used for assignee chips.
- Converted responsible-person selectors in `Pages/ActionTasks/_TaskCreatePanel.cshtml` and `_TaskRegister.cshtml` to data-driven searchable picks (offline-safe enhancement) and added a lightweight client-side enhancement in `wwwroot/js/pages/action-tasks/index.js` to enable search/filtering of `select` options without external libs.
- Refined inspector actions in `Pages/ActionTasks/_TaskDetails.cshtml` by adding data attributes for a status-select guard and disabling the `Update Status` button when no change would occur, and added a compact empty audit-state; preserved backend no-op logic already present in `Services/ActionTasks/ActionTaskService.cs`.
- UX polish and density tuning in `wwwroot/css/action-tracker.css` including subtler filter-chip styling, tightened typography and table row padding, quieted secondary text, and styles for the searchable-select wrapper and subtle sort links.

### Testing
- Attempted to run `dotnet build` in the execution environment but it failed with `dotnet: command not found`, so no compiled/test run could be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1678557208329a994f1c7fb73f5e2)