### PR TITLE
Enforce authorization on action-task status no-op updates

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -338,6 +338,14 @@ public class IndexModel : PageModel
                 return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
             }
 
+            // SECTION: Preserve permission enforcement even for status no-op submissions.
+            if (!_permission.CanUpdateTask(CurrentRole, CurrentUserId, task.AssignedToUserId))
+            {
+                TempData["ToastError"] = "You are not authorized to update this task.";
+                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+            }
+
+            // SECTION: Keep no-op handling for user-friendly messaging after permission validation.
             if (string.Equals(task.Status, status, StringComparison.OrdinalIgnoreCase))
             {
                 TempData["ToastMessage"] = "No status change applied because the selected status is already current.";


### PR DESCRIPTION
### Motivation
- Prevent unauthorized users from receiving a misleading successful "no-op" response when submitting the current status for an action task by ensuring permission checks run before any early return.

### Description
- Added an explicit permission guard in `OnPostUpdateStatusAsync` in `Pages/ActionTasks/Index.cshtml.cs` that calls `_permission.CanUpdateTask(CurrentRole, CurrentUserId, task.AssignedToUserId)` before the existing no-op short-circuit.
- Preserved the original user-facing no-op message when the submitted status matches the current status, but only after authorization is validated.
- Left the normal status update path (`_service.UpdateStatusAsync(...)`) unchanged for authorized users.

### Testing
- Attempted to run the focused unit tests with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTask"`, but the run failed because the environment lacks the .NET SDK (`dotnet: command not found`).
- Confirmed the change was applied and committed to the repository via a local commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35871323c8329b77fb032be04a76b)