### PR TITLE
Fix nested forms in Sprint Closure Review partial

### DIFF
--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -30,6 +30,30 @@
             </ul>
         </div>
 
+        @if (Model.ShouldShowCreateNextSprint)
+        {
+            @* SECTION: Standalone next sprint creation when no later carry-forward target exists. *@
+            <details class="at-next-sprint-panel" open="@Model.ShowCreateNextSprintPanel">
+                <summary class="btn btn-outline-primary btn-sm">Create Next Sprint</summary>
+                <div class="at-panel-note">Create a planned sprint after this sprint; it will then appear as a carry-forward target.</div>
+                <form method="post" asp-page-handler="CreateNextSprint" class="at-sprint-command-form">
+                    <input type="hidden" name="ViewMode" value="Sprints" />
+                    <input type="hidden" asp-for="NextSprintInput.SourceSprintId" value="@Model.SelectedSprint.Id" />
+                    <div asp-validation-summary="All" class="text-danger small"></div>
+                    <label class="form-label" asp-for="NextSprintInput.Name"></label>
+                    <input class="form-control" asp-for="NextSprintInput.Name" maxlength="160" />
+                    <label class="form-label" asp-for="NextSprintInput.StartDate"></label>
+                    <input class="form-control" asp-for="NextSprintInput.StartDate" type="date" />
+                    <label class="form-label" asp-for="NextSprintInput.EndDate"></label>
+                    <input class="form-control" asp-for="NextSprintInput.EndDate" type="date" />
+                    <label class="form-label" asp-for="NextSprintInput.Goal"></label>
+                    <textarea class="form-control" asp-for="NextSprintInput.Goal" rows="2" maxlength="2000"></textarea>
+                    <button type="submit" class="btn btn-primary btn-sm">Create Planned Next Sprint</button>
+                </form>
+            </details>
+        }
+
+        @* SECTION: Closure disposition form; keep this separate from create-next form to avoid invalid nested forms. *@
         <form method="post" asp-page-handler="CloseSprintWithDisposition" class="at-closure-form">
             <input type="hidden" asp-for="ClosureInput.SprintId" value="@Model.SelectedSprint.Id" />
             <input type="hidden" asp-for="ClosureInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
@@ -47,29 +71,6 @@
                     </select>
                     <div class="form-text">Next sprint is required only for tasks marked to move to next sprint.</div>
                 </div>
-
-                @if (Model.ShouldShowCreateNextSprint)
-                {
-                    @* SECTION: Closure-context next sprint creation when no later carry-forward target exists. *@
-                    <details class="at-next-sprint-panel" open="@Model.ShowCreateNextSprintPanel">
-                        <summary class="btn btn-outline-primary btn-sm">Create Next Sprint</summary>
-                        <div class="at-panel-note">Create a planned sprint after this sprint; it will then appear as a carry-forward target.</div>
-                        <form method="post" asp-page-handler="CreateNextSprint" class="at-sprint-command-form">
-                            <input type="hidden" name="ViewMode" value="Sprints" />
-                            <input type="hidden" asp-for="NextSprintInput.SourceSprintId" value="@Model.SelectedSprint.Id" />
-                            <div asp-validation-summary="All" class="text-danger small"></div>
-                            <label class="form-label" asp-for="NextSprintInput.Name"></label>
-                            <input class="form-control" asp-for="NextSprintInput.Name" maxlength="160" />
-                            <label class="form-label" asp-for="NextSprintInput.StartDate"></label>
-                            <input class="form-control" asp-for="NextSprintInput.StartDate" type="date" />
-                            <label class="form-label" asp-for="NextSprintInput.EndDate"></label>
-                            <input class="form-control" asp-for="NextSprintInput.EndDate" type="date" />
-                            <label class="form-label" asp-for="NextSprintInput.Goal"></label>
-                            <textarea class="form-control" asp-for="NextSprintInput.Goal" rows="2" maxlength="2000"></textarea>
-                            <button type="submit" class="btn btn-primary btn-sm">Create Planned Next Sprint</button>
-                        </form>
-                    </details>
-                }
 
                 <p class="at-panel-note">Each unfinished task must be moved either to next sprint or backlog before this sprint can close.</p>
 


### PR DESCRIPTION
### Motivation
- Prevent invalid nested HTML forms in the sprint closure UI which caused the Create Next Sprint submit to be absorbed by the closure form. 
- Ensure each action (`CreateNextSprint` and `CloseSprintWithDisposition`) has its own POST form so browser submissions target the intended handler. 
- Keep markup CSP-compliant with no inline scripts and maintain clear sectioning for maintainability.

### Description
- Moved the `CreateNextSprint` POST form out of the `CloseSprintWithDisposition` POST form in `Pages/ActionTasks/_SprintClosureReview.cshtml` so the two forms are siblings rather than nested. 
- Added a comment section and a `details` wrapper for the standalone next-sprint creation UI to preserve visual context while avoiding nested form markup. 
- Removed the duplicated in-form create-next block and preserved the closure disposition form and its task disposition inputs unchanged.

### Testing
- Ran a `python3` form-tag balance/nesting check which reported balanced form tags and no nested-form violations (pass). 
- Inspected the diff of `Pages/ActionTasks/_SprintClosureReview.cshtml` to verify the `CreateNextSprint` form is now outside the closure form (manual verification). 
- Attempted to run `dotnet test ProjectManagement.sln` but the `dotnet` CLI is not available in the environment so automated unit tests could not be executed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb232d62d88329af7f7aca96c34b3a)