### PR TITLE
Fix stale create-form ModelState blocking task updates

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -368,9 +368,10 @@ public class IndexModel : PageModel
     {
         await ResolveIdentityAsync();
 
-        // SECTION: Validate only update form data so unrelated create-task fields do not block update posting.
-        ModelState.ClearValidationState(nameof(Input));
-        ModelState.MarkFieldValid(nameof(Input));
+        // SECTION: Remove stale create-task model entries before validating update payload.
+        ClearModelStateEntries(nameof(Input));
+
+        // SECTION: Validate only update form data so create-task fields do not block update posting.
         TryValidateModel(UpdateInput, nameof(UpdateInput));
 
         if (!ModelState.IsValid)
@@ -390,6 +391,20 @@ public class IndexModel : PageModel
         }
 
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
+    }
+
+    // SECTION: Remove model-state entries for a bound root object and its nested properties.
+    private void ClearModelStateEntries(string rootKey)
+    {
+        var scopedKeys = ModelState.Keys
+            .Where(key => string.Equals(key, rootKey, StringComparison.Ordinal)
+                || key.StartsWith(rootKey + ".", StringComparison.Ordinal))
+            .ToList();
+
+        foreach (var key in scopedKeys)
+        {
+            ModelState.Remove(key);
+        }
     }
 
     // SECTION: Shared data loading


### PR DESCRIPTION
### Motivation
- Prevent leftover validation entries from the create-task form from blocking valid update submissions when posting task progress updates.

### Description
- Add a helper `ClearModelStateEntries(string rootKey)` that removes a root model key and its nested keys from `ModelState` in `Pages/ActionTasks/Index.cshtml.cs`.
- Replace the previous `ModelState.ClearValidationState(nameof(Input))` / `ModelState.MarkFieldValid(nameof(Input))` sequence in `OnPostAddUpdateAsync` with a call to `ClearModelStateEntries(nameof(Input))` to remove stale create-form entries before validating `UpdateInput`.
- Keep `TryValidateModel(UpdateInput, nameof(UpdateInput))` as the focused validation step so only the update payload is considered.

### Testing
- Ran `dotnet build` in this environment but it failed because the `dotnet` CLI is not installed, so no build/test artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37156dd8c83299880b26f0e0552e8)