### PR TITLE
Fix ActionTasks KPI compile error and nullability warnings

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -414,6 +414,7 @@ public class IndexModel : PageModel
     // SECTION: KPI helpers for dashboard and reports.
     public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
     public int OverdueCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
+    public int InProgressCount => CountByStatus(ActionTaskStatuses.InProgress);
     public int SubmittedCount => CountByStatus(ActionTaskStatuses.Submitted);
     public int BlockedCount => CountByStatus(ActionTaskStatuses.Blocked);
     public int ClosedCount => CountByStatus(ActionTaskStatuses.Closed);

--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -630,7 +630,7 @@ else
                                         var externalRemark = latestExternalRemark!;
                                         <article class="ongoing-remarks__item">
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
-                                                @Html.Raw(RenderRemark(externalRemark.Body))
+                                                @Html.Raw(RenderRemark(externalRemark.Body!))
                                             </div>
                                             <div class="ongoing-remarks__meta">
                                                 <span class="ongoing-remarks__author">@externalRemark.AuthorDisplayName</span>

--- a/Services/Reports/ProgressReview/ProgressReviewService.cs
+++ b/Services/Reports/ProgressReview/ProgressReviewService.cs
@@ -1898,7 +1898,7 @@ public sealed class ProgressReviewService : IProgressReviewService
 
         return workflowVersionLookup.ToDictionary(
             project => project.Id,
-            project => project.WorkflowVersion);
+            project => (string?)project.WorkflowVersion);
     }
 
     private string? BuildAttachmentUrl(string? storageKey)


### PR DESCRIPTION
### Motivation
- Ensure the codebase compiles and remove nullability warnings by providing missing KPI property and clarifying nullable types where the intent is already guarded.
- Prevent Razor null dereference warnings in guarded branches to satisfy nullable-analysis and avoid potential runtime issues.
- Align dictionary value nullability with the declared return type to eliminate mismatches reported by the analyzer.

### Description
- Added `InProgressCount` KPI helper to `Pages/ActionTasks/Index.cshtml.cs` to provide the in-progress task total used by `DashboardCommandFocusSummary` and avoid a missing identifier compile error. (file: `Pages/ActionTasks/Index.cshtml.cs`)
- Marked `externalRemark.Body` with the null-forgiving operator in `Pages/Projects/Ongoing/Index.cshtml` inside a branch that already checks for null/whitespace to silence the dereference warning while preserving behavior. (file: `Pages/Projects/Ongoing/Index.cshtml`)
- Explicitly cast the projected workflow version values to `string?` when building the lookup dictionary in `Services/Reports/ProgressReview/ProgressReviewService.cs` to match the method return type `IReadOnlyDictionary<int, string?>`. (file: `Services/Reports/ProgressReview/ProgressReviewService.cs`)

### Testing
- Attempted to run `dotnet build ProjectManagement.sln -v minimal`, but the .NET SDK is not available in this environment (`dotnet: command not found`), so a full build could not be executed here.
- Performed local static inspections (file diffs and source scans) to verify the added property and nullability fixes are in place and consistent with surrounding code; no automated tests were run due to missing SDK.
- Changes are limited to compile/nullability fixes and do not introduce behavioral logic changes; recommend running the full test suite and `dotnet build` in a proper .NET SDK environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16a0c591083298caf60cb7e866d4b)