### PR TITLE
Fix action task page test dependency setup

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -93,9 +93,13 @@ public class ActionTaskPageTests
         var sp = new ServiceCollection().BuildServiceProvider();
         var userManager = new UserManager<ApplicationUser>(new UserStore<ApplicationUser>(db), Options.Create(new IdentityOptions()), new PasswordHasher<ApplicationUser>(), Array.Empty<IUserValidator<ApplicationUser>>(), Array.Empty<IPasswordValidator<ApplicationUser>>(), new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), sp, NullLogger<UserManager<ApplicationUser>>.Instance);
 
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        // SECTION: Action task page services
+        var permission = new ActionTaskPermissionService();
+        var service = new ActionTaskService(db, permission);
         var collab = new StubCollabService();
-        var page = new IndexModel(service, collab, new ActionTaskPermissionService(), userManager);
+        var queryService = new ActionTaskQueryService();
+        var workflowPolicy = new ActionTaskWorkflowPolicy(permission);
+        var page = new IndexModel(service, collab, permission, queryService, workflowPolicy, userManager);
 
         var httpContext = new DefaultHttpContext
         {


### PR DESCRIPTION
### Motivation
- Tests for the Action Tasks page were failing with a constructor-argument error because the `IndexModel` now requires `ActionTaskQueryService` and `ActionTaskWorkflowPolicy` dependencies. 
- The test setup needed to supply matching runtime dependencies and keep permission wiring consistent to mirror production wiring.

### Description
- Updated `CreateSetupAsync` in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to instantiate a single `ActionTaskPermissionService` and reuse it for the service and workflow policy. 
- Added construction of `ActionTaskQueryService` and `ActionTaskWorkflowPolicy` and passed these into the `IndexModel` constructor. 
- Kept the rest of the test initialization unchanged, including the `StubCollabService` and `UserManager` setup.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter FullyQualifiedName~ProjectManagement.Tests.ActionTasks.ActionTaskPageTests`, but the command could not run because `dotnet` is not installed in the environment (test execution was not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faab139c5083298d375add212ff815)