### PR TITLE
Require sprint row-version for mutations, surface concurrency errors, and include ITO in ActionTracker policy

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -220,7 +220,7 @@ builder.Services.AddAuthorization(options =>
 
     // SECTION: Action tracker authorization policy
     options.AddPolicy("ActionTracker.Access", policy =>
-        policy.RequireRole(RoleNames.Comdt, RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta));
+        policy.RequireRole(RoleNames.Comdt, RoleNames.HoD, RoleNames.ProjectOfficer, RoleNames.Mco, RoleNames.Ta, RoleNames.Ito));
 
 
 });

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -63,7 +63,7 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.UpdateSprintAsync(sprint.Id, "Updated", "Goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "actor", RoleNames.ProjectOfficer));
+            service.UpdateSprintAsync(sprint.Id, sprint.RowVersion, "Updated", "Goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "actor", RoleNames.ProjectOfficer));
         Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
@@ -76,7 +76,7 @@ public class ActionSprintServiceTests
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
 
         // SECTION: Act
-        var active = await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+        var active = await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         Assert.Equal(ActionSprintStatus.Active, active.Status);
@@ -94,7 +94,7 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.ActivateSprintAsync(sprint.Id, "actor", RoleNames.ProjectOfficer));
+            service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "actor", RoleNames.ProjectOfficer));
         Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
@@ -106,11 +106,11 @@ public class ActionSprintServiceTests
         var service = CreateService(db);
         var first = await service.CreateSprintAsync(NewSprint("Sprint 1"), "planner", RoleNames.Comdt);
         var second = await service.CreateSprintAsync(NewSprint("Sprint 2"), "planner", RoleNames.Comdt);
-        await service.ActivateSprintAsync(first.Id, "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(first.Id, first.RowVersion, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.ActivateSprintAsync(second.Id, "planner", RoleNames.Comdt));
+            service.ActivateSprintAsync(second.Id, second.RowVersion, "planner", RoleNames.Comdt));
         Assert.Contains("Only one active sprint", ex.Message);
     }
 
@@ -121,10 +121,10 @@ public class ActionSprintServiceTests
         await using var db = CreateDb();
         var service = CreateService(db);
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
-        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+        await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.HoD);
 
         // SECTION: Act
-        var closed = await service.CloseSprintAsync(sprint.Id, "planner", RoleNames.HoD);
+        var closed = await service.CloseSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         Assert.Equal(ActionSprintStatus.Closed, closed.Status);
@@ -139,11 +139,11 @@ public class ActionSprintServiceTests
         await using var db = CreateDb();
         var service = CreateService(db);
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
-        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.CloseSprintAsync(sprint.Id, "actor", RoleNames.ProjectOfficer));
+            service.CloseSprintAsync(sprint.Id, sprint.RowVersion, "actor", RoleNames.ProjectOfficer));
         Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
@@ -156,11 +156,58 @@ public class ActionSprintServiceTests
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
 
         // SECTION: Act
-        var updated = await service.UpdateSprintAsync(sprint.Id, "Updated Sprint", "Updated goal", DateTime.UtcNow.Date.AddDays(1), DateTime.UtcNow.Date.AddDays(8), "planner", RoleNames.Comdt);
+        var updated = await service.UpdateSprintAsync(sprint.Id, sprint.RowVersion, "Updated Sprint", "Updated goal", DateTime.UtcNow.Date.AddDays(1), DateTime.UtcNow.Date.AddDays(8), "planner", RoleNames.Comdt);
 
         // SECTION: Assert
         Assert.Equal("Updated Sprint", updated.Name);
         Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == sprint.Id && x.ActionType == "SprintUpdated" && x.OldValue != null && x.NewValue != null);
+    }
+
+    [Fact]
+    public async Task UpdateSprintAsync_WithoutRowVersion_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateSprintAsync(sprint.Id, Array.Empty<byte>(), "Updated", "Goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "planner", RoleNames.Comdt));
+        Assert.Contains("row version", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task UpdateSprintAsync_WithStaleRowVersion_RaisesConcurrencyConflict()
+    {
+        // SECTION: Arrange
+        var databaseName = Guid.NewGuid().ToString();
+        var databaseRoot = new InMemoryDatabaseRoot();
+        byte[] staleRowVersion;
+        int sprintId;
+
+        await using (var setupDb = CreateDb(databaseName, databaseRoot))
+        {
+            var setupService = CreateService(setupDb);
+            var sprint = await setupService.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+            staleRowVersion = sprint.RowVersion.ToArray();
+            sprintId = sprint.Id;
+        }
+
+        await using (var currentDb = CreateDb(databaseName, databaseRoot))
+        {
+            var currentService = CreateService(currentDb);
+            var currentSprint = await currentDb.ActionSprints.SingleAsync(x => x.Id == sprintId);
+            await currentService.UpdateSprintAsync(currentSprint.Id, currentSprint.RowVersion, "Current Sprint", "Current goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "planner", RoleNames.Comdt);
+        }
+
+        await using var staleDb = CreateDb(databaseName, databaseRoot);
+        var staleService = CreateService(staleDb);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<ActionTaskConcurrencyException>(() =>
+            staleService.UpdateSprintAsync(sprintId, staleRowVersion, "Stale Sprint", "Stale goal", DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(7), "planner", RoleNames.Comdt));
+        Assert.Contains("updated by another user", ex.Message);
     }
 
     [Fact]
@@ -170,8 +217,8 @@ public class ActionSprintServiceTests
         await using var db = CreateDb();
         var service = CreateService(db);
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
-        await service.ActivateSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
-        await service.CloseSprintAsync(sprint.Id, "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
+        await service.CloseSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
 
         // SECTION: Act + Assert

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -45,13 +45,16 @@ public class ActionSprintService
         return sprint;
     }
 
-    public async Task<ActionSprint> UpdateSprintAsync(int sprintId, string name, string? goal, DateTime startDate, DateTime endDate, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionSprint> UpdateSprintAsync(int sprintId, byte[] rowVersion, string name, string? goal, DateTime startDate, DateTime endDate, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanEditSprint(role);
         _workflow.ValidateDateRange(startDate, endDate);
 
+        EnsureSprintRowVersionSupplied(rowVersion);
+
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanUpdate(sprint);
+        ApplySprintRowVersion(sprint, rowVersion);
 
         var performedAt = DateTime.UtcNow;
         var oldValue = DescribeSprint(sprint);
@@ -65,16 +68,19 @@ public class ActionSprintService
         sprint.UpdatedAtUtc = performedAt;
 
         AddSprintAudit(sprint.Id, "SprintUpdated", userId, role, performedAt, oldValue, DescribeSprint(sprint), $"Updated sprint: {sprint.Name}");
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveSprintChangesAsync(cancellationToken);
         return sprint;
     }
 
-    public async Task<ActionSprint> ActivateSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionSprint> ActivateSprintAsync(int sprintId, byte[] rowVersion, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanActivateSprint(role);
 
+        EnsureSprintRowVersionSupplied(rowVersion);
+
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanActivate(sprint);
+        ApplySprintRowVersion(sprint, rowVersion);
         _workflow.ValidateDateRange(sprint.StartDate, sprint.EndDate);
 
         var activeSprintExists = await _context.ActionSprints
@@ -94,16 +100,19 @@ public class ActionSprintService
         sprint.UpdatedAtUtc = performedAt;
 
         AddSprintAudit(sprint.Id, "SprintActivated", userId, role, performedAt, oldStatus, sprint.Status.ToString(), $"Activated sprint: {sprint.Name}");
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveSprintChangesAsync(cancellationToken);
         return sprint;
     }
 
-    public async Task<ActionSprint> CloseSprintAsync(int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionSprint> CloseSprintAsync(int sprintId, byte[] rowVersion, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanCloseSprint(role);
 
+        EnsureSprintRowVersionSupplied(rowVersion);
+
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanClose(sprint);
+        ApplySprintRowVersion(sprint, rowVersion);
 
         var performedAt = DateTime.UtcNow;
         var oldStatus = sprint.Status.ToString();
@@ -115,7 +124,7 @@ public class ActionSprintService
         sprint.UpdatedAtUtc = performedAt;
 
         AddSprintAudit(sprint.Id, "SprintClosed", userId, role, performedAt, oldStatus, sprint.Status.ToString(), $"Closed sprint: {sprint.Name}");
-        await _context.SaveChangesAsync(cancellationToken);
+        await SaveSprintChangesAsync(cancellationToken);
         return sprint;
     }
 
@@ -222,6 +231,32 @@ public class ActionSprintService
         if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException(message);
+        }
+    }
+
+    // SECTION: Sprint concurrency helpers
+    private static void EnsureSprintRowVersionSupplied(byte[] rowVersion)
+    {
+        if (rowVersion is not { Length: > 0 })
+        {
+            throw new InvalidOperationException("Sprint row version is required for this operation.");
+        }
+    }
+
+    private void ApplySprintRowVersion(ActionSprint sprint, byte[] rowVersion)
+    {
+        _context.Entry(sprint).Property(x => x.RowVersion).OriginalValue = rowVersion;
+    }
+
+    private async Task SaveSprintChangesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ActionTaskConcurrencyException("This sprint was updated by another user. Please reload the sprint details and try again.");
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent conflicting updates to `ActionSprint` by requiring a caller-supplied concurrency token for sprint mutations and enforcing it in the service layer.  
- Surface stale-update conflicts via the same user-facing concurrency exception pattern used by tasks so UI workflows can handle them consistently.  
- Allow ITO users to access the action tracker UI by adding the `ITO` role to the `ActionTracker.Access` authorization policy.

### Description
- Changed the signatures of `UpdateSprintAsync`, `ActivateSprintAsync`, and `CloseSprintAsync` in `Services/ActionTasks/ActionSprintService.cs` to accept a `byte[] rowVersion` and apply it to EF as the original value before saving.  
- Added sprint concurrency helpers: `EnsureSprintRowVersionSupplied`, `ApplySprintRowVersion`, and `SaveSprintChangesAsync`, and map `DbUpdateConcurrencyException` to the existing `ActionTaskConcurrencyException` message.  
- Replaced direct `_context.SaveChangesAsync` calls in the affected sprint mutators with `SaveSprintChangesAsync` to centralize concurrency handling.  
- Updated the authorization policy in `Program.cs` to include `RoleNames.Ito` for `ActionTracker.Access`.  
- Updated unit tests in `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` to pass `sprint.RowVersion` where required and added tests that verify missing and stale sprint row-version handling (`UpdateSprintAsync_WithoutRowVersion_RejectsRequest` and `UpdateSprintAsync_WithStaleRowVersion_RaisesConcurrencyConflict`).

### Testing
- Attempted to run the targeted unit tests with `dotnet test --filter ActionSprintServiceTests` but the `dotnet` CLI is not available in this environment so automated tests could not be executed.  
- Updated tests compile-time changes were made to `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` to align with the new signatures and added concurrency scenarios, but their execution is pending in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf191effc8329b2a0e69bc5a53877)