### PR TITLE
Auto-apply task register filters and single searchable Responsible Person picker

### DIFF
--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -6,7 +6,7 @@
 {
     <section class="at-panel mb-3">
         <h2>Task List Filters</h2>
-        <form method="get" class="row g-2">
+        <form id="taskFilterForm" method="get" class="row g-2" data-at-task-filter-form="true">
             <input type="hidden" name="viewMode" value="TaskList" />
             <div class="col-md-2">
                 <label class="form-label">Status</label>
@@ -44,20 +44,23 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Responsible Person</label>
-                <select class="form-select at-searchable-select" name="FilterAssigneeUserId" data-at-searchable-select="true" data-at-placeholder="All Responsible Persons">
-                    <option value="">All</option>
+                <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
+                <input
+                    type="search"
+                    class="form-control"
+                    id="FilterAssigneePicker"
+                    list="FilterAssigneeOptions"
+                    autocomplete="off"
+                    placeholder="All Responsible Persons"
+                    value="@(string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId) ? string.Empty : Model.ResolveAssigneeName(Model.FilterAssigneeUserId))"
+                    data-at-assignee-picker="true"
+                    data-at-assignee-target="FilterAssigneeUserId" />
+                <datalist id="FilterAssigneeOptions">
                     @foreach (var assignee in Model.AssignableUsers)
                     {
-                        @if (string.Equals(Model.FilterAssigneeUserId, assignee.UserId, StringComparison.Ordinal))
-                        {
-                            <option value="@assignee.UserId" selected>@assignee.DisplayName</option>
-                        }
-                        else
-                        {
-                            <option value="@assignee.UserId">@assignee.DisplayName</option>
-                        }
+                        <option value="@assignee.DisplayName" data-user-id="@assignee.UserId"></option>
                     }
-                </select>
+                </datalist>
             </div>
             <div class="col-md-2">
                 <label class="form-label">Due Date</label>
@@ -65,10 +68,9 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Search by title</label>
-                <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" />
+                <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
             </div>
             <div class="col-12 d-flex gap-2">
-                <button type="submit" class="btn btn-primary btn-sm">Apply Filters</button>
                 <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
             </div>
         </form>

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -59,9 +59,89 @@
         sync();
     }
 
+    // SECTION: Task register filter auto-apply and responsible-person searchable picker.
+    function initTaskRegisterFilters() {
+        const form = document.querySelector("[data-at-task-filter-form='true']");
+        if (!form) {
+            return;
+        }
+
+        const immediateControls = form.querySelectorAll("select[name='FilterStatus'], select[name='FilterPriority'], input[name='FilterDueDate']");
+        immediateControls.forEach((control) => {
+            control.addEventListener("change", () => {
+                form.requestSubmit();
+            });
+        });
+
+        const searchInput = form.querySelector("[data-at-filter-search='true']");
+        if (searchInput) {
+            let searchDebounceHandle;
+            searchInput.addEventListener("input", () => {
+                if (searchDebounceHandle) {
+                    window.clearTimeout(searchDebounceHandle);
+                }
+                searchDebounceHandle = window.setTimeout(() => {
+                    form.requestSubmit();
+                }, 400);
+            });
+        }
+
+        const assigneeInput = form.querySelector("[data-at-assignee-picker='true']");
+        if (!assigneeInput) {
+            return;
+        }
+
+        const targetId = assigneeInput.getAttribute("data-at-assignee-target");
+        const hiddenInput = targetId ? form.querySelector(`#${targetId}`) : null;
+        const optionsListId = assigneeInput.getAttribute("list");
+        const optionsList = optionsListId ? document.getElementById(optionsListId) : null;
+        if (!hiddenInput || !optionsList) {
+            return;
+        }
+
+        function syncAssigneeSelection() {
+            const typedName = (assigneeInput.value || "").trim();
+            if (!typedName) {
+                hiddenInput.value = "";
+                return true;
+            }
+
+            const matchedOption = Array.from(optionsList.options).find((option) =>
+                (option.value || "").trim().toLowerCase() === typedName.toLowerCase());
+
+            if (!matchedOption) {
+                hiddenInput.value = "";
+                return false;
+            }
+
+            hiddenInput.value = matchedOption.dataset.userId || "";
+            assigneeInput.value = matchedOption.value;
+            return true;
+        }
+
+        assigneeInput.addEventListener("change", () => {
+            syncAssigneeSelection();
+            form.requestSubmit();
+        });
+
+        assigneeInput.addEventListener("keydown", (event) => {
+            if (event.key !== "Enter") {
+                return;
+            }
+            event.preventDefault();
+            syncAssigneeSelection();
+            form.requestSubmit();
+        });
+
+        assigneeInput.addEventListener("blur", () => {
+            syncAssigneeSelection();
+        });
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
         openCreateTaskModalOnLoad();
         initSearchableSelects();
         initStatusUpdateGuard();
+        initTaskRegisterFilters();
     });
 })();


### PR DESCRIPTION
### Motivation
- Make the Task Register behave like an operational register by applying filters immediately when changed. 
- Replace the existing two-control Responsible Person area with a single searchable picker that binds to the existing `FilterAssigneeUserId` query parameter. 
- Preserve GET-based filtering, active filter chips, and the `Reset` action while removing the explicit `Apply Filters` step.

### Description
- Added a stable filter form hook by setting `id="taskFilterForm"` and `data-at-task-filter-form="true"` on the Task List filter form in `Pages/ActionTasks/_TaskRegister.cshtml` and removed the `Apply Filters` button. 
- Replaced the previous select/text combo for Responsible Person with a single visible `input[type=search]` backed by a hidden `FilterAssigneeUserId` input and a `datalist` of `AssignableUsers`, displaying `Rank Full Name` and placeholder `All Responsible Persons`. 
- Implemented client-side auto-apply logic in `wwwroot/js/pages/action-tasks/index.js` via `initTaskRegisterFilters()`, which immediately submits the form on `Status`, `Priority`, and `Due Date` changes, debounces `Search by title` input (400ms), and syncs the assignee picker (display name → user id) submitting on change or Enter. 
- Kept existing searchable-select utilities and active filter chips behavior intact, and avoided inline scripts to remain CSP-friendly and suitable for offline deployment.

### Testing
- Attempted to run a build with `dotnet build`, but it failed in this environment because the .NET SDK is not installed (`dotnet: command not found`), so no server-side build was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16d947a3083299f441101fb605530)