### PR TITLE
Add intent-specific authorization checks for action task collaboration

### DIFF
--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -51,7 +51,15 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         files ??= Array.Empty<IFormFile>();
 
         var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
-        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        var hasBody = !string.IsNullOrWhiteSpace(body);
+        var hasFiles = files is { Count: > 0 } && files.Any(x => x.Length > 0);
+
+        if (!_permission.CanAddTaskUpdate(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to add updates for this task.");
+        }
+
+        if (hasFiles && !_permission.CanUploadTaskAttachment(role, userId, task.AssignedToUserId))
         {
             throw new InvalidOperationException("You are not authorized to add updates for this task.");
         }
@@ -61,8 +69,6 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             throw new InvalidOperationException("Invalid update type.");
         }
 
-        var hasBody = !string.IsNullOrWhiteSpace(body);
-        var hasFiles = files is { Count: > 0 } && files.Any(x => x.Length > 0);
         if (!hasBody && !hasFiles)
         {
             throw new InvalidOperationException("Update text is required unless at least one attachment is uploaded.");
@@ -122,7 +128,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
     public async Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
     {
         var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
-        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        if (!_permission.CanViewTaskThread(role, userId, task.AssignedToUserId))
         {
             throw new InvalidOperationException("You are not authorized to view updates for this task.");
         }
@@ -138,7 +144,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
     public async Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
     {
         var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
-        if (!_permission.CanViewLogs(role, userId, task.AssignedToUserId))
+        if (!_permission.CanViewTaskThread(role, userId, task.AssignedToUserId))
         {
             throw new InvalidOperationException("You are not authorized to view attachments for this task.");
         }

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -37,6 +37,18 @@ public class ActionTaskPermissionService
     public bool CanViewLogs(string role, string currentUserId, string ownerUserId)
         => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
 
+    // SECTION: Thread Read Authorization
+    public bool CanViewTaskThread(string role, string currentUserId, string ownerUserId)
+        => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
+
+    // SECTION: Update Write Authorization
+    public bool CanAddTaskUpdate(string role, string currentUserId, string ownerUserId)
+        => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
+
+    // SECTION: Attachment Write Authorization
+    public bool CanUploadTaskAttachment(string role, string currentUserId, string ownerUserId)
+        => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
+
     public bool CanUpdateTask(string role, string currentUserId, string ownerUserId)
         => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
 


### PR DESCRIPTION
### Motivation
- Make authorization intent-specific for task collaboration actions so checks clearly express read vs write vs attachment privileges.  
- Replace the generic `CanViewLogs` gate with purpose-built checks while preserving the existing owner-or-admin access semantics.  

### Description
- Added three new permission methods to `Services/ActionTasks/ActionTaskPermissionService.cs`: `CanViewTaskThread`, `CanAddTaskUpdate`, and `CanUploadTaskAttachment`, with section comments `Thread Read Authorization`, `Update Write Authorization`, and `Attachment Write Authorization`.  
- Updated `Services/ActionTasks/ActionTaskCollaborationService.cs` to use `CanAddTaskUpdate` (and `CanUploadTaskAttachment` when attachments are present) in `AddUpdateAsync`, and to use `CanViewTaskThread` in `GetUpdatesAsync` and `GetAttachmentMetadataByUpdateAsync`.  
- Preserved prior authorization logic by implementing the new methods to mirror the existing owner-or-privileged-role behavior and retained the original, safe unauthorized exception messages.  
- Affected files: `ActionTaskPermissionService.cs` and `ActionTaskCollaborationService.cs`.  

### Testing
- Attempted to run `dotnet build` in the execution environment, but it failed with `dotnet: command not found` so no compile/test run completed.  
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2809b5f8832981347f8ff95cd014)