### PR TITLE
Fix action task row version snapshot drift

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1812,7 +1812,7 @@ namespace ProjectManagement.Data
             builder.Entity<ActionTaskItem>(e =>
             {
                 // SECTION: Optimistic concurrency token mapping for action tasks
-                e.Property(x => x.RowVersion).IsRowVersion();
+                ConfigureRowVersion(e);
                 e.HasIndex(x => new { x.AssignedToUserId, x.Status });
                 e.HasIndex(x => new { x.DueDate, x.Status });
                 e.HasIndex(x => x.IsDeleted);

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2230,7 +2230,7 @@ namespace ProjectManagement.Migrations
 
                     b.Property<byte[]>("RowVersion")
                         .IsConcurrencyToken()
-                        .ValueGeneratedOnAddOrUpdate()
+                        .IsRequired()
                         .HasColumnType("bytea");
 
                     b.Property<string>("Status")


### PR DESCRIPTION
### Motivation
- Prevent EF from re-scaffolding a nullable→non-nullable `AlterColumn` for `ActionTasks.RowVersion` by removing snapshot/mapping drift. 
- Ensure `ActionTaskItem` uses the same app-managed PostgreSQL `bytea` concurrency-token pattern as other entities so runtime concurrency logic is consistent. 

### Description
- Replace the `ActionTaskItem`-specific `.IsRowVersion()` call with the shared `ConfigureRowVersion(e)` mapping so row-version configuration is consistent and app-managed; change made in `Data/ApplicationDbContext.cs`. 
- Update the EF model snapshot so `ActionTaskItem.RowVersion` is marked `IsRequired()` instead of `ValueGeneratedOnAddOrUpdate()`, removing the metadata that caused EF to scaffold the nullable→non-nullable `AlterColumn`; change made in `Migrations/ApplicationDbContextModelSnapshot.cs`. 
- These changes address the root cause of the EF warning (snapshot drift) rather than attempting to keep or modify the previously scaffolded migration that introduced the warning. 

### Testing
- Attempted `dotnet build ProjectManagement.csproj --no-restore` but it could not be executed in this environment because `dotnet` is not installed. 
- Ran a `python3` snapshot verification that inspected the `ActionTaskItem` block in `Migrations/ApplicationDbContextModelSnapshot.cs` and confirmed there is no `TaskId1` shadow FK, no `ValueGeneratedOnAddOrUpdate` on the `RowVersion` property, and the snapshot shows `RowVersion` as required. 
- Ran a repository check (`git diff --check`) which reported no indexable whitespace issues and returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad04ab7748329999531b8bc71a8a4)