### PR TITLE
Preserve ActionTasks RowVersion during repair rollback

### DIFF
--- a/Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs
+++ b/Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs
@@ -58,61 +58,13 @@ namespace ProjectManagement.Migrations
                 defaultValue: Array.Empty<byte>());
         }
 
-        // SECTION: Remove ActionTasks optimistic concurrency column
+        // SECTION: Preserve ActionTasks optimistic concurrency column on rollback
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            // SECTION: PostgreSQL idempotent RowVersion rollback
-            if (ActiveProvider.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
-            {
-                migrationBuilder.Sql(
-                    """
-                    ALTER TABLE "ActionTasks"
-                    DROP COLUMN IF EXISTS "RowVersion";
-                    """);
-
-                return;
-            }
-
-            // SECTION: SQLite rollback leaves the original concurrency migration untouched
-            if (ActiveProvider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
-
-            // SECTION: SQL Server idempotent RowVersion rollback
-            if (ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
-            {
-                migrationBuilder.Sql(
-                    """
-                    IF COL_LENGTH(N'ActionTasks', N'RowVersion') IS NOT NULL
-                    BEGIN
-                        DECLARE @ConstraintName nvarchar(200);
-
-                        SELECT @ConstraintName = dc.name
-                        FROM sys.default_constraints dc
-                        INNER JOIN sys.columns c
-                            ON c.default_object_id = dc.object_id
-                        INNER JOIN sys.tables t
-                            ON t.object_id = c.object_id
-                        WHERE t.name = N'ActionTasks'
-                            AND c.name = N'RowVersion';
-
-                        IF @ConstraintName IS NOT NULL
-                        BEGIN
-                            EXEC(N'ALTER TABLE [ActionTasks] DROP CONSTRAINT [' + @ConstraintName + N']');
-                        END
-
-                        ALTER TABLE [ActionTasks] DROP COLUMN [RowVersion];
-                    END
-                    """);
-
-                return;
-            }
-
-            // SECTION: Provider-neutral RowVersion rollback
-            migrationBuilder.DropColumn(
-                name: "RowVersion",
-                table: "ActionTasks");
+            // SECTION: Non-destructive rollback
+            // This repair migration may be a no-op when RowVersion was already created by
+            // 20260505130000_AddActionTaskRowVersionConcurrency. Dropping the column here
+            // would break the model after rolling back only this repair migration.
         }
     }
 }


### PR DESCRIPTION
### Motivation
- The repair migration `20261125170000_EnsureActionTaskRowVersionColumn` previously included provider-specific `DROP COLUMN`/`DropColumn` logic in `Down()` that could remove an existing `ActionTasks.RowVersion` column created by an earlier concurrency migration, which would break the model when only this repair migration is rolled back.

### Description
- Updated `Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs` to make `Down()` non-destructive and replaced the provider-specific column-drop logic with a no-op rollback that preserves the `RowVersion` column.
- Left the `Up()` idempotent behavior intact for PostgreSQL, SQLite, SQL Server, and provider-neutral code so the migration still ensures the `RowVersion` column exists when missing.
- Added explanatory comments referencing the original concurrency migration `20260505130000_AddActionTaskRowVersionConcurrency` to clarify rollback safety.

### Testing
- Searched the migration file with `rg -n "DROP COLUMN IF EXISTS|DropColumn|Preserve ActionTasks|Non-destructive rollback|20260505130000"` and confirmed no destructive rollback statements remain.
- Ran the guard script `if rg -n "DROP COLUMN IF EXISTS|DropColumn" Migrations/20261125170000_EnsureActionTaskRowVersionColumn.cs; then exit 1; else echo "No destructive RowVersion rollback statements found."; fi` which returned the expected non-destructive confirmation.
- Ran `git diff --check` with no whitespace errors reported, and attempted `dotnet test` but it could not run because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad71ab8048329aa18f8434c20d423)