### PR TITLE
Add idempotent EF Core migration to ensure ActionTasks.RowVersion column

### DIFF
--- a/Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs
+++ b/Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs
@@ -1,0 +1,118 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125170000_EnsureActionTaskRowVersionColumn")]
+    public class EnsureActionTaskRowVersionColumn : Migration
+    {
+        // SECTION: Ensure ActionTasks optimistic concurrency column exists
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // SECTION: PostgreSQL idempotent RowVersion repair
+            if (ActiveProvider.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    ALTER TABLE "ActionTasks"
+                    ADD COLUMN IF NOT EXISTS "RowVersion" bytea NOT NULL
+                    DEFAULT decode(md5(random()::text || clock_timestamp()::text), 'hex');
+                    """);
+
+                return;
+            }
+
+            // SECTION: SQLite already receives RowVersion from the original concurrency migration
+            if (ActiveProvider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // SECTION: SQL Server idempotent RowVersion repair
+            if (ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    IF COL_LENGTH(N'ActionTasks', N'RowVersion') IS NULL
+                    BEGIN
+                        ALTER TABLE [ActionTasks]
+                        ADD [RowVersion] varbinary(max) NOT NULL
+                        CONSTRAINT [DF_ActionTasks_RowVersion] DEFAULT 0x;
+                    END
+                    """);
+
+                return;
+            }
+
+            // SECTION: Provider-neutral RowVersion repair
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "ActionTasks",
+                type: "bytea",
+                nullable: false,
+                defaultValue: Array.Empty<byte>());
+        }
+
+        // SECTION: Remove ActionTasks optimistic concurrency column
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // SECTION: PostgreSQL idempotent RowVersion rollback
+            if (ActiveProvider.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    ALTER TABLE "ActionTasks"
+                    DROP COLUMN IF EXISTS "RowVersion";
+                    """);
+
+                return;
+            }
+
+            // SECTION: SQLite rollback leaves the original concurrency migration untouched
+            if (ActiveProvider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // SECTION: SQL Server idempotent RowVersion rollback
+            if (ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    IF COL_LENGTH(N'ActionTasks', N'RowVersion') IS NOT NULL
+                    BEGIN
+                        DECLARE @ConstraintName nvarchar(200);
+
+                        SELECT @ConstraintName = dc.name
+                        FROM sys.default_constraints dc
+                        INNER JOIN sys.columns c
+                            ON c.default_object_id = dc.object_id
+                        INNER JOIN sys.tables t
+                            ON t.object_id = c.object_id
+                        WHERE t.name = N'ActionTasks'
+                            AND c.name = N'RowVersion';
+
+                        IF @ConstraintName IS NOT NULL
+                        BEGIN
+                            EXEC(N'ALTER TABLE [ActionTasks] DROP CONSTRAINT [' + @ConstraintName + N']');
+                        END
+
+                        ALTER TABLE [ActionTasks] DROP COLUMN [RowVersion];
+                    END
+                    """);
+
+                return;
+            }
+
+            // SECTION: Provider-neutral RowVersion rollback
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "ActionTasks");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the `ActionTasks` table always has an optimistic concurrency `RowVersion` column in a safe, idempotent way across database providers to repair missing columns without affecting providers that already have the column.

### Description
- Add a new EF Core migration `EnsureActionTaskRowVersionColumn` that adds/removes the `RowVersion` column in `Up`/`Down` with provider-specific logic. 
- For PostgreSQL the migration runs `ALTER TABLE "ActionTasks" ADD COLUMN IF NOT EXISTS "RowVersion" bytea NOT NULL DEFAULT decode(md5(random()::text || clock_timestamp()::text), 'hex');` to be idempotent. 
- For SQL Server the migration checks `COL_LENGTH` and adds a `varbinary(max)` column with a default constraint and removes the default constraint before dropping the column on rollback. 
- For SQLite the migration no-ops because the original concurrency migration already provides the column, and a provider-neutral fallback `AddColumn`/`DropColumn` is included for other providers. 

### Testing
- Ran `dotnet build` to ensure the project compiles successfully. 
- Ran the automated test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad3ef28148329b7a0fd5cdd4d9a59)