### PR TITLE
Refine Kanban card hierarchy and interaction affordance

### DIFF
--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -1,8 +1,9 @@
-@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>, string>
+@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>, string, bool>
 @{
     var pageModel = Model.Item1;
     var tasks = Model.Item2;
     var emptyMessage = Model.Item3;
+    var hideStatusBadge = Model.Item4;
 }
 
 @if (!tasks.Any())
@@ -16,16 +17,18 @@ else
         {
             var task = item.Task;
             <article class="at-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                <div class="at-card-top-row">
-                    <a class="at-card-title-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">AT-@task.Id</a>
-                    <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                </div>
-                <a class="at-card-subject" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">@task.Title</a>
-                <div class="small text-muted">@item.AssigneeName</div>
-                <div class="at-card-footer">
-                    <div class="small text-muted">Due @task.DueDate.ToString("dd MMM yyyy")</div>
-                    <div class="small at-card-status">@task.Status</div>
-                </div>
+                <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" aria-label="Open task AT-@task.Id details">
+                    <div class="at-card-top-row">
+                        <h3 class="at-card-subject">@task.Title</h3>
+                        <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                    </div>
+                    <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
+                    <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                    @if (!hideStatusBadge)
+                    {
+                        <div class="small at-card-status">@task.Status</div>
+                    }
+                </a>
             </article>
         }
     </div>

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -5,23 +5,23 @@
     <div class="at-board-grid is-kanban">
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Assigned</h2><span class="at-count-chip">@Model.KanbanAssignedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.", true)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>In Progress</h2><span class="at-count-chip">@Model.KanbanInProgressTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No in progress tasks.", true)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Blocked</h2><span class="at-count-chip">@Model.KanbanBlockedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.", true)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Submitted</h2><span class="at-count-chip">@Model.KanbanSubmittedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.", true)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Closed</h2><span class="at-count-chip">@Model.KanbanClosedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks.", true)' />
         </article>
     </div>
 </section>

--- a/Pages/ActionTasks/_TaskSprintBoard.cshtml
+++ b/Pages/ActionTasks/_TaskSprintBoard.cshtml
@@ -5,19 +5,19 @@
     <div class="at-board-grid at-board-grid-sprint">
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Due Today</h2><span class="at-count-chip">@Model.DueTodayTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks", false)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Due This Week</h2><span class="at-count-chip">@Model.DueThisWeekTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks", false)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Due Later</h2><span class="at-count-chip">@Model.DueLaterTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks", false)' />
         </article>
         <article class="at-panel at-board-column">
             <div class="at-panel-heading"><h2>Overdue</h2><span class="at-count-chip">@Model.SprintOverdueTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.")' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.", false)' />
         </article>
     </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -572,31 +572,42 @@ html {
 .at-task-card {
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
-    padding: .65rem;
     background: var(--at-surface-soft);
-    transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .at-task-card:hover {
-    transform: translateY(-1px);
+    border-color: #b9c8de;
+    background: #f3f7fd;
 }
 
-.at-card-title-link {
-    font-weight: 750;
-    color: var(--at-blue);
+.at-task-card-link {
+    display: block;
     text-decoration: none;
-}
-
-.at-card-title-link:hover {
-    text-decoration: underline;
+    color: inherit;
+    padding: .65rem;
+    cursor: pointer;
 }
 
 .at-card-subject {
-    display: block;
-    text-decoration: none;
+    margin: 0;
     color: var(--at-text);
-    font-weight: 700;
-    margin: 0.2rem 0 0.3rem;
+    font-size: 0.98rem;
+    font-weight: 760;
+    line-height: 1.3;
+}
+
+.at-card-meta {
+    margin-top: 0.28rem;
+    font-size: 0.79rem;
+    color: #64748b;
+}
+
+.at-card-due {
+    margin-top: 0.2rem;
+    font-size: 0.82rem;
+    color: #334155;
+    font-weight: 600;
 }
 
 .at-card-top-row,
@@ -607,16 +618,11 @@ html {
     gap: 0.45rem;
 }
 
-.at-card-footer {
-    margin-top: 0.2rem;
-}
-
 .at-card-status {
+    margin-top: 0.18rem;
     color: #64748b;
+    font-size: 0.78rem;
     font-weight: 600;
-}
-.at-card-footer span {
-    color: #7a8798;
 }
 .at-sort-link {
     color: inherit;
@@ -640,8 +646,9 @@ html {
 
 .at-task-card.is-selected,
 .at-mini-row.is-selected {
-    border-color: var(--at-border);
+    border-color: #9bb8ef;
     border-left: 4px solid var(--at-blue);
+    background: #eef4ff;
 }
 
 .at-table tbody tr.is-selected td {
@@ -761,9 +768,10 @@ html {
 }
 
 .at-empty-inline {
-    margin: 0.2rem 0;
+    margin: 0.1rem 0 0.2rem;
     font-size: 0.78rem;
     color: var(--at-muted);
+    line-height: 1.35;
 }
 
 .at-create-trigger {


### PR DESCRIPTION
### Motivation
- Reduce redundancy and improve scanability by removing per-card status badges in the Kanban view while keeping status grouping at the column level.
- Promote task title as the primary visual anchor and demote Task ID into a quieter metadata line with assignee.
- Preserve priority and due-date visibility, tighten empty-column presentation, and make cards clearly interactive without introducing any sprint concepts.

### Description
- Updated shared card partial `Pages/ActionTasks/_TaskCards.cshtml` to accept an extra boolean in the tuple model (`hideStatusBadge`) and restructured the markup to make the title primary, `AT-{id} · assignee` secondary, due date operational, and priority badge top-right, while rendering status conditionally when `hideStatusBadge` is `false`.
- Replaced split links with a single full-card link (`.at-task-card-link`) so the whole card is clickable and added an accessible `aria-label` for the target action.
- Changed Kanban board partial `Pages/ActionTasks/_TaskKanban.cshtml` to pass Kanban-specific compact empty copy and `true` for `hideStatusBadge` so per-card status badges are removed only in Kanban view.
- Kept due/sprint board behavior intact by passing `false` for `hideStatusBadge` in `Pages/ActionTasks/_TaskSprintBoard.cshtml` so status badges still appear in non-Kanban boards.
- Polished CSS in `wwwroot/css/action-tracker.css`: added `.at-task-card-link`, refined `.at-card-subject`, `.at-card-meta`, `.at-card-due`, hover and selected states, and tightened compact empty-inline spacing to match the new visual hierarchy.
- No sprint-related features were added and existing grouping/count chips remain unchanged.

### Testing
- Attempted an automated build with `dotnet build`, but it failed in this environment because the `dotnet` SDK is not available (`/bin/bash: line 1: dotnet: command not found`).
- No other automated tests were run in this environment; changes are limited to view partials and CSS to minimize risk to other features.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1947595288329874537526236e6ef)