### PR TITLE
Add Action Tracker sprint domain support

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -50,6 +50,7 @@ namespace ProjectManagement.Data
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
         public DbSet<TodoItem> TodoItems => Set<TodoItem>();
         public DbSet<ActionTaskItem> ActionTasks => Set<ActionTaskItem>();
+        public DbSet<ActionSprint> ActionSprints => Set<ActionSprint>();
         public DbSet<ActionTaskAuditLog> ActionTaskAuditLogs => Set<ActionTaskAuditLog>();
         public DbSet<ActionTaskUpdate> ActionTaskUpdates => Set<ActionTaskUpdate>();
         public DbSet<ActionTaskAttachment> ActionTaskAttachments => Set<ActionTaskAttachment>();
@@ -1815,6 +1816,7 @@ namespace ProjectManagement.Data
                 ConfigureRowVersion(e);
                 e.HasIndex(x => new { x.AssignedToUserId, x.Status });
                 e.HasIndex(x => new { x.DueDate, x.Status });
+                e.HasIndex(x => x.SprintId);
                 e.HasIndex(x => x.IsDeleted);
                 e.Property(x => x.Title).IsRequired().HasMaxLength(200);
                 e.Property(x => x.Description).IsRequired().HasMaxLength(4000);
@@ -1826,6 +1828,31 @@ namespace ProjectManagement.Data
                 e.Property(x => x.Status).IsRequired().HasMaxLength(32);
                 // SECTION: Action task due dates are stored as date-only values
                 e.Property(x => x.DueDate).HasColumnType("date");
+                e.Property(x => x.IsDeleted).HasDefaultValue(false);
+                // SECTION: Optional sprint link; null SprintId keeps a task in backlog
+                e.HasOne(x => x.Sprint)
+                    .WithMany(x => x.Tasks)
+                    .HasForeignKey(x => x.SprintId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<ActionSprint>(e =>
+            {
+                // SECTION: Sprint indexing strategy
+                e.HasIndex(x => x.Status);
+                e.HasIndex(x => new { x.StartDate, x.EndDate });
+                e.HasIndex(x => x.IsDeleted);
+
+                // SECTION: Sprint field constraints
+                e.Property(x => x.Name).IsRequired().HasMaxLength(160);
+                e.Property(x => x.Goal).HasMaxLength(2000);
+                e.Property(x => x.Status).HasConversion<string>().IsRequired().HasMaxLength(32);
+                e.Property(x => x.CreatedByUserId).IsRequired().HasMaxLength(450);
+                e.Property(x => x.CreatedByRole).IsRequired().HasMaxLength(64);
+                e.Property(x => x.UpdatedByUserId).HasMaxLength(450);
+                e.Property(x => x.UpdatedByRole).HasMaxLength(64);
+                e.Property(x => x.StartDate).HasColumnType("date");
+                e.Property(x => x.EndDate).HasColumnType("date");
                 e.Property(x => x.IsDeleted).HasDefaultValue(false);
             });
 

--- a/Migrations/20261125180000_AddActionSprints.cs
+++ b/Migrations/20261125180000_AddActionSprints.cs
@@ -1,0 +1,97 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125180000_AddActionSprints")]
+    public partial class AddActionSprints : Migration
+    {
+        // SECTION: Add sprint domain tables and task backlog link
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ActionSprints",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: false),
+                    Goal = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    StartDate = table.Column<DateTime>(type: "date", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "date", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    CreatedByRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    UpdatedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    UpdatedByRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    ActivatedAtUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    ClosedAtUtc = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionSprints", x => x.Id);
+                });
+
+            migrationBuilder.AddColumn<int>(
+                name: "SprintId",
+                table: "ActionTasks",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionSprints_IsDeleted",
+                table: "ActionSprints",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionSprints_StartDate_EndDate",
+                table: "ActionSprints",
+                columns: new[] { "StartDate", "EndDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionSprints_Status",
+                table: "ActionSprints",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionTasks_SprintId",
+                table: "ActionTasks",
+                column: "SprintId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActionTasks_ActionSprints_SprintId",
+                table: "ActionTasks",
+                column: "SprintId",
+                principalTable: "ActionSprints",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        // SECTION: Remove sprint domain tables and task backlog link
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActionTasks_ActionSprints_SprintId",
+                table: "ActionTasks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ActionTasks_SprintId",
+                table: "ActionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "SprintId",
+                table: "ActionTasks");
+
+            migrationBuilder.DropTable(
+                name: "ActionSprints");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2232,6 +2232,80 @@ namespace ProjectManagement.Migrations
                     b.ToTable("ActionTaskAuditLogs");
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.ActionSprint", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTime?>("ActivatedAtUtc")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<DateTime?>("ClosedAtUtc")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<DateTime>("CreatedAtUtc")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<string>("CreatedByRole")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("CreatedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<DateTime>("EndDate")
+                        .HasColumnType("date");
+
+                    b.Property<string>("Goal")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<bool>("IsDeleted")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false);
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(160)
+                        .HasColumnType("character varying(160)");
+
+                    b.Property<DateTime>("StartDate")
+                        .HasColumnType("date");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(32)
+                        .HasColumnType("character varying(32)");
+
+                    b.Property<DateTime?>("UpdatedAtUtc")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<string>("UpdatedByRole")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("UpdatedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("IsDeleted");
+
+                    b.HasIndex("Status");
+
+                    b.HasIndex("StartDate", "EndDate");
+
+                    b.ToTable("ActionSprints");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.ActionTaskItem", b =>
                 {
                     b.Property<int>("Id")
@@ -2289,6 +2363,9 @@ namespace ProjectManagement.Migrations
                         .IsRequired()
                         .HasColumnType("bytea");
 
+                    b.Property<int?>("SprintId")
+                        .HasColumnType("integer");
+
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(32)
@@ -2305,6 +2382,8 @@ namespace ProjectManagement.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("IsDeleted");
+
+                    b.HasIndex("SprintId");
 
                     b.HasIndex("AssignedToUserId", "Status");
 
@@ -6596,6 +6675,11 @@ namespace ProjectManagement.Migrations
                         .OnDelete(DeleteBehavior.Restrict);
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.ActionSprint", b =>
+                {
+                    b.Navigation("Tasks");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.ActionTaskAuditLog", b =>
                 {
                     b.HasOne("ProjectManagement.Models.ActionTaskItem", "Task")
@@ -6605,6 +6689,16 @@ namespace ProjectManagement.Migrations
                         .IsRequired();
 
                     b.Navigation("Task");
+                });
+
+            modelBuilder.Entity("ProjectManagement.Models.ActionTaskItem", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.ActionSprint", "Sprint")
+                        .WithMany("Tasks")
+                        .HasForeignKey("SprintId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("Sprint");
                 });
 
             modelBuilder.Entity("ProjectManagement.Models.ActionTaskUpdate", b =>

--- a/Models/ActionSprint.cs
+++ b/Models/ActionSprint.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class ActionSprint
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required, StringLength(160)]
+    public string Name { get; set; } = string.Empty;
+
+    [StringLength(2000)]
+    public string? Goal { get; set; }
+
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+
+    public ActionSprintStatus Status { get; set; } = ActionSprintStatus.Planned;
+
+    [Required, StringLength(450)]
+    public string CreatedByUserId { get; set; } = string.Empty;
+
+    [Required, StringLength(64)]
+    public string CreatedByRole { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    [StringLength(450)]
+    public string? UpdatedByUserId { get; set; }
+
+    [StringLength(64)]
+    public string? UpdatedByRole { get; set; }
+
+    public DateTime? UpdatedAtUtc { get; set; }
+    public DateTime? ActivatedAtUtc { get; set; }
+    public DateTime? ClosedAtUtc { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public ICollection<ActionTaskItem> Tasks { get; set; } = new List<ActionTaskItem>();
+}

--- a/Models/ActionSprintStatus.cs
+++ b/Models/ActionSprintStatus.cs
@@ -1,0 +1,8 @@
+namespace ProjectManagement.Models;
+
+public enum ActionSprintStatus
+{
+    Planned = 0,
+    Active = 1,
+    Closed = 2
+}

--- a/Models/ActionTaskItem.cs
+++ b/Models/ActionTaskItem.cs
@@ -56,6 +56,10 @@ public class ActionTaskItem
     public DateTime? SubmittedOn { get; set; }
     public DateTime? ClosedOn { get; set; }
 
+    // SECTION: Optional sprint assignment; null represents the backlog
+    public int? SprintId { get; set; }
+    public ActionSprint? Sprint { get; set; }
+
     // SECTION: Optimistic concurrency token for task updates
     public byte[] RowVersion { get; set; } = Array.Empty<byte>();
 

--- a/Program.cs
+++ b/Program.cs
@@ -386,6 +386,8 @@ builder.Services.AddScoped<ITodoService, TodoService>();
 builder.Services.AddScoped<ActionTaskPermissionService>();
 builder.Services.AddScoped<ActionTaskQueryService>();
 builder.Services.AddScoped<ActionTaskWorkflowPolicy>();
+builder.Services.AddScoped<ActionSprintWorkflowPolicy>();
+builder.Services.AddScoped<ActionSprintService>();
 builder.Services.AddScoped<IActionTaskService, ActionTaskService>();
 builder.Services.AddScoped<IActionTaskCollaborationService, ActionTaskCollaborationService>();
 builder.Services.Configure<TodoOptions>(

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using ProjectManagement.Configuration;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionSprintServiceTests
+{
+    [Fact]
+    public async Task CreateSprintAsync_WithPlanningAuthority_CreatesPlannedSprint()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+
+        // SECTION: Act
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        Assert.True(sprint.Id > 0);
+        Assert.Equal(ActionSprintStatus.Planned, sprint.Status);
+        Assert.Equal("planner", sprint.CreatedByUserId);
+    }
+
+    [Fact]
+    public async Task CreateSprintAsync_WithInvalidDateRange_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = NewSprint(startOffsetDays: 5, endOffsetDays: 1);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateSprintAsync(sprint, "planner", RoleNames.HoD));
+        Assert.Contains("start date", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task ActivateSprintAsync_PlannedSprint_BecomesActive()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+
+        // SECTION: Act
+        var active = await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        Assert.Equal(ActionSprintStatus.Active, active.Status);
+        Assert.NotNull(active.ActivatedAtUtc);
+    }
+
+    [Fact]
+    public async Task ActivateSprintAsync_WhenAnotherSprintActive_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var first = await service.CreateSprintAsync(NewSprint("Sprint 1"), "planner", RoleNames.Comdt);
+        var second = await service.CreateSprintAsync(NewSprint("Sprint 2"), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(first.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ActivateSprintAsync(second.Id, "planner", RoleNames.Comdt));
+        Assert.Contains("Only one active sprint", ex.Message);
+    }
+
+    [Fact]
+    public async Task CloseSprintAsync_ActiveSprint_BecomesClosed()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act
+        var closed = await service.CloseSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        Assert.Equal(ActionSprintStatus.Closed, closed.Status);
+        Assert.NotNull(closed.ClosedAtUtc);
+    }
+
+    [Fact]
+    public async Task AssignTaskToSprintAsync_WhenSprintClosed_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
+        await service.CloseSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt));
+        Assert.Contains("closed sprint", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task MoveTaskToBacklogAsync_ClearsSprintIdAndAuditsMove()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act
+        var backlogTask = await service.MoveTaskToBacklogAsync(task.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        Assert.Null(backlogTask.SprintId);
+        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskMovedToBacklog");
+    }
+
+    // SECTION: Test helpers
+    private static ActionSprintService CreateService(ApplicationDbContext db)
+        => new(db, new ActionTaskPermissionService(), new ActionSprintWorkflowPolicy());
+
+    private static ApplicationDbContext CreateDb()
+        => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
+
+    private static ApplicationDbContext CreateDb(string databaseName, InMemoryDatabaseRoot databaseRoot)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static ActionSprint NewSprint(string name = "Sprint A", int startOffsetDays = 0, int endOffsetDays = 14)
+        => new()
+        {
+            Name = name,
+            Goal = "Deliver sprint goal",
+            StartDate = DateTime.UtcNow.Date.AddDays(startOffsetDays),
+            EndDate = DateTime.UtcNow.Date.AddDays(endOffsetDays)
+        };
+
+    private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db)
+    {
+        var task = new ActionTaskItem
+        {
+            Title = "Task",
+            Description = "Task",
+            CreatedByUserId = "creator",
+            AssignedToUserId = "assignee",
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = DateTime.UtcNow.AddDays(1),
+            Priority = "Normal",
+            AssignedOn = DateTime.UtcNow,
+            Status = ActionTaskStatuses.Assigned,
+            RowVersion = [1, 2, 3]
+        };
+
+        db.ActionTasks.Add(task);
+        await db.SaveChangesAsync();
+        return task;
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
@@ -26,4 +26,53 @@ public class ActionTaskPermissionServiceTests
         Assert.True(ownerCanWrite);
         Assert.False(nonOwnerCannotWrite);
     }
+    [Theory]
+    [InlineData(RoleNames.Comdt, RoleNames.HoD, true)]
+    [InlineData(RoleNames.Comdt, RoleNames.ProjectOfficer, true)]
+    [InlineData(RoleNames.Comdt, RoleNames.Mco, true)]
+    [InlineData(RoleNames.Comdt, RoleNames.Ta, true)]
+    [InlineData(RoleNames.Comdt, RoleNames.Ito, true)]
+    [InlineData(RoleNames.HoD, RoleNames.HoD, false)]
+    [InlineData(RoleNames.HoD, RoleNames.ProjectOfficer, true)]
+    [InlineData(RoleNames.HoD, RoleNames.Mco, true)]
+    [InlineData(RoleNames.HoD, RoleNames.Ta, true)]
+    [InlineData(RoleNames.HoD, RoleNames.Ito, true)]
+    [InlineData(RoleNames.HoD, RoleNames.Comdt, false)]
+    [InlineData(RoleNames.ProjectOfficer, RoleNames.Ta, false)]
+    [InlineData(RoleNames.Mco, RoleNames.Ta, false)]
+    [InlineData(RoleNames.Ta, RoleNames.Ito, false)]
+    [InlineData(RoleNames.Ito, RoleNames.Ta, false)]
+    public void AssignmentMatrix_IsEnforcedExactly(string assignerRole, string assigneeRole, bool expected)
+    {
+        // SECTION: Arrange
+        var service = new ActionTaskPermissionService();
+
+        // SECTION: Act
+        var canAssign = service.CanAssign(assignerRole, assigneeRole);
+
+        // SECTION: Assert
+        Assert.Equal(expected, canAssign);
+    }
+
+    [Theory]
+    [InlineData(RoleNames.Comdt, true)]
+    [InlineData(RoleNames.HoD, true)]
+    [InlineData(RoleNames.ProjectOfficer, false)]
+    [InlineData(RoleNames.Mco, false)]
+    [InlineData(RoleNames.Ta, false)]
+    [InlineData(RoleNames.Ito, false)]
+    public void SprintManagementPermissions_AreLimitedToPlanningAuthorities(string role, bool expected)
+    {
+        // SECTION: Arrange
+        var service = new ActionTaskPermissionService();
+
+        // SECTION: Act
+        var canManageSprints = service.CanManageSprints(role);
+        var canMoveTasksInSprint = service.CanMoveTasksInSprint(role);
+
+        // SECTION: Assert
+        Assert.Equal(expected, canManageSprints);
+        Assert.Equal(expected, canMoveTasksInSprint);
+    }
+
 }

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Data;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public class ActionSprintService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ActionTaskPermissionService _permission;
+    private readonly ActionSprintWorkflowPolicy _workflow;
+
+    public ActionSprintService(
+        ApplicationDbContext context,
+        ActionTaskPermissionService permission,
+        ActionSprintWorkflowPolicy workflow)
+    {
+        _context = context;
+        _permission = permission;
+        _workflow = workflow;
+    }
+
+    // SECTION: Sprint mutation APIs
+    public async Task<ActionSprint> CreateSprintAsync(ActionSprint sprint, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanManageSprint(role);
+        _workflow.ValidateDateRange(sprint.StartDate, sprint.EndDate);
+
+        sprint.Status = ActionSprintStatus.Planned;
+        sprint.CreatedByUserId = userId;
+        sprint.CreatedByRole = role;
+        sprint.CreatedAtUtc = DateTime.UtcNow;
+        sprint.StartDate = sprint.StartDate.Date;
+        sprint.EndDate = sprint.EndDate.Date;
+
+        _context.ActionSprints.Add(sprint);
+        await _context.SaveChangesAsync(cancellationToken);
+        return sprint;
+    }
+
+    public async Task<ActionSprint> UpdateSprintAsync(int sprintId, string name, string? goal, DateTime startDate, DateTime endDate, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanManageSprint(role);
+        _workflow.ValidateDateRange(startDate, endDate);
+
+        var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
+        _workflow.EnsureCanUpdate(sprint);
+
+        sprint.Name = name;
+        sprint.Goal = goal;
+        sprint.StartDate = startDate.Date;
+        sprint.EndDate = endDate.Date;
+        sprint.UpdatedByUserId = userId;
+        sprint.UpdatedByRole = role;
+        sprint.UpdatedAtUtc = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return sprint;
+    }
+
+    public async Task<ActionSprint> ActivateSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanManageSprint(role);
+
+        var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
+        _workflow.EnsureCanActivate(sprint);
+        _workflow.ValidateDateRange(sprint.StartDate, sprint.EndDate);
+
+        var activeSprintExists = await _context.ActionSprints
+            .AnyAsync(x => x.Id != sprintId && !x.IsDeleted && x.Status == ActionSprintStatus.Active, cancellationToken);
+        if (activeSprintExists)
+        {
+            throw new InvalidOperationException("Only one active sprint is allowed.");
+        }
+
+        sprint.Status = ActionSprintStatus.Active;
+        sprint.ActivatedAtUtc = DateTime.UtcNow;
+        sprint.UpdatedByUserId = userId;
+        sprint.UpdatedByRole = role;
+        sprint.UpdatedAtUtc = sprint.ActivatedAtUtc;
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return sprint;
+    }
+
+    public async Task<ActionSprint> CloseSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanManageSprint(role);
+
+        var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
+        _workflow.EnsureCanClose(sprint);
+
+        sprint.Status = ActionSprintStatus.Closed;
+        sprint.ClosedAtUtc = DateTime.UtcNow;
+        sprint.UpdatedByUserId = userId;
+        sprint.UpdatedByRole = role;
+        sprint.UpdatedAtUtc = sprint.ClosedAtUtc;
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return sprint;
+    }
+
+    // SECTION: Sprint task assignment APIs
+    public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanMoveTasksInSprint(role);
+
+        var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
+        _workflow.EnsureCanAcceptTask(sprint);
+
+        var oldValue = task.SprintId?.ToString();
+        task.SprintId = sprint.Id;
+        AddTaskSprintAudit(task.Id, "TaskAssignedToSprint", userId, role, oldValue, sprint.Id.ToString(), $"Assigned to sprint: {sprint.Name}");
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return task;
+    }
+
+    public async Task<ActionTaskItem> MoveTaskToBacklogAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanMoveTasksInSprint(role);
+
+        var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        if (task.SprintId.HasValue)
+        {
+            var currentSprint = await GetSprintForUpdateAsync(task.SprintId.Value, cancellationToken);
+            _workflow.EnsureCanUpdate(currentSprint);
+        }
+
+        var oldValue = task.SprintId?.ToString();
+        task.SprintId = null;
+        AddTaskSprintAudit(task.Id, "TaskMovedToBacklog", userId, role, oldValue, null, "Moved to backlog.");
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return task;
+    }
+
+    // SECTION: Authorization helpers
+    private void EnsureCanManageSprint(string role)
+    {
+        if (!_permission.CanManageSprints(role))
+        {
+            throw new InvalidOperationException("You are not authorized to manage sprints.");
+        }
+    }
+
+    private void EnsureCanMoveTasksInSprint(string role)
+    {
+        if (!_permission.CanMoveTasksInSprint(role))
+        {
+            throw new InvalidOperationException("You are not authorized to move tasks into or out of sprints.");
+        }
+    }
+
+    // SECTION: Entity loading helpers
+    private async Task<ActionSprint> GetSprintForUpdateAsync(int sprintId, CancellationToken cancellationToken)
+        => await _context.ActionSprints.FirstOrDefaultAsync(x => x.Id == sprintId && !x.IsDeleted, cancellationToken)
+            ?? throw new InvalidOperationException("Sprint not found.");
+
+    private async Task<ActionTaskItem> GetTaskForUpdateAsync(int taskId, CancellationToken cancellationToken)
+        => await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken)
+            ?? throw new InvalidOperationException("Task not found.");
+
+    // SECTION: Audit helpers
+    private void AddTaskSprintAudit(int taskId, string actionType, string userId, string role, string? oldValue, string? newValue, string remarks)
+    {
+        _context.ActionTaskAuditLogs.Add(new ActionTaskAuditLog
+        {
+            TaskId = taskId,
+            ActionType = actionType,
+            PerformedByUserId = userId,
+            PerformedByRole = role,
+            PerformedAt = DateTime.UtcNow,
+            OldValue = oldValue,
+            NewValue = newValue,
+            Remarks = remarks
+        });
+    }
+}

--- a/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
@@ -1,0 +1,49 @@
+using System;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public class ActionSprintWorkflowPolicy
+{
+    // SECTION: Sprint date validation
+    public void ValidateDateRange(DateTime startDate, DateTime endDate)
+    {
+        if (startDate.Date > endDate.Date)
+        {
+            throw new InvalidOperationException("Sprint start date must be on or before the end date.");
+        }
+    }
+
+    // SECTION: Sprint lifecycle validation
+    public void EnsureCanUpdate(ActionSprint sprint)
+    {
+        if (sprint.Status == ActionSprintStatus.Closed)
+        {
+            throw new InvalidOperationException("Closed sprints are immutable in the normal workflow.");
+        }
+    }
+
+    public void EnsureCanActivate(ActionSprint sprint)
+    {
+        if (sprint.Status != ActionSprintStatus.Planned)
+        {
+            throw new InvalidOperationException("Only planned sprints can be activated.");
+        }
+    }
+
+    public void EnsureCanClose(ActionSprint sprint)
+    {
+        if (sprint.Status != ActionSprintStatus.Active)
+        {
+            throw new InvalidOperationException("Only active sprints can be closed.");
+        }
+    }
+
+    public void EnsureCanAcceptTask(ActionSprint sprint)
+    {
+        if (sprint.Status == ActionSprintStatus.Closed)
+        {
+            throw new InvalidOperationException("Tasks cannot be assigned to a closed sprint.");
+        }
+    }
+}

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -6,12 +6,21 @@ namespace ProjectManagement.Services.ActionTasks;
 
 public class ActionTaskPermissionService
 {
-    private static readonly string[] AssignmentTargets =
+    private static readonly string[] ComdtAssignmentTargets =
     {
         RoleNames.HoD,
         RoleNames.ProjectOfficer,
         RoleNames.Mco,
-        RoleNames.Ta
+        RoleNames.Ta,
+        RoleNames.Ito
+    };
+
+    private static readonly string[] HoDAssignmentTargets =
+    {
+        RoleNames.ProjectOfficer,
+        RoleNames.Mco,
+        RoleNames.Ta,
+        RoleNames.Ito
     };
 
     // SECTION: Role capability checks
@@ -20,16 +29,27 @@ public class ActionTaskPermissionService
 
     public bool CanAssign(string assignerRole, string assigneeRole)
     {
-        if (assignerRole != RoleNames.Comdt && assignerRole != RoleNames.HoD)
+        if (string.Equals(assignerRole, RoleNames.Comdt, StringComparison.OrdinalIgnoreCase))
         {
-            return false;
+            return ComdtAssignmentTargets.Contains(assigneeRole, StringComparer.OrdinalIgnoreCase);
         }
 
-        return AssignmentTargets.Contains(assigneeRole, StringComparer.OrdinalIgnoreCase);
+        if (string.Equals(assignerRole, RoleNames.HoD, StringComparison.OrdinalIgnoreCase))
+        {
+            return HoDAssignmentTargets.Contains(assigneeRole, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 
     public bool CanClose(string role)
         => role == RoleNames.Comdt || role == RoleNames.HoD;
+
+    public bool CanManageSprints(string role)
+        => role == RoleNames.Comdt || role == RoleNames.HoD;
+
+    public bool CanMoveTasksInSprint(string role)
+        => CanManageSprints(role);
 
     public bool CanViewAll(string role)
         => role == RoleNames.Comdt || role == RoleNames.HoD;
@@ -53,5 +73,5 @@ public class ActionTaskPermissionService
         => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
 
     public bool CanSubmit(string role)
-        => role is RoleNames.Comdt or RoleNames.HoD or RoleNames.ProjectOfficer or RoleNames.Mco or RoleNames.Ta;
+        => role is RoleNames.Comdt or RoleNames.HoD or RoleNames.ProjectOfficer or RoleNames.Mco or RoleNames.Ta or RoleNames.Ito;
 }

--- a/Services/ActionTasks/ActionTaskRoleResolver.cs
+++ b/Services/ActionTasks/ActionTaskRoleResolver.cs
@@ -14,7 +14,8 @@ public static class ActionTaskRoleResolver
         RoleNames.HoD,
         RoleNames.ProjectOfficer,
         RoleNames.Mco,
-        RoleNames.Ta
+        RoleNames.Ta,
+        RoleNames.Ito
     };
 
     // SECTION: Resolve highest-precedence action-tracker role
@@ -32,7 +33,7 @@ public static class ActionTaskRoleResolver
     }
 
     public static IReadOnlyList<string> AllowedAssignmentRoles()
-        => new[] { RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta };
+        => new[] { RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta, RoleNames.Ito };
 
     // SECTION: Resolve highest-precedence tracker role from user role list
     public static string? ResolveFromRoles(IEnumerable<string> roles)


### PR DESCRIPTION
### Motivation

- Introduce a Phase 1A sprint domain to support sprint planning and controlled task movement without changing existing task lifecycle or UI behaviors.  
- Enforce the requested assignment matrix and sprint authority rules in a low-regression, service-layer manner.  
- Keep integrations minimal so current collaboration, attachments, audit, inspector, register, dashboard, kanban and routing remain intact.

### Description

- Added the sprint domain model `ActionSprint` and enum `ActionSprintStatus` and stored sprint status as a string via EF conversion, with `Planned`, `Active`, and `Closed` states and audit/timestamps (`Models/ActionSprint.cs`, `Models/ActionSprintStatus.cs`).  
- Extended `ActionTaskItem` with nullable `SprintId` and optional navigation `Sprint` so `SprintId == null` represents backlog, and preserved task lifecycle fields (modified `Models/ActionTaskItem.cs`).  
- Updated `ApplicationDbContext` to add `DbSet<ActionSprint>`, configure the optional FK from `ActionTaskItem.SprintId` with `Restrict` delete behavior, and add indexes on `SprintId`, sprint `Status`, and `StartDate/EndDate` (modified `Data/ApplicationDbContext.cs`).  
- Added EF migration `20261125180000_AddActionSprints` to create the `ActionSprints` table, add nullable `ActionTasks.SprintId`, create indexes, and create a restrictive FK (new `Migrations/20261125180000_AddActionSprints.cs`).  
- Implemented `ActionSprintWorkflowPolicy` to centralize date and lifecycle validation rules and immutability of closed sprints (new `Services/ActionTasks/ActionSprintWorkflowPolicy.cs`).  
- Implemented `ActionSprintService` providing `CreateSprintAsync`, `UpdateSprintAsync`, `ActivateSprintAsync`, `CloseSprintAsync`, `AssignTaskToSprintAsync`, and `MoveTaskToBacklogAsync`, enforcing single-active-sprint at activation and rejecting assignment to closed sprints while emitting minimal task audit entries (new `Services/ActionTasks/ActionSprintService.cs`).  
- Extended `ActionTaskPermissionService` to enforce the exact assignment matrix, to add sprint management permissions limited to `Comdt` and `HoD`, and to include `Ito` where requested; updated `ActionTaskRoleResolver` to include `ITO` in precedence and assignable roles (modified `Services/ActionTasks/ActionTaskPermissionService.cs` and `Services/ActionTasks/ActionTaskRoleResolver.cs`).  
- Registered `ActionSprintWorkflowPolicy` and `ActionSprintService` in DI with minimal `Program.cs` changes (modified `Program.cs`).  
- Used existing `ActionTaskAuditLog` to add sprint-related task movement audit entries when tasks are assigned to or moved from a sprint (implemented in `ActionSprintService`).  
- Added automated tests covering the permission matrix and core sprint operations including create, invalid date rejection, activate, single-active-sprint enforcement, close, cannot-assign-to-closed-sprint, and move-to-backlog (new `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` and updated `ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs`).

### Testing

- Added unit tests for permission matrix (`ActionTaskPermissionServiceTests`) and sprint service flows (`ActionSprintServiceTests`) but they were not executed in this environment because the `dotnet` CLI is not available.  
- Verified repository-level checks such as `git diff --check` and inspected diffs to ensure model and migration changes are compile-safe locally; `dotnet build`/`dotnet test` could not be run here due to missing tooling.  
- Migration file `20261125180000_AddActionSprints` was added and included in the model snapshot so `dotnet ef migrations` / `Database.Migrate()` in a fully provisioned environment should apply the schema changes (test `ApplicationDatabaseMigrationsTests` would validate pending migrations when executed in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae37587f48329b03e97b6fae512ac)