### PR TITLE
Fix assignee picker collisions for duplicate display names

### DIFF
--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -45,6 +45,24 @@
             <div class="col-md-3">
                 <label class="form-label">Responsible Person</label>
                 <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
+                @{
+                    // SECTION: Build unique, user-readable datalist labels even when display names collide.
+                    var duplicateDisplayNames = Model.AssignableUsers
+                        .Where(u => !string.IsNullOrWhiteSpace(u.DisplayName))
+                        .GroupBy(u => u.DisplayName.Trim(), StringComparer.OrdinalIgnoreCase)
+                        .Where(g => g.Count() > 1)
+                        .Select(g => g.Key)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                    var selectedAssignee = string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId)
+                        ? null
+                        : Model.AssignableUsers.FirstOrDefault(u => string.Equals(u.UserId, Model.FilterAssigneeUserId, StringComparison.Ordinal));
+                    var selectedDisplayName = (selectedAssignee?.DisplayName ?? string.Empty).Trim();
+                    var selectedUserId = (selectedAssignee?.UserId ?? string.Empty).Trim();
+                    var selectedAssigneeLabel = string.IsNullOrWhiteSpace(selectedDisplayName)
+                        ? selectedUserId
+                        : (duplicateDisplayNames.Contains(selectedDisplayName) ? $"{selectedDisplayName} ({selectedUserId})" : selectedDisplayName);
+                }
                 <input
                     type="search"
                     class="form-control"
@@ -52,13 +70,13 @@
                     list="FilterAssigneeOptions"
                     autocomplete="off"
                     placeholder="All Responsible Persons"
-                    value="@(string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId) ? string.Empty : Model.ResolveAssigneeName(Model.FilterAssigneeUserId))"
+                    value="@selectedAssigneeLabel"
                     data-at-assignee-picker="true"
                     data-at-assignee-target="FilterAssigneeUserId" />
                 <datalist id="FilterAssigneeOptions">
                     @foreach (var assignee in Model.AssignableUsers)
                     {
-                        <option value="@assignee.DisplayName" data-user-id="@assignee.UserId"></option>
+                        <option value="@((duplicateDisplayNames.Contains((assignee.DisplayName ?? string.Empty).Trim()) ? $"{assignee.DisplayName} ({assignee.UserId})" : assignee.DisplayName) ?? assignee.UserId)" data-user-id="@assignee.UserId"></option>
                     }
                 </datalist>
             </div>


### PR DESCRIPTION
### Motivation
- The Responsible Person filter used a datalist with display names which could be ambiguous when multiple users share the same `DisplayName`, breaking mapping from the visible picker value back to the hidden `FilterAssigneeUserId`.
- Provide unique, user-readable labels in the picker so selecting or pre-filling a filter always resolves to the correct user.

### Description
- Added server-side logic in `Pages/ActionTasks/_TaskRegister.cshtml` to detect duplicate `DisplayName` values and build a `duplicateDisplayNames` set using `Model.AssignableUsers`.
- Compute a `selectedAssigneeLabel` for the prefilled picker value that uses the `(<UserId>)` suffix only when the display name is duplicated, otherwise keep the simple display name.
- Render datalist `option` values using the same duplicate-safe label format so visible options are unique while preserving `data-user-id` for binding on submit.
- Kept labels concise for unique names and fall back to `UserId` when a display name is empty.

### Testing
- Attempted an automated build with `dotnet build -nologo -v minimal`, but the command could not run because `dotnet` is not available in this environment.  
- No other automated tests were executed in this environment; runtime validation is recommended in a local/CI environment with `dotnet` available to confirm behavior and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f174c0a6388329b07749791fa5d677)