### PR TITLE
Fix task update posting, make attachments atomic, and compact inspector UI

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -367,6 +367,12 @@ public class IndexModel : PageModel
     public async Task<IActionResult> OnPostAddUpdateAsync()
     {
         await ResolveIdentityAsync();
+
+        // SECTION: Validate only update form data so unrelated create-task fields do not block update posting.
+        ModelState.ClearValidationState(nameof(Input));
+        ModelState.MarkFieldValid(nameof(Input));
+        TryValidateModel(UpdateInput, nameof(UpdateInput));
+
         if (!ModelState.IsValid)
         {
             TempData["ToastError"] = "Unable to post update. Please check the entered details and try again.";
@@ -375,7 +381,7 @@ public class IndexModel : PageModel
 
         try
         {
-            await _collaborationService.AddUpdateAsync(UpdateInput.TaskId, UpdateInput.Body, UpdateInput.UpdateType, CurrentUserId, CurrentRole, UpdateInput.Files);
+            await _collaborationService.AddUpdateAsync(UpdateInput.TaskId, UpdateInput.Body, ActionTaskUpdateTypes.Progress, CurrentUserId, CurrentRole, UpdateInput.Files);
             TempData["ToastMessage"] = "Task update posted.";
         }
         catch (InvalidOperationException ex)
@@ -942,9 +948,6 @@ public class IndexModel : PageModel
 
         [StringLength(4000)]
         public string Body { get; set; } = string.Empty;
-
-        [Required, StringLength(32)]
-        public string UpdateType { get; set; } = ActionTaskUpdateTypes.Progress;
 
         public List<IFormFile> Files { get; set; } = new();
     }

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -5,11 +5,11 @@
     @* SECTION: Inspector header with compact identity and close action. *@
     <div class="at-inspector-header">
         <div class="at-detail-hero">
-            <div class="at-section-eyebrow">Task Inspector</div>
-            <h2 class="at-panel-title mb-1">AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
+            <h2 class="at-panel-title mb-0">AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
             @if (Model.SelectedTask is not null)
             {
-                <div class="d-flex gap-2 flex-wrap">
+                <div class="at-detail-assignee">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div>
+                <div class="d-flex gap-2 flex-wrap at-detail-meta">
                     <span class="@Model.GetStatusBadgeClass(Model.SelectedTask.Status)">@Model.SelectedTask.Status</span>
                     <span class="@Model.GetPriorityBadgeClass(Model.SelectedTask.Priority)">@Model.SelectedTask.Priority</span>
                     <span class="at-detail-due">Due @Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</span>
@@ -21,6 +21,72 @@
 
     @if (Model.SelectedTask is not null)
     {
+        @* SECTION: Progress & updates work journal with attachments. *@
+        <section class="at-task-updates mb-3" aria-label="Progress and Updates">
+            <h3>Progress &amp; Updates</h3>
+            <p class="at-helper-text">Record progress, comments and supporting documents without changing task status.</p>
+            <form method="post" asp-page-handler="AddUpdate" class="at-action-card" enctype="multipart/form-data">
+                <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
+                <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                <div class="mb-2">
+                    <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
+                    <textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="Add progress details or clarification notes"></textarea>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label at-small" asp-for="UpdateInput.Files">Supporting files</label>
+                    <input class="form-control form-control-sm" asp-for="UpdateInput.Files" type="file" multiple />
+                    <div class="form-text at-small">Allowed: PDF, Word, Excel, JPG, PNG, TXT.</div>
+                </div>
+                <button type="submit" class="btn btn-primary btn-sm">Post Update</button>
+            </form>
+
+            @if (!Model.SelectedTaskUpdates.Any())
+            {
+                <div class="at-empty-state mt-2"><div class="fw-semibold">No updates posted for this task yet.</div></div>
+            }
+            else
+            {
+                <div class="at-audit-list at-update-thread mt-2">
+                    @foreach (var update in Model.SelectedTaskUpdates)
+                    {
+                        <div class="at-audit-item">
+                            <div class="d-flex justify-content-between gap-2 flex-wrap">
+                                <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong></div>
+                                <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
+                            </div>
+                            <div class="at-audit-remarks at-remarks-text">@update.Body</div>
+                            @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
+                            {
+                                <div class="at-update-files mt-2">
+                                    @foreach (var file in files)
+                                    {
+                                        var typeLabel = file.ContentType switch
+                                        {
+                                            "application/pdf" => "PDF",
+                                            "application/msword" => "DOC",
+                                            "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "DOCX",
+                                            "application/vnd.ms-excel" => "XLS",
+                                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "XLSX",
+                                            "image/jpeg" => "JPG",
+                                            "image/png" => "PNG",
+                                            "text/plain" => "TXT",
+                                            _ => "FILE"
+                                        };
+                                        <div class="at-update-file-item">
+                                            <span class="at-file-type">@typeLabel</span>
+                                            <a class="at-file-name" href="@file.DownloadUrl" title="@file.FileName">@file.FileName</a>
+                                            <span class="at-file-size">@ProjectManagement.Helpers.FileSizeFormatter.FormatFileSize(file.FileSize)</span>
+                                            <a class="btn btn-outline-secondary btn-sm" href="@file.DownloadUrl">Download</a>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </section>
+
         @* SECTION: Context-valid task actions rendered inside inspector only. *@
         <section class="at-inspector-actions" aria-label="Task Actions">
             <h3>Task Actions</h3>
@@ -99,83 +165,9 @@
                 <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
             </div>
         </section>
-
-        @* SECTION: Progress & updates work journal with attachments. *@
-        <section class="at-task-updates mb-3" aria-label="Progress and Updates">
-            <h3>Progress &amp; Updates</h3>
-            <p class="at-helper-text">Use this section to record progress, comments, and supporting documents without changing task status.</p>
-            <form method="post" asp-page-handler="AddUpdate" class="at-action-card" enctype="multipart/form-data">
-                <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
-                <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                <div class="at-action-title">Post Update</div>
-                <div class="mb-2">
-                    <label class="form-label at-small" asp-for="UpdateInput.UpdateType">Update Type</label>
-                    <select class="form-select form-select-sm" asp-for="UpdateInput.UpdateType">
-                        <option value="Progress">Progress</option>
-                        <option value="Comment">Comment</option>
-                    </select>
-                </div>
-                <div class="mb-2">
-                    <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
-                    <textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="Add progress details or clarification notes"></textarea>
-                </div>
-                <div class="mb-2">
-                    <label class="form-label at-small" asp-for="UpdateInput.Files">Add supporting files</label>
-                    <input class="form-control form-control-sm" asp-for="UpdateInput.Files" type="file" multiple />
-                    <div class="form-text at-small">Allowed file types: PDF, Word, Excel, JPG, PNG, TXT. Maximum file size as per upload policy.</div>
-                </div>
-                <button type="submit" class="btn btn-primary btn-sm">Post Update</button>
-            </form>
-
-            @if (!Model.SelectedTaskUpdates.Any())
-            {
-                <div class="at-empty-state mt-2"><div class="fw-semibold">No updates posted for this task yet.</div></div>
-            }
-            else
-            {
-                <div class="at-audit-list mt-2">
-                    @foreach (var update in Model.SelectedTaskUpdates)
-                    {
-                        <div class="at-audit-item">
-                            <div class="d-flex justify-content-between gap-2 flex-wrap">
-                                <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong><span class="text-muted"> · @update.UpdateType</span></div>
-                                <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
-                            </div>
-                            <div class="at-audit-remarks at-remarks-text">@update.Body</div>
-                            @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
-                            {
-                                <div class="at-update-files mt-2">
-                                    @foreach (var file in files)
-                                    {
-                                        var typeLabel = file.ContentType switch
-                                        {
-                                            "application/pdf" => "PDF",
-                                            "application/msword" => "DOC",
-                                            "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "DOCX",
-                                            "application/vnd.ms-excel" => "XLS",
-                                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "XLSX",
-                                            "image/jpeg" => "JPG",
-                                            "image/png" => "PNG",
-                                            "text/plain" => "TXT",
-                                            _ => "FILE"
-                                        };
-                                        <div class="at-update-file-item">
-                                            <span class="at-file-type">@typeLabel</span>
-                                            <a class="at-file-name" href="@file.DownloadUrl" title="@file.FileName">@file.FileName</a>
-                                            <span class="at-file-size">@ProjectManagement.Helpers.FileSizeFormatter.FormatFileSize(file.FileSize)</span>
-                                            <a class="btn btn-outline-secondary btn-sm" href="@file.DownloadUrl">Download</a>
-                                        </div>
-                                    }
-                                </div>
-                            }
-                        </div>
-                    }
-                </div>
-            }
-        </section>
     }
 
-    <h3 class="h5 mb-2">Audit Trail</h3>
+    <h3 class="h5 mb-2 at-audit-title">Audit Trail</h3>
     @if (!Model.SelectedTaskLogs.Any())
     {
         <div class="at-empty-state">

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -76,24 +76,46 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         // SECTION: Validate all uploaded files before persisting update
         ValidateAttachments(files);
 
-        var update = new ActionTaskUpdate
-        {
-            TaskId = taskId,
-            CreatedByUserId = userId,
-            CreatedAtUtc = DateTime.UtcNow,
-            UpdateType = ActionTaskUpdateTypes.All.First(x => string.Equals(x, updateType, StringComparison.OrdinalIgnoreCase)),
-            Body = hasBody ? body.Trim() : "Attachment update",
-            IsDeleted = false
-        };
-        _context.ActionTaskUpdates.Add(update);
-        await _context.SaveChangesAsync(cancellationToken);
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        var committedFiles = new List<string>();
 
-        foreach (var file in files.Where(x => x.Length > 0))
+        try
         {
-            await AddAttachmentAsync(taskId, update.Id, userId, file, cancellationToken);
+            var update = new ActionTaskUpdate
+            {
+                TaskId = taskId,
+                CreatedByUserId = userId,
+                CreatedAtUtc = DateTime.UtcNow,
+                UpdateType = ActionTaskUpdateTypes.All.First(x => string.Equals(x, updateType, StringComparison.OrdinalIgnoreCase)),
+                Body = hasBody ? body.Trim() : "Attachment update",
+                IsDeleted = false
+            };
+
+            _context.ActionTaskUpdates.Add(update);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            foreach (var file in files.Where(x => x.Length > 0))
+            {
+                var storedPath = await AddAttachmentAsync(taskId, update.Id, userId, file, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(storedPath))
+                {
+                    committedFiles.Add(storedPath);
+                }
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return update;
         }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            foreach (var filePath in committedFiles)
+            {
+                SafeDelete(filePath);
+            }
 
-        return update;
+            throw;
+        }
     }
 
     // SECTION: Read updates for inspector thread
@@ -135,12 +157,12 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
                 group => (IReadOnlyList<ActionTaskAttachmentMetadata>)group.Select(ToMetadata).ToList());
     }
 
-    private async Task AddAttachmentAsync(int taskId, int updateId, string userId, IFormFile file, CancellationToken cancellationToken)
+    private async Task<string?> AddAttachmentAsync(int taskId, int updateId, string userId, IFormFile file, CancellationToken cancellationToken)
     {
         ValidateAttachment(file);
         if (file.Length <= 0)
         {
-            return;
+            return null;
         }
 
         var sanitizedFileName = Path.GetFileName(file.FileName);
@@ -182,6 +204,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             IsDeleted = false
         });
         await _context.SaveChangesAsync(cancellationToken);
+        return absolutePath;
     }
 
     // SECTION: Attachment validation helpers

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -401,8 +401,18 @@ html {
 /* SECTION: Details dossier and audit */
 .at-detail-hero {
     display: grid;
-    gap: 0.35rem;
+    gap: 0.2rem;
     flex: 1;
+}
+
+.at-detail-assignee {
+    color: var(--at-text);
+    font-size: 0.85rem;
+    font-weight: 650;
+}
+
+.at-detail-meta {
+    align-items: center;
 }
 
 .at-inspector-header {
@@ -410,7 +420,7 @@ html {
     justify-content: space-between;
     align-items: start;
     gap: 0.75rem;
-    margin-bottom: 0.8rem;
+    margin-bottom: 0.65rem;
 }
 
 .at-inspector-close {
@@ -428,8 +438,8 @@ html {
 
 .at-inspector-actions {
     display: grid;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
+    gap: 0.55rem;
+    margin-bottom: 0.75rem;
 }
 
 .at-inspector-actions h3,
@@ -443,7 +453,7 @@ html {
     border: 1px solid var(--at-border);
     border-radius: 14px;
     background: #f8fafc;
-    padding: 0.8rem;
+    padding: 0.65rem;
 }
 
 .at-action-title {
@@ -458,11 +468,11 @@ html {
 .at-task-details-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: .65rem 1rem;
+    gap: .45rem .8rem;
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
     background: var(--at-surface-soft);
-    padding: .9rem;
+    padding: .7rem;
 }
 
 .at-grid-span-2 {
@@ -476,7 +486,7 @@ html {
 }
 
 .at-audit-item {
-    padding: .85rem 1rem;
+    padding: .6rem .75rem;
     border-bottom: 1px solid #e5e7eb;
 }
 
@@ -485,14 +495,23 @@ html {
 }
 
 .at-audit-remarks {
-    margin-top: .45rem;
-    padding: .55rem .7rem;
+    margin-top: .35rem;
+    padding: .45rem .6rem;
     border-left: 3px solid var(--at-border-strong, #94a3b8);
     background: #f8fafc;
     color: var(--at-text);
     border-radius: .35rem;
     white-space: pre-line;
     line-height: 1.45;
+}
+
+.at-update-thread .at-audit-item {
+    background: #ffffff;
+}
+
+.at-audit-title {
+    color: var(--at-muted);
+    font-size: 0.94rem;
 }
 
 .at-active-filters {


### PR DESCRIPTION
### Motivation
- Fix a blocker where posting Progress & Updates was prevented by unrelated Create Task validation due to multiple bound forms on the same page.
- Ensure update + attachment persistence is all-or-nothing so failed uploads do not leave half-saved state or orphaned metadata.
- Simplify the inspector UI by making Progress & Updates the primary workspace and removing the unused Update Type dropdown.

### Description
- Scope validation to only the update form in `OnPostAddUpdateAsync` by clearing unrelated `Input` validation and explicitly validating `UpdateInput`, and default updates to the `Progress` type (remove `UpdateType` from the bound input). (File: `Pages/ActionTasks/Index.cshtml.cs`)
- Wrap update creation and attachment persistence in a DB transaction, validate files up-front, make `AddAttachmentAsync` return the stored path, and cleanup moved files on failure so the whole operation rolls back on error. (File: `Services/ActionTasks/ActionTaskCollaborationService.cs`)
- Reorder and slim the inspector Razor so the hierarchy is: compact header, Progress & Updates (composer first), Task Actions, Task Information, then Audit Trail, and remove the `Update Type` UI element while showing attachments beneath each update. (File: `Pages/ActionTasks/_TaskDetails.cshtml`)
- Reduce inspector vertical spacing and add small utility classes to keep the layout compact while preserving multiline-safe rendering; no inline scripts were added (CSS: `wwwroot/css/action-tracker.css`).

### Testing
- Attempted a local build with `dotnet build` but it failed because the `dotnet` CLI is not available in the environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35f8e54c4832983f1d8adfcfbb702)