### PR TITLE
Implement Action Tracker sprint closure review workflow

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -57,6 +57,8 @@ public class IndexModel : PageModel
     public ActionSprint? ActiveSprint { get; private set; }
     public ActionSprint? SelectedSprint { get; private set; }
     public ActionTaskQueryService.ActionSprintSummary SprintSummary { get; private set; } = ActionTaskQueryService.ActionSprintSummary.Empty;
+    public ActionTaskQueryService.ActionSprintClosureReview SprintClosureReview { get; private set; } = ActionTaskQueryService.ActionSprintClosureReview.Empty;
+    public ActionTaskQueryService.ActiveSprintOperationalMetrics ActiveSprintMetrics { get; private set; } = ActionTaskQueryService.ActiveSprintOperationalMetrics.Empty;
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<ActionTaskUpdate> SelectedTaskUpdates { get; private set; } = Array.Empty<ActionTaskUpdate>();
     public IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>> UpdateAttachments { get; private set; } = new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>();
@@ -107,6 +109,9 @@ public class IndexModel : PageModel
     [BindProperty]
     public AddTaskUpdateInput UpdateInput { get; set; } = new();
 
+    [BindProperty]
+    public SprintClosureInput ClosureInput { get; set; } = new();
+
     // SECTION: UI state projections
     public bool CanCreate => _permission.CanCreate(CurrentRole);
     public bool CanClose => _permission.CanClose(CurrentRole);
@@ -146,6 +151,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
     public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
     public IReadOnlyList<ActionSprint> AssignableSprints => Sprints.Where(s => s.Status != ActionSprintStatus.Closed).ToList();
+    public IReadOnlyList<ActionSprint> ClosureTargetSprints => SprintClosureReview.TargetSprintOptions;
 
     // SECTION: Sprint planning visibility helpers for lifecycle-aware UI actions.
     public bool CanAssignTaskToSprint(ActionTaskItem task)
@@ -166,6 +172,11 @@ public class IndexModel : PageModel
         CanPlanSprints
         && SelectedSprint is not null
         && SelectedSprint.Status != ActionSprintStatus.Closed;
+
+    public bool CanReviewSprintClosure =>
+        CanPlanSprints
+        && SelectedSprint is not null
+        && SelectedSprint.Status == ActionSprintStatus.Active;
 
     // SECTION: Selected-task projection helper
     public bool IsSelectedTask(ActionTaskItem task)
@@ -444,6 +455,35 @@ public class IndexModel : PageModel
         return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
     }
 
+    // SECTION: Close active sprint after explicit closure review disposition.
+    public async Task<IActionResult> OnPostCloseSprintWithDispositionAsync()
+    {
+        await ResolveIdentityAsync();
+        try
+        {
+            await _sprintService.CloseSprintWithDispositionAsync(
+                ClosureInput.SprintId,
+                DecodeRowVersion(ClosureInput.RowVersion),
+                ClosureInput.CarryForwardTaskIds,
+                ClosureInput.TargetSprintId,
+                ClosureInput.BacklogTaskIds,
+                ClosureInput.Remarks,
+                CurrentUserId,
+                CurrentRole);
+            TempData["ToastMessage"] = "Sprint closed after closure review.";
+        }
+        catch (ActionTaskConcurrencyException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToPage(new { ViewMode = "Sprints", SelectedSprintId = ClosureInput.SprintId });
+    }
+
     // SECTION: Post task progress update with optional attachments
     public async Task<IActionResult> OnPostAddUpdateAsync()
     {
@@ -519,6 +559,8 @@ public class IndexModel : PageModel
         SelectedSprint = readModel.SprintReadModel.SelectedSprint;
         SelectedSprintId = SelectedSprint?.Id ?? SelectedSprintId;
         SprintSummary = readModel.SprintReadModel.Summary;
+        SprintClosureReview = readModel.SprintReadModel.ClosureReview;
+        ActiveSprintMetrics = readModel.ActiveSprintMetrics;
         DueTodayTasks = readModel.DueBuckets.Today;
         DueThisWeekTasks = readModel.DueBuckets.ThisWeek;
         DueLaterTasks = readModel.DueBuckets.Later;
@@ -909,6 +951,24 @@ public class IndexModel : PageModel
 
         [Required, StringLength(24)]
         public string Priority { get; set; } = "Normal";
+    }
+
+    public sealed class SprintClosureInput
+    {
+        [Required]
+        public int SprintId { get; set; }
+
+        [Required]
+        public string RowVersion { get; set; } = string.Empty;
+
+        public int? TargetSprintId { get; set; }
+
+        public List<int> CarryForwardTaskIds { get; set; } = new();
+
+        public List<int> BacklogTaskIds { get; set; } = new();
+
+        [Required, StringLength(2000)]
+        public string Remarks { get; set; } = string.Empty;
     }
 
     public sealed class AddTaskUpdateInput

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -1,0 +1,100 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@* SECTION: Sprint closure review and explicit disposition workflow. *@
+@if (Model.SelectedSprint is not null && Model.CanReviewSprintClosure)
+{
+    var review = Model.SprintClosureReview;
+    <section class="at-panel at-closure-review" data-at-closure-review="true">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Sprint Closure Review</h2>
+                <p class="at-panel-note">Review unfinished work and record where each task will continue before closing the sprint.</p>
+            </div>
+            <span class="at-count-chip">@review.UnfinishedTasks.Count unfinished</span>
+        </div>
+
+        <div class="at-closure-metrics" aria-label="Sprint closure review summary">
+            <div><span>@review.CompletedTasks.Count</span><small>Completed</small></div>
+            <div><span>@review.UnfinishedTasks.Count</span><small>Unfinished</small></div>
+            <div><span>@review.BlockedTasks.Count</span><small>Blocked</small></div>
+            <div><span>@review.SubmittedPendingClosureTasks.Count</span><small>Submitted pending closure</small></div>
+        </div>
+
+        <div class="at-closure-recommendations">
+            <strong>Recommended disposition:</strong>
+            <ul>
+                @foreach (var option in review.RecommendedDispositionOptions)
+                {
+                    <li>@option</li>
+                }
+            </ul>
+        </div>
+
+        <form method="post" asp-page-handler="CloseSprintWithDisposition" class="at-closure-form">
+            <input type="hidden" asp-for="ClosureInput.SprintId" value="@Model.SelectedSprint.Id" />
+            <input type="hidden" asp-for="ClosureInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
+
+            @if (review.UnfinishedTasks.Any())
+            {
+                <div class="at-closure-target-row">
+                    <label class="form-label" asp-for="ClosureInput.TargetSprintId">Next sprint for carry-forward</label>
+                    <select class="form-select" asp-for="ClosureInput.TargetSprintId">
+                        <option value="">Select next sprint when carrying tasks forward</option>
+                        @foreach (var sprint in Model.ClosureTargetSprints)
+                        {
+                            <option value="@sprint.Id">@sprint.Name (@sprint.Status) · @sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</option>
+                        }
+                    </select>
+                </div>
+
+                <div class="at-closure-task-table" role="table" aria-label="Unfinished sprint tasks requiring disposition">
+                    <div class="at-closure-task-row at-closure-task-head" role="row">
+                        <span>Task</span>
+                        <span>Status</span>
+                        <span>Move to next sprint</span>
+                        <span>Move to backlog</span>
+                    </div>
+                    @foreach (var task in review.UnfinishedTasks)
+                    {
+                        <div class="at-closure-task-row" role="row">
+                            <span>
+                                <strong>AT-@task.Id</strong> @task.Title
+                                <small>Due @task.DueDate.ToString("dd MMM yyyy")</small>
+                            </span>
+                            <span><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></span>
+                            <label class="at-closure-choice">
+                                <input type="checkbox" name="ClosureInput.CarryForwardTaskIds" value="@task.Id" data-at-closure-choice="carry" />
+                                <span>Next sprint</span>
+                            </label>
+                            <label class="at-closure-choice">
+                                <input type="checkbox" name="ClosureInput.BacklogTaskIds" value="@task.Id" data-at-closure-choice="backlog" />
+                                <span>Backlog</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="at-empty-state at-empty-state-compact">All tasks in this sprint are completed. Add closure remarks and close the sprint.</div>
+            }
+
+            <label class="form-label" asp-for="ClosureInput.Remarks">Closure remarks</label>
+            <textarea class="form-control" asp-for="ClosureInput.Remarks" rows="3" maxlength="2000" required placeholder="Summarize command decision and disposition rationale."></textarea>
+
+            <div class="at-closure-actions">
+                <button type="submit" class="btn btn-danger">Close Sprint with Review</button>
+            </div>
+        </form>
+    </section>
+}
+else if (Model.SelectedSprint?.Status == ProjectManagement.Models.ActionSprintStatus.Closed)
+{
+    <section class="at-panel at-closure-review is-readonly">
+        <div class="at-panel-heading">
+            <h2>Sprint Closure Review</h2>
+            <span class="at-sprint-status-pill">Closed</span>
+        </div>
+        <p class="at-empty-inline">This sprint is closed and remains read-only in the normal workflow.</p>
+    </section>
+}

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -12,6 +12,32 @@
     <strong>Command Focus:</strong> @Model.DashboardCommandFocusSummary
 </section>
 
+@* SECTION: Active sprint operational health metrics. *@
+<section class="at-panel at-active-sprint-dashboard">
+    <div class="at-panel-heading">
+        <div>
+            <h2>Active Sprint Health</h2>
+            @if (!string.IsNullOrWhiteSpace(Model.ActiveSprintMetrics.ActiveSprintName))
+            {
+                <p class="at-panel-note">@Model.ActiveSprintMetrics.ActiveSprintName · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
+            }
+            else
+            {
+                <p class="at-panel-note">No active sprint is currently set.</p>
+            }
+        </div>
+    </div>
+    <div class="at-sprint-health-grid" aria-label="Active sprint health metrics">
+        <article><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong></article>
+        <article><h3>Completed</h3><strong>@Model.ActiveSprintMetrics.CompletedTasks</strong></article>
+        <article><h3>In progress</h3><strong>@Model.ActiveSprintMetrics.InProgressTasks</strong></article>
+        <article><h3>Blocked</h3><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></article>
+        <article><h3>Overdue in sprint</h3><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></article>
+        <article><h3>Backlog</h3><strong>@Model.ActiveSprintMetrics.BacklogTasks</strong></article>
+        <article><h3>Carry-forward candidates</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong></article>
+    </div>
+</section>
+
 @* SECTION: Attention-required panels with compact task rows. *@
 <section class="at-section-group">
     <h2 class="at-section-title">Attention Required</h2>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -93,6 +93,8 @@
             </section>
         }
 
+        <partial name="_SprintClosureReview" model="Model" />
+
         @* SECTION: Status-grouped sprint task board. *@
         <section class="at-board-scroll" aria-label="Selected sprint task board">
             <div class="at-board-grid is-sprints">

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -308,6 +308,87 @@ public class ActionSprintServiceTests
         Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
+
+    [Fact]
+    public async Task CloseSprintAsync_WithUnfinishedTasks_RequiresClosureReview()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt));
+        Assert.Contains("closure review", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task CloseSprintWithDispositionAsync_CarriesForwardSelectedTaskWithoutCloningAndAuditsMove()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.Comdt);
+        var target = await service.CreateSprintAsync(NewSprint("Next", 15, 30), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act
+        await service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), "Continue next cycle", "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        var movedTask = await db.ActionTasks.SingleAsync(t => t.Id == task.Id);
+        Assert.Equal(target.Id, movedTask.SprintId);
+        Assert.Equal(1, await db.ActionTasks.CountAsync());
+        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskCarriedForward");
+        Assert.Contains(await db.ActionSprintAuditLogs.ToListAsync(), x => x.SprintId == source.Id && x.ActionType == "SprintClosed" && x.Remarks!.Contains("Carried forward: 1"));
+    }
+
+    [Fact]
+    public async Task CloseSprintWithDispositionAsync_MovesSelectedTaskToBacklog()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.HoD);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Blocked);
+        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act
+        await service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, Array.Empty<int>(), null, new[] { task.Id }, "Return to backlog", "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        var movedTask = await db.ActionTasks.SingleAsync(t => t.Id == task.Id);
+        Assert.Null(movedTask.SprintId);
+        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskRemovedFromSprint");
+    }
+
+    [Fact]
+    public async Task CloseSprintWithDispositionAsync_RejectsMovementIntoClosedSprint()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.Comdt);
+        var target = await service.CreateSprintAsync(NewSprint("Closed Target", 15, 30), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(target.Id, target.RowVersion, "planner", RoleNames.Comdt);
+        await service.CloseSprintAsync(target.Id, target.RowVersion, "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), "Invalid carry", "planner", RoleNames.Comdt));
+        Assert.Contains("closed sprint", ex.Message.ToLowerInvariant());
+    }
+
     // SECTION: Test helpers
     private static ActionSprintService CreateService(ApplicationDbContext db)
         => new(db, new ActionTaskPermissionService(), new ActionSprintWorkflowPolicy());

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -1,0 +1,65 @@
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskQueryServiceSprintMetricsTests
+{
+    [Fact]
+    public void BuildReadModel_ComputesActiveSprintDashboardMetricsAndClosureReview()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var activeSprint = new ActionSprint { Id = 7, Name = "Active Ops", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(14) };
+        var nextSprint = new ActionSprint { Id = 8, Name = "Next Ops", Status = ActionSprintStatus.Planned, StartDate = today.AddDays(15), EndDate = today.AddDays(30) };
+        var tasks = new[]
+        {
+            NewTask(1, activeSprint.Id, ActionTaskStatuses.Closed, today.AddDays(-1)),
+            NewTask(2, activeSprint.Id, ActionTaskStatuses.InProgress, today.AddDays(1)),
+            NewTask(3, activeSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(-2)),
+            NewTask(4, activeSprint.Id, ActionTaskStatuses.Submitted, today.AddDays(2)),
+            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3))
+        };
+        var service = new ActionTaskQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, activeSprint.Id, new[] { activeSprint, nextSprint }, null, null, null, null, null, null, null),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal("Active Ops", model.ActiveSprintMetrics.ActiveSprintName);
+        Assert.Equal(4, model.ActiveSprintMetrics.TotalTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.CompletedTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.InProgressTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.BlockedTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.OverdueTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.BacklogTasks);
+        Assert.Equal(3, model.ActiveSprintMetrics.CarryForwardCandidateTasks);
+        Assert.Equal(1, model.SprintReadModel.ClosureReview.CompletedTasks.Count);
+        Assert.Equal(3, model.SprintReadModel.ClosureReview.UnfinishedTasks.Count);
+        Assert.Equal(nextSprint.Id, model.SprintReadModel.ClosureReview.TargetSprintOptions.Single().Id);
+    }
+
+    // SECTION: Test data helper
+    private static ActionTaskItem NewTask(int id, int? sprintId, string status, DateTime dueDate)
+        => new()
+        {
+            Id = id,
+            Title = $"Task {id}",
+            Description = "Task",
+            CreatedByUserId = "creator",
+            AssignedToUserId = "assignee",
+            CreatedByRole = "HoD",
+            AssignedToRole = "TA",
+            AssignedOn = dueDate.AddDays(-2),
+            DueDate = dueDate,
+            Priority = "Normal",
+            Status = status,
+            SprintId = sprintId,
+            ClosedOn = status == ActionTaskStatuses.Closed ? dueDate : null,
+            SubmittedOn = status == ActionTaskStatuses.Submitted ? dueDate.AddDays(-1) : null
+        };
+}

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -133,6 +135,12 @@ public class ActionSprintService
         _workflow.EnsureCanClose(sprint);
         ApplySprintRowVersion(sprint, rowVersion);
 
+        var unfinishedTaskCount = await CountUnfinishedSprintTasksAsync(sprint.Id, cancellationToken);
+        if (unfinishedTaskCount > 0)
+        {
+            throw new InvalidOperationException("Sprint contains unfinished tasks. Use the closure review to move unfinished tasks to the next sprint or backlog before closing.");
+        }
+
         var performedAt = DateTime.UtcNow;
         var oldStatus = sprint.Status.ToString();
 
@@ -143,6 +151,85 @@ public class ActionSprintService
         sprint.UpdatedAtUtc = performedAt;
 
         AddSprintAudit(sprint.Id, "SprintClosed", userId, role, performedAt, oldStatus, sprint.Status.ToString(), $"Closed sprint: {sprint.Name}");
+        await SaveSprintChangesAsync(cancellationToken);
+        return sprint;
+    }
+
+    public async Task<ActionSprint> CloseSprintWithDispositionAsync(int sprintId, byte[] rowVersion, IReadOnlyCollection<int> carryForwardTaskIds, int? targetSprintId, IReadOnlyCollection<int> backlogTaskIds, string remarks, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanCloseSprint(role);
+        EnsureSprintRowVersionSupplied(rowVersion);
+        if (string.IsNullOrWhiteSpace(remarks))
+        {
+            throw new InvalidOperationException("Closure remarks are required when closing a sprint through closure review.");
+        }
+
+        var carryIds = (carryForwardTaskIds ?? Array.Empty<int>()).Distinct().ToList();
+        var backIds = (backlogTaskIds ?? Array.Empty<int>()).Distinct().ToList();
+        var duplicateDispositionIds = carryIds.Intersect(backIds).ToList();
+        if (duplicateDispositionIds.Count > 0)
+        {
+            throw new InvalidOperationException("Each unfinished task can have only one closure disposition.");
+        }
+
+        var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
+        _workflow.EnsureCanClose(sprint);
+        ApplySprintRowVersion(sprint, rowVersion);
+
+        ActionSprint? targetSprint = null;
+        if (carryIds.Count > 0)
+        {
+            if (!targetSprintId.HasValue)
+            {
+                throw new InvalidOperationException("Select a target sprint for carry-forward tasks.");
+            }
+
+            targetSprint = await GetSprintForUpdateAsync(targetSprintId.Value, cancellationToken);
+            _workflow.EnsureCanCarryForward(sprint, targetSprint);
+        }
+
+        var unfinishedTasks = await _context.ActionTasks
+            .Where(t => !t.IsDeleted && t.SprintId == sprint.Id && t.Status != ActionTaskStatuses.Closed)
+            .OrderBy(t => t.Id)
+            .ToListAsync(cancellationToken);
+
+        var dispositionedIds = carryIds.Concat(backIds).Distinct().ToHashSet();
+        var missingDispositionIds = unfinishedTasks.Select(t => t.Id).Where(id => !dispositionedIds.Contains(id)).ToList();
+        if (missingDispositionIds.Count > 0)
+        {
+            throw new InvalidOperationException("All unfinished tasks must be moved to the next sprint or backlog before the sprint can close.");
+        }
+
+        var invalidDispositionIds = dispositionedIds.Except(unfinishedTasks.Select(t => t.Id)).ToList();
+        if (invalidDispositionIds.Count > 0)
+        {
+            throw new InvalidOperationException("Closure disposition includes tasks that are not unfinished tasks in this sprint.");
+        }
+
+        var performedAt = DateTime.UtcNow;
+        foreach (var task in unfinishedTasks.Where(t => carryIds.Contains(t.Id)))
+        {
+            var oldValue = task.SprintId?.ToString();
+            task.SprintId = targetSprint!.Id;
+            AddTaskSprintAudit(task.Id, "TaskCarriedForward", userId, role, oldValue, targetSprint.Id.ToString(), $"Carried forward from sprint {sprint.Name} to {targetSprint.Name}. Closure remarks: {remarks.Trim()}", performedAt);
+        }
+
+        foreach (var task in unfinishedTasks.Where(t => backIds.Contains(t.Id)))
+        {
+            var oldValue = task.SprintId?.ToString();
+            task.SprintId = null;
+            AddTaskSprintAudit(task.Id, "TaskRemovedFromSprint", userId, role, oldValue, null, $"Moved from sprint {sprint.Name} to backlog during closure. Closure remarks: {remarks.Trim()}", performedAt);
+        }
+
+        var oldStatus = sprint.Status.ToString();
+        sprint.Status = ActionSprintStatus.Closed;
+        sprint.ClosedAtUtc = performedAt;
+        sprint.UpdatedByUserId = userId;
+        sprint.UpdatedByRole = role;
+        sprint.UpdatedAtUtc = performedAt;
+
+        var detail = $"Closed sprint: {sprint.Name}. Carried forward: {carryIds.Count}. Moved to backlog: {backIds.Count}. Remarks: {remarks.Trim()}";
+        AddSprintAudit(sprint.Id, "SprintClosed", userId, role, performedAt, oldStatus, sprint.Status.ToString(), detail);
         await SaveSprintChangesAsync(cancellationToken);
         return sprint;
     }
@@ -181,6 +268,7 @@ public class ActionSprintService
 
         var oldValue = task.SprintId?.ToString();
         task.SprintId = null;
+        AddTaskSprintAudit(task.Id, "TaskRemovedFromSprint", userId, role, oldValue, null, "Removed from sprint and moved to backlog.");
         AddTaskSprintAudit(task.Id, "TaskMovedToBacklog", userId, role, oldValue, null, "Moved to backlog.");
 
         await _context.SaveChangesAsync(cancellationToken);
@@ -188,6 +276,9 @@ public class ActionSprintService
     }
 
     // SECTION: Authorization helpers
+    private async Task<int> CountUnfinishedSprintTasksAsync(int sprintId, CancellationToken cancellationToken)
+        => await _context.ActionTasks.CountAsync(t => !t.IsDeleted && t.SprintId == sprintId && t.Status != ActionTaskStatuses.Closed, cancellationToken);
+
     private void EnsureCanCreateSprint(string role)
     {
         if (!_permission.CanCreateSprint(role))
@@ -280,7 +371,7 @@ public class ActionSprintService
     }
 
     // SECTION: Audit helpers
-    private void AddTaskSprintAudit(int taskId, string actionType, string userId, string role, string? oldValue, string? newValue, string remarks)
+    private void AddTaskSprintAudit(int taskId, string actionType, string userId, string role, string? oldValue, string? newValue, string remarks, DateTime? performedAt = null)
     {
         _context.ActionTaskAuditLogs.Add(new ActionTaskAuditLog
         {
@@ -288,7 +379,7 @@ public class ActionSprintService
             ActionType = actionType,
             PerformedByUserId = userId,
             PerformedByRole = role,
-            PerformedAt = DateTime.UtcNow,
+            PerformedAt = performedAt ?? DateTime.UtcNow,
             OldValue = oldValue,
             NewValue = newValue,
             Remarks = remarks

--- a/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
@@ -46,4 +46,18 @@ public class ActionSprintWorkflowPolicy
             throw new InvalidOperationException("Tasks cannot be assigned to a closed sprint.");
         }
     }
+
+    public void EnsureCanCarryForward(ActionSprint sourceSprint, ActionSprint targetSprint)
+    {
+        EnsureCanClose(sourceSprint);
+        if (targetSprint.Id == sourceSprint.Id)
+        {
+            throw new InvalidOperationException("Carry-forward target sprint must be different from the sprint being closed.");
+        }
+
+        if (targetSprint.Status == ActionSprintStatus.Closed)
+        {
+            throw new InvalidOperationException("Tasks cannot be carried forward into a closed sprint.");
+        }
+    }
 }

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -21,6 +21,7 @@ public sealed class ActionTaskQueryService
         var taskList = request.IsTaskListView ? ApplyTaskListFilters(tasks, request, assigneeNames).ToList() : tasks;
         var backlogTasks = BuildBacklogTasks(tasks, request, assigneeNames);
         var sprintReadModel = BuildSprintReadModel(tasks, request.Sprints, request.SelectedSprintId, assigneeNames);
+        var activeSprintMetrics = BuildActiveSprintMetrics(tasks, sprintReadModel.ActiveSprint);
 
         return new ActionTaskReadModel
         {
@@ -28,6 +29,7 @@ public sealed class ActionTaskQueryService
             TaskListTasks = taskList,
             BacklogTasks = backlogTasks,
             SprintReadModel = sprintReadModel,
+            ActiveSprintMetrics = activeSprintMetrics,
             CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
             OverdueTasks = tasks.Where(t => IsOpen(t) && t.DueDate.Date < DateTime.UtcNow.Date).OrderBy(t => t.DueDate).Take(5).ToList(),
             RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
@@ -92,7 +94,10 @@ public sealed class ActionTaskQueryService
             BacklogTasks = backlogTasks,
             Summary = selectedSprint is null
                 ? ActionSprintSummary.Empty
-                : BuildSprintSummary(selectedSprint, selectedTasks, backlogTasks.Count, assigneeNames)
+                : BuildSprintSummary(selectedSprint, selectedTasks, backlogTasks.Count, assigneeNames),
+            ClosureReview = selectedSprint is null
+                ? ActionSprintClosureReview.Empty
+                : BuildClosureReview(selectedSprint, selectedTasks, orderedSprints)
         };
     }
 
@@ -119,6 +124,67 @@ public sealed class ActionTaskQueryService
             SubmittedCount = submittedTasks,
             BacklogCount = backlogCount,
             AssigneeCount = assigneeCount
+        };
+    }
+
+    // SECTION: Closure review read model for explicit end-of-sprint disposition.
+    private static ActionSprintClosureReview BuildClosureReview(ActionSprint sprint, IReadOnlyList<ActionTaskItem> sprintTasks, IReadOnlyList<ActionSprint> sprints)
+    {
+        var unfinishedTasks = sprintTasks.Where(IsOpen).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+        var targetOptions = sprints
+            .Where(s => s.Id != sprint.Id && s.Status != ActionSprintStatus.Closed)
+            .OrderBy(s => s.StartDate)
+            .ThenBy(s => s.Id)
+            .ToList();
+
+        return new ActionSprintClosureReview
+        {
+            SprintId = sprint.Id,
+            CanCloseDirectly = sprint.Status == ActionSprintStatus.Active && unfinishedTasks.Count == 0,
+            CompletedTasks = sprintTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            UnfinishedTasks = unfinishedTasks,
+            BlockedTasks = sprintTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            SubmittedPendingClosureTasks = sprintTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).ToList(),
+            TargetSprintOptions = targetOptions,
+            RecommendedDispositionOptions = BuildRecommendedDispositionOptions(unfinishedTasks, targetOptions)
+        };
+    }
+
+    private static IReadOnlyList<string> BuildRecommendedDispositionOptions(IReadOnlyList<ActionTaskItem> unfinishedTasks, IReadOnlyList<ActionSprint> targetOptions)
+    {
+        if (unfinishedTasks.Count == 0)
+        {
+            return new[] { "Close sprint after recording closure remarks." };
+        }
+
+        var options = new List<string> { "Move unfinished tasks with continuing operational value to the next open sprint.", "Move deferred or unscheduled tasks to backlog." };
+        if (targetOptions.Count == 0)
+        {
+            options.Add("Create or reopen a planned sprint before carrying tasks forward.");
+        }
+
+        return options;
+    }
+
+    // SECTION: Active sprint dashboard metrics scoped to operational task health.
+    private static ActiveSprintOperationalMetrics BuildActiveSprintMetrics(IReadOnlyList<ActionTaskItem> tasks, ActionSprint? activeSprint)
+    {
+        var activeSprintTasks = activeSprint is null
+            ? new List<ActionTaskItem>()
+            : tasks.Where(t => t.SprintId == activeSprint.Id).ToList();
+        var today = DateTime.UtcNow.Date;
+
+        return new ActiveSprintOperationalMetrics
+        {
+            ActiveSprintName = activeSprint?.Name,
+            ActiveSprintDateRange = activeSprint is null ? null : $"{activeSprint.StartDate:dd MMM yyyy} – {activeSprint.EndDate:dd MMM yyyy}",
+            TotalTasks = activeSprintTasks.Count,
+            CompletedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
+            InProgressTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)),
+            BlockedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)),
+            OverdueTasks = activeSprintTasks.Count(t => IsOpen(t) && t.DueDate.Date < today),
+            BacklogTasks = tasks.Count(t => t.SprintId is null),
+            CarryForwardCandidateTasks = activeSprintTasks.Count(t => IsOpen(t))
         };
     }
 
@@ -211,6 +277,7 @@ public sealed class ActionTaskQueryService
         public IReadOnlyList<ActionTaskItem> TaskListTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> BacklogTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public ActionSprintReadModel SprintReadModel { get; init; } = new();
+        public ActiveSprintOperationalMetrics ActiveSprintMetrics { get; init; } = ActiveSprintOperationalMetrics.Empty;
         public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> OverdueTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> RecentlySubmittedTasks { get; init; } = Array.Empty<ActionTaskItem>();
@@ -240,6 +307,7 @@ public sealed class ActionTaskQueryService
         public IReadOnlyList<ActionTaskItem> SelectedSprintTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public IReadOnlyList<ActionTaskItem> BacklogTasks { get; init; } = Array.Empty<ActionTaskItem>();
         public ActionSprintSummary Summary { get; init; } = ActionSprintSummary.Empty;
+        public ActionSprintClosureReview ClosureReview { get; init; } = ActionSprintClosureReview.Empty;
     }
 
     public sealed class ActionSprintSummary
@@ -257,6 +325,33 @@ public sealed class ActionTaskQueryService
         public int SubmittedCount { get; init; }
         public int BacklogCount { get; init; }
         public int AssigneeCount { get; init; }
+    }
+
+    public sealed class ActionSprintClosureReview
+    {
+        public static ActionSprintClosureReview Empty { get; } = new();
+        public int? SprintId { get; init; }
+        public bool CanCloseDirectly { get; init; }
+        public IReadOnlyList<ActionTaskItem> CompletedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> UnfinishedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> BlockedTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionTaskItem> SubmittedPendingClosureTasks { get; init; } = Array.Empty<ActionTaskItem>();
+        public IReadOnlyList<ActionSprint> TargetSprintOptions { get; init; } = Array.Empty<ActionSprint>();
+        public IReadOnlyList<string> RecommendedDispositionOptions { get; init; } = Array.Empty<string>();
+    }
+
+    public sealed class ActiveSprintOperationalMetrics
+    {
+        public static ActiveSprintOperationalMetrics Empty { get; } = new();
+        public string? ActiveSprintName { get; init; }
+        public string? ActiveSprintDateRange { get; init; }
+        public int TotalTasks { get; init; }
+        public int CompletedTasks { get; init; }
+        public int InProgressTasks { get; init; }
+        public int BlockedTasks { get; init; }
+        public int OverdueTasks { get; init; }
+        public int BacklogTasks { get; init; }
+        public int CarryForwardCandidateTasks { get; init; }
     }
 
     public sealed class ActionTaskReportReadModel

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1219,3 +1219,129 @@ html {
     font-weight: 750;
     margin-bottom: 0.55rem;
 }
+
+/* SECTION: Sprint closure review workflow */
+.at-closure-review {
+    border-color: #fecaca;
+}
+
+.at-closure-review.is-readonly {
+    border-color: var(--at-border);
+}
+
+.at-closure-metrics,
+.at-sprint-health-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.7rem;
+    margin: 0.85rem 0;
+}
+
+.at-closure-metrics div,
+.at-sprint-health-grid article {
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: var(--at-surface-soft);
+    padding: 0.75rem;
+}
+
+.at-closure-metrics span,
+.at-sprint-health-grid strong {
+    display: block;
+    color: var(--at-text);
+    font-size: 1.25rem;
+    font-weight: 850;
+}
+
+.at-closure-metrics small,
+.at-sprint-health-grid h3 {
+    color: var(--at-muted);
+    font-size: 0.78rem;
+    font-weight: 750;
+    margin: 0;
+}
+
+.at-closure-recommendations {
+    border: 1px solid #fde68a;
+    border-radius: 12px;
+    background: #fffbeb;
+    color: #78350f;
+    padding: 0.75rem 0.9rem;
+    margin-bottom: 0.9rem;
+}
+
+.at-closure-recommendations ul {
+    margin: 0.35rem 0 0;
+    padding-left: 1.15rem;
+}
+
+.at-closure-form {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.at-closure-target-row {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.at-closure-task-table {
+    display: grid;
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.at-closure-task-row {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) 150px 150px 130px;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.7rem 0.8rem;
+    border-bottom: 1px solid var(--at-border);
+}
+
+.at-closure-task-row:last-child {
+    border-bottom: 0;
+}
+
+.at-closure-task-head {
+    background: #f8fafc;
+    color: var(--at-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.at-closure-task-row small {
+    display: block;
+    color: var(--at-muted);
+    font-weight: 650;
+}
+
+.at-closure-choice {
+    display: inline-flex;
+    gap: 0.4rem;
+    align-items: center;
+    font-weight: 750;
+}
+
+.at-closure-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.at-active-sprint-dashboard {
+    margin-bottom: 1rem;
+}
+
+@media (max-width: 767px) {
+    .at-closure-task-row {
+        grid-template-columns: 1fr;
+    }
+
+    .at-closure-task-head {
+        display: none;
+    }
+}

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -155,6 +155,32 @@
         });
     }
 
+    // SECTION: Keep closure disposition choices mutually exclusive per task.
+    function initSprintClosureReview() {
+        const review = document.querySelector("[data-at-closure-review='true']");
+        if (!review) {
+            return;
+        }
+
+        review.addEventListener("change", (event) => {
+            const input = event.target;
+            if (!input || input.getAttribute("data-at-closure-choice") === null || !input.checked) {
+                return;
+            }
+
+            const row = input.closest(".at-closure-task-row");
+            if (!row) {
+                return;
+            }
+
+            row.querySelectorAll("input[data-at-closure-choice]").forEach((candidate) => {
+                if (candidate !== input) {
+                    candidate.checked = false;
+                }
+            });
+        });
+    }
+
 
     // SECTION: Sticky inspector action panel orchestration and keyboard behavior.
     function initInspectorActionPanels() {
@@ -217,6 +243,7 @@
         initStatusUpdateGuard();
         initTaskRegisterFilters();
         initSprintSelector();
+        initSprintClosureReview();
         initInspectorActionPanels();
     });
 })();


### PR DESCRIPTION
### Motivation
- Complete Sprint Phase 1C by adding an explicit sprint closure review and disposition flow so sprints do not close silently when unfinished tasks remain.
- Provide operational carry‑forward that moves the same task (no cloning), makes the movement auditable, and prevents movement into closed sprints.
- Surface sprint‑aware health metrics on the dashboard so operational owners can see active sprint status at a glance.

### Description
- Added a closure review read model and active sprint metrics to `Services/ActionTasks/ActionTaskQueryService.cs` (`BuildClosureReview`, `BuildActiveSprintMetrics`, new DTOs `ActionSprintClosureReview` and `ActiveSprintOperationalMetrics`).
- Implemented closure disposition logic in `Services/ActionTasks/ActionSprintService.cs` with `CloseSprintWithDispositionAsync`, prevented silent close when unfinished tasks exist, preserved task identity when carrying forward (`SprintId` updated), and recorded audit entries (`TaskCarriedForward`, `TaskRemovedFromSprint`, `SprintClosed`).
- Extended `ActionSprintWorkflowPolicy` to validate carry‑forward targets, added UI partial `Pages/ActionTasks/_SprintClosureReview.cshtml`, wired into sprint view (`_TaskSprints.cshtml`) and dashboard (`_TaskDashboard.cshtml`), and added safe JS (`wwwroot/js/pages/action-tasks/index.js`) and CSS (`wwwroot/css/action-tracker.css`) for interaction and presentation.
- Updated page model `Pages/ActionTasks/Index.cshtml.cs` to expose closure review and active sprint metrics, bind `SprintClosureInput`, and added handler `OnPostCloseSprintWithDispositionAsync` to call the new service path.
- Tests: added unit tests in `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` for silent close prevention, carry‑forward and backlog disposition and audit checks, and a read‑model test in `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` for dashboard metrics and closure review counts.

### Testing
- Ran `git diff --check` to verify no whitespace/format issues, which passed with no errors reported.
- Added unit tests: `CloseSprintAsync_WithUnfinishedTasks_RequiresClosureReview`, `CloseSprintWithDispositionAsync_CarriesForwardSelectedTaskWithoutCloningAndAuditsMove`, `CloseSprintWithDispositionAsync_MovesSelectedTaskToBacklog`, `CloseSprintWithDispositionAsync_RejectsMovementIntoClosedSprint`, and `BuildReadModel_ComputesActiveSprintDashboardMetricsAndClosureReview` (tests are present in the test project).
- Attempted to run the affected test group with `dotnet test --filter

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb15f610648329a09bd231260be721)