### PR TITLE
Add ActionTasks unit tests for service, collaboration, permission, and page behaviors

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Application.Security;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+using ProjectManagement.Services.Storage;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskCollaborationServiceTests
+{
+    [Fact]
+    public async Task AttachmentValidation_RejectsTypeCountAndSize()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, "owner");
+
+        var badType = BuildFile("bad.exe", "application/octet-stream", 128);
+        var overSize = BuildFile("big.txt", "text/plain", 26L * 1024 * 1024);
+        var manyFiles = Enumerable.Range(1, 11).Select(i => BuildFile($"f{i}.txt", "text/plain", 10)).ToArray();
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Comment, "owner", RoleNames.Ta, [badType]));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Comment, "owner", RoleNames.Ta, [overSize]));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Comment, "owner", RoleNames.Ta, manyFiles));
+    }
+
+    [Fact]
+    public async Task InaccessibleReadAndWrite_AreDenied()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, "owner");
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.GetUpdatesAsync(task.Id, "other", RoleNames.Ta));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Progress, "other", RoleNames.Ta, Array.Empty<IFormFile>()));
+    }
+
+    private static ActionTaskCollaborationService CreateService(ApplicationDbContext db)
+        => new(db, new ActionTaskPermissionService(), new TestUploadRootProvider(), new PassFileSecurityValidator(), new StubUrlBuilder());
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db, string assignee)
+    {
+        var task = new ActionTaskItem
+        {
+            Title = "Task",
+            Description = "Desc",
+            CreatedByUserId = "creator",
+            AssignedToUserId = assignee,
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = DateTime.UtcNow.AddDays(1),
+            Priority = "Normal",
+            AssignedOn = DateTime.UtcNow,
+            Status = ActionTaskStatuses.Assigned
+        };
+        db.ActionTasks.Add(task);
+        await db.SaveChangesAsync();
+        return task;
+    }
+
+    private static IFormFile BuildFile(string name, string contentType, long bytes)
+    {
+        var stream = new MemoryStream(new byte[bytes]);
+        return new FormFile(stream, 0, bytes, "files", name) { Headers = new HeaderDictionary(), ContentType = contentType };
+    }
+
+    private sealed class TestUploadRootProvider : IUploadRootProvider
+    {
+        public string RootPath => Path.GetTempPath();
+        public string GetProjectRoot(int projectId) => RootPath;
+        public string GetProjectPhotosRoot(int projectId) => RootPath;
+        public string GetProjectDocumentsRoot(int projectId) => RootPath;
+        public string GetProjectCommentsRoot(int projectId) => RootPath;
+        public string GetProjectVideosRoot(int projectId) => RootPath;
+        public string GetSocialMediaRoot(string storagePrefix, Guid eventId) => RootPath;
+    }
+
+    private sealed class PassFileSecurityValidator : IFileSecurityValidator
+    {
+        public void ValidateRelativePath(string relativePath) { }
+        public Task<bool> IsSafeAsync(string filePath, string contentType, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    }
+
+    private sealed class StubUrlBuilder : IProtectedFileUrlBuilder
+    {
+        public string CreateDownloadUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null) => storageKey;
+        public string CreateInlineUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null) => storageKey;
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1,0 +1,126 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Pages.ActionTasks;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskPageTests
+{
+    [Fact]
+    public async Task OnGet_InvalidTaskId_DoesNotThrowAndClearsSelection()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyTasks";
+        page.TaskId = 9999;
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.Null(page.TaskId);
+        Assert.Null(page.SelectedTask);
+    }
+
+    [Fact]
+    public async Task MyTasksView_StaysActiveWhenSortingTaskList()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyTasks";
+        page.SortBy = "title";
+        page.SortDir = "desc";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.True(page.IsMyTasksView);
+        Assert.Equal("MyTasks", page.ResolvedViewMode);
+    }
+
+    [Fact]
+    public async Task CreateValidationFailure_ReopensPanel()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.Input = new IndexModel.CreateTaskInput();
+        page.ModelState.AddModelError("Input.Title", "required");
+
+        // SECTION: Act
+        var result = await page.OnPostCreateAsync();
+
+        // SECTION: Assert
+        Assert.IsType<PageResult>(result);
+        Assert.True(page.ShowCreateModal);
+    }
+
+    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        var db = new ApplicationDbContext(options);
+
+        var user = new ApplicationUser
+        {
+            Id = "user-1", UserName = "user1@test", NormalizedUserName = "USER1@TEST", Email = "user1@test", NormalizedEmail = "USER1@TEST", SecurityStamp = Guid.NewGuid().ToString(), FullName = "User One"
+        };
+        db.Users.Add(user);
+        db.ActionTasks.Add(new ActionTaskItem
+        {
+            Title = "Mine", Description = "d", CreatedByUserId = "creator", AssignedToUserId = "user-1", CreatedByRole = RoleNames.HoD, AssignedToRole = RoleNames.Ta, DueDate = DateTime.UtcNow.AddDays(1), Priority = "Normal", AssignedOn = DateTime.UtcNow, Status = ActionTaskStatuses.Assigned
+        });
+        await db.SaveChangesAsync();
+
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var userManager = new UserManager<ApplicationUser>(new UserStore<ApplicationUser>(db), Options.Create(new IdentityOptions()), new PasswordHasher<ApplicationUser>(), Array.Empty<IUserValidator<ApplicationUser>>(), Array.Empty<IPasswordValidator<ApplicationUser>>(), new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), sp, NullLogger<UserManager<ApplicationUser>>.Instance);
+
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var collab = new StubCollabService();
+        var page = new IndexModel(service, collab, new ActionTaskPermissionService(), userManager);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "user-1"),
+                new Claim(ClaimTypes.Role, RoleNames.Ta)
+            }, "TestAuth"))
+        };
+
+        page.PageContext = new PageContext(new ActionContext(httpContext, new RouteData(), new ActionDescriptor()));
+        page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
+        return (page, db);
+    }
+
+    private sealed class StubCollabService : IActionTaskCollaborationService
+    {
+        public Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default) => Task.FromResult((IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>)new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>());
+        public Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default) => Task.FromResult(new List<ActionTaskUpdate>());
+    }
+
+    private sealed class DictionaryTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => new Dictionary<string, object?>();
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values) { }
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
@@ -1,0 +1,29 @@
+using ProjectManagement.Configuration;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskPermissionServiceTests
+{
+    [Fact]
+    public void RoleVisibilityAndWritePermissions_AreEnforced()
+    {
+        // SECTION: Arrange
+        var service = new ActionTaskPermissionService();
+
+        // SECTION: Act
+        var comdtCanViewAll = service.CanViewAll(RoleNames.Comdt);
+        var hodCanViewAll = service.CanViewAll(RoleNames.HoD);
+        var taCannotViewAll = service.CanViewAll(RoleNames.Ta);
+
+        var ownerCanWrite = service.CanAddTaskUpdate(RoleNames.Ta, "owner", "owner");
+        var nonOwnerCannotWrite = service.CanAddTaskUpdate(RoleNames.Ta, "other", "owner");
+
+        // SECTION: Assert
+        Assert.True(comdtCanViewAll);
+        Assert.True(hodCanViewAll);
+        Assert.False(taCannotViewAll);
+        Assert.True(ownerCanWrite);
+        Assert.False(nonOwnerCannotWrite);
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskServiceTests
+{
+    [Fact]
+    public async Task CreateAndNoOpUpdateAndInvalidTransition_AreHandled()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await service.CreateTaskAsync(new ActionTaskItem
+        {
+            Title = "Task A",
+            Description = "Desc",
+            AssignedToUserId = "assignee",
+            CreatedByUserId = "creator",
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = DateTime.UtcNow.AddDays(1),
+            Priority = "High"
+        });
+
+        // SECTION: Act + Assert
+        Assert.Equal(ActionTaskStatuses.Assigned, task.Status);
+
+        await service.UpdateStatusAsync(task.Id, task.RowVersion, ActionTaskStatuses.Assigned, "assignee", RoleNames.Ta);
+        var logsAfterNoOp = await db.ActionTaskAuditLogs.CountAsync(x => x.TaskId == task.Id);
+        Assert.Equal(1, logsAfterNoOp);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateStatusAsync(task.Id, task.RowVersion, ActionTaskStatuses.Closed, "assignee", RoleNames.Ta));
+        Assert.Contains("Use the close action", ex.Message);
+    }
+
+    [Fact]
+    public async Task RemarksAndLifecycleRules_AreEnforced()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateStatusAsync(task.Id, task.RowVersion, ActionTaskStatuses.Blocked, "assignee", RoleNames.Ta, null));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SubmitTaskAsync(task.Id, task.RowVersion, "other-user", RoleNames.Ta, "submit"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskAsync(task.Id, task.RowVersion, "cmd", RoleNames.Comdt, "close"));
+
+        await service.SubmitTaskAsync(task.Id, task.RowVersion, "assignee", RoleNames.Ta, "ready");
+        var submitted = await service.GetTaskAsync(task.Id);
+        Assert.Equal(ActionTaskStatuses.Submitted, submitted!.Status);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskAsync(task.Id, submitted.RowVersion, "non-cmd", RoleNames.Ta, "close"));
+    }
+
+    [Fact]
+    public async Task LogsReadAndUpdateWrite_AccessDeniedForIneligibleUser()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "owner");
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.GetTaskLogsAsync(task.Id, "other", RoleNames.Ta));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateStatusAsync(task.Id, task.RowVersion, ActionTaskStatuses.InProgress, "other", RoleNames.Ta));
+    }
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db, string status, string assignee)
+    {
+        var task = new ActionTaskItem
+        {
+            Title = "Task",
+            Description = "Task",
+            CreatedByUserId = "creator",
+            AssignedToUserId = assignee,
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = DateTime.UtcNow.AddDays(1),
+            Priority = "Normal",
+            AssignedOn = DateTime.UtcNow,
+            Status = status,
+            RowVersion = [1, 2, 3]
+        };
+
+        db.ActionTasks.Add(task);
+        await db.SaveChangesAsync();
+        return task;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide targeted unit tests for the Action Tasks subsystem to cover lifecycle, authorization, attachment handling and page UI behaviors. 
- Ensure tests are deterministic and offline-safe so they can run in CI in isolated environments using in-memory EF Core and local fakes. 
- Make page tests assert UI state (e.g. `ShowCreateModal`) and view-mode stability to protect UX regressions.

### Description
- Added a new test folder `ProjectManagement.Tests/ActionTasks/` with four files: `ActionTaskServiceTests.cs`, `ActionTaskCollaborationServiceTests.cs`, `ActionTaskPermissionServiceTests.cs`, and `ActionTaskPageTests.cs`.
- `ActionTaskServiceTests.cs` covers task creation baseline, no-op update behavior, invalid transition rejection, remarks/lifecycle rules, submit/close role constraints, and read/update authorization denial checks.
- `ActionTaskCollaborationServiceTests.cs` covers attachment validation (type/count/size) and verifies read/write denial for unauthorized users while using local stubs for `IUploadRootProvider`, `IFileSecurityValidator`, and `IProtectedFileUrlBuilder`.
- `ActionTaskPermissionServiceTests.cs` verifies role visibility and owner vs non-owner write behavior, and `ActionTaskPageTests.cs` exercises page-model behavior including invalid `taskId` handling, My Tasks view sorting stability, and create validation reopening the create panel; all tests follow clear `// SECTION: Arrange/Act/Assert` markers.

### Testing
- Attempted to run the tests with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTasks"`, but the `dotnet` CLI is not available in this environment so automated test execution could not be performed here. 
- All tests are written to be offline-safe and use `UseInMemoryDatabase` and local stubs/fakes so they can be executed reliably in CI or a local developer machine with `dotnet` available. 
- The test code is structured to run under `dotnet test` and exercises the requested scenarios; please run `dotnet test` in CI or locally to execute them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa29a7d3f08329ae1486cb8ff8c196)