### PR TITLE
Fix EF audit-log FK, tighten submit rules, add create validation and tests

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1838,7 +1838,7 @@ namespace ProjectManagement.Data
                 e.Property(x => x.PerformedByRole).IsRequired().HasMaxLength(64);
                 e.Property(x => x.Remarks).HasMaxLength(2000);
                 // SECTION: Enforce task-to-audit-log referential integrity
-                e.HasOne<ActionTaskItem>()
+                e.HasOne(x => x.Task)
                     .WithMany()
                     .HasForeignKey(x => x.TaskId)
                     .OnDelete(DeleteBehavior.Cascade);

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -195,6 +195,15 @@ public class IndexModel : PageModel
             return Page();
         }
 
+        // SECTION: Business validation for due-date discipline
+        if (Input.DueDate.Date < DateTime.UtcNow.Date)
+        {
+            ModelState.AddModelError(nameof(Input.DueDate), "Due date cannot be in the past.");
+            ShowCreateModal = true;
+            await LoadDataAsync();
+            return Page();
+        }
+
         var assignedUser = await _users.FindByIdAsync(Input.AssignedToUserId);
         if (assignedUser is null)
         {
@@ -423,7 +432,7 @@ public class IndexModel : PageModel
         }
 
         // SECTION: Selected detail read-model boundary
-        SelectedTask = _queryService.SelectTask(Tasks, TaskId);
+        SelectedTask = _queryService.SelectTask(readModel.ScopeTasks, TaskId);
         if (SelectedTask is null)
         {
             TaskId = null;
@@ -562,206 +571,6 @@ public class IndexModel : PageModel
     public int ToPercent(int value, int max) =>
         max <= 0 ? 0 : (int)Math.Round((double)value / max * 100);
 
-    private IReadOnlyList<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks)
-    {
-        var query = tasks.AsEnumerable();
-
-        if (!string.IsNullOrWhiteSpace(FilterStatus))
-        {
-            query = query.Where(t => string.Equals(t.Status, FilterStatus, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrWhiteSpace(FilterPriority))
-        {
-            query = query.Where(t => string.Equals(t.Priority, FilterPriority, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrWhiteSpace(FilterAssigneeUserId))
-        {
-            query = query.Where(t => string.Equals(t.AssignedToUserId, FilterAssigneeUserId, StringComparison.Ordinal));
-        }
-
-        if (FilterDueDate.HasValue)
-        {
-            var dueDate = FilterDueDate.Value.Date;
-            query = query.Where(t => t.DueDate.Date == dueDate);
-        }
-
-        if (!string.IsNullOrWhiteSpace(FilterSearch))
-        {
-            var search = FilterSearch.Trim();
-            query = query.Where(t => t.Title.Contains(search, StringComparison.OrdinalIgnoreCase));
-        }
-        return ApplyTaskListSorting(query).ToList();
-    }
-    // SECTION: Task list sorting after filters.
-    private IEnumerable<ActionTaskItem> ApplyTaskListSorting(IEnumerable<ActionTaskItem> query)
-    {
-        var sortBy = (SortBy ?? "due").Trim().ToLowerInvariant();
-        var descending = string.Equals(SortDir, "desc", StringComparison.OrdinalIgnoreCase);
-        Func<ActionTaskItem, int> statusOrder = task => task.Status switch
-        {
-            ActionTaskStatuses.Assigned => 1,
-            ActionTaskStatuses.InProgress => 2,
-            ActionTaskStatuses.Blocked => 3,
-            ActionTaskStatuses.Submitted => 4,
-            ActionTaskStatuses.Closed => 5,
-            _ => 99
-        };
-        Func<ActionTaskItem, int> priorityOrder = task => task.Priority switch
-        {
-            "Critical" => 1,
-            "High" => 2,
-            "Normal" => 3,
-            "Low" => 4,
-            _ => 99
-        };
-        var ordered = sortBy switch
-        {
-            "title" => descending ? query.OrderByDescending(t => t.Title) : query.OrderBy(t => t.Title),
-            "assignee" => descending ? query.OrderByDescending(t => ResolveAssigneeName(t.AssignedToUserId)) : query.OrderBy(t => ResolveAssigneeName(t.AssignedToUserId)),
-            "status" => descending ? query.OrderByDescending(statusOrder).ThenBy(t => t.DueDate) : query.OrderBy(statusOrder).ThenBy(t => t.DueDate),
-            "priority" => descending ? query.OrderByDescending(priorityOrder).ThenBy(t => t.DueDate) : query.OrderBy(priorityOrder).ThenBy(t => t.DueDate),
-            "id" => descending ? query.OrderByDescending(t => t.Id) : query.OrderBy(t => t.Id),
-            _ => descending ? query.OrderByDescending(t => t.DueDate) : query.OrderBy(t => t.DueDate)
-        };
-        return ordered.ThenBy(t => t.Id);
-    }
-
-    private void BuildDashboardCollections(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
-    {
-        var utcNow = DateTime.UtcNow;
-
-        CriticalOpenTasks = tasks
-            .Where(t => string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase)
-                        && !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.DueDate)
-            .Take(5)
-            .ToList();
-
-        OverdueTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-                        && t.DueDate.Date < utcNow.Date)
-            .OrderBy(t => t.DueDate)
-            .Take(5)
-            .ToList();
-
-        RecentlySubmittedTasks = tasks
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue)
-            .Take(5)
-            .ToList();
-
-        // SECTION: Dashboard Recently Updated Projection
-        RecentlyUpdatedTasks = tasks
-            .OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue)
-            .ThenByDescending(t => t.Id)
-            .Take(5)
-            .ToList();
-    }
-
-    // SECTION: Activity Timestamp Derivation
-    private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
-    {
-        activityByTaskId.TryGetValue(task.Id, out var activityTimestampUtc);
-        return activityTimestampUtc
-            ?? task.SubmittedOn
-            ?? task.AssignedOn;
-    }
-
-    private void BuildKanbanCollections(IReadOnlyList<ActionTaskItem> tasks)
-    {
-        KanbanAssignedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)).ToList();
-        KanbanInProgressTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)).ToList();
-        KanbanBlockedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
-        KanbanSubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
-        KanbanClosedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).ToList();
-    }
-
-    private void BuildSprintCollections(IReadOnlyList<ActionTaskItem> tasks)
-    {
-        var utcToday = DateTime.UtcNow.Date;
-        var endOfWeek = utcToday.AddDays(7);
-
-        SprintOverdueTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-                        && t.DueDate.Date < utcToday)
-            .OrderBy(t => t.DueDate)
-            .ToList();
-
-        DueTodayTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-                        && t.DueDate.Date == utcToday)
-            .OrderBy(t => t.DueDate)
-            .ToList();
-
-        DueThisWeekTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-                        && t.DueDate.Date > utcToday
-                        && t.DueDate.Date <= endOfWeek)
-            .OrderBy(t => t.DueDate)
-            .ToList();
-
-        DueLaterTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-                        && t.DueDate.Date > endOfWeek)
-            .OrderBy(t => t.DueDate)
-            .ToList();
-    }
-
-    private void BuildReportCollections(IReadOnlyList<ActionTaskItem> tasks)
-    {
-        var utcToday = DateTime.UtcNow.Date;
-        var openTasks = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        AssigneePendingCounts = tasks
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-            .GroupBy(t => ResolveAssigneeName(t.AssignedToUserId))
-            .OrderByDescending(group => group.Count())
-            .ThenBy(group => group.Key)
-            .Select(group => new CountSummary(group.Key, group.Count()))
-            .ToList();
-
-        PriorityCounts = tasks
-            .GroupBy(t => t.Priority)
-            .OrderByDescending(group => group.Count())
-            .ThenBy(group => group.Key)
-            .Select(group => new CountSummary(group.Key, group.Count()))
-            .ToList();
-
-        StatusCounts = tasks
-            .GroupBy(t => t.Status)
-            .OrderByDescending(group => group.Count())
-            .ThenBy(group => group.Key)
-            .Select(group => new CountSummary(group.Key, group.Count()))
-            .ToList();
-
-        // SECTION: Open-task ageing buckets for command trend analysis.
-        OpenAgeingBuckets = new[]
-        {
-            new CountSummary("0 to 3 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)),
-            new CountSummary("4 to 7 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)),
-            new CountSummary("8 to 14 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)),
-            new CountSummary("15+ days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15))
-        };
-
-        // SECTION: Overdue ageing buckets for late-task exposure.
-        OverdueAgeingBuckets = new[]
-        {
-            new CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)),
-            new CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)),
-            new CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8))
-        };
-        var submittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
-        SubmittedPendingClosureAgeingBuckets = new[]
-        {
-            new CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)),
-            new CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)),
-            new CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4))
-        };
-    }
     // SECTION: Report top-attention prioritization.
     private IReadOnlyList<TaskDisplayItem> BuildTopAttentionItems()
     {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -58,6 +58,26 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task TaskList_SelectedTaskLoadsWhenFilteredOutOfRegister()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        var selectedTaskId = await setup.Db.ActionTasks.Select(t => t.Id).SingleAsync();
+        page.ViewMode = "TaskList";
+        page.FilterStatus = ActionTaskStatuses.Closed;
+        page.TaskId = selectedTaskId;
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.Empty(page.Tasks);
+        Assert.NotNull(page.SelectedTask);
+        Assert.Equal(selectedTaskId, page.SelectedTask!.Id);
+    }
+
+    [Fact]
     public async Task CreateValidationFailure_ReopensPanel()
     {
         // SECTION: Arrange
@@ -74,7 +94,52 @@ public class ActionTaskPageTests
         Assert.True(page.ShowCreateModal);
     }
 
-    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync()
+    [Fact]
+    public async Task CreatePastDueDate_ReopensPanelAndRejectsTask()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        var existingTaskCount = await setup.Db.ActionTasks.CountAsync();
+        page.Input = new IndexModel.CreateTaskInput
+        {
+            Title = "Late task",
+            Description = "Should be rejected",
+            AssignedToUserId = "user-1",
+            DueDate = DateTime.UtcNow.Date.AddDays(-1),
+            Priority = "Normal"
+        };
+
+        // SECTION: Act
+        var result = await page.OnPostCreateAsync();
+
+        // SECTION: Assert
+        Assert.IsType<PageResult>(result);
+        Assert.True(page.ShowCreateModal);
+        Assert.False(page.ModelState.IsValid);
+        Assert.Equal(existingTaskCount, await setup.Db.ActionTasks.CountAsync());
+        Assert.Contains(page.ModelState[nameof(IndexModel.CreateTaskInput.DueDate)]!.Errors, e => e.ErrorMessage == "Due date cannot be in the past.");
+    }
+
+    [Fact]
+    public void AuditLogModel_DoesNotCreateShadowTaskIdRelationship()
+    {
+        // SECTION: Arrange
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var db = new ApplicationDbContext(options);
+
+        // SECTION: Act
+        var entityType = db.Model.FindEntityType(typeof(ActionTaskAuditLog))!;
+        var taskId1 = entityType.FindProperty("TaskId1");
+
+        // SECTION: Assert
+        Assert.Null(taskId1);
+        Assert.Single(entityType.GetForeignKeys().Where(fk => fk.PrincipalEntityType.ClrType == typeof(ActionTaskItem)));
+    }
+
+    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync(string currentRole = RoleNames.HoD)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
         var db = new ApplicationDbContext(options);
@@ -84,6 +149,8 @@ public class ActionTaskPageTests
             Id = "user-1", UserName = "user1@test", NormalizedUserName = "USER1@TEST", Email = "user1@test", NormalizedEmail = "USER1@TEST", SecurityStamp = Guid.NewGuid().ToString(), FullName = "User One"
         };
         db.Users.Add(user);
+        db.Roles.Add(new IdentityRole { Id = RoleNames.Ta, Name = RoleNames.Ta, NormalizedName = RoleNames.Ta.ToUpperInvariant() });
+        db.UserRoles.Add(new IdentityUserRole<string> { UserId = user.Id, RoleId = RoleNames.Ta });
         db.ActionTasks.Add(new ActionTaskItem
         {
             Title = "Mine", Description = "d", CreatedByUserId = "creator", AssignedToUserId = "user-1", CreatedByRole = RoleNames.HoD, AssignedToRole = RoleNames.Ta, DueDate = DateTime.UtcNow.AddDays(1), Priority = "Normal", AssignedOn = DateTime.UtcNow, Status = ActionTaskStatuses.Assigned
@@ -106,7 +173,7 @@ public class ActionTaskPageTests
             User = new ClaimsPrincipal(new ClaimsIdentity(new[]
             {
                 new Claim(ClaimTypes.NameIdentifier, "user-1"),
-                new Claim(ClaimTypes.Role, RoleNames.Ta)
+                new Claim(ClaimTypes.Role, currentRole)
             }, "TestAuth"))
         };
 

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using ProjectManagement.Configuration;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
@@ -60,8 +61,39 @@ public class ActionTaskServiceTests
         var submitted = await service.GetTaskAsync(task.Id);
         Assert.Equal(ActionTaskStatuses.Submitted, submitted!.Status);
 
+        var resubmitEx = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SubmitTaskAsync(task.Id, submitted.RowVersion, "assignee", RoleNames.Ta, "again"));
+        Assert.Contains("Only assigned, in-progress, or blocked tasks can be submitted.", resubmitEx.Message);
+
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.CloseTaskAsync(task.Id, submitted.RowVersion, "non-cmd", RoleNames.Ta, "close"));
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_WithStaleRowVersion_ThrowsConcurrencyException()
+    {
+        // SECTION: Arrange
+        var databaseName = Guid.NewGuid().ToString();
+        var databaseRoot = new InMemoryDatabaseRoot();
+        await using var staleDb = CreateDb(databaseName, databaseRoot);
+        var task = await SeedTaskAsync(staleDb, ActionTaskStatuses.Assigned, "assignee");
+        var staleRowVersion = task.RowVersion.ToArray();
+        staleDb.ChangeTracker.Clear();
+        _ = await staleDb.ActionTasks.SingleAsync(x => x.Id == task.Id);
+
+        await using (var concurrentDb = CreateDb(databaseName, databaseRoot))
+        {
+            var concurrentTask = await concurrentDb.ActionTasks.SingleAsync(x => x.Id == task.Id);
+            concurrentTask.RowVersion = [9, 9, 9];
+            concurrentTask.Status = ActionTaskStatuses.InProgress;
+            await concurrentDb.SaveChangesAsync();
+        }
+
+        var service = new ActionTaskService(staleDb, new ActionTaskPermissionService());
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<ActionTaskConcurrencyException>(() =>
+            service.UpdateStatusAsync(task.Id, staleRowVersion, ActionTaskStatuses.Blocked, "assignee", RoleNames.Ta, "blocked"));
     }
 
     [Fact]
@@ -81,9 +113,12 @@ public class ActionTaskServiceTests
     }
 
     private static ApplicationDbContext CreateDb()
+        => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
+
+    private static ApplicationDbContext CreateDb(string databaseName, InMemoryDatabaseRoot databaseRoot)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseInMemoryDatabase(databaseName, databaseRoot)
             .Options;
         return new ApplicationDbContext(options);
     }

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -219,6 +219,11 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Closed tasks cannot be submitted.");
         }
 
+        if (!CanSubmitFromStatus(task.Status))
+        {
+            throw new InvalidOperationException("Only assigned, in-progress, or blocked tasks can be submitted.");
+        }
+
         // SECTION: Remarks validation for submit action
         if (IsBlank(remarks))
         {
@@ -342,6 +347,14 @@ public class ActionTaskService : IActionTaskService
     }
 
     private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
+
+    // SECTION: Submit workflow guard
+    private static bool CanSubmitFromStatus(string currentStatus)
+    {
+        return string.Equals(currentStatus, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentStatus, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+    }
 
     // SECTION: Workflow transition guard
     private static bool IsAllowedTransition(string currentStatus, string nextStatus)


### PR DESCRIPTION
### Motivation

- Prevent EF Core from creating a shadow FK `TaskId1` by fixing an audit-log relationship mapping that caused migration warnings and potential data-loss scaffolding.  
- Ensure the UI inspector always loads a valid selected task even when the register view is filtered.  
- Hardening workflow and input validation by enforcing submit source states and rejecting past-due create requests server-side.

### Description

- Bind the `ActionTaskAuditLog` relationship to the `Task` navigation in `Data/ApplicationDbContext.cs` by replacing `HasOne<ActionTaskItem>()` with `HasOne(x => x.Task)` to remove the duplicate/shadow FK.  
- Resolve selected task against the full visible scope by changing `SelectedTask = _queryService.SelectTask(Tasks, TaskId);` to `SelectedTask = _queryService.SelectTask(readModel.ScopeTasks, TaskId);` in `Pages/ActionTasks/Index.cshtml.cs`.  
- Add server-side past-due validation in `OnPostCreateAsync()` to reject create requests with `Input.DueDate` earlier than `DateTime.UtcNow.Date` and keep the create modal open.  
- Remove obsolete page-local query helper methods that are now provided by `ActionTaskQueryService`, and tighten `SubmitTaskAsync()` in `Services/ActionTasks/ActionTaskService.cs` to only allow submit from `Assigned`, `In Progress`, or `Blocked` states (added `CanSubmitFromStatus` guard).  
- Add and update unit tests in `ProjectManagement.Tests/ActionTasks` to cover: selected-task resolution when filtered out, past-due create rejection, audit-log FK model shape (no `TaskId1`), resubmit guard, and a stale-row-version concurrency scenario; also adjust InMemory DB usage to support concurrency tests.

### Testing

- Ran `git diff --check` to verify there are no whitespace/conflict issues and it completed with no errors.  
- Attempted to run unit tests with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ActionTaskServiceTests --no-restore` but the environment lacks the `dotnet` CLI so tests could not be executed here.  
- New automated tests were added to `ProjectManagement.Tests/ActionTasks` to validate the fixes, but their pass/fail status is unverified until run in a CI or local environment with the .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69facac6cd2c8329aeb34a67004ee227)