### PR TITLE
Harden Action Tracker sprint Phase 1A backend

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -51,6 +51,7 @@ namespace ProjectManagement.Data
         public DbSet<TodoItem> TodoItems => Set<TodoItem>();
         public DbSet<ActionTaskItem> ActionTasks => Set<ActionTaskItem>();
         public DbSet<ActionSprint> ActionSprints => Set<ActionSprint>();
+        public DbSet<ActionSprintAuditLog> ActionSprintAuditLogs => Set<ActionSprintAuditLog>();
         public DbSet<ActionTaskAuditLog> ActionTaskAuditLogs => Set<ActionTaskAuditLog>();
         public DbSet<ActionTaskUpdate> ActionTaskUpdates => Set<ActionTaskUpdate>();
         public DbSet<ActionTaskAttachment> ActionTaskAttachments => Set<ActionTaskAttachment>();
@@ -1838,6 +1839,9 @@ namespace ProjectManagement.Data
 
             builder.Entity<ActionSprint>(e =>
             {
+                // SECTION: Optimistic concurrency token mapping for action sprints
+                ConfigureRowVersion(e);
+
                 // SECTION: Sprint indexing strategy
                 e.HasIndex(x => x.Status);
                 e.HasIndex(x => new { x.StartDate, x.EndDate });
@@ -1854,6 +1858,21 @@ namespace ProjectManagement.Data
                 e.Property(x => x.StartDate).HasColumnType("date");
                 e.Property(x => x.EndDate).HasColumnType("date");
                 e.Property(x => x.IsDeleted).HasDefaultValue(false);
+            });
+
+            builder.Entity<ActionSprintAuditLog>(e =>
+            {
+                e.HasIndex(x => new { x.SprintId, x.PerformedAt });
+                e.HasIndex(x => x.PerformedByUserId);
+                e.Property(x => x.ActionType).IsRequired().HasMaxLength(64);
+                e.Property(x => x.PerformedByUserId).IsRequired().HasMaxLength(450);
+                e.Property(x => x.PerformedByRole).IsRequired().HasMaxLength(64);
+                e.Property(x => x.Remarks).HasMaxLength(2000);
+                // SECTION: Keep sprint lifecycle audit entries with their sprint record
+                e.HasOne(x => x.Sprint)
+                    .WithMany(x => x.AuditLogs)
+                    .HasForeignKey(x => x.SprintId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             builder.Entity<ActionTaskAuditLog>(e =>

--- a/Migrations/20261125190000_AddActionSprintAuditAndConcurrency.cs
+++ b/Migrations/20261125190000_AddActionSprintAuditAndConcurrency.cs
@@ -1,0 +1,72 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125190000_AddActionSprintAuditAndConcurrency")]
+    public partial class AddActionSprintAuditAndConcurrency : Migration
+    {
+        // SECTION: Add sprint lifecycle audit storage and concurrency token
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "ActionSprints",
+                type: "bytea",
+                nullable: false,
+                defaultValue: Array.Empty<byte>());
+
+            migrationBuilder.CreateTable(
+                name: "ActionSprintAuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SprintId = table.Column<int>(type: "integer", nullable: false),
+                    ActionType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    PerformedByUserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    PerformedByRole = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    PerformedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    OldValue = table.Column<string>(type: "text", nullable: true),
+                    NewValue = table.Column<string>(type: "text", nullable: true),
+                    Remarks = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActionSprintAuditLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ActionSprintAuditLogs_ActionSprints_SprintId",
+                        column: x => x.SprintId,
+                        principalTable: "ActionSprints",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionSprintAuditLogs_PerformedByUserId",
+                table: "ActionSprintAuditLogs",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActionSprintAuditLogs_SprintId_PerformedAt",
+                table: "ActionSprintAuditLogs",
+                columns: new[] { "SprintId", "PerformedAt" });
+        }
+
+        // SECTION: Remove sprint lifecycle audit storage and concurrency token
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ActionSprintAuditLogs");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "ActionSprints");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2184,6 +2184,54 @@ namespace ProjectManagement.Migrations
                     b.ToTable("ActionTaskAttachments");
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.ActionSprintAuditLog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("ActionType")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("NewValue")
+                        .HasColumnType("text");
+
+                    b.Property<string>("OldValue")
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("PerformedAt")
+                        .HasColumnType("timestamp without time zone");
+
+                    b.Property<string>("PerformedByRole")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.Property<string>("PerformedByUserId")
+                        .IsRequired()
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
+                    b.Property<string>("Remarks")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<int>("SprintId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PerformedByUserId");
+
+                    b.HasIndex("SprintId", "PerformedAt");
+
+                    b.ToTable("ActionSprintAuditLogs");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.ActionTaskAuditLog", b =>
                 {
                     b.Property<int>("Id")
@@ -2275,6 +2323,11 @@ namespace ProjectManagement.Migrations
                         .IsRequired()
                         .HasMaxLength(160)
                         .HasColumnType("character varying(160)");
+
+                    b.Property<byte[]>("RowVersion")
+                        .IsConcurrencyToken()
+                        .IsRequired()
+                        .HasColumnType("bytea");
 
                     b.Property<DateTime>("StartDate")
                         .HasColumnType("date");
@@ -6675,8 +6728,21 @@ namespace ProjectManagement.Migrations
                         .OnDelete(DeleteBehavior.Restrict);
                 });
 
+            modelBuilder.Entity("ProjectManagement.Models.ActionSprintAuditLog", b =>
+                {
+                    b.HasOne("ProjectManagement.Models.ActionSprint", "Sprint")
+                        .WithMany("AuditLogs")
+                        .HasForeignKey("SprintId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Sprint");
+                });
+
             modelBuilder.Entity("ProjectManagement.Models.ActionSprint", b =>
                 {
+                    b.Navigation("AuditLogs");
+
                     b.Navigation("Tasks");
                 });
 

--- a/Models/ActionSprint.cs
+++ b/Models/ActionSprint.cs
@@ -40,5 +40,10 @@ public class ActionSprint
 
     public bool IsDeleted { get; set; }
 
+    // SECTION: Optimistic concurrency token for sprint updates
+    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+
+    // SECTION: Sprint relationships
     public ICollection<ActionTaskItem> Tasks { get; set; } = new List<ActionTaskItem>();
+    public ICollection<ActionSprintAuditLog> AuditLogs { get; set; } = new List<ActionSprintAuditLog>();
 }

--- a/Models/ActionSprintAuditLog.cs
+++ b/Models/ActionSprintAuditLog.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Models;
+
+public class ActionSprintAuditLog
+{
+    [Key]
+    public int Id { get; set; }
+
+    public int SprintId { get; set; }
+
+    // SECTION: Audit action metadata
+    [Required, StringLength(64)]
+    public string ActionType { get; set; } = string.Empty;
+
+    [Required, StringLength(450)]
+    public string PerformedByUserId { get; set; } = string.Empty;
+
+    [Required, StringLength(64)]
+    public string PerformedByRole { get; set; } = string.Empty;
+
+    public DateTime PerformedAt { get; set; }
+
+    // SECTION: Audit value snapshot
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+
+    [StringLength(2000)]
+    public string? Remarks { get; set; }
+
+    // SECTION: Sprint relationship
+    public ActionSprint? Sprint { get; set; }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -23,6 +23,7 @@ public class ActionSprintServiceTests
         Assert.True(sprint.Id > 0);
         Assert.Equal(ActionSprintStatus.Planned, sprint.Status);
         Assert.Equal("planner", sprint.CreatedByUserId);
+        Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == sprint.Id && x.ActionType == "SprintCreated");
     }
 
     [Fact]
@@ -40,6 +41,33 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
+    public async Task CreateSprintAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateSprintAsync(NewSprint(), "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task UpdateSprintAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateSprintAsync(sprint.Id, "Updated", "Goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
     public async Task ActivateSprintAsync_PlannedSprint_BecomesActive()
     {
         // SECTION: Arrange
@@ -53,6 +81,21 @@ public class ActionSprintServiceTests
         // SECTION: Assert
         Assert.Equal(ActionSprintStatus.Active, active.Status);
         Assert.NotNull(active.ActivatedAtUtc);
+        Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == sprint.Id && x.ActionType == "SprintActivated");
+    }
+
+    [Fact]
+    public async Task ActivateSprintAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ActivateSprintAsync(sprint.Id, "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
     [Fact]
@@ -86,6 +129,38 @@ public class ActionSprintServiceTests
         // SECTION: Assert
         Assert.Equal(ActionSprintStatus.Closed, closed.Status);
         Assert.NotNull(closed.ClosedAtUtc);
+        Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == sprint.Id && x.ActionType == "SprintClosed");
+    }
+
+    [Fact]
+    public async Task CloseSprintAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintAsync(sprint.Id, "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task UpdateSprintAsync_WithPlanningAuthority_UpdatesAndAuditsSprint()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Act
+        var updated = await service.UpdateSprintAsync(sprint.Id, "Updated Sprint", "Updated goal", DateTime.UtcNow.Date.AddDays(1), DateTime.UtcNow.Date.AddDays(8), "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        Assert.Equal("Updated Sprint", updated.Name);
+        Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == sprint.Id && x.ActionType == "SprintUpdated" && x.OldValue != null && x.NewValue != null);
     }
 
     [Fact]
@@ -106,6 +181,36 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
+    public async Task AssignTaskToSprintAsync_WhenTaskClosed_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Closed);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt));
+        Assert.Contains("closed tasks cannot be assigned", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task AssignTaskToSprintAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
     public async Task MoveTaskToBacklogAsync_ClearsSprintIdAndAuditsMove()
     {
         // SECTION: Arrange
@@ -121,6 +226,39 @@ public class ActionSprintServiceTests
         // SECTION: Assert
         Assert.Null(backlogTask.SprintId);
         Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskMovedToBacklog");
+    }
+
+    [Fact]
+    public async Task MoveTaskToBacklogAsync_WhenTaskClosed_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Closed);
+        task.SprintId = sprint.Id;
+        await db.SaveChangesAsync();
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.MoveTaskToBacklogAsync(task.Id, "planner", RoleNames.HoD));
+        Assert.Contains("closed tasks cannot be moved", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task MoveTaskToBacklogAsync_WithNonAuthority_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.MoveTaskToBacklogAsync(task.Id, "actor", RoleNames.ProjectOfficer));
+        Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
     // SECTION: Test helpers
@@ -147,8 +285,9 @@ public class ActionSprintServiceTests
             EndDate = DateTime.UtcNow.Date.AddDays(endOffsetDays)
         };
 
-    private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db)
+    private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db, string status = ActionTaskStatuses.Assigned)
     {
+        var now = DateTime.UtcNow;
         var task = new ActionTaskItem
         {
             Title = "Task",
@@ -157,10 +296,11 @@ public class ActionSprintServiceTests
             AssignedToUserId = "assignee",
             CreatedByRole = RoleNames.HoD,
             AssignedToRole = RoleNames.Ta,
-            DueDate = DateTime.UtcNow.AddDays(1),
+            DueDate = now.AddDays(1),
             Priority = "Normal",
-            AssignedOn = DateTime.UtcNow,
-            Status = ActionTaskStatuses.Assigned,
+            AssignedOn = now,
+            Status = status,
+            ClosedOn = string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) ? now : null,
             RowVersion = [1, 2, 3]
         };
 

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
@@ -69,10 +69,22 @@ public class ActionTaskPermissionServiceTests
         // SECTION: Act
         var canManageSprints = service.CanManageSprints(role);
         var canMoveTasksInSprint = service.CanMoveTasksInSprint(role);
+        var canCreateSprint = service.CanCreateSprint(role);
+        var canEditSprint = service.CanEditSprint(role);
+        var canActivateSprint = service.CanActivateSprint(role);
+        var canCloseSprint = service.CanCloseSprint(role);
+        var canAssignTaskToSprint = service.CanAssignTaskToSprint(role);
+        var canMoveTaskToBacklog = service.CanMoveTaskToBacklog(role);
 
         // SECTION: Assert
         Assert.Equal(expected, canManageSprints);
         Assert.Equal(expected, canMoveTasksInSprint);
+        Assert.Equal(expected, canCreateSprint);
+        Assert.Equal(expected, canEditSprint);
+        Assert.Equal(expected, canActivateSprint);
+        Assert.Equal(expected, canCloseSprint);
+        Assert.Equal(expected, canAssignTaskToSprint);
+        Assert.Equal(expected, canMoveTaskToBacklog);
     }
 
 }

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -26,28 +26,35 @@ public class ActionSprintService
     // SECTION: Sprint mutation APIs
     public async Task<ActionSprint> CreateSprintAsync(ActionSprint sprint, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanManageSprint(role);
+        EnsureCanCreateSprint(role);
         _workflow.ValidateDateRange(sprint.StartDate, sprint.EndDate);
 
+        var performedAt = DateTime.UtcNow;
         sprint.Status = ActionSprintStatus.Planned;
         sprint.CreatedByUserId = userId;
         sprint.CreatedByRole = role;
-        sprint.CreatedAtUtc = DateTime.UtcNow;
+        sprint.CreatedAtUtc = performedAt;
         sprint.StartDate = sprint.StartDate.Date;
         sprint.EndDate = sprint.EndDate.Date;
 
         _context.ActionSprints.Add(sprint);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        AddSprintAudit(sprint.Id, "SprintCreated", userId, role, performedAt, null, DescribeSprint(sprint), $"Created sprint: {sprint.Name}");
         await _context.SaveChangesAsync(cancellationToken);
         return sprint;
     }
 
     public async Task<ActionSprint> UpdateSprintAsync(int sprintId, string name, string? goal, DateTime startDate, DateTime endDate, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanManageSprint(role);
+        EnsureCanEditSprint(role);
         _workflow.ValidateDateRange(startDate, endDate);
 
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanUpdate(sprint);
+
+        var performedAt = DateTime.UtcNow;
+        var oldValue = DescribeSprint(sprint);
 
         sprint.Name = name;
         sprint.Goal = goal;
@@ -55,15 +62,16 @@ public class ActionSprintService
         sprint.EndDate = endDate.Date;
         sprint.UpdatedByUserId = userId;
         sprint.UpdatedByRole = role;
-        sprint.UpdatedAtUtc = DateTime.UtcNow;
+        sprint.UpdatedAtUtc = performedAt;
 
+        AddSprintAudit(sprint.Id, "SprintUpdated", userId, role, performedAt, oldValue, DescribeSprint(sprint), $"Updated sprint: {sprint.Name}");
         await _context.SaveChangesAsync(cancellationToken);
         return sprint;
     }
 
     public async Task<ActionSprint> ActivateSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanManageSprint(role);
+        EnsureCanActivateSprint(role);
 
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanActivate(sprint);
@@ -76,29 +84,37 @@ public class ActionSprintService
             throw new InvalidOperationException("Only one active sprint is allowed.");
         }
 
+        var performedAt = DateTime.UtcNow;
+        var oldStatus = sprint.Status.ToString();
+
         sprint.Status = ActionSprintStatus.Active;
-        sprint.ActivatedAtUtc = DateTime.UtcNow;
+        sprint.ActivatedAtUtc = performedAt;
         sprint.UpdatedByUserId = userId;
         sprint.UpdatedByRole = role;
-        sprint.UpdatedAtUtc = sprint.ActivatedAtUtc;
+        sprint.UpdatedAtUtc = performedAt;
 
+        AddSprintAudit(sprint.Id, "SprintActivated", userId, role, performedAt, oldStatus, sprint.Status.ToString(), $"Activated sprint: {sprint.Name}");
         await _context.SaveChangesAsync(cancellationToken);
         return sprint;
     }
 
     public async Task<ActionSprint> CloseSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanManageSprint(role);
+        EnsureCanCloseSprint(role);
 
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanClose(sprint);
 
+        var performedAt = DateTime.UtcNow;
+        var oldStatus = sprint.Status.ToString();
+
         sprint.Status = ActionSprintStatus.Closed;
-        sprint.ClosedAtUtc = DateTime.UtcNow;
+        sprint.ClosedAtUtc = performedAt;
         sprint.UpdatedByUserId = userId;
         sprint.UpdatedByRole = role;
-        sprint.UpdatedAtUtc = sprint.ClosedAtUtc;
+        sprint.UpdatedAtUtc = performedAt;
 
+        AddSprintAudit(sprint.Id, "SprintClosed", userId, role, performedAt, oldStatus, sprint.Status.ToString(), $"Closed sprint: {sprint.Name}");
         await _context.SaveChangesAsync(cancellationToken);
         return sprint;
     }
@@ -106,9 +122,11 @@ public class ActionSprintService
     // SECTION: Sprint task assignment APIs
     public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanMoveTasksInSprint(role);
+        EnsureCanAssignTaskToSprint(role);
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        EnsureTaskIsNotClosed(task, "Closed tasks cannot be assigned to a sprint.");
+
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanAcceptTask(sprint);
 
@@ -122,9 +140,11 @@ public class ActionSprintService
 
     public async Task<ActionTaskItem> MoveTaskToBacklogAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
     {
-        EnsureCanMoveTasksInSprint(role);
+        EnsureCanMoveTaskToBacklog(role);
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between sprint and backlog.");
+
         if (task.SprintId.HasValue)
         {
             var currentSprint = await GetSprintForUpdateAsync(task.SprintId.Value, cancellationToken);
@@ -140,19 +160,51 @@ public class ActionSprintService
     }
 
     // SECTION: Authorization helpers
-    private void EnsureCanManageSprint(string role)
+    private void EnsureCanCreateSprint(string role)
     {
-        if (!_permission.CanManageSprints(role))
+        if (!_permission.CanCreateSprint(role))
         {
-            throw new InvalidOperationException("You are not authorized to manage sprints.");
+            throw new InvalidOperationException("You are not authorized to create sprints.");
         }
     }
 
-    private void EnsureCanMoveTasksInSprint(string role)
+    private void EnsureCanEditSprint(string role)
     {
-        if (!_permission.CanMoveTasksInSprint(role))
+        if (!_permission.CanEditSprint(role))
         {
-            throw new InvalidOperationException("You are not authorized to move tasks into or out of sprints.");
+            throw new InvalidOperationException("You are not authorized to update sprints.");
+        }
+    }
+
+    private void EnsureCanActivateSprint(string role)
+    {
+        if (!_permission.CanActivateSprint(role))
+        {
+            throw new InvalidOperationException("You are not authorized to activate sprints.");
+        }
+    }
+
+    private void EnsureCanCloseSprint(string role)
+    {
+        if (!_permission.CanCloseSprint(role))
+        {
+            throw new InvalidOperationException("You are not authorized to close sprints.");
+        }
+    }
+
+    private void EnsureCanAssignTaskToSprint(string role)
+    {
+        if (!_permission.CanAssignTaskToSprint(role))
+        {
+            throw new InvalidOperationException("You are not authorized to assign tasks to sprints.");
+        }
+    }
+
+    private void EnsureCanMoveTaskToBacklog(string role)
+    {
+        if (!_permission.CanMoveTaskToBacklog(role))
+        {
+            throw new InvalidOperationException("You are not authorized to move tasks to backlog.");
         }
     }
 
@@ -164,6 +216,14 @@ public class ActionSprintService
     private async Task<ActionTaskItem> GetTaskForUpdateAsync(int taskId, CancellationToken cancellationToken)
         => await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken)
             ?? throw new InvalidOperationException("Task not found.");
+
+    private static void EnsureTaskIsNotClosed(ActionTaskItem task, string message)
+    {
+        if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
 
     // SECTION: Audit helpers
     private void AddTaskSprintAudit(int taskId, string actionType, string userId, string role, string? oldValue, string? newValue, string remarks)
@@ -180,4 +240,22 @@ public class ActionSprintService
             Remarks = remarks
         });
     }
+
+    private void AddSprintAudit(int sprintId, string actionType, string userId, string role, DateTime performedAt, string? oldValue, string? newValue, string remarks)
+    {
+        _context.ActionSprintAuditLogs.Add(new ActionSprintAuditLog
+        {
+            SprintId = sprintId,
+            ActionType = actionType,
+            PerformedByUserId = userId,
+            PerformedByRole = role,
+            PerformedAt = performedAt,
+            OldValue = oldValue,
+            NewValue = newValue,
+            Remarks = remarks
+        });
+    }
+
+    private static string DescribeSprint(ActionSprint sprint)
+        => $"Name={sprint.Name}; Goal={sprint.Goal}; StartDate={sprint.StartDate:yyyy-MM-dd}; EndDate={sprint.EndDate:yyyy-MM-dd}; Status={sprint.Status}";
 }

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -25,7 +25,7 @@ public class ActionTaskPermissionService
 
     // SECTION: Role capability checks
     public bool CanCreate(string role)
-        => role == RoleNames.Comdt || role == RoleNames.HoD;
+        => IsPlanningAuthority(role);
 
     public bool CanAssign(string assignerRole, string assigneeRole)
     {
@@ -43,16 +43,36 @@ public class ActionTaskPermissionService
     }
 
     public bool CanClose(string role)
-        => role == RoleNames.Comdt || role == RoleNames.HoD;
+        => IsPlanningAuthority(role);
 
+    // SECTION: Sprint lifecycle permission checks
+    public bool CanCreateSprint(string role)
+        => IsPlanningAuthority(role);
+
+    public bool CanEditSprint(string role)
+        => IsPlanningAuthority(role);
+
+    public bool CanActivateSprint(string role)
+        => IsPlanningAuthority(role);
+
+    public bool CanCloseSprint(string role)
+        => IsPlanningAuthority(role);
+
+    public bool CanAssignTaskToSprint(string role)
+        => IsPlanningAuthority(role);
+
+    public bool CanMoveTaskToBacklog(string role)
+        => IsPlanningAuthority(role);
+
+    // SECTION: Backward-compatible broad sprint capability checks
     public bool CanManageSprints(string role)
-        => role == RoleNames.Comdt || role == RoleNames.HoD;
+        => IsPlanningAuthority(role);
 
     public bool CanMoveTasksInSprint(string role)
-        => CanManageSprints(role);
+        => IsPlanningAuthority(role);
 
     public bool CanViewAll(string role)
-        => role == RoleNames.Comdt || role == RoleNames.HoD;
+        => IsPlanningAuthority(role);
 
     public bool CanViewLogs(string role, string currentUserId, string ownerUserId)
         => CanViewAll(role) || string.Equals(currentUserId, ownerUserId, StringComparison.Ordinal);
@@ -74,4 +94,9 @@ public class ActionTaskPermissionService
 
     public bool CanSubmit(string role)
         => role is RoleNames.Comdt or RoleNames.HoD or RoleNames.ProjectOfficer or RoleNames.Mco or RoleNames.Ta or RoleNames.Ito;
+
+    // SECTION: Shared role helpers
+    private static bool IsPlanningAuthority(string role)
+        => string.Equals(role, RoleNames.Comdt, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(role, RoleNames.HoD, StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
### Motivation
- Make Phase 1A sprint backend safer and more explicit by adding targeted authorization checks, audit coverage and optimistic concurrency without changing UI or scope. 
- Prevent data regressions by rejecting invalid state transitions (notably assigning closed tasks to sprints) and by preserving existing Phase 1A semantics. 
- Provide minimal audit traces for sprint lifecycle events so future UI/workflow work can rely on recorded sprint actions.

### Description
- Permission surface: added explicit sprint permission methods to `ActionTaskPermissionService`: `CanCreateSprint`, `CanEditSprint`, `CanActivateSprint`, `CanCloseSprint`, `CanAssignTaskToSprint`, `CanMoveTaskToBacklog`, while keeping backward-compatible broad checks. (file: `Services/ActionTasks/ActionTaskPermissionService.cs`).
- Service authorization & validation: updated `ActionSprintService` to use the explicit permission checks and added closed-task validation so a task with `Status == Closed` cannot be assigned to a sprint and cannot be moved to/from a sprint/backlog. (file: `Services/ActionTasks/ActionSprintService.cs`).
- Sprint lifecycle audit: added `ActionSprintAuditLog` entity + EF mapping + `DbSet<ActionSprintAuditLog>` and wrote audit entries for `SprintCreated`, `SprintUpdated`, `SprintActivated`, and `SprintClosed` capturing action, actor, timestamp and old/new/remarks. (files: `Models/ActionSprintAuditLog.cs`, `Data/ApplicationDbContext.cs`).
- Optimistic concurrency: added `RowVersion` to `ActionSprint` and configured EF mapping consistent with existing byte-array concurrency tokens used elsewhere. (files: `Models/ActionSprint.cs`, `Data/ApplicationDbContext.cs`).
- Migration: added migration `Migrations/20261125190000_AddActionSprintAuditAndConcurrency.cs` to create `ActionSprintAuditLogs` and add `ActionSprints.RowVersion`.
- Tests: expanded unit tests to cover the explicit permissions and unauthorized paths plus closed-task checks and sprint-audit assertions. New/updated tests live under `ProjectManagement.Tests/ActionTasks` (files updated: `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs`, `ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs`).
- Files of primary interest changed/added: `Services/ActionTasks/ActionSprintService.cs`, `Services/ActionTasks/ActionTaskPermissionService.cs`, `Models/ActionSprint.cs`, `Models/ActionSprintAuditLog.cs` (new), `Data/ApplicationDbContext.cs`, `Migrations/20261125190000_AddActionSprintAuditAndConcurrency.cs` (new), `Migrations/ApplicationDbContextModelSnapshot.cs` (updated), and tests under `ProjectManagement.Tests/ActionTasks`.

### Testing
- Added unit tests for explicit permission checks and unauthorized actor attempts to: create, update, activate, close sprints; assign tasks to sprint; move tasks to backlog; and closed-task rejection paths (see `ProjectManagement.Tests/ActionTasks/*`).
- Ran repository checks (`git diff --check`) — no whitespace diff issues found. 
- Attempted to run build/tests in this environment but `dotnet` is not available here, so `dotnet build` / `dotnet test` could not be executed; the new tests therefore could not be executed in CI from this environment. 
- Migration: added migration file `20261125190000_AddActionSprintAuditAndConcurrency` to bring DB schema in sync with model changes; please run `dotnet ef migrations add` / `dotnet ef database update` in your normal development/CI environment to apply and validate migrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faecb6dc4c83298921cffb61578577)