### PR TITLE
Resolve selected task from visible scope and guard detail loading

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -427,15 +427,31 @@ public class IndexModel : PageModel
             ? ApplyTaskListFilters(tasks)
             : tasks;
 
-        if (TaskId.HasValue)
+        // SECTION: Selected Task Resolution
+        if (!TaskId.HasValue)
         {
-            SelectedTask = tasks.FirstOrDefault(t => t.Id == TaskId.Value);
-            SelectedTaskLogs = await _service.GetTaskLogsAsync(TaskId.Value, CurrentUserId, CurrentRole);
-            SelectedTaskUpdates = await _collaborationService.GetUpdatesAsync(TaskId.Value, CurrentUserId, CurrentRole);
-            UpdateAttachments = await _collaborationService.GetAttachmentMetadataByUpdateAsync(TaskId.Value, CurrentUserId, CurrentRole);
-            TaskActorNames = await LoadTaskActorNamesAsync(SelectedTaskLogs);
-            TaskActorNames = await MergeActorNamesAsync(TaskActorNames, SelectedTaskUpdates);
+            return;
         }
+
+        var visibleTaskScope = Tasks;
+        SelectedTask = visibleTaskScope.FirstOrDefault(t => t.Id == TaskId.Value);
+        if (SelectedTask is null)
+        {
+            TaskId = null;
+            SelectedTask = null;
+            SelectedTaskLogs = Array.Empty<ActionTaskAuditLog>();
+            SelectedTaskUpdates = Array.Empty<ActionTaskUpdate>();
+            UpdateAttachments = new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>();
+            TempData["ToastError"] = "The selected task is no longer available in the current view.";
+            return;
+        }
+
+        // SECTION: Selected Task Detail Loading
+        SelectedTaskLogs = await _service.GetTaskLogsAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
+        SelectedTaskUpdates = await _collaborationService.GetUpdatesAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
+        UpdateAttachments = await _collaborationService.GetAttachmentMetadataByUpdateAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
+        TaskActorNames = await LoadTaskActorNamesAsync(SelectedTaskLogs);
+        TaskActorNames = await MergeActorNamesAsync(TaskActorNames, SelectedTaskUpdates);
     }
 
     private async Task<IReadOnlyDictionary<string, string>> MergeActorNamesAsync(IReadOnlyDictionary<string, string> current, IReadOnlyList<ActionTaskUpdate> updates)


### PR DESCRIPTION
### Motivation
- Ensure the page only loads details (logs, updates, attachments) for tasks that are visible under the current view/filters to prevent exposing or loading stale/out-of-scope data.
- Make selected-task behavior idempotent for valid deep links while gracefully clearing state for invalid/stale selections.

### Description
- Modified `LoadDataAsync()` in `Pages/ActionTasks/Index.cshtml.cs` to resolve the selected task against the already-filtered `Tasks` collection instead of the unfiltered source list.
- Added a `// SECTION: Selected Task Resolution` branch that returns early if `TaskId` is not set and clears `TaskId`, `SelectedTask`, `SelectedTaskLogs`, `SelectedTaskUpdates`, and `UpdateAttachments` with a safe `TempData["ToastError"]` when the selected task is not in scope.
- Added a `// SECTION: Selected Task Detail Loading` branch that only calls `GetTaskLogsAsync`, `GetUpdatesAsync`, and attachment metadata retrieval when the `SelectedTask` exists in the visible scope.
- Kept existing behavior for valid task links intact so detail loading remains idempotent for in-scope selections.

### Testing
- Attempted to build with `dotnet build -nologo`, but the environment lacks the .NET SDK and the command failed with `/bin/bash: line 1: dotnet: command not found`.
- No automated unit/integration tests were run in this environment due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa23234cc483298b3fc0bb49a92a05)