### PR TITLE
Derive per-task last-activity timestamp and use it for Dashboard "Recently Updated"

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -428,8 +428,11 @@ public class IndexModel : PageModel
         AssignableUsers = await LoadAssignableUsersAsync();
         TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(tasks);
 
+        // SECTION: Activity Timestamp Derivation
+        var activityByTaskId = await _service.GetLastActivityUtcByTaskIdsAsync(tasks.Select(t => t.Id).ToArray());
+
         // SECTION: Populate overview and grouping collections
-        BuildDashboardCollections(tasks);
+        BuildDashboardCollections(tasks, activityByTaskId);
         BuildKanbanCollections(tasks);
         BuildSprintCollections(tasks);
         BuildReportCollections(tasks);
@@ -651,7 +654,7 @@ public class IndexModel : PageModel
         return ordered.ThenBy(t => t.Id);
     }
 
-    private void BuildDashboardCollections(IReadOnlyList<ActionTaskItem> tasks)
+    private void BuildDashboardCollections(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
     {
         var utcNow = DateTime.UtcNow;
 
@@ -675,10 +678,21 @@ public class IndexModel : PageModel
             .Take(5)
             .ToList();
 
+        // SECTION: Dashboard Recently Updated Projection
         RecentlyUpdatedTasks = tasks
-            .OrderByDescending(t => t.SubmittedOn ?? t.AssignedOn)
+            .OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue)
+            .ThenByDescending(t => t.Id)
             .Take(5)
             .ToList();
+    }
+
+    // SECTION: Activity Timestamp Derivation
+    private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
+    {
+        activityByTaskId.TryGetValue(task.Id, out var activityTimestampUtc);
+        return activityTimestampUtc
+            ?? task.SubmittedOn
+            ?? task.AssignedOn;
     }
 
     private void BuildKanbanCollections(IReadOnlyList<ActionTaskItem> tasks)

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -57,6 +57,39 @@ public class ActionTaskService : IActionTaskService
             .ToListAsync(cancellationToken);
     }
 
+
+    public async Task<Dictionary<int, DateTime?>> GetLastActivityUtcByTaskIdsAsync(IReadOnlyCollection<int> taskIds, CancellationToken cancellationToken = default)
+    {
+        if (taskIds.Count == 0)
+        {
+            return new Dictionary<int, DateTime?>();
+        }
+
+        var updateActivity = await _context.ActionTaskUpdates
+            .AsNoTracking()
+            .Where(x => taskIds.Contains(x.TaskId))
+            .GroupBy(x => x.TaskId)
+            .Select(g => new { TaskId = g.Key, LastUpdateUtc = g.Max(x => x.CreatedOn) })
+            .ToDictionaryAsync(x => x.TaskId, x => (DateTime?)x.LastUpdateUtc, cancellationToken);
+
+        var auditActivity = await _context.ActionTaskAuditLogs
+            .AsNoTracking()
+            .Where(x => taskIds.Contains(x.TaskId))
+            .GroupBy(x => x.TaskId)
+            .Select(g => new { TaskId = g.Key, LastAuditUtc = g.Max(x => x.PerformedAt) })
+            .ToDictionaryAsync(x => x.TaskId, x => (DateTime?)x.LastAuditUtc, cancellationToken);
+
+        var result = new Dictionary<int, DateTime?>(taskIds.Count);
+        foreach (var taskId in taskIds)
+        {
+            updateActivity.TryGetValue(taskId, out var lastUpdateUtc);
+            auditActivity.TryGetValue(taskId, out var lastAuditUtc);
+            result[taskId] = lastUpdateUtc ?? lastAuditUtc;
+        }
+
+        return result;
+    }
+
     // SECTION: Task mutation APIs
     public async Task<ActionTaskItem> CreateTaskAsync(ActionTaskItem task, CancellationToken cancellationToken = default)
     {

--- a/Services/ActionTasks/IActionTaskService.cs
+++ b/Services/ActionTasks/IActionTaskService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,4 +15,5 @@ public interface IActionTaskService
     Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default);
     Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
+    Task<Dictionary<int, DateTime?>> GetLastActivityUtcByTaskIdsAsync(IReadOnlyCollection<int> taskIds, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
### Motivation
- Ensure the dashboard "Recently Updated" collection reflects the true last activity for a task by considering collaboration updates and audit logs (not just `SubmittedOn`/`AssignedOn`).
- Provide a null-safe, deterministic ordering with a stable tie-breaker to avoid nondeterministic list ordering.
- Perform the projection server-side and add clear section comments to make the logic easy to find and maintain.

### Description
- Added `Task<Dictionary<int, DateTime?>> GetLastActivityUtcByTaskIdsAsync(IReadOnlyCollection<int> taskIds, ...)` to `IActionTaskService` and implemented it in `ActionTaskService` to compute per-task activity as max `ActionTaskUpdates.CreatedOn` else max `ActionTaskAuditLogs.PerformedAt`.
- Wired the page model load flow in `Pages/ActionTasks/Index.cshtml.cs` to call the new service method under the `// SECTION: Activity Timestamp Derivation` comment and pass the resulting `activityByTaskId` into `BuildDashboardCollections`.
- Updated `BuildDashboardCollections` to accept `activityByTaskId`, added `// SECTION: Dashboard Recently Updated Projection`, and changed `RecentlyUpdatedTasks` to order by `ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue` with a deterministic secondary ordering `.ThenByDescending(t => t.Id)`.
- Added a helper `ResolveLastActivityUtc` that returns service-derived activity timestamp, else `SubmittedOn`, else `AssignedOn`; no client-side/inline JS was introduced and the projection remains server-side only.

### Testing
- Attempted to run a compile with `dotnet build -nologo`, but the environment reporting prevented compilation because the `dotnet` CLI is not installed (`dotnet: command not found`).
- No other automated tests were executed in this environment due to the missing runtime toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa26dddc788329b504da5616f0ff4f)