### PR TITLE
Fix per-task last-activity timestamp to use later of update and audit

### DIFF
--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -84,10 +84,26 @@ public class ActionTaskService : IActionTaskService
         {
             updateActivity.TryGetValue(taskId, out var lastUpdateUtc);
             auditActivity.TryGetValue(taskId, out var lastAuditUtc);
-            result[taskId] = lastUpdateUtc ?? lastAuditUtc;
+
+            result[taskId] = MaxNullableUtc(lastUpdateUtc, lastAuditUtc);
         }
 
         return result;
+    }
+
+    private static DateTime? MaxNullableUtc(DateTime? firstUtc, DateTime? secondUtc)
+    {
+        if (!firstUtc.HasValue)
+        {
+            return secondUtc;
+        }
+
+        if (!secondUtc.HasValue)
+        {
+            return firstUtc;
+        }
+
+        return firstUtc.Value >= secondUtc.Value ? firstUtc : secondUtc;
     }
 
     // SECTION: Task mutation APIs


### PR DESCRIPTION
### Motivation
- Correct a high-priority bug where `GetLastActivityUtcByTaskIdsAsync` could return a stale timestamp by preferring update activity even when a newer audit event existed.

### Description
- Updated `GetLastActivityUtcByTaskIdsAsync` in `Services/ActionTasks/ActionTaskService.cs` to compute per-task activity as the later of update and audit timestamps instead of using `lastUpdateUtc ?? lastAuditUtc`.
- Added a null-safe helper `MaxNullableUtc(DateTime? firstUtc, DateTime? secondUtc)` that returns the non-null timestamp when one side is null and the maximum when both are present.
- The change preserves existing behavior when only one source exists and ensures correct ordering for dashboard "Recently Updated" when both sources are present.

### Testing
- Ran `git diff --check` to validate the diff; no whitespace or diff-check issues reported.
- Attempted `dotnet build -nologo` but the environment lacks the `dotnet` CLI so compilation could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa15a9ac483299ddba6d2999283d2)