### PR TITLE
Fix task update posting validation scope and compact task inspector

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -368,8 +368,8 @@ public class IndexModel : PageModel
     {
         await ResolveIdentityAsync();
 
-        // SECTION: Remove stale create-task model entries before validating update payload.
-        ClearModelStateEntries(nameof(Input));
+        // SECTION: Reset model validation scope for update posting only.
+        ModelState.Clear();
 
         // SECTION: Validate only update form data so create-task fields do not block update posting.
         TryValidateModel(UpdateInput, nameof(UpdateInput));
@@ -387,24 +387,15 @@ public class IndexModel : PageModel
         }
         catch (InvalidOperationException ex)
         {
-            TempData["ToastError"] = ex.Message;
+            TempData["ToastError"] = string.Equals(
+                ex.Message,
+                "Update text is required unless at least one attachment is uploaded.",
+                StringComparison.Ordinal)
+                ? "Enter an update or attach at least one file."
+                : ex.Message;
         }
 
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
-    }
-
-    // SECTION: Remove model-state entries for a bound root object and its nested properties.
-    private void ClearModelStateEntries(string rootKey)
-    {
-        var scopedKeys = ModelState.Keys
-            .Where(key => string.Equals(key, rootKey, StringComparison.Ordinal)
-                || key.StartsWith(rootKey + ".", StringComparison.Ordinal))
-            .ToList();
-
-        foreach (var key in scopedKeys)
-        {
-            ModelState.Remove(key);
-        }
     }
 
     // SECTION: Shared data loading

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -22,10 +22,10 @@
     @if (Model.SelectedTask is not null)
     {
         @* SECTION: Progress & updates work journal with attachments. *@
-        <section class="at-task-updates mb-3" aria-label="Progress and Updates">
+        <section class="at-task-updates at-inspector-section" aria-label="Progress and Updates">
             <h3>Progress &amp; Updates</h3>
             <p class="at-helper-text">Record progress, comments and supporting documents without changing task status.</p>
-            <form method="post" asp-page-handler="AddUpdate" class="at-action-card" enctype="multipart/form-data">
+            <form method="post" asp-page-handler="AddUpdate" class="at-action-card at-journal-card" enctype="multipart/form-data">
                 <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                 <div class="mb-2">
@@ -42,7 +42,7 @@
 
             @if (!Model.SelectedTaskUpdates.Any())
             {
-                <div class="at-empty-state mt-2"><div class="fw-semibold">No updates posted for this task yet.</div></div>
+                <div class="at-empty-state at-empty-state-compact mt-2"><div>No updates posted yet.</div></div>
             }
             else
             {
@@ -88,12 +88,12 @@
         </section>
 
         @* SECTION: Context-valid task actions rendered inside inspector only. *@
-        <section class="at-inspector-actions" aria-label="Task Actions">
+        <section class="at-inspector-actions at-inspector-section" aria-label="Task Actions">
             <h3>Task Actions</h3>
 
             @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
             {
-                <form method="post" asp-page-handler="UpdateStatus" class="at-action-card">
+                <form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact">
                     <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                     <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                     <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
@@ -124,7 +124,7 @@
 
             @if (Model.CanSubmitTask(Model.SelectedTask))
             {
-                <form method="post" asp-page-handler="Submit" class="at-action-card">
+                <form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact">
                     <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                     <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                     <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
@@ -139,7 +139,7 @@
 
             @if (Model.CanCloseTask(Model.SelectedTask))
             {
-                <form method="post" asp-page-handler="Close" class="at-action-card">
+                <form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact">
                     <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                     <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                     <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
@@ -154,11 +154,9 @@
         </section>
 
         @* SECTION: Task metadata for inspector context. *@
-        <section class="at-task-info mb-3" aria-label="Task Information">
+        <section class="at-task-info at-inspector-section" aria-label="Task Information">
             <h3>Task Information</h3>
             <div class="at-task-details-grid">
-                <div><span class="text-muted">Title</span><div class="fw-semibold">@Model.SelectedTask.Title</div></div>
-                <div><span class="text-muted">Responsible Person</span><div class="fw-semibold">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div></div>
                 <div class="at-grid-span-2"><span class="text-muted">Description</span><div class="fw-semibold at-description-text">@Model.SelectedTask.Description</div></div>
                 <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
                 <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
@@ -170,7 +168,7 @@
     <h3 class="h5 mb-2 at-audit-title">Audit Trail</h3>
     @if (!Model.SelectedTaskLogs.Any())
     {
-        <div class="at-empty-state">
+        <div class="at-empty-state at-empty-state-compact">
             <div class="fw-semibold">No audit logs recorded for this task yet.</div>
         </div>
     }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -420,7 +420,7 @@ html {
     justify-content: space-between;
     align-items: start;
     gap: 0.75rem;
-    margin-bottom: 0.65rem;
+    margin-bottom: 0.45rem;
 }
 
 .at-inspector-close {
@@ -438,8 +438,7 @@ html {
 
 .at-inspector-actions {
     display: grid;
-    gap: 0.55rem;
-    margin-bottom: 0.75rem;
+    gap: 0.4rem;
 }
 
 .at-inspector-actions h3,
@@ -451,28 +450,39 @@ html {
 
 .at-action-card {
     border: 1px solid var(--at-border);
-    border-radius: 14px;
+    border-radius: 12px;
     background: #f8fafc;
-    padding: 0.65rem;
+    padding: 0.55rem;
+}
+.at-inspector-section {
+    margin-bottom: 0.55rem;
+}
+
+.at-journal-card {
+    background: #fbfdff;
+}
+
+.at-action-card-compact {
+    padding: 0.5rem;
 }
 
 .at-action-title {
-    font-size: 0.78rem;
-    font-weight: 800;
+    font-size: 0.74rem;
+    font-weight: 760;
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--at-muted);
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.35rem;
 }
 
 .at-task-details-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: .45rem .8rem;
+    gap: .4rem .65rem;
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
     background: var(--at-surface-soft);
-    padding: .7rem;
+    padding: .55rem;
 }
 
 .at-grid-span-2 {
@@ -486,7 +496,7 @@ html {
 }
 
 .at-audit-item {
-    padding: .6rem .75rem;
+    padding: .45rem .6rem;
     border-bottom: 1px solid #e5e7eb;
 }
 
@@ -495,14 +505,14 @@ html {
 }
 
 .at-audit-remarks {
-    margin-top: .35rem;
-    padding: .45rem .6rem;
+    margin-top: .25rem;
+    padding: .35rem .5rem;
     border-left: 3px solid var(--at-border-strong, #94a3b8);
     background: #f8fafc;
     color: var(--at-text);
     border-radius: .35rem;
     white-space: pre-line;
-    line-height: 1.45;
+    line-height: 1.4;
 }
 
 .at-update-thread .at-audit-item {
@@ -511,7 +521,8 @@ html {
 
 .at-audit-title {
     color: var(--at-muted);
-    font-size: 0.94rem;
+    font-size: 0.86rem;
+    font-weight: 700;
 }
 
 .at-active-filters {
@@ -804,15 +815,16 @@ html {
 /* SECTION: Empty states */
 .at-empty-state {
     border: 1px dashed #cbd5e1;
-    border-radius: 14px;
-    padding: 1.25rem;
+    border-radius: 12px;
+    padding: 0.8rem;
     background: #f8fafc;
     color: #475569;
 }
 
 .at-empty-state-compact {
-    padding: 0.8rem;
+    padding: 0.5rem 0.6rem;
     min-height: auto;
+    font-size: 0.82rem;
 }
 
 .at-empty-icon {


### PR DESCRIPTION
### Motivation
- The update-post flow could be blocked by unrelated `CreateTaskInput` validation entries remaining in `ModelState`, preventing valid progress updates and attachments from being posted. 
- Improve Task Inspector density and hierarchy so the drawer feels like a compact execution workspace without redesigning other module features. 

### Description
- Ensure `OnPostAddUpdateAsync()` clears the full validation scope and re-validates only `UpdateInput` by replacing the scoped-clear helper with `ModelState.Clear()` followed by `TryValidateModel(UpdateInput, nameof(UpdateInput))` so create-task fields no longer influence update posting. (Updated `Pages/ActionTasks/Index.cshtml.cs`.)
- Surface a clear UI message for empty submissions by mapping the collaboration service empty-post exception text to the friendly message: "Enter an update or attach at least one file." (Updated `Pages/ActionTasks/Index.cshtml.cs`.)
- Remove the previous `ClearModelStateEntries` helper usage (the helper itself was removed from the handler scope). (Updated `Pages/ActionTasks/Index.cshtml.cs`.)
- Compacted inspector markup by adding compact section/card classes and reducing repeated metadata (keeps required section order: Header, Progress & Updates, Task Actions, Task Information, Audit Trail) and updated empty-state copy for updates and audit. (Updated `Pages/ActionTasks/_TaskDetails.cshtml`.)
- Toned down visual weight and vertical spacing in the inspector via CSS tweaks (header spacing, action-card padding, grid gaps, audit trail padding/gaps, compact empty-state styles) while preserving multiline-safe rendering using `white-space: pre-line`. (Updated `wwwroot/css/action-tracker.css`.)
- Files changed: `Pages/ActionTasks/Index.cshtml.cs`, `Pages/ActionTasks/_TaskDetails.cshtml`, `wwwroot/css/action-tracker.css`.

### Testing
- Attempted an automated project build with `dotnet build` in this environment, but the `dotnet` CLI is not available here so the build could not be executed (`/bin/bash: dotnet: command not found`).
- No other automated tests were run in this environment; recommend running full compile + integration tests and the acceptance scenarios: text-only, file-only, text+file, invalid file type, oversize file, and empty-post to verify the mapped error message and file handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3721947b08329b2c7949bcc8293bf)