### PR TITLE
Validate task update payloads before save

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -345,6 +345,12 @@ public class IndexModel : PageModel
     public async Task<IActionResult> OnPostAddUpdateAsync()
     {
         await ResolveIdentityAsync();
+        if (!ModelState.IsValid)
+        {
+            TempData["ToastError"] = "Unable to post update. Please check the entered details and try again.";
+            return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
+        }
+
         try
         {
             await _collaborationService.AddUpdateAsync(UpdateInput.TaskId, UpdateInput.Body, UpdateInput.UpdateType, CurrentUserId, CurrentRole, UpdateInput.Files);

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -48,6 +48,8 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
     // SECTION: Add update with optional attachments
     public async Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default)
     {
+        files ??= Array.Empty<IFormFile>();
+
         var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
         if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
         {
@@ -70,6 +72,9 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         {
             throw new InvalidOperationException($"A maximum of {MaxAttachmentsPerUpdate} files can be attached per update.");
         }
+
+        // SECTION: Validate all uploaded files before persisting update
+        ValidateAttachments(files);
 
         var update = new ActionTaskUpdate
         {
@@ -132,19 +137,10 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
 
     private async Task AddAttachmentAsync(int taskId, int updateId, string userId, IFormFile file, CancellationToken cancellationToken)
     {
+        ValidateAttachment(file);
         if (file.Length <= 0)
         {
             return;
-        }
-
-        if (file.Length > MaxFileSizeBytes)
-        {
-            throw new InvalidOperationException("File size exceeds the 25 MB limit.");
-        }
-
-        if (!AllowedContentTypes.Contains(file.ContentType))
-        {
-            throw new InvalidOperationException("This file type is not allowed.");
         }
 
         var sanitizedFileName = Path.GetFileName(file.FileName);
@@ -186,6 +182,33 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             IsDeleted = false
         });
         await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    // SECTION: Attachment validation helpers
+    private static void ValidateAttachments(IReadOnlyList<IFormFile> files)
+    {
+        foreach (var file in files)
+        {
+            ValidateAttachment(file);
+        }
+    }
+
+    private static void ValidateAttachment(IFormFile file)
+    {
+        if (file.Length <= 0)
+        {
+            return;
+        }
+
+        if (file.Length > MaxFileSizeBytes)
+        {
+            throw new InvalidOperationException("File size exceeds the 25 MB limit.");
+        }
+
+        if (!AllowedContentTypes.Contains(file.ContentType))
+        {
+            throw new InvalidOperationException("This file type is not allowed.");
+        }
     }
 
     private ActionTaskAttachmentMetadata ToMetadata(ActionTaskAttachment attachment)


### PR DESCRIPTION
### Motivation
- Prevent partial-update database writes when a later attachment is invalid by validating attachments up-front. 
- Make attachment validation consistent and reusable to reduce duplication and maintenance surface. 
- Reject malformed page payloads early to avoid invoking service logic with invalid input.

### Description
- Ensure `files` is non-null in `AddUpdateAsync` by coalescing to `Array.Empty<IFormFile>()` and validate all uploads via `ValidateAttachments` before persisting the `ActionTaskUpdate` record. 
- Add `ValidateAttachments` and `ValidateAttachment` helpers that centralize checks for zero-length, maximum size (`25 MB`) and allowed content types, and reuse them from `AddAttachmentAsync`. 
- Call `ValidateAttachment` at the start of `AddAttachmentAsync` so per-file persistence reuses the same checks. 
- Enforce `ModelState` validation in the page handler `OnPostAddUpdateAsync` to return a user-facing error and avoid calling the service with invalid input.

### Testing
- Attempted to run `dotnet build` in this environment, but the command failed with `/bin/bash: dotnet: command not found`, so a full build/test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3437d18e4832986cc0bb11a8a3bef)