### PR TITLE
Action Tracker Sprint Phase 1B: Backlog & Sprints read-model and UI

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -20,7 +20,9 @@
             @* SECTION: Icon-led rail links for compact enterprise navigation. *@
             <a title="Dashboard" asp-page="/ActionTasks/Index" asp-route-viewMode="Dashboard" class="@(Model.IsDashboardView ? "active" : string.Empty)"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Dashboard</span></a>
             <a title="My Tasks" asp-page="/ActionTasks/Index" asp-route-viewMode="MyTasks" class="@(Model.IsMyTasksView ? "active" : string.Empty)"><i class="bi bi-check2-circle" aria-hidden="true"></i><span>My Tasks</span></a>
-            <a title="Due" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)"><i class="bi bi-calendar2-week" aria-hidden="true"></i><span>Due</span></a>
+            <a title="Due Board" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprint" class="@(Model.IsSprintBoardView ? "active" : string.Empty)"><i class="bi bi-calendar2-week" aria-hidden="true"></i><span>Due Board</span></a>
+            <a title="Backlog" asp-page="/ActionTasks/Index" asp-route-viewMode="Backlog" class="@(Model.IsBacklogView ? "active" : string.Empty)"><i class="bi bi-inbox" aria-hidden="true"></i><span>Backlog</span></a>
+            <a title="Sprints" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprints" class="@(Model.IsSprintsView ? "active" : string.Empty)"><i class="bi bi-calendar-range" aria-hidden="true"></i><span>Sprints</span></a>
             <a title="Kanban" asp-page="/ActionTasks/Index" asp-route-viewMode="Kanban" class="@(Model.IsKanbanView ? "active" : string.Empty)"><i class="bi bi-columns-gap" aria-hidden="true"></i><span>Kanban</span></a>
             <a title="Register" asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="@(Model.IsTaskListView ? "active" : string.Empty)"><i class="bi bi-list-task" aria-hidden="true"></i><span>Register</span></a>
             <a title="Reports" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)"><i class="bi bi-bar-chart" aria-hidden="true"></i><span>Reports</span></a>
@@ -60,6 +62,14 @@
         else if (Model.IsSprintBoardView)
         {
             <partial name="_TaskSprintBoard" model="Model" />
+        }
+        else if (Model.IsBacklogView)
+        {
+            <partial name="_TaskBacklog" model="Model" />
+        }
+        else if (Model.IsSprintsView)
+        {
+            <partial name="_TaskSprints" model="Model" />
         }
         else if (Model.IsReportsView)
         {

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -20,15 +20,17 @@ public class IndexModel : PageModel
     private readonly IActionTaskService _service;
     private readonly IActionTaskCollaborationService _collaborationService;
     private readonly ActionTaskPermissionService _permission;
+    private readonly ActionSprintService _sprintService;
     private readonly ActionTaskQueryService _queryService;
     private readonly ActionTaskWorkflowPolicy _workflowPolicy;
     private readonly UserManager<ApplicationUser> _users;
 
-    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionTaskQueryService queryService, ActionTaskWorkflowPolicy workflowPolicy, UserManager<ApplicationUser> users)
+    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionSprintService sprintService, ActionTaskQueryService queryService, ActionTaskWorkflowPolicy workflowPolicy, UserManager<ApplicationUser> users)
     {
         _service = service;
         _collaborationService = collaborationService;
         _permission = permission;
+        _sprintService = sprintService;
         _queryService = queryService;
         _workflowPolicy = workflowPolicy;
         _users = users;
@@ -48,6 +50,13 @@ public class IndexModel : PageModel
     public IReadOnlyList<ActionTaskItem> DueThisWeekTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> DueLaterTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> SprintOverdueTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> BacklogTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> SelectedSprintTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionTaskItem> SprintBacklogTasks { get; private set; } = Array.Empty<ActionTaskItem>();
+    public IReadOnlyList<ActionSprint> Sprints { get; private set; } = Array.Empty<ActionSprint>();
+    public ActionSprint? ActiveSprint { get; private set; }
+    public ActionSprint? SelectedSprint { get; private set; }
+    public ActionTaskQueryService.ActionSprintSummary SprintSummary { get; private set; } = ActionTaskQueryService.ActionSprintSummary.Empty;
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<ActionTaskUpdate> SelectedTaskUpdates { get; private set; } = Array.Empty<ActionTaskUpdate>();
     public IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>> UpdateAttachments { get; private set; } = new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>();
@@ -65,6 +74,9 @@ public class IndexModel : PageModel
 
     [BindProperty(SupportsGet = true)]
     public int? TaskId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? SelectedSprintId { get; set; }
 
     [BindProperty(SupportsGet = true)]
     public string? FilterStatus { get; set; }
@@ -104,11 +116,15 @@ public class IndexModel : PageModel
     public bool IsTaskListView => string.Equals(ResolvedViewMode, "TaskList", StringComparison.OrdinalIgnoreCase);
     public bool IsKanbanView => string.Equals(ResolvedViewMode, "Kanban", StringComparison.OrdinalIgnoreCase);
     public bool IsSprintBoardView => string.Equals(ResolvedViewMode, "Sprint", StringComparison.OrdinalIgnoreCase);
+    public bool IsBacklogView => string.Equals(ResolvedViewMode, "Backlog", StringComparison.OrdinalIgnoreCase);
+    public bool IsSprintsView => string.Equals(ResolvedViewMode, "Sprints", StringComparison.OrdinalIgnoreCase);
     public bool IsReportsView => string.Equals(ResolvedViewMode, "Reports", StringComparison.OrdinalIgnoreCase);
     public string PageHeading => ResolvedViewMode switch
     {
         "MyTasks" => "My Tasks",
-        "Sprint" => "Due Window Board",
+        "Sprint" => "Due Board",
+        "Backlog" => "Task Backlog",
+        "Sprints" => "Sprint Board",
         "Kanban" => "Task Kanban Board",
         "TaskList" => "Command Task Register",
         "Reports" => "Task Command Summary",
@@ -117,7 +133,9 @@ public class IndexModel : PageModel
     public string PageSubtitle => ResolvedViewMode switch
     {
         "MyTasks" => "Tasks assigned to the logged-in user.",
-        "Sprint" => "Tasks grouped by due date and urgency.",
+        "Sprint" => "Existing due-bucket view grouped by due date and urgency.",
+        "Backlog" => "Tasks not assigned to a sprint.",
+        "Sprints" => "Real sprint task view with controlled planning actions.",
         "Kanban" => "Tasks grouped by current workflow status.",
         "TaskList" => "Filterable register of all visible tasks.",
         "Reports" => "Summary of pending, critical, blocked and closed tasks.",
@@ -126,6 +144,8 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
+    public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
+    public IReadOnlyList<ActionSprint> AssignableSprints => Sprints.Where(s => s.Status != ActionSprintStatus.Closed).ToList();
 
     // SECTION: Selected-task projection helper
     public bool IsSelectedTask(ActionTaskItem task)
@@ -165,6 +185,25 @@ public class IndexModel : PageModel
             ? assigneeName
             : "User";
     }
+
+    public string ResolveSprintName(int? sprintId)
+    {
+        if (!sprintId.HasValue)
+        {
+            return "Backlog";
+        }
+
+        return Sprints.FirstOrDefault(s => s.Id == sprintId.Value)?.Name ?? $"Sprint #{sprintId.Value}";
+    }
+
+    public string GetSprintBadgeText(ActionTaskItem task)
+        => task.SprintId.HasValue ? ResolveSprintName(task.SprintId) : "Backlog";
+
+    public string GetSprintBadgeClass(ActionTaskItem task)
+        => task.SprintId.HasValue ? "at-scope-badge at-scope-badge-sprint" : "at-scope-badge at-scope-badge-backlog";
+
+    public IReadOnlyList<TaskDisplayItem> GetSprintTasksByStatus(string status)
+        => ToDisplayItems(SelectedSprintTasks.Where(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase)).ToList());
 
     public string ResolveActorName(string performedByUserId)
     {
@@ -281,7 +320,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
     }
 
     // SECTION: Close task by command role
@@ -302,7 +341,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
     }
 
     // SECTION: Update in-flight status
@@ -316,14 +355,14 @@ public class IndexModel : PageModel
             if (task is null)
             {
                 TempData["ToastError"] = "Task not found.";
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
             }
 
             // SECTION: Preserve permission enforcement even for status no-op submissions.
             if (!_permission.CanUpdateTask(CurrentRole, CurrentUserId, task.AssignedToUserId))
             {
                 TempData["ToastError"] = "You are not authorized to update this task.";
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
             }
 
             // SECTION: Keep no-op handling for user-friendly messaging after permission validation.
@@ -331,7 +370,7 @@ public class IndexModel : PageModel
             if (!string.IsNullOrWhiteSpace(noOpMessage))
             {
                 TempData["ToastMessage"] = noOpMessage;
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
             }
 
             await _service.UpdateStatusAsync(id, DecodeRowVersion(rowVersion), status, CurrentUserId, CurrentRole, remarks);
@@ -346,7 +385,43 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+    }
+
+    // SECTION: Assign backlog or visible task into an available sprint.
+    public async Task<IActionResult> OnPostAssignToSprintAsync(int id, int sprintId)
+    {
+        await ResolveIdentityAsync();
+
+        try
+        {
+            await _sprintService.AssignTaskToSprintAsync(id, sprintId, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task assigned to sprint.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId = sprintId });
+    }
+
+    // SECTION: Move a sprint task back to backlog without altering task lifecycle state.
+    public async Task<IActionResult> OnPostMoveToBacklogAsync(int id)
+    {
+        await ResolveIdentityAsync();
+
+        try
+        {
+            await _sprintService.MoveTaskToBacklogAsync(id, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task moved to backlog.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
     }
 
     // SECTION: Post task progress update with optional attachments
@@ -363,7 +438,7 @@ public class IndexModel : PageModel
         if (!ModelState.IsValid)
         {
             TempData["ToastError"] = "Unable to post update. Please check the entered details and try again.";
-            return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
+            return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId, SelectedSprintId });
         }
 
         try
@@ -381,7 +456,7 @@ public class IndexModel : PageModel
                 : ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId });
+        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId, SelectedSprintId });
     }
 
     // SECTION: Shared data loading
@@ -390,6 +465,7 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
 
         var tasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
+        var sprints = await _sprintService.GetSprintsAsync();
 
         // SECTION: Query read-model dependencies
         AssignableUsers = await LoadAssignableUsersAsync();
@@ -399,7 +475,7 @@ public class IndexModel : PageModel
         var activityByTaskId = await _service.GetLastActivityUtcByTaskIdsAsync(tasks.Select(t => t.Id).ToArray());
         var readModel = _queryService.BuildReadModel(
             tasks,
-            new ActionTaskQueryService.ActionTaskQueryRequest(CurrentUserId, IsMyTasksView, IsTaskListView, FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir),
+            new ActionTaskQueryService.ActionTaskQueryRequest(CurrentUserId, IsMyTasksView, IsTaskListView, IsBacklogView, SelectedSprintId, sprints, FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir),
             TaskAssigneeNames,
             activityByTaskId);
 
@@ -415,6 +491,14 @@ public class IndexModel : PageModel
         KanbanSubmittedTasks = readModel.KanbanSubmittedTasks;
         KanbanClosedTasks = readModel.KanbanClosedTasks;
         SprintOverdueTasks = readModel.DueBuckets.Overdue;
+        BacklogTasks = readModel.BacklogTasks;
+        SelectedSprintTasks = readModel.SprintReadModel.SelectedSprintTasks;
+        SprintBacklogTasks = readModel.SprintReadModel.BacklogTasks;
+        Sprints = readModel.SprintReadModel.Sprints;
+        ActiveSprint = readModel.SprintReadModel.ActiveSprint;
+        SelectedSprint = readModel.SprintReadModel.SelectedSprint;
+        SelectedSprintId = SelectedSprint?.Id ?? SelectedSprintId;
+        SprintSummary = readModel.SprintReadModel.Summary;
         DueTodayTasks = readModel.DueBuckets.Today;
         DueThisWeekTasks = readModel.DueBuckets.ThisWeek;
         DueLaterTasks = readModel.DueBuckets.Later;
@@ -511,6 +595,15 @@ public class IndexModel : PageModel
     public IReadOnlyList<TaskDisplayItem> SprintOverdueTaskDisplays =>
         ToDisplayItems(SprintOverdueTasks);
 
+    public IReadOnlyList<TaskDisplayItem> BacklogTaskDisplays =>
+        ToDisplayItems(BacklogTasks);
+
+    public IReadOnlyList<TaskDisplayItem> SelectedSprintTaskDisplays =>
+        ToDisplayItems(SelectedSprintTasks);
+
+    public IReadOnlyList<TaskDisplayItem> SprintBacklogTaskDisplays =>
+        ToDisplayItems(SprintBacklogTasks);
+
     // SECTION: KPI helpers for dashboard and reports.
     public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
     public int OverdueCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
@@ -532,7 +625,7 @@ public class IndexModel : PageModel
         string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase));
 
     public bool HasActiveFilters =>
-        IsTaskListView &&
+        (IsTaskListView || IsBacklogView) &&
         (!string.IsNullOrWhiteSpace(FilterStatus)
          || !string.IsNullOrWhiteSpace(FilterPriority)
          || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
@@ -765,6 +858,8 @@ public class IndexModel : PageModel
             _ when string.Equals(normalized, "TaskList", StringComparison.OrdinalIgnoreCase) => "TaskList",
             _ when string.Equals(normalized, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
             _ when string.Equals(normalized, "Sprint", StringComparison.OrdinalIgnoreCase) => "Sprint",
+            _ when string.Equals(normalized, "Backlog", StringComparison.OrdinalIgnoreCase) => "Backlog",
+            _ when string.Equals(normalized, "Sprints", StringComparison.OrdinalIgnoreCase) => "Sprints",
             _ when string.Equals(normalized, "Reports", StringComparison.OrdinalIgnoreCase) => "Reports",
             _ => "Dashboard"
         };

--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -1,0 +1,147 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+@using ProjectManagement.Models
+
+@* SECTION: Backlog filters reuse the module's controlled register-style filtering. *@
+<section class="at-panel mb-3">
+    <div class="at-panel-heading">
+        <div>
+            <h2>Backlog Filters</h2>
+            <p class="at-panel-note">Backlog shows only tasks where SprintId is empty.</p>
+        </div>
+        <span class="at-count-chip">@Model.BacklogTaskDisplays.Count tasks</span>
+    </div>
+    <form method="get" class="row g-2" data-at-task-filter-form="true">
+        <input type="hidden" name="viewMode" value="Backlog" />
+        <div class="col-md-2">
+            <label class="form-label">Status</label>
+            <select class="form-select" name="FilterStatus">
+                <option value="">All</option>
+                @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
+                {
+                    if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
+                    {
+                        <option value="@status" selected>@status</option>
+                    }
+                    else
+                    {
+                        <option value="@status">@status</option>
+                    }
+                }
+            </select>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Priority</label>
+            <select class="form-select" name="FilterPriority">
+                <option value="">All</option>
+                @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
+                {
+                    if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
+                    {
+                        <option value="@priority" selected>@priority</option>
+                    }
+                    else
+                    {
+                        <option value="@priority">@priority</option>
+                    }
+                }
+            </select>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Responsible Person</label>
+            <select class="form-select" name="FilterAssigneeUserId">
+                <option value="">All</option>
+                @foreach (var assignee in Model.TaskAssigneeNames.OrderBy(x => x.Value))
+                {
+                    if (string.Equals(Model.FilterAssigneeUserId, assignee.Key, StringComparison.Ordinal))
+                    {
+                        <option value="@assignee.Key" selected>@assignee.Value</option>
+                    }
+                    else
+                    {
+                        <option value="@assignee.Key">@assignee.Value</option>
+                    }
+                }
+            </select>
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Due Date</label>
+            <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Search by title</label>
+            <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Backlog" class="btn btn-outline-secondary w-100">Reset</a>
+        </div>
+    </form>
+</section>
+
+@* SECTION: Backlog task list and controlled sprint assignment action. *@
+<section class="at-panel">
+    <div class="at-panel-heading">
+        <h2>Backlog Tasks</h2>
+        @if (Model.CanPlanSprints)
+        {
+            <span class="at-panel-note">Comdt and HoD can assign tasks into open sprints.</span>
+        }
+    </div>
+
+    @if (!Model.BacklogTaskDisplays.Any())
+    {
+        <div class="at-empty-state">No backlog tasks match the current filter.</div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table at-table align-middle">
+                <thead>
+                    <tr>
+                        <th>Task</th>
+                        <th>Responsible Person</th>
+                        <th>Priority</th>
+                        <th>Status</th>
+                        <th>Due Date</th>
+                        @if (Model.CanPlanSprints)
+                        {
+                            <th>Assign to Sprint</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model.BacklogTaskDisplays)
+                    {
+                        var task = item.Task;
+                        <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                            <td>
+                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Backlog">AT-@task.Id · @task.Title</a>
+                                <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
+                            </td>
+                            <td>@item.AssigneeName</td>
+                            <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
+                            <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
+                            <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                            @if (Model.CanPlanSprints)
+                            {
+                                <td>
+                                    <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form">
+                                        <input type="hidden" name="ViewMode" value="Backlog" />
+                                        <input type="hidden" name="id" value="@task.Id" />
+                                        <select class="form-select form-select-sm" name="sprintId" aria-label="Select sprint for AT-@task.Id" required>
+                                            <option value="">Select sprint</option>
+                                            @foreach (var sprint in Model.AssignableSprints)
+                                            {
+                                                <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
+                                            }
+                                        </select>
+                                        <button type="submit" class="btn btn-primary btn-sm" @(Model.AssignableSprints.Any() ? null : "disabled")>Assign</button>
+                                    </form>
+                                </td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</section>

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -24,6 +24,7 @@ else
                     </div>
                     <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
                     <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                    <div class="mt-1"><span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span></div>
                     @if (!hideStatusBadge)
                     {
                         <div class="small at-card-status">@task.Status</div>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -15,6 +15,7 @@
                         <span class="@Model.GetStatusBadgeClass(Model.SelectedTask.Status)">@Model.SelectedTask.Status</span>
                         <span class="@Model.GetPriorityBadgeClass(Model.SelectedTask.Priority)">@Model.SelectedTask.Priority</span>
                         <span class="at-detail-due">Due @Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</span>
+                        <span class="@Model.GetSprintBadgeClass(Model.SelectedTask)">@Model.GetSprintBadgeText(Model.SelectedTask)</span>
                     </div>
                     <div class="at-inspector-snapshot">
                         <span>Last update: @((Model.SelectedTaskUpdates.FirstOrDefault()?.CreatedAtUtc ?? Model.SelectedTask.AssignedOn).ToString("dd MMM yyyy, HH:mm"))</span>
@@ -23,7 +24,7 @@
                     </div>
                 }
             </div>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
         </header>
 
         @if (Model.SelectedTask is not null)
@@ -133,6 +134,7 @@
                         <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
                         <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
                         <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+                        <div><span class="text-muted">Sprint / Backlog</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
                     </div>
                 </details>
             </div>
@@ -145,6 +147,7 @@
                         <form method="post" asp-page-handler="AddUpdate" class="at-action-card at-journal-card" enctype="multipart/form-data">
                             <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
                             <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                             <div class="at-action-title">Add Update</div>
                             <div class="mb-2">
                                 <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
@@ -168,6 +171,7 @@
                             <summary class="visually-hidden">Open status panel</summary>
                             <form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
@@ -206,6 +210,7 @@
                             <summary class="visually-hidden">Open submit panel</summary>
                             <form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
@@ -228,6 +233,7 @@
                             <summary class="visually-hidden">Open close panel</summary>
                             <form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -154,6 +154,7 @@
                             <td>
                                 <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@Model.ResolvedViewMode">@task.Title</a>
                                 <div class="at-task-desc-preview">@task.Description</div>
+                                <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
                             </td>
                             <td>
                                 <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -1,0 +1,142 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+@using ProjectManagement.Models
+
+@* SECTION: Sprint selector and metadata summary. *@
+<section class="at-sprint-layout">
+    <aside class="at-panel at-sprint-list-panel">
+        <div class="at-panel-heading">
+            <h2>Sprints</h2>
+            <span class="at-count-chip">@Model.Sprints.Count</span>
+        </div>
+        @if (Model.ActiveSprint is not null)
+        {
+            <div class="at-active-sprint-note">Active: @Model.ActiveSprint.Name</div>
+        }
+        @if (!Model.Sprints.Any())
+        {
+            <div class="at-empty-state at-empty-state-compact">No sprints are available yet.</div>
+        }
+        else
+        {
+            <form method="get" class="at-sprint-selector-form" data-at-sprint-selector="true">
+                <input type="hidden" name="viewMode" value="Sprints" />
+                <label class="form-label at-small" for="SelectedSprintId">Select Sprint</label>
+                <select class="form-select" id="SelectedSprintId" name="SelectedSprintId">
+                    @foreach (var sprint in Model.Sprints)
+                    {
+                        if (Model.SelectedSprint?.Id == sprint.Id)
+                        {
+                            <option value="@sprint.Id" selected>@sprint.Name (@sprint.Status)</option>
+                        }
+                        else
+                        {
+                            <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
+                        }
+                    }
+                </select>
+                <button type="submit" class="btn btn-outline-primary btn-sm">Open Sprint</button>
+            </form>
+        }
+    </aside>
+
+    <div class="at-sprint-main">
+        <section class="at-panel at-sprint-meta-panel">
+            @if (Model.SelectedSprint is null)
+            {
+                <div class="at-empty-state">Select a sprint to view sprint tasks.</div>
+            }
+            else
+            {
+                <div class="at-sprint-meta-header">
+                    <div>
+                        <div class="at-section-eyebrow">Selected Sprint</div>
+                        <h2>@Model.SelectedSprint.Name</h2>
+                        <div class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</div>
+                    </div>
+                    <span class="at-sprint-status-pill">@Model.SelectedSprint.Status</span>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal))
+                {
+                    <div class="at-command-focus-strip mt-2"><strong>Command focus:</strong> @Model.SelectedSprint.Goal</div>
+                }
+                <div class="at-sprint-summary-grid" aria-label="Sprint summary">
+                    <div><span>@Model.SprintSummary.TaskCount</span><small>Total tasks</small></div>
+                    <div><span>@Model.SprintSummary.OpenCount</span><small>Open</small></div>
+                    <div><span>@Model.SprintSummary.BlockedCount</span><small>Blocked</small></div>
+                    <div><span>@Model.SprintSummary.SubmittedCount</span><small>Submitted</small></div>
+                    <div><span>@Model.SprintSummary.BacklogCount</span><small>Backlog</small></div>
+                </div>
+            }
+        </section>
+
+        @if (Model.CanPlanSprints && Model.SelectedSprint is not null)
+        {
+            @* SECTION: Controlled backlog-to-sprint assignment without drag-and-drop planning. *@
+            <section class="at-panel at-sprint-planning-panel">
+                <div class="at-panel-heading">
+                    <h2>Add Backlog Task to Sprint</h2>
+                    <span class="at-panel-note">Available to Comdt and HoD only.</span>
+                </div>
+                <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
+                    <input type="hidden" name="ViewMode" value="Sprints" />
+                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint.Id" />
+                    <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
+                    <select class="form-select" name="id" aria-label="Select backlog task" required>
+                        <option value="">Select backlog task</option>
+                        @foreach (var item in Model.SprintBacklogTaskDisplays)
+                        {
+                            <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
+                        }
+                    </select>
+                    <button type="submit" class="btn btn-primary" @(Model.SprintBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Sprint</button>
+                </form>
+            </section>
+        }
+
+        @* SECTION: Status-grouped sprint task board. *@
+        <section class="at-board-scroll" aria-label="Selected sprint task board">
+            <div class="at-board-grid is-sprints">
+                @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed })
+                {
+                    var groupedTasks = Model.GetSprintTasksByStatus(status);
+                    <article class="at-panel at-board-column">
+                        <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
+                        @if (!groupedTasks.Any())
+                        {
+                            <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
+                        }
+                        else
+                        {
+                            <div class="at-task-cards">
+                                @foreach (var item in groupedTasks)
+                                {
+                                    var task = item.Task;
+                                    <article class="at-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                        <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
+                                            <div class="at-card-top-row">
+                                                <h3 class="at-card-subject">@task.Title</h3>
+                                                <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                            </div>
+                                            <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
+                                            <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                                            <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
+                                        </a>
+                                        @if (Model.CanPlanSprints && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
+                                                <input type="hidden" name="ViewMode" value="Sprints" />
+                                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                                <input type="hidden" name="id" value="@task.Id" />
+                                                <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
+                                            </form>
+                                        }
+                                    </article>
+                                }
+                            </div>
+                        }
+                    </article>
+                }
+            </div>
+        </section>
+    </div>
+</section>

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -23,6 +23,25 @@ public class ActionSprintService
         _workflow = workflow;
     }
 
+
+    // SECTION: Sprint read APIs
+    public async Task<List<ActionSprint>> GetSprintsAsync(CancellationToken cancellationToken = default)
+        => await _context.ActionSprints
+            .AsNoTracking()
+            .Where(x => !x.IsDeleted)
+            .OrderByDescending(x => x.Status == ActionSprintStatus.Active)
+            .ThenByDescending(x => x.StartDate)
+            .ThenByDescending(x => x.Id)
+            .ToListAsync(cancellationToken);
+
+    public async Task<ActionSprint?> GetActiveSprintAsync(CancellationToken cancellationToken = default)
+        => await _context.ActionSprints
+            .AsNoTracking()
+            .Where(x => !x.IsDeleted && x.Status == ActionSprintStatus.Active)
+            .OrderByDescending(x => x.StartDate)
+            .ThenByDescending(x => x.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
     // SECTION: Sprint mutation APIs
     public async Task<ActionSprint> CreateSprintAsync(ActionSprint sprint, string userId, string role, CancellationToken cancellationToken = default)
     {

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -19,11 +19,15 @@ public sealed class ActionTaskQueryService
             : sourceTasks.ToList();
 
         var taskList = request.IsTaskListView ? ApplyTaskListFilters(tasks, request, assigneeNames).ToList() : tasks;
+        var backlogTasks = BuildBacklogTasks(tasks, request, assigneeNames);
+        var sprintReadModel = BuildSprintReadModel(tasks, request.Sprints, request.SelectedSprintId, assigneeNames);
 
         return new ActionTaskReadModel
         {
             ScopeTasks = tasks,
             TaskListTasks = taskList,
+            BacklogTasks = backlogTasks,
+            SprintReadModel = sprintReadModel,
             CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
             OverdueTasks = tasks.Where(t => IsOpen(t) && t.DueDate.Date < DateTime.UtcNow.Date).OrderBy(t => t.DueDate).Take(5).ToList(),
             RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
@@ -48,6 +52,74 @@ public sealed class ActionTaskQueryService
     {
         activityByTaskId.TryGetValue(task.Id, out var activityTimestampUtc);
         return activityTimestampUtc ?? task.SubmittedOn ?? task.AssignedOn;
+    }
+
+    // SECTION: Backlog read-model projection where null SprintId is the backlog contract.
+    private static IReadOnlyList<ActionTaskItem> BuildBacklogTasks(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var backlogTasks = tasks.Where(t => t.SprintId is null).ToList();
+        return request.IsBacklogView
+            ? ApplyTaskListFilters(backlogTasks, request, assigneeNames).ToList()
+            : backlogTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+    }
+
+    // SECTION: Sprint read-model projection for selected sprint operational rendering.
+    private static ActionSprintReadModel BuildSprintReadModel(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, int? selectedSprintId, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var orderedSprints = sprints
+            .OrderByDescending(s => s.Status == ActionSprintStatus.Active)
+            .ThenByDescending(s => s.StartDate)
+            .ThenByDescending(s => s.Id)
+            .ToList();
+
+        var activeSprint = orderedSprints.FirstOrDefault(s => s.Status == ActionSprintStatus.Active);
+        var selectedSprint = selectedSprintId.HasValue
+            ? orderedSprints.FirstOrDefault(s => s.Id == selectedSprintId.Value)
+            : activeSprint ?? orderedSprints.FirstOrDefault();
+
+        var selectedTasks = selectedSprint is null
+            ? new List<ActionTaskItem>()
+            : tasks.Where(t => t.SprintId == selectedSprint.Id).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+
+        var backlogTasks = tasks.Where(t => t.SprintId is null).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+
+        return new ActionSprintReadModel
+        {
+            Sprints = orderedSprints,
+            ActiveSprint = activeSprint,
+            SelectedSprint = selectedSprint,
+            SelectedSprintTasks = selectedTasks,
+            BacklogTasks = backlogTasks,
+            Summary = selectedSprint is null
+                ? ActionSprintSummary.Empty
+                : BuildSprintSummary(selectedSprint, selectedTasks, backlogTasks.Count, assigneeNames)
+        };
+    }
+
+    // SECTION: Compact sprint summary suitable for low-risk UI exposure.
+    private static ActionSprintSummary BuildSprintSummary(ActionSprint sprint, IReadOnlyList<ActionTaskItem> sprintTasks, int backlogCount, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var openTasks = sprintTasks.Count(IsOpen);
+        var closedTasks = sprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
+        var blockedTasks = sprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase));
+        var submittedTasks = sprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase));
+        var assigneeCount = sprintTasks.Select(t => assigneeNames.TryGetValue(t.AssignedToUserId, out var name) ? name : t.AssignedToUserId).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        return new ActionSprintSummary
+        {
+            SprintId = sprint.Id,
+            Title = sprint.Name,
+            Status = sprint.Status.ToString(),
+            DateRange = $"{sprint.StartDate:dd MMM yyyy} – {sprint.EndDate:dd MMM yyyy}",
+            CommandFocus = sprint.Goal,
+            TaskCount = sprintTasks.Count,
+            OpenCount = openTasks,
+            ClosedCount = closedTasks,
+            BlockedCount = blockedTasks,
+            SubmittedCount = submittedTasks,
+            BacklogCount = backlogCount,
+            AssigneeCount = assigneeCount
+        };
     }
 
     private static ActionTaskDueBuckets BuildDueBuckets(IReadOnlyList<ActionTaskItem> tasks)
@@ -93,7 +165,7 @@ public sealed class ActionTaskQueryService
         var sortBy = (request.SortBy ?? "due").Trim().ToLowerInvariant();
         var descending = string.Equals(request.SortDir, "desc", StringComparison.OrdinalIgnoreCase);
         Func<ActionTaskItem, string> assignee = t => assigneeNames.TryGetValue(t.AssignedToUserId, out var n) ? n : "User";
-        Func<ActionTaskItem, int> statusOrder = task => task.Status switch { ActionTaskStatuses.Assigned => 1, ActionTaskStatuses.InProgress => 2, ActionTaskStatuses.Blocked => 3, ActionTaskStatuses.Submitted => 4, ActionTaskStatuses.Closed => 5, _ => 99 };
+        Func<ActionTaskItem, int> statusOrder = StatusOrder;
         Func<ActionTaskItem, int> priorityOrder = task => task.Priority switch { "Critical" => 1, "High" => 2, "Normal" => 3, "Low" => 4, _ => 99 };
         var ordered = sortBy switch
         {
@@ -107,10 +179,24 @@ public sealed class ActionTaskQueryService
         return ordered.ThenBy(t => t.Id);
     }
 
+    // SECTION: Shared operational status ordering for boards and filtered lists.
+    private static int StatusOrder(ActionTaskItem task) => task.Status switch
+    {
+        ActionTaskStatuses.Assigned => 1,
+        ActionTaskStatuses.InProgress => 2,
+        ActionTaskStatuses.Blocked => 3,
+        ActionTaskStatuses.Submitted => 4,
+        ActionTaskStatuses.Closed => 5,
+        _ => 99
+    };
+
     public sealed record ActionTaskQueryRequest(
         string CurrentUserId,
         bool IsMyTasksView,
         bool IsTaskListView,
+        bool IsBacklogView,
+        int? SelectedSprintId,
+        IReadOnlyList<ActionSprint> Sprints,
         string? FilterStatus,
         string? FilterPriority,
         string? FilterAssigneeUserId,
@@ -123,6 +209,8 @@ public sealed class ActionTaskQueryService
     {
         public IReadOnlyList<ActionTaskItem> ScopeTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> TaskListTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> BacklogTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public ActionSprintReadModel SprintReadModel { get; init; } = new();
         public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> OverdueTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> RecentlySubmittedTasks { get; init; } = Array.Empty<ActionTaskItem>();
@@ -136,7 +224,49 @@ public sealed class ActionTaskQueryService
         public ActionTaskReportReadModel Reports { get; init; } = new();
     }
 
-    public sealed class ActionTaskDueBuckets { public IReadOnlyList<ActionTaskItem> Overdue { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> Today { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> ThisWeek { get; init; } = Array.Empty<ActionTaskItem>(); public IReadOnlyList<ActionTaskItem> Later { get; init; } = Array.Empty<ActionTaskItem>(); }
-    public sealed class ActionTaskReportReadModel { public IReadOnlyList<CountSummary> AssigneePendingCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> PriorityCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> StatusCounts { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>(); }
+    public sealed class ActionTaskDueBuckets
+    {
+        public IReadOnlyList<ActionTaskItem> Overdue { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> Today { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> ThisWeek { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> Later { get; init; } = Array.Empty<ActionTaskItem>();
+    }
+
+    public sealed class ActionSprintReadModel
+    {
+        public IReadOnlyList<ActionSprint> Sprints { get; init; } = Array.Empty<ActionSprint>();
+        public ActionSprint? ActiveSprint { get; init; }
+        public ActionSprint? SelectedSprint { get; init; }
+        public IReadOnlyList<ActionTaskItem> SelectedSprintTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> BacklogTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public ActionSprintSummary Summary { get; init; } = ActionSprintSummary.Empty;
+    }
+
+    public sealed class ActionSprintSummary
+    {
+        public static ActionSprintSummary Empty { get; } = new();
+        public int? SprintId { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string Status { get; init; } = string.Empty;
+        public string DateRange { get; init; } = string.Empty;
+        public string? CommandFocus { get; init; }
+        public int TaskCount { get; init; }
+        public int OpenCount { get; init; }
+        public int ClosedCount { get; init; }
+        public int BlockedCount { get; init; }
+        public int SubmittedCount { get; init; }
+        public int BacklogCount { get; init; }
+        public int AssigneeCount { get; init; }
+    }
+
+    public sealed class ActionTaskReportReadModel
+    {
+        public IReadOnlyList<CountSummary> AssigneePendingCounts { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> PriorityCounts { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> StatusCounts { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+    }
     public sealed record CountSummary(string Name, int Count);
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1058,3 +1058,164 @@ html {
     opacity: 0.9;
     background: #f1f5f9;
 }
+
+/* SECTION: Sprint and backlog scope badges */
+.at-scope-badge {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    border-radius: 999px;
+    padding: 0.12rem 0.45rem;
+    font-size: 0.72rem;
+    font-weight: 750;
+    line-height: 1.25;
+    border: 1px solid transparent;
+}
+
+.at-scope-badge-sprint {
+    color: #1e3a8a;
+    background: #dbeafe;
+    border-color: #bfdbfe;
+}
+
+.at-scope-badge-backlog {
+    color: #475569;
+    background: #f1f5f9;
+    border-color: #cbd5e1;
+}
+
+/* SECTION: Backlog and sprint planning surfaces */
+.at-inline-sprint-form,
+.at-sprint-add-form {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.at-inline-sprint-form .form-select {
+    min-width: 13rem;
+}
+
+.at-sprint-layout {
+    display: grid;
+    grid-template-columns: minmax(230px, 280px) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.at-sprint-list-panel {
+    position: sticky;
+    top: 5rem;
+}
+
+.at-sprint-selector-form {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.at-sprint-main {
+    display: grid;
+    gap: 1rem;
+    min-width: 0;
+}
+
+.at-sprint-meta-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.at-sprint-meta-header h2 {
+    margin-bottom: 0.15rem;
+}
+
+.at-sprint-date-range {
+    color: var(--at-muted);
+    font-size: 0.86rem;
+    font-weight: 650;
+}
+
+.at-sprint-status-pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    color: #0f172a;
+    background: #e0f2fe;
+    border: 1px solid #bae6fd;
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+
+.at-sprint-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(90px, 1fr));
+    gap: 0.65rem;
+    margin-top: 0.85rem;
+}
+
+.at-sprint-summary-grid div {
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    padding: 0.6rem;
+    background: var(--at-surface-soft);
+}
+
+.at-sprint-summary-grid span,
+.at-sprint-summary-grid small {
+    display: block;
+}
+
+.at-sprint-summary-grid span {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--at-text);
+}
+
+.at-sprint-summary-grid small {
+    color: var(--at-muted);
+    font-weight: 700;
+}
+
+.at-board-grid.is-sprints {
+    grid-template-columns: repeat(5, minmax(260px, 1fr));
+}
+
+.at-card-action-form {
+    padding: 0 0.65rem 0.65rem;
+}
+
+@media (max-width: 991px) {
+    .at-sprint-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .at-sprint-list-panel {
+        position: static;
+    }
+
+    .at-sprint-summary-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-inline-sprint-form,
+    .at-sprint-add-form {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .at-inline-sprint-form .form-select {
+        min-width: 0;
+    }
+}
+
+/* SECTION: Active sprint selector note */
+.at-active-sprint-note {
+    border: 1px solid #bfdbfe;
+    background: #eff6ff;
+    color: #1e40af;
+    border-radius: 10px;
+    padding: 0.45rem 0.55rem;
+    font-size: 0.8rem;
+    font-weight: 750;
+    margin-bottom: 0.55rem;
+}

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -66,7 +66,7 @@
             return;
         }
 
-        const immediateControls = form.querySelectorAll("select[name='FilterStatus'], select[name='FilterPriority'], input[name='FilterDueDate']");
+        const immediateControls = form.querySelectorAll("select[name='FilterStatus'], select[name='FilterPriority'], select[name='FilterAssigneeUserId'], input[name='FilterDueDate']");
         immediateControls.forEach((control) => {
             control.addEventListener("change", () => {
                 form.requestSubmit();
@@ -138,6 +138,23 @@
         });
     }
 
+    // SECTION: Sprint selector opens selected sprint through safe GET navigation.
+    function initSprintSelector() {
+        const form = document.querySelector("[data-at-sprint-selector='true']");
+        if (!form) {
+            return;
+        }
+
+        const selector = form.querySelector("select[name='SelectedSprintId']");
+        if (!selector) {
+            return;
+        }
+
+        selector.addEventListener("change", () => {
+            form.requestSubmit();
+        });
+    }
+
 
     // SECTION: Sticky inspector action panel orchestration and keyboard behavior.
     function initInspectorActionPanels() {
@@ -199,6 +216,7 @@
         initSearchableSelects();
         initStatusUpdateGuard();
         initTaskRegisterFilters();
+        initSprintSelector();
         initInspectorActionPanels();
     });
 })();


### PR DESCRIPTION
### Motivation
- Expose real Backlog and Sprints views in the Action Tracker UI and read-model while keeping the existing due-bucket screen and task lifecycle intact.
- Provide a controlled, permissioned surface for assigning tasks to sprints and moving tasks back to backlog for Phase 1B without implementing carry-forward, closure review, drag-and-drop planning, or analytics.

### Description
- Renamed the user-facing label for the legacy sprint/due-buckets view to `Due Board` while keeping the underlying `Sprint` view mode intact and preserving existing due-bucket logic.
- Added backlog and sprint read-model support in `ActionTaskQueryService` and sprint list/read APIs in `ActionSprintService` to surface `SprintId == null` backlog tasks, available sprints, active/selected sprint, selected-sprint tasks, and a compact sprint summary.
- Introduced `Pages/ActionTasks/_TaskBacklog.cshtml` and `Pages/ActionTasks/_TaskSprints.cshtml` partials and extended the `Index` page/model to load sprint/backlog projections, support `SelectedSprintId`, and provide page handlers `OnPostAssignToSprintAsync` and `OnPostMoveToBacklogAsync` that call the existing `ActionSprintService` (permission checks reused from `ActionTaskPermissionService`).
- Made minimal UI updates to show sprint/backlog badges on task cards, register rows and inspector (`GetSprintBadgeText`/`GetSprintBadgeClass` helpers), added small JS (`wwwroot/js/pages/action-tasks/index.js`) to support sprint selector and filter auto-submit, and added restrained CSS styles (`wwwroot/css/action-tracker.css`) for badges and sprint layouts.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues; the check passed.
- Scanned templates and JS for inline scripts/event-attr additions with `rg` to confirm no new inline scripts were introduced; the check passed (`index.js` remains an external file). 
- Attempted to run `dotnet build` but the container lacked the .NET SDK (`dotnet: command not found`), so a full build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf4fbcdc8832999b721ed9beca6bb)