### PR TITLE
Add migration for ActionTask collaboration indexes

### DIFF
--- a/Migrations/20261125160000_AddActionTaskCollaborationIndexes.cs
+++ b/Migrations/20261125160000_AddActionTaskCollaborationIndexes.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125160000_AddActionTaskCollaborationIndexes")]
+    public partial class AddActionTaskCollaborationIndexes : Migration
+    {
+        // SECTION: Add indexes for action task update and attachment filters
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTaskUpdates_CreatedByUserId",
+                table: "ActionTaskUpdates",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTaskUpdates_IsDeleted",
+                table: "ActionTaskUpdates",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTaskAttachments_IsDeleted",
+                table: "ActionTaskAttachments",
+                column: "IsDeleted");
+        }
+
+        // SECTION: Remove indexes for action task update and attachment filters
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ActionTaskUpdates_CreatedByUserId",
+                table: "ActionTaskUpdates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ActionTaskUpdates_IsDeleted",
+                table: "ActionTaskUpdates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ActionTaskAttachments_IsDeleted",
+                table: "ActionTaskAttachments");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2293,6 +2293,10 @@ namespace ProjectManagement.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("CreatedByUserId");
+
+                    b.HasIndex("IsDeleted");
+
                     b.HasIndex("TaskId", "CreatedAtUtc");
 
                     b.ToTable("ActionTaskUpdates");
@@ -2344,6 +2348,8 @@ namespace ProjectManagement.Migrations
                         .HasColumnType("character varying(450)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("IsDeleted");
 
                     b.HasIndex("TaskId");
 


### PR DESCRIPTION
### Motivation
- Ensure the database has explicit indexes that match `ApplicationDbContext` configuration for Action Task collaboration entities to improve query/filter performance and support soft-delete/ownership filters.

### Description
- Added a new EF Core migration `Migrations/20261125160000_AddActionTaskCollaborationIndexes.cs` which creates indexes `IX_ActionTaskUpdates_CreatedByUserId`, `IX_ActionTaskUpdates_IsDeleted`, and `IX_ActionTaskAttachments_IsDeleted` and provides matching `Down()` logic to drop them.
- Updated `Migrations/ApplicationDbContextModelSnapshot.cs` to include the new index metadata for `ActionTaskUpdates` and `ActionTaskAttachments` so the snapshot matches the model.
- Kept changes non-destructive and consistent with existing idempotent repair migrations for the Action Tracker area.

### Testing
- Attempted to build with `dotnet build --no-restore` but the `dotnet` SDK is not available in the environment so no automated build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa4bf334c83298105a7288d76096f)