### PR TITLE
Fix ActionTask row-version migration backfill

### DIFF
--- a/Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs
+++ b/Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs
@@ -14,8 +14,24 @@ namespace ProjectManagement.Migrations
                 table: "ActionTasks",
                 type: "bytea",
                 rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.Sql(
+                @"UPDATE ""ActionTasks""
+                  SET ""RowVersion"" = decode(md5('ActionTasks.RowVersion:' || ""Id""::text || ':' || clock_timestamp()::text), 'hex')
+                  WHERE ""RowVersion"" IS NULL OR length(""RowVersion"") = 0;");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "RowVersion",
+                table: "ActionTasks",
+                type: "bytea",
+                rowVersion: true,
                 nullable: false,
-                defaultValue: new byte[0]);
+                defaultValueSql: "decode(md5(random()::text || clock_timestamp()::text), 'hex')",
+                oldClrType: typeof(byte[]),
+                oldType: "bytea",
+                oldRowVersion: true,
+                oldNullable: true);
         }
 
         // SECTION: Remove optimistic concurrency token from action tasks


### PR DESCRIPTION
### Motivation
- The migration previously set `ActionTasks.RowVersion` to an empty byte array which yields an empty Base64 token in the UI and causes `DecodeRowVersion` to treat migrated tasks as missing, breaking submit/close/status updates for pre-existing tasks.

### Description
- Updated `Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs` to add the `RowVersion` column as nullable first, backfill existing rows with non-empty `bytea` tokens using a PostgreSQL `UPDATE` statement, and then alter the column to be non-nullable with a `defaultValueSql` that generates non-empty `bytea` values for future inserts.
- Replaced the empty-array default with `decode(md5(random()::text || clock_timestamp()::text), 'hex')` and used a per-row MD5-based expression during the backfill to ensure migrated rows receive non-empty tokens.

### Testing
- Ran `git diff --check` which passed with no whitespace/patch errors.
- Attempted to run `dotnet test` but the `dotnet` CLI is not installed in this environment so tests could not be executed here.
- Verified the migration file was updated and contains the add-null -> backfill -> alter-to-required sequence described above by inspecting `Migrations/20260505130000_AddActionTaskRowVersionConcurrency.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa0712c0c8329b2c9eedca6571b1b)