### PR TITLE
Reports: rename headings, add compact zero-state, and tighten report layout

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -100,7 +100,7 @@ public class IndexModel : PageModel
         "Sprint" => "Due Window Board",
         "Kanban" => "Task Kanban Board",
         "TaskList" => "Command Task Register",
-        "Reports" => "Task Performance Summary",
+        "Reports" => "Task Command Summary",
         _ => "Command Task Dashboard"
     };
     public string PageSubtitle => ResolvedViewMode switch
@@ -618,18 +618,21 @@ public class IndexModel : PageModel
             .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
             .GroupBy(t => ResolveAssigneeName(t.AssignedToUserId))
             .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key)
             .Select(group => new CountSummary(group.Key, group.Count()))
             .ToList();
 
         PriorityCounts = tasks
             .GroupBy(t => t.Priority)
             .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key)
             .Select(group => new CountSummary(group.Key, group.Count()))
             .ToList();
 
         StatusCounts = tasks
             .GroupBy(t => t.Status)
             .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key)
             .Select(group => new CountSummary(group.Key, group.Count()))
             .ToList();
 
@@ -672,7 +675,6 @@ public class IndexModel : PageModel
             .ThenBy(x => x.Task.DueDate)
             .ThenBy(x => x.Task.Id)
             .Take(3)
-            .Where(x => x.Score < 99)
             .Select(x => x.Task)
             .ToList();
         return ToDisplayItems(top);
@@ -686,7 +688,7 @@ public class IndexModel : PageModel
         if (string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && isCritical) return 3;
         if (isCritical) return 4;
         if (string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)) return 5;
-        return 99;
+        return 6;
     }
 
     private async Task ResolveIdentityAsync()

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -2,7 +2,7 @@
 
 @* SECTION: Report KPI strip. *@
 <section class="at-section-group">
-    <h2 class="at-section-title">KPI Strip</h2>
+    <h2 class="at-section-title">Overview</h2>
     <section class="at-kpis at-kpis-reports">
         <article><h3>Active</h3><strong>@Model.ActiveCount</strong><p>All open workflow tasks.</p></article>
         <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Urgent open tasks.</p></article>
@@ -40,7 +40,7 @@
             @foreach (var item in Model.StatusCounts)
             {
                 <div class="at-metric-row">
-                    <span>@item.Name</span>
+                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
                     <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
                     <strong>@item.Count</strong>
                 </div>
@@ -57,7 +57,7 @@
                     @foreach (var item in Model.OpenAgeingBuckets)
                     {
                         <div class="at-metric-row">
-                            <span>@item.Name</span>
+                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
                             <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.OpenAgeingBucketsMax)%"></div></div>
                             <strong>@item.Count</strong>
                         </div>
@@ -70,7 +70,7 @@
                     @foreach (var item in Model.OverdueAgeingBuckets)
                     {
                         <div class="at-metric-row">
-                            <span>@item.Name</span>
+                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
                             <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.OverdueAgeingBucketsMax)%"></div></div>
                             <strong>@item.Count</strong>
                         </div>
@@ -80,27 +80,34 @@
         </div>
     </article>
     <article class="at-panel">
-        <h2>Submitted Pending Closure Ageing</h2>
+        <h2>Pending Closure Ageing</h2>
         <p class="at-panel-note">Ageing buckets for submitted tasks awaiting closure.</p>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
-            {
-                <div class="at-metric-row">
-                    <span>@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedCount == 0 ? 1 : Model.SubmittedCount)%"></div></div>
-                    <strong>@item.Count</strong>
-                </div>
-            }
-        </div>
+        @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
+        {
+            <p class="at-empty-state-note">No submitted tasks are awaiting closure.</p>
+        }
+        else
+        {
+            <div class="at-metric-bars">
+                @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedCount == 0 ? 1 : Model.SubmittedCount)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        }
     </article>
     <article class="at-panel">
-        <h2>Responsible Person Workload</h2>
-        <p class="at-panel-note">Pending tasks grouped by responsible person.</p>
-        <div class="at-metric-bars">
+        <h2>Assignee Workload</h2>
+        <p class="at-panel-note">Pending tasks grouped by assignee.</p>
+        <div class="at-metric-bars at-metric-bars-tight">
             @foreach (var item in Model.AssigneePendingCounts)
             {
                 <div class="at-metric-row">
-                    <span>@item.Name</span>
+                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
                     <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.AssigneePendingCountsMax)%"></div></div>
                     <strong>@item.Count</strong>
                 </div>
@@ -114,7 +121,7 @@
             @foreach (var item in Model.PriorityCounts)
             {
                 <div class="at-metric-row">
-                    <span>@item.Name</span>
+                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
                     <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.PriorityCountsMax)%"></div></div>
                     <strong>@item.Count</strong>
                 </div>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -675,7 +675,28 @@ html {
 /* SECTION: Reports metric bars */
 .at-metric-bars {
     display: grid;
-    gap: 0.45rem;
+    gap: 0.4rem;
+}
+
+.at-metric-bars-tight {
+    gap: 0.35rem;
+}
+
+.at-metric-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.at-empty-state-note {
+    margin: 0.35rem 0 0;
+    padding: 0.55rem 0.65rem;
+    border: 1px dashed #cbd5e1;
+    border-radius: 10px;
+    background: #f8fafc;
+    color: var(--at-muted);
+    font-size: 0.81rem;
 }
 
 .at-metric-row {
@@ -709,7 +730,7 @@ html {
 .at-ageing-grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 0.7rem;
+    gap: 0.5rem;
 }
 
 /* SECTION: Empty states */


### PR DESCRIPTION
### Motivation
- Make the Reports page language sharper and user-facing by replacing internal labels with clearer headings and preserving the existing metrics and layout.  
- Reduce visual emptiness in sparse report cards (especially Pending Closure Ageing) without redesigning the cards or changing reporting semantics.  
- Improve assignee workload presentation ordering and long-name handling so the list reads cleaner and more stable.  
- Ensure the Top Attention ordering includes lower-priority active tasks as the final tier rather than excluding them entirely.

### Description
- Change the Reports page title mapping from `"Task Performance Summary"` to `"Task Command Summary"` in `Pages/ActionTasks/Index.cshtml.cs`.  
- Rename UI headings in the Razor partial `Pages/ActionTasks/_TaskReports.cshtml`: `KPI Strip` → `Overview`, `Responsible Person Workload` → `Assignee Workload` (and update the subtitle), and `Submitted Pending Closure Ageing` → `Pending Closure Ageing`.  
- Add a compact zero-state for the submitted-pending-closure card so when `SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0)` the card shows `No submitted tasks are awaiting closure.` instead of rendering three zero bars.  
- Tighten visual spacing via `wwwroot/css/action-tracker.css` by slightly reducing metric gaps, adding `.at-metric-bars-tight`, `.at-metric-label` (ellipsis truncation) and `.at-empty-state-note` styles, and reducing ageing-grid gap.  
- Stabilize ordering for workload/summary lists by adding `ThenBy(group => group.Key)` when building `AssigneePendingCounts`, `PriorityCounts`, and `StatusCounts` in `BuildReportCollections` so ties are resolved by name.  
- Adjust Top Attention logic in `BuildTopAttentionItems` / `GetAttentionScore` so non-urgent active tasks are treated as a final priority tier (score `6`) and the previous filter that excluded high-score items was removed to preserve a stable Top-3 selection.

### Testing
- Attempted to build the project with `dotnet build`, but the build could not run in this environment because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).  
- Verified code changes with repository searches for the new headings, CSS classes, and sorting changes using `rg`, which found the updated strings and selectors.  
- Confirmed files were staged and committed locally (`git status --short` and commit recorded).  
- No automated unit or integration tests were executed in this environment due to missing runtime toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17a71759883298b46c4322532329c)