### PR TITLE
Fix ActionTask create audit relationship mapping

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1836,7 +1836,7 @@ namespace ProjectManagement.Data
                 e.Property(x => x.PerformedByRole).IsRequired().HasMaxLength(64);
                 e.Property(x => x.Remarks).HasMaxLength(2000);
                 // SECTION: Enforce task-to-audit-log referential integrity
-                e.HasOne<ActionTaskItem>()
+                e.HasOne(x => x.Task)
                     .WithMany()
                     .HasForeignKey(x => x.TaskId)
                     .OnDelete(DeleteBehavior.Cascade);


### PR DESCRIPTION
### Motivation
- Prevent TaskCreated audit rows from being inserted with a missing/invalid `TaskId` when a new `ActionTaskItem` and its audit entry are enqueued and saved together by ensuring EF can propagate the generated task key from the navigation.

### Description
- Updated the EF mapping for `ActionTaskAuditLog` in `Data/ApplicationDbContext.cs` to use the `Task` navigation (`e.HasOne(x => x.Task)`) so that a `Task` navigation attached to a newly-added `ActionTaskItem` will cause EF to populate the `TaskId` FK when both entities are saved in the same unit of work; no other behavior changes were made.

### Testing
- Repository consistency check (`git diff --check`) passed.  
- Attempted to run `dotnet build` in this environment but the `dotnet` CLI is not available, so compilation and test suite execution should be run in CI or a local environment to fully validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa96e9bbb48329b465556f91b2829a)