### PR TITLE
Sprint Phase 1B: add lifecycle-aware UI helpers and tests

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -147,6 +147,26 @@ public class IndexModel : PageModel
     public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
     public IReadOnlyList<ActionSprint> AssignableSprints => Sprints.Where(s => s.Status != ActionSprintStatus.Closed).ToList();
 
+    // SECTION: Sprint planning visibility helpers for lifecycle-aware UI actions.
+    public bool CanAssignTaskToSprint(ActionTaskItem task)
+    {
+        return _permission.CanAssignTaskToSprint(CurrentRole)
+               && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+               && AssignableSprints.Any();
+    }
+
+    public bool CanMoveTaskToBacklog(ActionTaskItem task)
+    {
+        return _permission.CanMoveTaskToBacklog(CurrentRole)
+               && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+               && CanModifySelectedSprint;
+    }
+
+    public bool CanModifySelectedSprint =>
+        CanPlanSprints
+        && SelectedSprint is not null
+        && SelectedSprint.Status != ActionSprintStatus.Closed;
+
     // SECTION: Selected-task projection helper
     public bool IsSelectedTask(ActionTaskItem task)
     {
@@ -603,6 +623,11 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<TaskDisplayItem> SprintBacklogTaskDisplays =>
         ToDisplayItems(SprintBacklogTasks);
+
+    public IReadOnlyList<TaskDisplayItem> AssignableBacklogTaskDisplays =>
+        ToDisplayItems(SprintBacklogTasks
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+            .ToList());
 
     // SECTION: KPI helpers for dashboard and reports.
     public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));

--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -83,7 +83,7 @@
         <h2>Backlog Tasks</h2>
         @if (Model.CanPlanSprints)
         {
-            <span class="at-panel-note">Comdt and HoD can assign tasks into open sprints.</span>
+            <span class="at-panel-note">Comdt and HoD can assign open tasks into open sprints.</span>
         }
     </div>
 
@@ -124,6 +124,8 @@
                             @if (Model.CanPlanSprints)
                             {
                                 <td>
+                                    @if (Model.CanAssignTaskToSprint(task))
+                                    {
                                     <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form">
                                         <input type="hidden" name="ViewMode" value="Backlog" />
                                         <input type="hidden" name="id" value="@task.Id" />
@@ -134,8 +136,13 @@
                                                 <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
                                             }
                                         </select>
-                                        <button type="submit" class="btn btn-primary btn-sm" @(Model.AssignableSprints.Any() ? null : "disabled")>Assign</button>
+                                        <button type="submit" class="btn btn-primary btn-sm">Assign</button>
                                     </form>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted small">Not assignable</span>
+                                    }
                                 </td>
                             }
                         </tr>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -69,7 +69,7 @@
             }
         </section>
 
-        @if (Model.CanPlanSprints && Model.SelectedSprint is not null)
+        @if (Model.CanModifySelectedSprint)
         {
             @* SECTION: Controlled backlog-to-sprint assignment without drag-and-drop planning. *@
             <section class="at-panel at-sprint-planning-panel">
@@ -83,12 +83,12 @@
                     <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
                     <select class="form-select" name="id" aria-label="Select backlog task" required>
                         <option value="">Select backlog task</option>
-                        @foreach (var item in Model.SprintBacklogTaskDisplays)
+                        @foreach (var item in Model.AssignableBacklogTaskDisplays)
                         {
                             <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
                         }
                     </select>
-                    <button type="submit" class="btn btn-primary" @(Model.SprintBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Sprint</button>
+                    <button type="submit" class="btn btn-primary" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Sprint</button>
                 </form>
             </section>
         }
@@ -121,7 +121,7 @@
                                             <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
                                             <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
                                         </a>
-                                        @if (Model.CanPlanSprints && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+                                        @if (Model.CanMoveTaskToBacklog(task))
                                         {
                                             <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
                                                 <input type="hidden" name="ViewMode" value="Sprints" />

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -121,6 +121,97 @@ public class ActionTaskPageTests
         Assert.Contains(page.ModelState[nameof(IndexModel.CreateTaskInput.DueDate)]!.Errors, e => e.ErrorMessage == "Due date cannot be in the past.");
     }
 
+
+    [Fact]
+    public async Task BacklogView_ShowsOnlyTasksWithoutSprintAssignment()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
+        await setup.Db.SaveChangesAsync();
+        setup.Db.ActionTasks.Add(NewTask("Sprint task", ActionTaskStatuses.Assigned, sprint.Id));
+        setup.Db.ActionTasks.Add(NewTask("Closed backlog", ActionTaskStatuses.Closed));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Backlog";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.NotEmpty(page.BacklogTasks);
+        Assert.All(page.BacklogTasks, task => Assert.Null(task.SprintId));
+        Assert.Contains(page.BacklogTasks, task => task.Title == "Mine");
+        Assert.Contains(page.BacklogTasks, task => task.Title == "Closed backlog");
+        Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Sprint task");
+    }
+
+    [Fact]
+    public async Task SprintsView_SelectsActiveSprintByDefault()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        AddSprint(setup.Db, "Older planned sprint", ActionSprintStatus.Planned, startOffsetDays: -14);
+        var activeSprint = AddSprint(setup.Db, "Current active sprint", ActionSprintStatus.Active, startOffsetDays: -1);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.NotNull(page.SelectedSprint);
+        Assert.Equal(activeSprint.Id, page.SelectedSprint!.Id);
+        Assert.Equal(activeSprint.Id, page.SelectedSprintId);
+        Assert.True(page.CanModifySelectedSprint);
+    }
+
+    [Fact]
+    public async Task SprintsView_DoesNotOfferClosedBacklogTasksForAssignment()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
+        setup.Db.ActionTasks.Add(NewTask("Closed backlog", ActionTaskStatuses.Closed));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.Contains(page.SprintBacklogTasks, task => task.Title == "Closed backlog");
+        Assert.DoesNotContain(page.AssignableBacklogTaskDisplays, item => item.Task.Title == "Closed backlog");
+        Assert.All(page.AssignableBacklogTaskDisplays, item => Assert.NotEqual(ActionTaskStatuses.Closed, item.Task.Status));
+        Assert.False(page.CanAssignTaskToSprint(page.SprintBacklogTasks.Single(task => task.Title == "Closed backlog")));
+    }
+
+    [Fact]
+    public async Task SelectedClosedSprint_IsReadOnlyInUiHelperLogic()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var closedSprint = AddSprint(setup.Db, "Closed Sprint", ActionSprintStatus.Closed, startOffsetDays: -7);
+        await setup.Db.SaveChangesAsync();
+        setup.Db.ActionTasks.Add(NewTask("Closed sprint task", ActionTaskStatuses.Assigned, closedSprint.Id));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+        page.SelectedSprintId = closedSprint.Id;
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.NotNull(page.SelectedSprint);
+        Assert.Equal(ActionSprintStatus.Closed, page.SelectedSprint!.Status);
+        Assert.False(page.CanModifySelectedSprint);
+        var sprintTask = Assert.Single(page.SelectedSprintTasks);
+        Assert.False(page.CanMoveTaskToBacklog(sprintTask));
+    }
+
     [Fact]
     public void AuditLogModel_DoesNotCreateShadowTaskIdRelationship()
     {
@@ -166,7 +257,9 @@ public class ActionTaskPageTests
         var collab = new StubCollabService();
         var queryService = new ActionTaskQueryService();
         var workflowPolicy = new ActionTaskWorkflowPolicy(permission);
-        var page = new IndexModel(service, collab, permission, queryService, workflowPolicy, userManager);
+        var sprintWorkflowPolicy = new ActionSprintWorkflowPolicy();
+        var sprintService = new ActionSprintService(db, permission, sprintWorkflowPolicy);
+        var page = new IndexModel(service, collab, permission, sprintService, queryService, workflowPolicy, userManager);
 
         var httpContext = new DefaultHttpContext
         {
@@ -180,6 +273,44 @@ public class ActionTaskPageTests
         page.PageContext = new PageContext(new ActionContext(httpContext, new RouteData(), new ActionDescriptor()));
         page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
         return (page, db);
+    }
+
+
+    private static ActionSprint AddSprint(ApplicationDbContext db, string name, ActionSprintStatus status, int startOffsetDays = 0)
+    {
+        // SECTION: Sprint test fixture creation helper.
+        var sprint = new ActionSprint
+        {
+            Name = name,
+            Goal = $"Goal for {name}",
+            StartDate = DateTime.UtcNow.Date.AddDays(startOffsetDays),
+            EndDate = DateTime.UtcNow.Date.AddDays(startOffsetDays + 7),
+            Status = status,
+            CreatedByUserId = "creator",
+            CreatedByRole = RoleNames.HoD,
+            CreatedAtUtc = DateTime.UtcNow
+        };
+        db.ActionSprints.Add(sprint);
+        return sprint;
+    }
+
+    private static ActionTaskItem NewTask(string title, string status, int? sprintId = null)
+    {
+        // SECTION: Action task test fixture creation helper.
+        return new ActionTaskItem
+        {
+            Title = title,
+            Description = "d",
+            CreatedByUserId = "creator",
+            AssignedToUserId = "user-1",
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = DateTime.UtcNow.AddDays(2),
+            Priority = "Normal",
+            AssignedOn = DateTime.UtcNow,
+            Status = status,
+            SprintId = sprintId
+        };
     }
 
     private sealed class StubCollabService : IActionTaskCollaborationService


### PR DESCRIPTION
### Motivation
- Prevent sprint planning UI from offering assignment or modification actions for closed tasks or when the selected sprint is closed by enforcing lifecycle-aware checks in the page model.
- Make UI behavior explicit and testable by adding small helpers and updating views to use them rather than broad permission checks.
- Fix page-test construction so the `IndexModel` test setup satisfies the new `ActionSprintService` dependency.

### Description
- Added page-model helpers in `Pages/ActionTasks/Index.cshtml.cs`: `CanAssignTaskToSprint`, `CanMoveTaskToBacklog`, `CanModifySelectedSprint`, and `AssignableBacklogTaskDisplays` that exclude closed tasks/sprints and account for assignable sprint availability.
- Updated backlog UI `Pages/ActionTasks/_TaskBacklog.cshtml` to render the assign-to-sprint control only when `CanAssignTaskToSprint(task)` is true and to show a muted state when assignment is not allowed.
- Updated sprints UI `Pages/ActionTasks/_TaskSprints.cshtml` to only render the backlog-to-sprint panel when `CanModifySelectedSprint` is true, use `AssignableBacklogTaskDisplays` for the dropdown, and guard move-to-backlog actions with `CanMoveTaskToBacklog(task)`.
- Fixed `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` setup to instantiate `ActionSprintWorkflowPolicy` and `ActionSprintService` and pass the sprint service into the `IndexModel` constructor, and added test helpers `AddSprint` and `NewTask`.
- Added page tests in `ActionTaskPageTests` covering: backlog view shows only tasks with `SprintId == null`, sprints view selects the active sprint by default, closed backlog tasks are excluded from assignment lists, and a selected closed sprint is read-only in the UI helper logic.

### Testing
- Attempted to run the action-task page tests with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ActionTaskPageTests` but the `dotnet` CLI was unavailable in this environment so the test run was not performed.
- Verified code changes via repository searches for the new helpers and their usages using `rg` which confirmed the updated references and view substitutions (searches succeeded).
- No compile or automated test results are available from this environment due to the missing `dotnet` tool; these should be executed in CI or a local environment to validate build and test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0e9c11588329b1da1e83a81963a4)