### PR TITLE
Enforce later carry-forward sprints, clarify closure review UI, and add tests

### DIFF
--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -45,7 +45,10 @@
                             <option value="@sprint.Id">@sprint.Name (@sprint.Status) · @sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</option>
                         }
                     </select>
+                    <div class="form-text">Next sprint is required only for tasks marked to move to next sprint.</div>
                 </div>
+
+                <p class="at-panel-note">Each unfinished task must be moved either to next sprint or backlog before this sprint can close.</p>
 
                 <div class="at-closure-task-table" role="table" aria-label="Unfinished sprint tasks requiring disposition">
                     <div class="at-closure-task-row at-closure-task-head" role="row">

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -370,6 +370,46 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
+    public async Task CloseSprintWithDispositionAsync_WithPartialDisposition_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.Comdt);
+        var target = await service.CreateSprintAsync(NewSprint("Next", 15, 30), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
+        var carriedTask = await SeedTaskAsync(db, ActionTaskStatuses.Assigned);
+        var undispositionedTask = await SeedTaskAsync(db, ActionTaskStatuses.Blocked);
+        await service.AssignTaskToSprintAsync(carriedTask.Id, source.Id, "planner", RoleNames.Comdt);
+        await service.AssignTaskToSprintAsync(undispositionedTask.Id, source.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { carriedTask.Id }, target.Id, Array.Empty<int>(), "Only one task dispositioned", "planner", RoleNames.Comdt));
+        Assert.Contains("all unfinished tasks", ex.Message.ToLowerInvariant());
+    }
+
+    [Theory]
+    [InlineData(-15, 0)]
+    [InlineData(0, 14)]
+    public async Task CloseSprintWithDispositionAsync_RejectsCarryForwardIntoOlderOrNonLaterSprint(int targetStartOffsetDays, int targetEndOffsetDays)
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.Comdt);
+        var target = await service.CreateSprintAsync(NewSprint("Older or Same Target", targetStartOffsetDays, targetEndOffsetDays), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db);
+        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), "Invalid target timing", "planner", RoleNames.Comdt));
+        Assert.Contains("must be later", ex.Message.ToLowerInvariant());
+    }
+
+    [Fact]
     public async Task CloseSprintWithDispositionAsync_RejectsMovementIntoClosedSprint()
     {
         // SECTION: Arrange

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -12,6 +12,9 @@ public class ActionTaskQueryServiceSprintMetricsTests
         var today = DateTime.UtcNow.Date;
         var activeSprint = new ActionSprint { Id = 7, Name = "Active Ops", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(14) };
         var nextSprint = new ActionSprint { Id = 8, Name = "Next Ops", Status = ActionSprintStatus.Planned, StartDate = today.AddDays(15), EndDate = today.AddDays(30) };
+        var olderSprint = new ActionSprint { Id = 9, Name = "Older Ops", Status = ActionSprintStatus.Planned, StartDate = today.AddDays(-15), EndDate = today.AddDays(-1) };
+        var sameStartSprint = new ActionSprint { Id = 10, Name = "Same Start Ops", Status = ActionSprintStatus.Planned, StartDate = today, EndDate = today.AddDays(7) };
+        var closedLaterSprint = new ActionSprint { Id = 11, Name = "Closed Later Ops", Status = ActionSprintStatus.Closed, StartDate = today.AddDays(31), EndDate = today.AddDays(45) };
         var tasks = new[]
         {
             NewTask(1, activeSprint.Id, ActionTaskStatuses.Closed, today.AddDays(-1)),
@@ -25,7 +28,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         // SECTION: Act
         var model = service.BuildReadModel(
             tasks,
-            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, activeSprint.Id, new[] { activeSprint, nextSprint }, null, null, null, null, null, null, null),
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, activeSprint.Id, new[] { activeSprint, nextSprint, olderSprint, sameStartSprint, closedLaterSprint }, null, null, null, null, null, null, null),
             new Dictionary<string, string> { ["assignee"] = "Assignee" },
             new Dictionary<int, DateTime?>());
 

--- a/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
@@ -55,6 +55,11 @@ public class ActionSprintWorkflowPolicy
             throw new InvalidOperationException("Carry-forward target sprint must be different from the sprint being closed.");
         }
 
+        if (targetSprint.StartDate.Date <= sourceSprint.StartDate.Date)
+        {
+            throw new InvalidOperationException("Carry-forward target sprint must be later than the sprint being closed.");
+        }
+
         if (targetSprint.Status == ActionSprintStatus.Closed)
         {
             throw new InvalidOperationException("Tasks cannot be carried forward into a closed sprint.");

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -132,7 +132,7 @@ public sealed class ActionTaskQueryService
     {
         var unfinishedTasks = sprintTasks.Where(IsOpen).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
         var targetOptions = sprints
-            .Where(s => s.Id != sprint.Id && s.Status != ActionSprintStatus.Closed)
+            .Where(s => s.Id != sprint.Id && s.Status != ActionSprintStatus.Closed && s.StartDate.Date > sprint.StartDate.Date)
             .OrderBy(s => s.StartDate)
             .ThenBy(s => s.Id)
             .ToList();


### PR DESCRIPTION
### Motivation
- Prevent carry-forwarding unfinished work into the same or earlier sprint to match expected sprint progression rules. 
- Ensure closure review only offers valid target sprints and gives clearer guidance to users about required dispositions. 
- Add service-level tests to reject partial dispositions and invalid carry-forward targets so the workflow enforces completeness and correct timing.

### Description
- Enforce timing check in `ActionSprintWorkflowPolicy.EnsureCanCarryForward` so `targetSprint.StartDate` must be later than `sourceSprint.StartDate`, while preserving the existing closed-sprint rejection. (`Services/ActionTasks/ActionSprintWorkflowPolicy.cs`)
- Restrict closure-review target options in `ActionTaskQueryService.BuildClosureReview` to non-closed sprints that start after the sprint being closed. (`Services/ActionTasks/ActionTaskQueryService.cs`)
- Improve closure review UI by adding explanatory text that each unfinished task must be moved to next sprint or backlog and that the next sprint selection is only required for carry-forwarded tasks. (`Pages/ActionTasks/_SprintClosureReview.cshtml`)
- Add unit tests to cover the new rules: a test rejecting closure when only a subset of unfinished tasks are dispositioned and a theory rejecting carry-forward into older or non-later sprints, and extend the closure-review query test-cases to include older/same/closed sprints. (`ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs`, `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs`)

### Testing
- Added automated unit tests: `CloseSprintWithDispositionAsync_WithPartialDisposition_RejectsRequest` and `CloseSprintWithDispositionAsync_RejectsCarryForwardIntoOlderOrNonLaterSprint` and expanded `ActionTaskQueryServiceSprintMetricsTests` to validate filtering; these tests are included in the repository test project. 
- `dotnet build` / `dotnet test` were not executed in this environment because the `dotnet` CLI is not installed here, so automated tests were not run by this rollout. 
- Recommended local verification commands: run `dotnet build ProjectManagement.sln` and `dotnet test ProjectManagement.sln` to validate the changes and confirm all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1b8f6cf883299c326ab595f7c030)