### PR TITLE
Refactor Action Tasks read models into Query and Workflow services

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -20,13 +20,17 @@ public class IndexModel : PageModel
     private readonly IActionTaskService _service;
     private readonly IActionTaskCollaborationService _collaborationService;
     private readonly ActionTaskPermissionService _permission;
+    private readonly ActionTaskQueryService _queryService;
+    private readonly ActionTaskWorkflowPolicy _workflowPolicy;
     private readonly UserManager<ApplicationUser> _users;
 
-    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, UserManager<ApplicationUser> users)
+    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionTaskQueryService queryService, ActionTaskWorkflowPolicy workflowPolicy, UserManager<ApplicationUser> users)
     {
         _service = service;
         _collaborationService = collaborationService;
         _permission = permission;
+        _queryService = queryService;
+        _workflowPolicy = workflowPolicy;
         _users = users;
     }
 
@@ -121,13 +125,7 @@ public class IndexModel : PageModel
     };
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
-    public IReadOnlyList<string> AllowedStatusOptions => new[]
-    {
-        ActionTaskStatuses.Assigned,
-        ActionTaskStatuses.InProgress,
-        ActionTaskStatuses.Blocked,
-        ActionTaskStatuses.Submitted
-    };
+    public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
 
     // SECTION: Selected-task projection helper
     public bool IsSelectedTask(ActionTaskItem task)
@@ -138,61 +136,27 @@ public class IndexModel : PageModel
     // SECTION: Per-task action visibility helpers
     public bool CanSubmitTask(ActionTaskItem task)
     {
-        return !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(task.AssignedToUserId, CurrentUserId, StringComparison.Ordinal);
+        return _workflowPolicy.CanSubmitTask(task, CurrentUserId);
     }
 
     public bool CanCloseTask(ActionTaskItem task)
     {
-        return CanClose
-            && string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+        return _workflowPolicy.CanCloseTask(task, CurrentRole);
     }
 
     public bool CanUpdateTaskStatus(ActionTaskItem task)
     {
-        return !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-            && (_permission.CanViewAll(CurrentRole) || string.Equals(task.AssignedToUserId, CurrentUserId, StringComparison.Ordinal));
+        return _workflowPolicy.CanUpdateTaskStatus(task, CurrentRole, CurrentUserId);
     }
 
     public string GetStatusBadgeClass(string status)
     {
-        if (string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-status-progress";
-        }
-
-        if (string.Equals(status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-status-blocked";
-        }
-
-        if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-status-submitted";
-        }
-
-        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-status-closed";
-        }
-
-        return "at-badge at-badge-status-assigned";
+        return _workflowPolicy.GetStatusBadgeClass(status);
     }
 
     public string GetPriorityBadgeClass(string priority)
     {
-        if (string.Equals(priority, "Critical", StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-priority-critical";
-        }
-
-        if (string.Equals(priority, "High", StringComparison.OrdinalIgnoreCase))
-        {
-            return "at-badge at-badge-priority-high";
-        }
-
-        return "at-badge at-badge-priority-normal";
+        return _workflowPolicy.GetPriorityBadgeClass(priority);
     }
 
     public string ResolveAssigneeName(string assignedToUserId)
@@ -354,9 +318,10 @@ public class IndexModel : PageModel
             }
 
             // SECTION: Keep no-op handling for user-friendly messaging after permission validation.
-            if (string.Equals(task.Status, status, StringComparison.OrdinalIgnoreCase))
+            var noOpMessage = _workflowPolicy.ValidateStatusUpdate(task, status);
+            if (!string.IsNullOrWhiteSpace(noOpMessage))
             {
-                TempData["ToastMessage"] = "No status change applied because the selected status is already current.";
+                TempData["ToastMessage"] = noOpMessage;
                 return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
             }
 
@@ -417,30 +382,39 @@ public class IndexModel : PageModel
 
         var tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
 
-        // SECTION: Apply view-specific filtering
-        if (IsMyTasksView)
-        {
-            tasks = tasks
-                .Where(t => string.Equals(t.AssignedToUserId, CurrentUserId, StringComparison.Ordinal))
-                .ToList();
-        }
-
+        // SECTION: Query read-model dependencies
         AssignableUsers = await LoadAssignableUsersAsync();
         TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(tasks);
 
-        // SECTION: Activity Timestamp Derivation
+        // SECTION: Query read-model orchestration boundary
         var activityByTaskId = await _service.GetLastActivityUtcByTaskIdsAsync(tasks.Select(t => t.Id).ToArray());
+        var readModel = _queryService.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest(CurrentUserId, IsMyTasksView, IsTaskListView, FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir),
+            TaskAssigneeNames,
+            activityByTaskId);
 
-        // SECTION: Populate overview and grouping collections
-        BuildDashboardCollections(tasks, activityByTaskId);
-        BuildKanbanCollections(tasks);
-        BuildSprintCollections(tasks);
-        BuildReportCollections(tasks);
-
-        // SECTION: Apply task-list filters only in task list mode
-        Tasks = IsTaskListView
-            ? ApplyTaskListFilters(tasks)
-            : tasks;
+        // SECTION: Read-model projections assignment boundary
+        Tasks = readModel.TaskListTasks;
+        CriticalOpenTasks = readModel.CriticalOpenTasks;
+        OverdueTasks = readModel.OverdueTasks;
+        RecentlySubmittedTasks = readModel.RecentlySubmittedTasks;
+        RecentlyUpdatedTasks = readModel.RecentlyUpdatedTasks;
+        KanbanAssignedTasks = readModel.KanbanAssignedTasks;
+        KanbanInProgressTasks = readModel.KanbanInProgressTasks;
+        KanbanBlockedTasks = readModel.KanbanBlockedTasks;
+        KanbanSubmittedTasks = readModel.KanbanSubmittedTasks;
+        KanbanClosedTasks = readModel.KanbanClosedTasks;
+        SprintOverdueTasks = readModel.DueBuckets.Overdue;
+        DueTodayTasks = readModel.DueBuckets.Today;
+        DueThisWeekTasks = readModel.DueBuckets.ThisWeek;
+        DueLaterTasks = readModel.DueBuckets.Later;
+        AssigneePendingCounts = readModel.Reports.AssigneePendingCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        PriorityCounts = readModel.Reports.PriorityCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        StatusCounts = readModel.Reports.StatusCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        OpenAgeingBuckets = readModel.Reports.OpenAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        OverdueAgeingBuckets = readModel.Reports.OverdueAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        SubmittedPendingClosureAgeingBuckets = readModel.Reports.SubmittedPendingClosureAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
 
         // SECTION: Selected Task Resolution
         if (!TaskId.HasValue)
@@ -448,8 +422,8 @@ public class IndexModel : PageModel
             return;
         }
 
-        var visibleTaskScope = Tasks;
-        SelectedTask = visibleTaskScope.FirstOrDefault(t => t.Id == TaskId.Value);
+        // SECTION: Selected detail read-model boundary
+        SelectedTask = _queryService.SelectTask(Tasks, TaskId);
         if (SelectedTask is null)
         {
             TaskId = null;

--- a/Program.cs
+++ b/Program.cs
@@ -384,6 +384,8 @@ builder.Services.AddHostedService<UserPurgeWorker>();
 builder.Services.AddSingleton<IClock, SystemClock>();
 builder.Services.AddScoped<ITodoService, TodoService>();
 builder.Services.AddScoped<ActionTaskPermissionService>();
+builder.Services.AddScoped<ActionTaskQueryService>();
+builder.Services.AddScoped<ActionTaskWorkflowPolicy>();
 builder.Services.AddScoped<IActionTaskService, ActionTaskService>();
 builder.Services.AddScoped<IActionTaskCollaborationService, ActionTaskCollaborationService>();
 builder.Services.Configure<TodoOptions>(

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskQueryService
+{
+    // SECTION: Compose all read-model slices used by Action Tasks pages.
+    public ActionTaskReadModel BuildReadModel(
+        IReadOnlyList<ActionTaskItem> sourceTasks,
+        ActionTaskQueryRequest request,
+        IReadOnlyDictionary<string, string> assigneeNames,
+        IReadOnlyDictionary<int, DateTime?> activityByTaskId)
+    {
+        var tasks = request.IsMyTasksView
+            ? sourceTasks.Where(t => string.Equals(t.AssignedToUserId, request.CurrentUserId, StringComparison.Ordinal)).ToList()
+            : sourceTasks.ToList();
+
+        var taskList = request.IsTaskListView ? ApplyTaskListFilters(tasks, request, assigneeNames).ToList() : tasks;
+
+        return new ActionTaskReadModel
+        {
+            ScopeTasks = tasks,
+            TaskListTasks = taskList,
+            CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
+            OverdueTasks = tasks.Where(t => IsOpen(t) && t.DueDate.Date < DateTime.UtcNow.Date).OrderBy(t => t.DueDate).Take(5).ToList(),
+            RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
+            RecentlyUpdatedTasks = tasks.OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue).ThenByDescending(t => t.Id).Take(5).ToList(),
+            KanbanAssignedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)).ToList(),
+            KanbanInProgressTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)).ToList(),
+            KanbanBlockedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList(),
+            KanbanSubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList(),
+            KanbanClosedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).ToList(),
+            DueBuckets = BuildDueBuckets(tasks),
+            Reports = BuildReportModel(tasks, assigneeNames)
+        };
+    }
+
+    public ActionTaskItem? SelectTask(IReadOnlyList<ActionTaskItem> visibleTasks, int? taskId)
+        => !taskId.HasValue ? null : visibleTasks.FirstOrDefault(t => t.Id == taskId.Value);
+
+    private static bool IsOpen(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    private static bool IsCriticalOpen(ActionTaskItem task) => IsOpen(task) && string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
+
+    private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
+    {
+        activityByTaskId.TryGetValue(task.Id, out var activityTimestampUtc);
+        return activityTimestampUtc ?? task.SubmittedOn ?? task.AssignedOn;
+    }
+
+    private static ActionTaskDueBuckets BuildDueBuckets(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var today = DateTime.UtcNow.Date;
+        var endOfWeek = today.AddDays(7);
+        return new ActionTaskDueBuckets
+        {
+            Overdue = tasks.Where(t => IsOpen(t) && t.DueDate.Date < today).OrderBy(t => t.DueDate).ToList(),
+            Today = tasks.Where(t => IsOpen(t) && t.DueDate.Date == today).OrderBy(t => t.DueDate).ToList(),
+            ThisWeek = tasks.Where(t => IsOpen(t) && t.DueDate.Date > today && t.DueDate.Date <= endOfWeek).OrderBy(t => t.DueDate).ToList(),
+            Later = tasks.Where(t => IsOpen(t) && t.DueDate.Date > endOfWeek).OrderBy(t => t.DueDate).ToList()
+        };
+    }
+
+    private static ActionTaskReportReadModel BuildReportModel(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var utcToday = DateTime.UtcNow.Date;
+        var openTasks = tasks.Where(IsOpen).ToList();
+        var submittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
+        string Assignee(string id) => assigneeNames.TryGetValue(id, out var name) ? name : "User";
+
+        return new ActionTaskReportReadModel
+        {
+            AssigneePendingCounts = openTasks.GroupBy(t => Assignee(t.AssignedToUserId)).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
+            PriorityCounts = tasks.GroupBy(t => t.Priority).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
+            StatusCounts = tasks.GroupBy(t => t.Status).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
+            OpenAgeingBuckets = new[] { new CountSummary("0 to 3 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)), new CountSummary("4 to 7 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)), new CountSummary("8 to 14 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)), new CountSummary("15+ days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15)) },
+            OverdueAgeingBuckets = new[] { new CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)), new CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)), new CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8)) },
+            SubmittedPendingClosureAgeingBuckets = new[] { new CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)), new CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)), new CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4)) }
+        };
+    }
+
+    private static IEnumerable<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var query = tasks.AsEnumerable();
+        if (!string.IsNullOrWhiteSpace(request.FilterStatus)) query = query.Where(t => string.Equals(t.Status, request.FilterStatus, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(request.FilterPriority)) query = query.Where(t => string.Equals(t.Priority, request.FilterPriority, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(request.FilterAssigneeUserId)) query = query.Where(t => string.Equals(t.AssignedToUserId, request.FilterAssigneeUserId, StringComparison.Ordinal));
+        if (request.FilterDueDate.HasValue) { var d = request.FilterDueDate.Value.Date; query = query.Where(t => t.DueDate.Date == d); }
+        if (!string.IsNullOrWhiteSpace(request.FilterSearch)) { var s = request.FilterSearch.Trim(); query = query.Where(t => t.Title.Contains(s, StringComparison.OrdinalIgnoreCase)); }
+
+        var sortBy = (request.SortBy ?? "due").Trim().ToLowerInvariant();
+        var descending = string.Equals(request.SortDir, "desc", StringComparison.OrdinalIgnoreCase);
+        Func<ActionTaskItem, string> assignee = t => assigneeNames.TryGetValue(t.AssignedToUserId, out var n) ? n : "User";
+        Func<ActionTaskItem, int> statusOrder = task => task.Status switch { ActionTaskStatuses.Assigned => 1, ActionTaskStatuses.InProgress => 2, ActionTaskStatuses.Blocked => 3, ActionTaskStatuses.Submitted => 4, ActionTaskStatuses.Closed => 5, _ => 99 };
+        Func<ActionTaskItem, int> priorityOrder = task => task.Priority switch { "Critical" => 1, "High" => 2, "Normal" => 3, "Low" => 4, _ => 99 };
+        var ordered = sortBy switch
+        {
+            "title" => descending ? query.OrderByDescending(t => t.Title) : query.OrderBy(t => t.Title),
+            "assignee" => descending ? query.OrderByDescending(assignee) : query.OrderBy(assignee),
+            "status" => descending ? query.OrderByDescending(statusOrder).ThenBy(t => t.DueDate) : query.OrderBy(statusOrder).ThenBy(t => t.DueDate),
+            "priority" => descending ? query.OrderByDescending(priorityOrder).ThenBy(t => t.DueDate) : query.OrderBy(priorityOrder).ThenBy(t => t.DueDate),
+            "id" => descending ? query.OrderByDescending(t => t.Id) : query.OrderBy(t => t.Id),
+            _ => descending ? query.OrderByDescending(t => t.DueDate) : query.OrderBy(t => t.DueDate)
+        };
+        return ordered.ThenBy(t => t.Id);
+    }
+
+    public sealed record ActionTaskQueryRequest(
+        string CurrentUserId,
+        bool IsMyTasksView,
+        bool IsTaskListView,
+        string? FilterStatus,
+        string? FilterPriority,
+        string? FilterAssigneeUserId,
+        DateTime? FilterDueDate,
+        string? FilterSearch,
+        string? SortBy,
+        string? SortDir);
+
+    public sealed class ActionTaskReadModel
+    {
+        public IReadOnlyList<ActionTaskItem> ScopeTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> TaskListTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> OverdueTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> RecentlySubmittedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> RecentlyUpdatedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> KanbanAssignedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> KanbanInProgressTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> KanbanBlockedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> KanbanSubmittedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> KanbanClosedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public ActionTaskDueBuckets DueBuckets { get; init; } = new();
+        public ActionTaskReportReadModel Reports { get; init; } = new();
+    }
+
+    public sealed class ActionTaskDueBuckets { public IReadOnlyList<ActionTaskItem> Overdue { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> Today { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> ThisWeek { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> Later { get; init; } = Array.Empty<ActionTaskItem>(); }
+    public sealed class ActionTaskReportReadModel { public IReadOnlyList<CountSummary> AssigneePendingCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> PriorityCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> StatusCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); }
+    public sealed record CountSummary(string Name, int Count);
+}

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskWorkflowPolicy
+{
+    private readonly ActionTaskPermissionService _permission;
+
+    public ActionTaskWorkflowPolicy(ActionTaskPermissionService permission)
+    {
+        _permission = permission;
+    }
+
+    // SECTION: Supported transition targets for in-flight status updates.
+    public IReadOnlyList<string> AllowedStatusOptions => new[]
+    {
+        ActionTaskStatuses.Assigned,
+        ActionTaskStatuses.InProgress,
+        ActionTaskStatuses.Blocked,
+        ActionTaskStatuses.Submitted
+    };
+
+    // SECTION: Action availability guards.
+    public bool CanSubmitTask(ActionTaskItem task, string currentUserId)
+    {
+        return !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(task.AssignedToUserId, currentUserId, StringComparison.Ordinal);
+    }
+
+    public bool CanCloseTask(ActionTaskItem task, string currentRole)
+    {
+        return _permission.CanClose(currentRole)
+            && string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool CanUpdateTaskStatus(ActionTaskItem task, string currentRole, string currentUserId)
+    {
+        return !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            && (_permission.CanViewAll(currentRole) || string.Equals(task.AssignedToUserId, currentUserId, StringComparison.Ordinal));
+    }
+
+    // SECTION: Transition and remarks validation for command handlers.
+    public string? ValidateStatusUpdate(ActionTaskItem task, string targetStatus)
+    {
+        if (string.Equals(task.Status, targetStatus, StringComparison.OrdinalIgnoreCase))
+        {
+            return "No status change applied because the selected status is already current.";
+        }
+
+        return null;
+    }
+
+    public string? ValidateOptionalRemarks(string? remarks)
+    {
+        if (remarks is null)
+        {
+            return null;
+        }
+
+        return remarks.Length > 4000 ? "Remarks cannot exceed 4000 characters." : null;
+    }
+
+    // SECTION: UI style mapping helpers.
+    public string GetStatusBadgeClass(string status)
+    {
+        if (string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-progress";
+        if (string.Equals(status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-blocked";
+        if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-submitted";
+        if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-status-closed";
+        return "at-badge at-badge-status-assigned";
+    }
+
+    public string GetPriorityBadgeClass(string priority)
+    {
+        if (string.Equals(priority, "Critical", StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-priority-critical";
+        if (string.Equals(priority, "High", StringComparison.OrdinalIgnoreCase)) return "at-badge at-badge-priority-high";
+        return "at-badge at-badge-priority-normal";
+    }
+}


### PR DESCRIPTION
### Motivation
- Separate read-model shaping and workflow/business-rule logic out of the `Index` page model to improve maintainability and testability while preserving existing Razor contracts. 
- Centralize status/priority badge mapping, transition validation and action-availability checks to reduce duplication and make UI behavior decisions easier to evolve. 

### Description
- Added `Services/ActionTasks/ActionTaskQueryService.cs` which composes read-model slices for dashboard, register (filters/sorting), kanban lanes, due-window buckets, reports and selected-task lookup via `BuildReadModel` and `SelectTask` APIs. 
- Added `Services/ActionTasks/ActionTaskWorkflowPolicy.cs` which centralizes workflow guards, allowed status targets, no-op transition messaging, optional-remarks validation, and badge style mapping. 
- Registered the new services in DI by adding `ActionTaskQueryService` and `ActionTaskWorkflowPolicy` to `Program.cs`. 
- Refactored `Pages/ActionTasks/Index.cshtml.cs` to inject the new services, delegate non-handler shaping logic to `ActionTaskQueryService`, route workflow decisions through `ActionTaskWorkflowPolicy`, keep handler orchestration (identity, dispatch, UI result mapping) in the page model, preserve existing public properties/shape for Razor partials, and add section comments marking orchestration boundaries. 

### Testing
- Attempted an automated build with `dotnet build`, but the SDK is not available in this environment so the build could not be executed (`/bin/bash: line 1: dotnet: command not found`). 
- No automated unit or integration tests were run in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2adee8c08329b9a890e6846a99c3)