### PR TITLE
Fix ActionTasks create validation test role

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -61,7 +61,7 @@ public class ActionTaskPageTests
     public async Task CreateValidationFailure_ReopensPanel()
     {
         // SECTION: Arrange
-        var setup = await CreateSetupAsync();
+        var setup = await CreateSetupAsync(RoleNames.HoD);
         var page = setup.Page;
         page.Input = new IndexModel.CreateTaskInput();
         page.ModelState.AddModelError("Input.Title", "required");
@@ -74,7 +74,7 @@ public class ActionTaskPageTests
         Assert.True(page.ShowCreateModal);
     }
 
-    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync()
+    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync(string role = RoleNames.Ta)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
         var db = new ApplicationDbContext(options);
@@ -102,7 +102,7 @@ public class ActionTaskPageTests
             User = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
                 new Claim(ClaimTypes.NameIdentifier, "user-1"),
-                new Claim(ClaimTypes.Role, RoleNames.Ta)
+                new Claim(ClaimTypes.Role, role)
             }, "TestAuth"))
         };
 


### PR DESCRIPTION
### Motivation
- The `CreateValidationFailure_ReopensPanel` page test could not reach model-state validation because the shared test setup authenticated as `RoleNames.Ta`, and `IndexModel.OnPostCreateAsync` short-circuits with `Forbid()` when the current role cannot create tasks; the test must run with an authorized role to assert modal reopening.

### Description
- Updated the test to call `CreateSetupAsync(RoleNames.HoD)` for `CreateValidationFailure_ReopensPanel`, and changed `CreateSetupAsync` to accept an optional `role` parameter (defaulting to `RoleNames.Ta`) and use it when building the `ClaimsPrincipal` so callers can override the authenticated role.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTasks"`, but the `dotnet` CLI is not available in this environment so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa39ae5408329aaef88bc24fd4487)