### PR TITLE
Fix Razor activity stream type alignment and null-safety

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -39,20 +39,16 @@
             {
                 @* SECTION: Merge updates and logs into one chronological activity stream. *@
                 var activityEntries = Model.SelectedTaskUpdates
-                    .Select(update => new
-                    {
-                        Timestamp = update.CreatedAtUtc,
-                        EntryType = "Update",
-                        Update = update,
-                        Log = (dynamic?)null
-                    })
-                    .Concat(Model.SelectedTaskLogs.Select(log => new
-                    {
-                        Timestamp = log.PerformedAt,
-                        EntryType = "Log",
-                        Update = (dynamic?)null,
-                        Log = log
-                    }))
+                    .Select(update => (
+                        Timestamp: update.CreatedAtUtc,
+                        EntryType: "Update",
+                        Update: update,
+                        Log: (ProjectManagement.Models.ActionTaskAuditLog?)null))
+                    .Concat(Model.SelectedTaskLogs.Select(log => (
+                        Timestamp: log.PerformedAt,
+                        EntryType: "Log",
+                        Update: (ProjectManagement.Models.ActionTaskUpdate?)null,
+                        Log: log)))
                     .OrderByDescending(entry => entry.Timestamp)
                     .ToList();
 

--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -628,9 +628,10 @@ else
                                     else
                                     {
                                         var externalRemark = latestExternalRemark!;
+                                        var externalRemarkBody = externalRemark.Body ?? string.Empty;
                                         <article class="ongoing-remarks__item">
                                             <div class="ongoing-remarks__body ongoing-remarks__body--collapsed">
-                                                @Html.Raw(RenderRemark(externalRemark.Body!))
+                                                @Html.Raw(RenderRemark(externalRemarkBody))
                                             </div>
                                             <div class="ongoing-remarks__meta">
                                                 <span class="ongoing-remarks__author">@externalRemark.AuthorDisplayName</span>


### PR DESCRIPTION
### Motivation
- Resolve a Razor compile error where `Concat` failed due to mismatched anonymous projection shapes in the activity timeline, and eliminate a nullability/dereference warning when rendering external remarks.

### Description
- Adjusted `Pages/ActionTasks/_TaskDetails.cshtml` to project both sides of the merged activity stream into the same tuple shape with concrete nullable model types (`ActionTaskUpdate?` and `ActionTaskAuditLog?`) so `Concat` and subsequent ordering compile correctly.
- Updated `Pages/Projects/Ongoing/Index.cshtml` to normalize `latestExternalRemark.Body` into a non-null local `externalRemarkBody` before calling `RenderRemark` to avoid a possible null dereference and satisfy nullability checks.
- Kept changes localized to the two Razor files and preserved existing rendering and layout logic.

### Testing
- Attempted to run `dotnet build -v minimal` to validate compilation, but the environment does not have the .NET SDK installed and the command failed with `dotnet: command not found`.
- No automated unit tests were executed in this environment due to the missing `dotnet` CLI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d2342048329855e1ba1431e6c4f)