### PR TITLE
Fix ActionTask nullability warnings and CreatedOn compile error

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -7,7 +7,7 @@
         @* SECTION: Fixed header with compact identity and close action. *@
         <header class="at-inspector-header">
             <div class="at-detail-hero">
-                <h2 class="at-panel-title mb-0">AT-@Model.TaskId.Value · @(Model.SelectedTask?.Title ?? "Task")</h2>
+                <h2 class="at-panel-title mb-0">AT-@(Model.SelectedTask?.Id.ToString() ?? Model.TaskId?.ToString() ?? "—") · @(Model.SelectedTask?.Title ?? "Task")</h2>
                 @if (Model.SelectedTask is not null)
                 {
                     <div class="at-detail-assignee">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div>
@@ -38,26 +38,35 @@
                     }
                     else
                     {
-                        var activityEntries = Model.SelectedTaskUpdates
-                            .Select(update => (
-                                Timestamp: update.CreatedAtUtc,
-                                EntryType: "Update",
-                                Update: update,
-                                Log: (ProjectManagement.Models.ActionTaskAuditLog?)null))
-                            .Concat(Model.SelectedTaskLogs.Select(log => (
-                                Timestamp: log.PerformedAt,
-                                EntryType: "Log",
-                                Update: (ProjectManagement.Models.ActionTaskUpdate?)null,
-                                Log: log)))
+                        // SECTION: Timeline projection keeps update/log payloads nullable by design.
+                        var updateEntries = Model.SelectedTaskUpdates
+                            .Select(update => new
+                            {
+                                Timestamp = update.CreatedAtUtc,
+                                EntryType = "Update",
+                                Update = (ProjectManagement.Models.ActionTaskUpdate?)update,
+                                Log = (ProjectManagement.Models.ActionTaskAuditLog?)null
+                            });
+
+                        var logEntries = Model.SelectedTaskLogs
+                            .Select(log => new
+                            {
+                                Timestamp = log.PerformedAt,
+                                EntryType = "Log",
+                                Update = (ProjectManagement.Models.ActionTaskUpdate?)null,
+                                Log = (ProjectManagement.Models.ActionTaskAuditLog?)log
+                            });
+
+                        var activityEntries = updateEntries
+                            .Concat(logEntries)
                             .OrderByDescending(entry => entry.Timestamp)
                             .ToList();
 
                         <div class="at-activity-stream mt-2">
                             @foreach (var entry in activityEntries)
                             {
-                                if (entry.EntryType == "Update")
+                                if (entry.Update is { } update)
                                 {
-                                    var update = entry.Update;
                                     <article class="at-activity-update-card">
                                         <div class="d-flex justify-content-between gap-2 flex-wrap">
                                             <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong></div>
@@ -92,9 +101,8 @@
                                         }
                                     </article>
                                 }
-                                else
+                                else if (entry.Log is { } log)
                                 {
-                                    var log = entry.Log;
                                     <article class="at-activity-system-row @(log.ActionType == "Task Created" ? "at-system-event-created" : "")">
                                         <div class="d-flex justify-content-between gap-2 flex-wrap">
                                             <div>

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -69,7 +69,7 @@ public class ActionTaskService : IActionTaskService
             .AsNoTracking()
             .Where(x => taskIds.Contains(x.TaskId))
             .GroupBy(x => x.TaskId)
-            .Select(g => new { TaskId = g.Key, LastUpdateUtc = g.Max(x => x.CreatedOn) })
+            .Select(g => new { TaskId = g.Key, LastUpdateUtc = g.Max(x => x.CreatedAtUtc) })
             .ToDictionaryAsync(x => x.TaskId, x => (DateTime?)x.LastUpdateUtc, cancellationToken);
 
         var auditActivity = await _context.ActionTaskAuditLogs
@@ -84,10 +84,27 @@ public class ActionTaskService : IActionTaskService
         {
             updateActivity.TryGetValue(taskId, out var lastUpdateUtc);
             auditActivity.TryGetValue(taskId, out var lastAuditUtc);
-            result[taskId] = lastUpdateUtc ?? lastAuditUtc;
+            result[taskId] = GetLatestActivityUtc(lastUpdateUtc, lastAuditUtc);
         }
 
         return result;
+    }
+
+
+    // SECTION: Last activity helpers
+    private static DateTime? GetLatestActivityUtc(DateTime? lastUpdateUtc, DateTime? lastAuditUtc)
+    {
+        if (lastUpdateUtc is null)
+        {
+            return lastAuditUtc;
+        }
+
+        if (lastAuditUtc is null)
+        {
+            return lastUpdateUtc;
+        }
+
+        return lastUpdateUtc > lastAuditUtc ? lastUpdateUtc : lastAuditUtc;
     }
 
     // SECTION: Task mutation APIs


### PR DESCRIPTION
### Motivation
- Resolve compile and nullable-reference warnings in the action task area so activity timelines and last-activity calculations are correct and null-safe.
- Ensure Razor UI does not dereference nullable values (e.g. `TaskId.Value`) and that concatenated activity sequences have matching nullable payload shapes.

### Description
- Replace incorrect `ActionTaskUpdate.CreatedOn` usage with the actual `CreatedAtUtc` property in `GetLastActivityUtcByTaskIdsAsync` so LINQ projections compile correctly. (`Services/ActionTasks/ActionTaskService.cs`).
- Introduce a helper `GetLatestActivityUtc(DateTime? lastUpdateUtc, DateTime? lastAuditUtc)` to centralize last-activity resolution and correctly return the most recent timestamp across updates and audit logs. (`Services/ActionTasks/ActionTaskService.cs`).
- Make the task header rendering null-safe by showing `SelectedTask?.Id`, then falling back to the route `TaskId`, and finally to an em dash instead of using `TaskId.Value`. (`Pages/ActionTasks/_TaskDetails.cshtml`).
- Rework the activity timeline projection in the Razor partial to create matching anonymous objects with nullable `Update` and `Log` payloads before `Concat`, and use pattern matching (`is { }`) before dereferencing the selected payload to eliminate nullability warnings. (`Pages/ActionTasks/_TaskDetails.cshtml`).

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors; it passed.
- Attempted `dotnet build --no-restore` but it could not be executed in this environment because the `dotnet` CLI is not available, so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa989ab608329a73c138a2d3730a0)