### PR TITLE
Add Action Task row-version concurrency support end-to-end

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1811,6 +1811,8 @@ namespace ProjectManagement.Data
 
             builder.Entity<ActionTaskItem>(e =>
             {
+                // SECTION: Optimistic concurrency token mapping for action tasks
+                e.Property(x => x.RowVersion).IsRowVersion();
                 e.HasIndex(x => new { x.AssignedToUserId, x.Status });
                 e.HasIndex(x => new { x.DueDate, x.Status });
                 e.HasIndex(x => x.IsDeleted);

--- a/Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs
+++ b/Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    public partial class AddActionTaskRowVersionConcurrency : Migration
+    {
+        // SECTION: Add optimistic concurrency token to action tasks
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "ActionTasks",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+
+        // SECTION: Remove optimistic concurrency token from action tasks
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "ActionTasks");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2228,6 +2228,11 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(24)
                         .HasColumnType("character varying(24)");
 
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("bytea");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(32)

--- a/Models/ActionTaskItem.cs
+++ b/Models/ActionTaskItem.cs
@@ -56,5 +56,8 @@ public class ActionTaskItem
     public DateTime? SubmittedOn { get; set; }
     public DateTime? ClosedOn { get; set; }
 
+    // SECTION: Optimistic concurrency token for task updates
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+
     public bool IsDeleted { get; set; }
 }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -291,13 +291,17 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Submit task for closure review
-    public async Task<IActionResult> OnPostSubmitAsync(int id, string? remarks)
+    public async Task<IActionResult> OnPostSubmitAsync(int id, string rowVersion, string? remarks)
     {
         await ResolveIdentityAsync();
         try
         {
-            await _service.SubmitTaskAsync(id, CurrentUserId, CurrentRole, remarks);
+            await _service.SubmitTaskAsync(id, DecodeRowVersion(rowVersion), CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task submitted.";
+        }
+        catch (ActionTaskConcurrencyException ex)
+        {
+            TempData["ToastError"] = ex.Message;
         }
         catch (InvalidOperationException ex)
         {
@@ -308,13 +312,17 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Close task by command role
-    public async Task<IActionResult> OnPostCloseAsync(int id, string? remarks)
+    public async Task<IActionResult> OnPostCloseAsync(int id, string rowVersion, string? remarks)
     {
         await ResolveIdentityAsync();
         try
         {
-            await _service.CloseTaskAsync(id, CurrentUserId, CurrentRole, remarks);
+            await _service.CloseTaskAsync(id, DecodeRowVersion(rowVersion), CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task closed.";
+        }
+        catch (ActionTaskConcurrencyException ex)
+        {
+            TempData["ToastError"] = ex.Message;
         }
         catch (InvalidOperationException ex)
         {
@@ -325,7 +333,7 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Update in-flight status
-    public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string status, string? remarks)
+    public async Task<IActionResult> OnPostUpdateStatusAsync(int id, string rowVersion, string status, string? remarks)
     {
         await ResolveIdentityAsync();
         try
@@ -352,8 +360,12 @@ public class IndexModel : PageModel
                 return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
             }
 
-            await _service.UpdateStatusAsync(id, status, CurrentUserId, CurrentRole, remarks);
+            await _service.UpdateStatusAsync(id, DecodeRowVersion(rowVersion), status, CurrentUserId, CurrentRole, remarks);
             TempData["ToastMessage"] = "Task status updated.";
+        }
+        catch (ActionTaskConcurrencyException ex)
+        {
+            TempData["ToastError"] = ex.Message;
         }
         catch (InvalidOperationException ex)
         {
@@ -911,6 +923,25 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Resolve a safe, standardized view mode value for postback and redirects
+
+    // SECTION: Decode Base64 row-version tokens posted from forms
+    private static byte[] DecodeRowVersion(string rowVersion)
+    {
+        if (string.IsNullOrWhiteSpace(rowVersion))
+        {
+            throw new InvalidOperationException("Task version is missing. Please reload and try again.");
+        }
+
+        try
+        {
+            return Convert.FromBase64String(rowVersion);
+        }
+        catch (FormatException)
+        {
+            throw new InvalidOperationException("Task version is invalid. Please reload and try again.");
+        }
+    }
+
     private string ResolveViewMode()
     {
         var normalized = (ViewMode ?? string.Empty).Trim();

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -162,6 +162,7 @@
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
                                 <div class="at-action-title">Change Status</div>
                                 <div class="mb-2">
                                     <label class="form-label at-small">Target Status</label>
@@ -199,6 +200,7 @@
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
                                 <div class="at-action-title">Submit Task</div>
                                 <div class="mb-2">
                                     <label class="form-label at-small">Submission Remarks</label>
@@ -220,6 +222,7 @@
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
                                 <div class="at-action-title">Close Task</div>
                                 <div class="mb-2">
                                     <label class="form-label at-small">Closure Remarks</label>

--- a/Services/ActionTasks/ActionTaskConcurrencyException.cs
+++ b/Services/ActionTasks/ActionTaskConcurrencyException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+// SECTION: Domain-level concurrency exception surfaced to UI workflows.
+public sealed class ActionTaskConcurrencyException : InvalidOperationException
+{
+    public ActionTaskConcurrencyException(string message) : base(message)
+    {
+    }
+}

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -84,7 +84,7 @@ public class ActionTaskService : IActionTaskService
         return task;
     }
 
-    public async Task UpdateStatusAsync(int taskId, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    public async Task UpdateStatusAsync(int taskId, byte[] rowVersion, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
     {
         // SECTION: Validation
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
@@ -119,6 +119,9 @@ public class ActionTaskService : IActionTaskService
         // SECTION: Remarks validation for key transitions
         ValidateRemarksForStatusTransition(task.Status, status, remarks);
 
+        // SECTION: Concurrency token validation
+        _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
+
         // SECTION: State Mutation
         var oldStatus = task.Status;
         task.Status = status;
@@ -135,10 +138,17 @@ public class ActionTaskService : IActionTaskService
         _context.ActionTaskAuditLogs.Add(Log(taskId, "StatusUpdated", userId, role, oldStatus, task.Status, remarks));
 
         // SECTION: Persistence
-        await _context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ActionTaskConcurrencyException("This task was updated by another user. Please reload the task details and try again.");
+        }
     }
 
-    public async Task SubmitTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    public async Task SubmitTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
     {
         // SECTION: Validation
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
@@ -165,6 +175,9 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Remarks are required when submitting a task.");
         }
 
+        // SECTION: Concurrency token validation
+        _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
+
         // SECTION: State Mutation
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Submitted;
@@ -174,10 +187,17 @@ public class ActionTaskService : IActionTaskService
         _context.ActionTaskAuditLogs.Add(Log(taskId, "Submitted", userId, role, oldStatus, task.Status, remarks));
 
         // SECTION: Persistence
-        await _context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ActionTaskConcurrencyException("This task was updated by another user. Please reload the task details and try again.");
+        }
     }
 
-    public async Task CloseTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
+    public async Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
     {
         // SECTION: Validation
         if (!_permission.CanClose(role))
@@ -197,6 +217,9 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Closure remarks are required.");
         }
 
+        // SECTION: Concurrency token validation
+        _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
+
         // SECTION: State Mutation
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Closed;
@@ -206,7 +229,14 @@ public class ActionTaskService : IActionTaskService
         _context.ActionTaskAuditLogs.Add(Log(taskId, "Closed", userId, role, oldStatus, task.Status, remarks));
 
         // SECTION: Persistence
-        await _context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ActionTaskConcurrencyException("This task was updated by another user. Please reload the task details and try again.");
+        }
     }
 
     // SECTION: Audit logging

--- a/Services/ActionTasks/IActionTaskService.cs
+++ b/Services/ActionTasks/IActionTaskService.cs
@@ -9,9 +9,9 @@ public interface IActionTaskService
 {
     Task<List<ActionTaskItem>> GetTasksAsync(string userId, string role, CancellationToken cancellationToken = default);
     Task<ActionTaskItem> CreateTaskAsync(ActionTaskItem task, CancellationToken cancellationToken = default);
-    Task UpdateStatusAsync(int taskId, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
-    Task SubmitTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
-    Task CloseTaskAsync(int taskId, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task UpdateStatusAsync(int taskId, byte[] rowVersion, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task SubmitTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default);
     Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
### Motivation
- Prevent silent lost updates when multiple users act on the same task by adding optimistic concurrency control.  
- Surface a clear, UI-friendly error when concurrent mutations occur so users can reload and retry safely.  
- Keep the implementation CSP-safe and provider-appropriate (no inline script or client-side token tricks).  

### Description
- Added a `RowVersion` concurrency token to the `ActionTaskItem` model as `byte[] RowVersion` with an explanatory section comment.  
- Configured EF mapping for `ActionTaskItem` in `ApplicationDbContext` using `IsRowVersion()` so the provider tracks the token, and updated the model snapshot accordingly.  
- Created a migration `AddActionTaskRowVersionConcurrency` to add the `RowVersion` column to the `ActionTasks` table and updated `ApplicationDbContextModelSnapshot`.  
- Plumbed the token through the UI and service layers by encoding the token as Base64 in hidden fields in `Pages/ActionTasks/_TaskDetails.cshtml`, accepting `rowVersion` in `Index` handlers (decoded server-side), updating `IActionTaskService` signatures, and changing `ActionTaskService` to set `Entry(...).Property(x => x.RowVersion).OriginalValue = rowVersion` and translate `DbUpdateConcurrencyException` into a domain `ActionTaskConcurrencyException` with a user-facing message.  

### Testing
- Attempted to run `dotnet ef migrations add ...` in this environment but the `dotnet` CLI/SDK was not available so the migration was authored and the snapshot updated manually (command failed).  
- No automated unit or integration tests were executed against the modified code in this environment.  
- Repository-level verification commands (`git status` / `git commit`) were run to confirm the changes were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa24b9d4b88329b1572c87478d98df)