### PR TITLE
Add task progress updates and attachments (work journal & evidence)

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -51,6 +51,8 @@ namespace ProjectManagement.Data
         public DbSet<TodoItem> TodoItems => Set<TodoItem>();
         public DbSet<ActionTaskItem> ActionTasks => Set<ActionTaskItem>();
         public DbSet<ActionTaskAuditLog> ActionTaskAuditLogs => Set<ActionTaskAuditLog>();
+        public DbSet<ActionTaskUpdate> ActionTaskUpdates => Set<ActionTaskUpdate>();
+        public DbSet<ActionTaskAttachment> ActionTaskAttachments => Set<ActionTaskAttachment>();
         public DbSet<Celebration> Celebrations => Set<Celebration>();
         public DbSet<AuthEvent> AuthEvents => Set<AuthEvent>();
         public DbSet<DailyLoginStat> DailyLoginStats => Set<DailyLoginStat>();

--- a/Migrations/20260430170000_AddActionTaskCollaboration.cs
+++ b/Migrations/20260430170000_AddActionTaskCollaboration.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260430170000_AddActionTaskCollaboration")]
+    public class AddActionTaskCollaboration : Migration
+    {
+        // SECTION: Add task updates and attachments schema
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ActionTaskUpdates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TaskId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdateType = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Body = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionTaskUpdates", x => x.Id);
+                    table.ForeignKey("FK_ActionTaskUpdates_ActionTasks_TaskId", x => x.TaskId, "ActionTasks", "Id", onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ActionTaskAttachments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TaskId = table.Column<int>(type: "integer", nullable: false),
+                    UpdateId = table.Column<int>(type: "integer", nullable: true),
+                    UploadedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    UploadedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    OriginalFileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                    StorageKey = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    FileSize = table.Column<long>(type: "bigint", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionTaskAttachments", x => x.Id);
+                    table.ForeignKey("FK_ActionTaskAttachments_ActionTasks_TaskId", x => x.TaskId, "ActionTasks", "Id", onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey("FK_ActionTaskAttachments_ActionTaskUpdates_UpdateId", x => x.UpdateId, "ActionTaskUpdates", "Id", onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(name: "IX_ActionTaskUpdates_TaskId_CreatedAtUtc", table: "ActionTaskUpdates", columns: new[] { "TaskId", "CreatedAtUtc" });
+            migrationBuilder.CreateIndex(name: "IX_ActionTaskAttachments_TaskId", table: "ActionTaskAttachments", column: "TaskId");
+            migrationBuilder.CreateIndex(name: "IX_ActionTaskAttachments_UpdateId", table: "ActionTaskAttachments", column: "UpdateId");
+        }
+
+        // SECTION: Remove task updates and attachments schema
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "ActionTaskAttachments");
+            migrationBuilder.DropTable(name: "ActionTaskUpdates");
+        }
+    }
+}

--- a/Models/ActionTaskAttachment.cs
+++ b/Models/ActionTaskAttachment.cs
@@ -1,0 +1,32 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class ActionTaskAttachment
+{
+    [Key]
+    public int Id { get; set; }
+
+    public int TaskId { get; set; }
+
+    public int? UpdateId { get; set; }
+
+    [Required, StringLength(450)]
+    public string UploadedByUserId { get; set; } = string.Empty;
+
+    public DateTime UploadedAtUtc { get; set; }
+
+    [Required, StringLength(260)]
+    public string OriginalFileName { get; set; } = string.Empty;
+
+    [Required, StringLength(1024)]
+    public string StorageKey { get; set; } = string.Empty;
+
+    [Required, StringLength(200)]
+    public string ContentType { get; set; } = string.Empty;
+
+    public long FileSize { get; set; }
+
+    public bool IsDeleted { get; set; }
+}

--- a/Models/ActionTaskUpdate.cs
+++ b/Models/ActionTaskUpdate.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public static class ActionTaskUpdateTypes
+{
+    public const string Progress = "Progress";
+    public const string Comment = "Comment";
+
+    public static readonly string[] All =
+    {
+        Progress,
+        Comment
+    };
+}
+
+public class ActionTaskUpdate
+{
+    [Key]
+    public int Id { get; set; }
+
+    public int TaskId { get; set; }
+
+    [Required, StringLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    [Required, StringLength(32)]
+    public string UpdateType { get; set; } = ActionTaskUpdateTypes.Progress;
+
+    [Required, StringLength(4000)]
+    public string Body { get; set; } = string.Empty;
+
+    public bool IsDeleted { get; set; }
+}

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -17,12 +18,14 @@ namespace ProjectManagement.Pages.ActionTasks;
 public class IndexModel : PageModel
 {
     private readonly IActionTaskService _service;
+    private readonly IActionTaskCollaborationService _collaborationService;
     private readonly ActionTaskPermissionService _permission;
     private readonly UserManager<ApplicationUser> _users;
 
-    public IndexModel(IActionTaskService service, ActionTaskPermissionService permission, UserManager<ApplicationUser> users)
+    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, UserManager<ApplicationUser> users)
     {
         _service = service;
+        _collaborationService = collaborationService;
         _permission = permission;
         _users = users;
     }
@@ -42,6 +45,8 @@ public class IndexModel : PageModel
     public IReadOnlyList<ActionTaskItem> DueLaterTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> SprintOverdueTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
+    public IReadOnlyList<ActionTaskUpdate> SelectedTaskUpdates { get; private set; } = Array.Empty<ActionTaskUpdate>();
+    public IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>> UpdateAttachments { get; private set; } = new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>();
     public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
     public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
     public IReadOnlyDictionary<string, string> TaskActorNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -83,6 +88,8 @@ public class IndexModel : PageModel
 
     [BindProperty]
     public CreateTaskInput Input { get; set; } = new();
+    [BindProperty]
+    public AddTaskUpdateInput UpdateInput { get; set; } = new();
 
     // SECTION: UI state projections
     public bool CanCreate => _permission.CanCreate(CurrentRole);
@@ -334,6 +341,23 @@ public class IndexModel : PageModel
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
     }
 
+    // SECTION: Post task progress update with optional attachments
+    public async Task<IActionResult> OnPostAddUpdateAsync()
+    {
+        await ResolveIdentityAsync();
+        try
+        {
+            await _collaborationService.AddUpdateAsync(UpdateInput.TaskId, UpdateInput.Body, UpdateInput.UpdateType, CurrentUserId, CurrentRole, UpdateInput.Files);
+            TempData["ToastMessage"] = "Task update posted.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
+    }
+
     // SECTION: Shared data loading
     private async Task LoadDataAsync()
     {
@@ -367,8 +391,30 @@ public class IndexModel : PageModel
         {
             SelectedTask = tasks.FirstOrDefault(t => t.Id == TaskId.Value);
             SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
+            SelectedTaskUpdates = await _collaborationService.GetUpdatesAsync(TaskId.Value, CurrentUserId, CurrentRole);
+            UpdateAttachments = await _collaborationService.GetAttachmentMetadataByUpdateAsync(TaskId.Value, CurrentUserId, CurrentRole);
             TaskActorNames = await LoadTaskActorNamesAsync(SelectedTaskLogs);
+            TaskActorNames = await MergeActorNamesAsync(TaskActorNames, SelectedTaskUpdates);
         }
+    }
+
+    private async Task<IReadOnlyDictionary<string, string>> MergeActorNamesAsync(IReadOnlyDictionary<string, string> current, IReadOnlyList<ActionTaskUpdate> updates)
+    {
+        var userIds = updates.Select(x => x.CreatedByUserId).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal).ToList();
+        var missingIds = userIds.Where(x => !current.ContainsKey(x)).ToList();
+        if (missingIds.Count == 0)
+        {
+            return current;
+        }
+
+        var users = await _users.Users.Where(u => missingIds.Contains(u.Id)).Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email }).ToListAsync();
+        var merged = new Dictionary<string, string>(current, StringComparer.Ordinal);
+        foreach (var user in users)
+        {
+            merged[user.Id] = BuildPersonDisplayName(user.Rank, user.FullName, user.UserName, user.Email);
+        }
+
+        return merged;
     }
 
     // SECTION: Task display projections for richer UI cards and mini-lists.
@@ -859,6 +905,20 @@ public class IndexModel : PageModel
 
         [Required, StringLength(24)]
         public string Priority { get; set; } = "Normal";
+    }
+
+    public sealed class AddTaskUpdateInput
+    {
+        [Required]
+        public int TaskId { get; set; }
+
+        [StringLength(4000)]
+        public string Body { get; set; } = string.Empty;
+
+        [Required, StringLength(32)]
+        public string UpdateType { get; set; } = ActionTaskUpdateTypes.Progress;
+
+        public List<IFormFile> Files { get; set; } = new();
     }
 
     public sealed record UserOption(string UserId, string DisplayName, string Role);

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -99,6 +99,61 @@
                 <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
             </div>
         </section>
+
+        @* SECTION: Progress & updates work journal with attachments. *@
+        <section class="at-task-updates mb-3" aria-label="Progress and Updates">
+            <h3>Progress &amp; Updates</h3>
+            <form method="post" asp-page-handler="AddUpdate" class="at-action-card" enctype="multipart/form-data">
+                <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
+                <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                <div class="at-action-title">Post Update</div>
+                <div class="mb-2">
+                    <label class="form-label at-small" asp-for="UpdateInput.UpdateType">Update Type</label>
+                    <select class="form-select form-select-sm" asp-for="UpdateInput.UpdateType">
+                        <option value="Progress">Progress</option>
+                        <option value="Comment">Comment</option>
+                    </select>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
+                    <textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="Add progress details or clarification notes"></textarea>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label at-small" asp-for="UpdateInput.Files">Add supporting files</label>
+                    <input class="form-control form-control-sm" asp-for="UpdateInput.Files" type="file" multiple />
+                </div>
+                <button type="submit" class="btn btn-primary btn-sm">Post Update</button>
+            </form>
+
+            @if (!Model.SelectedTaskUpdates.Any())
+            {
+                <div class="at-empty-state mt-2"><div class="fw-semibold">No updates posted for this task yet.</div></div>
+            }
+            else
+            {
+                <div class="at-audit-list mt-2">
+                    @foreach (var update in Model.SelectedTaskUpdates)
+                    {
+                        <div class="at-audit-item">
+                            <div class="d-flex justify-content-between gap-2 flex-wrap">
+                                <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong><span class="text-muted"> · @update.UpdateType</span></div>
+                                <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
+                            </div>
+                            <div class="at-audit-remarks at-remarks-text">@update.Body</div>
+                            @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
+                            {
+                                <div class="d-flex flex-wrap gap-2 mt-1">
+                                    @foreach (var file in files)
+                                    {
+                                        <a class="btn btn-outline-secondary btn-sm" href="@file.DownloadUrl" title="@file.FileName">@file.FileName</a>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </section>
     }
 
     <h3 class="h5 mb-2">Audit Trail</h3>

--- a/Program.cs
+++ b/Program.cs
@@ -385,6 +385,7 @@ builder.Services.AddSingleton<IClock, SystemClock>();
 builder.Services.AddScoped<ITodoService, TodoService>();
 builder.Services.AddScoped<ActionTaskPermissionService>();
 builder.Services.AddScoped<IActionTaskService, ActionTaskService>();
+builder.Services.AddScoped<IActionTaskCollaborationService, ActionTaskCollaborationService>();
 builder.Services.Configure<TodoOptions>(
     builder.Configuration.GetSection("Todo"));
 builder.Services.AddScoped<ILoginAnalyticsService, LoginAnalyticsService>();

--- a/Services/ActionTasks/ActionTaskAttachmentMetadata.cs
+++ b/Services/ActionTasks/ActionTaskAttachmentMetadata.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed record ActionTaskAttachmentMetadata(
+    int Id,
+    int TaskId,
+    int? UpdateId,
+    string FileName,
+    string ContentType,
+    long FileSize,
+    string DownloadUrl,
+    string InlineUrl,
+    DateTime UploadedAtUtc,
+    string UploadedByUserId);

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Application.Security;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Storage;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskCollaborationService : IActionTaskCollaborationService
+{
+    private const int MaxAttachmentsPerUpdate = 10;
+    private const long MaxFileSizeBytes = 25L * 1024 * 1024;
+    private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "image/jpeg",
+        "image/png",
+        "text/plain"
+    };
+
+    private readonly ApplicationDbContext _context;
+    private readonly ActionTaskPermissionService _permission;
+    private readonly IUploadRootProvider _uploadRootProvider;
+    private readonly IFileSecurityValidator _fileSecurityValidator;
+    private readonly IProtectedFileUrlBuilder _urlBuilder;
+
+    public ActionTaskCollaborationService(ApplicationDbContext context, ActionTaskPermissionService permission, IUploadRootProvider uploadRootProvider, IFileSecurityValidator fileSecurityValidator, IProtectedFileUrlBuilder urlBuilder)
+    {
+        _context = context;
+        _permission = permission;
+        _uploadRootProvider = uploadRootProvider;
+        _fileSecurityValidator = fileSecurityValidator;
+        _urlBuilder = urlBuilder;
+    }
+
+    // SECTION: Add update with optional attachments
+    public async Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default)
+    {
+        var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to add updates for this task.");
+        }
+
+        if (!ActionTaskUpdateTypes.All.Contains(updateType, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Invalid update type.");
+        }
+
+        var hasBody = !string.IsNullOrWhiteSpace(body);
+        var hasFiles = files is { Count: > 0 } && files.Any(x => x.Length > 0);
+        if (!hasBody && !hasFiles)
+        {
+            throw new InvalidOperationException("Update text is required unless at least one attachment is uploaded.");
+        }
+
+        if (files.Count > MaxAttachmentsPerUpdate)
+        {
+            throw new InvalidOperationException($"A maximum of {MaxAttachmentsPerUpdate} files can be attached per update.");
+        }
+
+        var update = new ActionTaskUpdate
+        {
+            TaskId = taskId,
+            CreatedByUserId = userId,
+            CreatedAtUtc = DateTime.UtcNow,
+            UpdateType = ActionTaskUpdateTypes.All.First(x => string.Equals(x, updateType, StringComparison.OrdinalIgnoreCase)),
+            Body = hasBody ? body.Trim() : "Attachment update",
+            IsDeleted = false
+        };
+        _context.ActionTaskUpdates.Add(update);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        foreach (var file in files.Where(x => x.Length > 0))
+        {
+            await AddAttachmentAsync(taskId, update.Id, userId, file, cancellationToken);
+        }
+
+        return update;
+    }
+
+    // SECTION: Read updates for inspector thread
+    public async Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to view updates for this task.");
+        }
+
+        return await _context.ActionTaskUpdates
+            .AsNoTracking()
+            .Where(x => x.TaskId == taskId && !x.IsDeleted)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to view attachments for this task.");
+        }
+
+        var attachments = await _context.ActionTaskAttachments
+            .AsNoTracking()
+            .Where(x => x.TaskId == taskId && !x.IsDeleted && x.UpdateId.HasValue)
+            .OrderByDescending(x => x.UploadedAtUtc)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync(cancellationToken);
+
+        return attachments
+            .GroupBy(x => x.UpdateId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<ActionTaskAttachmentMetadata>)group.Select(ToMetadata).ToList());
+    }
+
+    private async Task AddAttachmentAsync(int taskId, int updateId, string userId, IFormFile file, CancellationToken cancellationToken)
+    {
+        if (file.Length <= 0)
+        {
+            return;
+        }
+
+        if (file.Length > MaxFileSizeBytes)
+        {
+            throw new InvalidOperationException("File size exceeds the 25 MB limit.");
+        }
+
+        if (!AllowedContentTypes.Contains(file.ContentType))
+        {
+            throw new InvalidOperationException("This file type is not allowed.");
+        }
+
+        var sanitizedFileName = Path.GetFileName(file.FileName);
+        var storageKey = BuildStorageKey(taskId, sanitizedFileName);
+        var absolutePath = ResolveAbsolutePath(storageKey);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await using (var tempOutput = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+            {
+                await file.CopyToAsync(tempOutput, cancellationToken);
+                await tempOutput.FlushAsync(cancellationToken);
+            }
+
+            await _fileSecurityValidator.IsSafeAsync(tempFile, file.ContentType, cancellationToken);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+            File.Move(tempFile, absolutePath, true);
+            tempFile = string.Empty;
+        }
+        catch
+        {
+            SafeDelete(tempFile);
+            SafeDelete(absolutePath);
+            throw;
+        }
+
+        _context.ActionTaskAttachments.Add(new ActionTaskAttachment
+        {
+            TaskId = taskId,
+            UpdateId = updateId,
+            UploadedByUserId = userId,
+            UploadedAtUtc = DateTime.UtcNow,
+            OriginalFileName = sanitizedFileName,
+            StorageKey = storageKey,
+            ContentType = file.ContentType,
+            FileSize = file.Length,
+            IsDeleted = false
+        });
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    private ActionTaskAttachmentMetadata ToMetadata(ActionTaskAttachment attachment)
+    {
+        return new ActionTaskAttachmentMetadata(
+            attachment.Id,
+            attachment.TaskId,
+            attachment.UpdateId,
+            attachment.OriginalFileName,
+            attachment.ContentType,
+            attachment.FileSize,
+            _urlBuilder.CreateDownloadUrl(attachment.StorageKey, attachment.OriginalFileName, attachment.ContentType),
+            _urlBuilder.CreateInlineUrl(attachment.StorageKey, attachment.OriginalFileName, attachment.ContentType),
+            attachment.UploadedAtUtc,
+            attachment.UploadedByUserId);
+    }
+
+    private static string BuildStorageKey(int taskId, string fileName)
+    {
+        var token = $"{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}-{fileName}";
+        return Path.Combine("action-tasks", taskId.ToString(CultureInfo.InvariantCulture), token).Replace('\\', '/');
+    }
+
+    private string ResolveAbsolutePath(string storageKey)
+    {
+        var relative = storageKey.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        return Path.Combine(_uploadRootProvider.RootPath, relative);
+    }
+
+    private static void SafeDelete(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try { if (File.Exists(path)) File.Delete(path); } catch { }
+    }
+}

--- a/Services/ActionTasks/IActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/IActionTaskCollaborationService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public interface IActionTaskCollaborationService
+{
+    Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default);
+    Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
### Motivation

- Separate human work-journal from system audit so assignees can post progress updates and attach evidence without forcing status changes.
- Provide a first-class collaboration model (updates + attachments) that reuses the project’s existing secure file validation and protected URL patterns.

### Description

- Added domain models `ActionTaskUpdate` and `ActionTaskAttachment` to represent progress entries and file evidence respectively (new files `Models/ActionTaskUpdate.cs`, `Models/ActionTaskAttachment.cs`).
- Added `IActionTaskCollaborationService` and `ActionTaskCollaborationService` to handle posting updates, validating and storing attachments, and producing protected attachment metadata and inline/download URLs (new files under `Services/ActionTasks/`).
- Extended `ApplicationDbContext` with `DbSet<ActionTaskUpdate>` and `DbSet<ActionTaskAttachment>`, and added an EF migration `Migrations/20260430170000_AddActionTaskCollaboration.cs` to create the new tables with FKs and indexes.
- Registered the collaboration service in DI (`Program.cs`) and updated the Action Tasks page model (`Pages/ActionTasks/Index.cshtml.cs`) to load updates and grouped attachment metadata, to accept `AddTaskUpdateInput`, and to expose `OnPostAddUpdateAsync`.
- Updated inspector UI partial (`Pages/ActionTasks/_TaskDetails.cshtml`) to add a new “Progress & Updates” section with a post-update form (type, body, multi-file upload) and chronological update + attachment display, keeping the existing Audit Trail separate.
- Followed existing storage/validation patterns by using `IUploadRootProvider`, `IFileSecurityValidator`, and `IProtectedFileUrlBuilder`, and enforced file count/size/type limits and security scanning in the collaboration service.

### Testing

- Attempted `dotnet build` in this environment but the `dotnet` CLI is not available here so a build could not be executed (build attempt failed: `/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33d8bbd0c832988811055173c2fc7)