### PR TITLE
Sprint closure: separate next-sprint form, strengthen date/carry-forward rules, simplify backlog audit, add tests

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -493,6 +493,7 @@ public class IndexModel : PageModel
         ModelState.Clear();
         TryValidateModel(NextSprintInput, nameof(NextSprintInput));
         ValidateSprintDateRange(NextSprintInput.StartDate, NextSprintInput.EndDate, nameof(NextSprintInput));
+        await ValidateNextSprintStartsAfterSourceSprintAsync();
 
         if (!ModelState.IsValid)
         {
@@ -1118,6 +1119,23 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Resolve a safe, standardized view mode value for postback and redirects
+
+
+    private async Task ValidateNextSprintStartsAfterSourceSprintAsync()
+    {
+        // SECTION: Closure-review next sprint sequencing validation.
+        var sourceSprint = (await _sprintService.GetSprintsAsync()).FirstOrDefault(s => s.Id == NextSprintInput.SourceSprintId);
+        if (sourceSprint is null)
+        {
+            ModelState.AddModelError($"{nameof(NextSprintInput)}.{nameof(CreateNextSprintInput.SourceSprintId)}", "Source sprint was not found. Reload the sprint closure review and try again.");
+            return;
+        }
+
+        if (NextSprintInput.StartDate.Date <= sourceSprint.EndDate.Date)
+        {
+            ModelState.AddModelError($"{nameof(NextSprintInput)}.{nameof(CreateNextSprintInput.StartDate)}", $"Next sprint start date must be later than the source sprint end date ({sourceSprint.EndDate:dd MMM yyyy}).");
+        }
+    }
 
     private void ValidateSprintDateRange(DateTime startDate, DateTime endDate, string prefix)
     {

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -30,6 +30,29 @@
             </ul>
         </div>
 
+        @if (review.UnfinishedTasks.Any() && Model.ShouldShowCreateNextSprint)
+        {
+            @* SECTION: Closure-context next sprint creation when no later carry-forward target exists. *@
+            <details class="at-next-sprint-panel" open="@Model.ShowCreateNextSprintPanel">
+                <summary class="btn btn-outline-primary btn-sm">Create Next Sprint</summary>
+                <div class="at-panel-note">Create a planned sprint after this sprint; it will then appear as a carry-forward target.</div>
+                <form method="post" asp-page-handler="CreateNextSprint" class="at-sprint-command-form">
+                    <input type="hidden" name="ViewMode" value="Sprints" />
+                    <input type="hidden" asp-for="NextSprintInput.SourceSprintId" value="@Model.SelectedSprint.Id" />
+                    <div asp-validation-summary="All" class="text-danger small"></div>
+                    <label class="form-label" asp-for="NextSprintInput.Name"></label>
+                    <input class="form-control" asp-for="NextSprintInput.Name" maxlength="160" />
+                    <label class="form-label" asp-for="NextSprintInput.StartDate"></label>
+                    <input class="form-control" asp-for="NextSprintInput.StartDate" type="date" />
+                    <label class="form-label" asp-for="NextSprintInput.EndDate"></label>
+                    <input class="form-control" asp-for="NextSprintInput.EndDate" type="date" />
+                    <label class="form-label" asp-for="NextSprintInput.Goal"></label>
+                    <textarea class="form-control" asp-for="NextSprintInput.Goal" rows="2" maxlength="2000"></textarea>
+                    <button type="submit" class="btn btn-primary btn-sm">Create Planned Next Sprint</button>
+                </form>
+            </details>
+        }
+
         <form method="post" asp-page-handler="CloseSprintWithDisposition" class="at-closure-form">
             <input type="hidden" asp-for="ClosureInput.SprintId" value="@Model.SelectedSprint.Id" />
             <input type="hidden" asp-for="ClosureInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
@@ -47,29 +70,6 @@
                     </select>
                     <div class="form-text">Next sprint is required only for tasks marked to move to next sprint.</div>
                 </div>
-
-                @if (Model.ShouldShowCreateNextSprint)
-                {
-                    @* SECTION: Closure-context next sprint creation when no later carry-forward target exists. *@
-                    <details class="at-next-sprint-panel" open="@Model.ShowCreateNextSprintPanel">
-                        <summary class="btn btn-outline-primary btn-sm">Create Next Sprint</summary>
-                        <div class="at-panel-note">Create a planned sprint after this sprint; it will then appear as a carry-forward target.</div>
-                        <form method="post" asp-page-handler="CreateNextSprint" class="at-sprint-command-form">
-                            <input type="hidden" name="ViewMode" value="Sprints" />
-                            <input type="hidden" asp-for="NextSprintInput.SourceSprintId" value="@Model.SelectedSprint.Id" />
-                            <div asp-validation-summary="All" class="text-danger small"></div>
-                            <label class="form-label" asp-for="NextSprintInput.Name"></label>
-                            <input class="form-control" asp-for="NextSprintInput.Name" maxlength="160" />
-                            <label class="form-label" asp-for="NextSprintInput.StartDate"></label>
-                            <input class="form-control" asp-for="NextSprintInput.StartDate" type="date" />
-                            <label class="form-label" asp-for="NextSprintInput.EndDate"></label>
-                            <input class="form-control" asp-for="NextSprintInput.EndDate" type="date" />
-                            <label class="form-label" asp-for="NextSprintInput.Goal"></label>
-                            <textarea class="form-control" asp-for="NextSprintInput.Goal" rows="2" maxlength="2000"></textarea>
-                            <button type="submit" class="btn btn-primary btn-sm">Create Planned Next Sprint</button>
-                        </form>
-                    </details>
-                }
 
                 <p class="at-panel-note">Each unfinished task must be moved either to next sprint or backlog before this sprint can close.</p>
 

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -417,7 +417,8 @@ public class ActionSprintServiceTests
     [Theory]
     [InlineData(-15, 0)]
     [InlineData(0, 14)]
-    public async Task CloseSprintWithDispositionAsync_RejectsCarryForwardIntoOlderOrNonLaterSprint(int targetStartOffsetDays, int targetEndOffsetDays)
+    [InlineData(7, 21)]
+    public async Task CloseSprintWithDispositionAsync_RejectsCarryForwardIntoOverlappingOrNonLaterSprint(int targetStartOffsetDays, int targetEndOffsetDays)
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -431,7 +432,7 @@ public class ActionSprintServiceTests
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), "Invalid target timing", "planner", RoleNames.Comdt));
-        Assert.Contains("must be later", ex.Message.ToLowerInvariant());
+        Assert.Contains("must start after", ex.Message.ToLowerInvariant());
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1,4 +1,12 @@
 using System.Security.Claims;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -403,6 +411,56 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task CreateNextSprintPageHandler_WhenStartDateOnSourceEndDate_ReopensPanelAndShowsModelError()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.Comdt);
+        var source = AddSprint(setup.Db, "Active Source", ActionSprintStatus.Active, startOffsetDays: 0);
+        setup.Db.ActionTasks.Add(NewTask("Carry me", ActionTaskStatuses.Assigned, source.Id));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.NextSprintInput = IndexModel.CreateNextSprintInput.FromSourceSprint(source);
+        page.NextSprintInput.StartDate = source.EndDate.Date;
+        page.NextSprintInput.EndDate = source.EndDate.Date.AddDays(14);
+
+        // SECTION: Act
+        var result = await page.OnPostCreateNextSprintAsync();
+
+        // SECTION: Assert
+        Assert.IsType<PageResult>(result);
+        Assert.True(page.ShowCreateNextSprintPanel);
+        Assert.False(page.ModelState.IsValid);
+        Assert.Contains(page.ModelState[$"{nameof(page.NextSprintInput)}.{nameof(IndexModel.CreateNextSprintInput.StartDate)}"]!.Errors, e => e.ErrorMessage.Contains("later than the source sprint end date", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(await setup.Db.ActionSprints.ToListAsync(), s => s.Name == page.NextSprintInput.Name && s.Id != source.Id);
+    }
+
+    [Fact]
+    public async Task SprintClosureReviewPartial_RendersCreateNextSprintFormOutsideClosureDispositionForm()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.Comdt);
+        var source = AddSprint(setup.Db, "Active Source", ActionSprintStatus.Active, startOffsetDays: 0);
+        setup.Db.ActionTasks.Add(NewTask("Carry me", ActionTaskStatuses.Assigned, source.Id));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+        page.SelectedSprintId = source.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderSprintClosureReviewAsync(page);
+
+        // SECTION: Assert
+        var createFormStart = html.IndexOf("at-sprint-command-form", StringComparison.Ordinal);
+        var closureFormStart = html.IndexOf("at-closure-form", StringComparison.Ordinal);
+        var closureFormEnd = html.IndexOf("</form>", closureFormStart, StringComparison.Ordinal);
+        Assert.Contains("handler=CreateNextSprint", html, StringComparison.Ordinal);
+        Assert.True(createFormStart >= 0, "Create next sprint form should render.");
+        Assert.True(closureFormStart >= 0, "Closure disposition form should render.");
+        Assert.True(createFormStart < closureFormStart || createFormStart > closureFormEnd, "Create next sprint form must not be nested inside the closure disposition form.");
+    }
+
+    [Fact]
     public async Task SprintHistoryReadModel_ReturnsAuditEventsWithActorVisibility()
     {
         // SECTION: Arrange
@@ -443,6 +501,68 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Null(taskId1);
         Assert.Single(entityType.GetForeignKeys().Where(fk => fk.PrincipalEntityType.ClrType == typeof(ActionTaskItem)));
+    }
+
+    private static async Task<string> RenderSprintClosureReviewAsync(IndexModel page)
+    {
+        // SECTION: Razor partial rendering helper for closure-review markup checks.
+        await using var writer = new StringWriter();
+        using var provider = BuildRazorServiceProvider();
+        using var scope = provider.CreateScope();
+        var scopedProvider = scope.ServiceProvider;
+        var viewEngine = scopedProvider.GetRequiredService<IRazorViewEngine>();
+        var tempDataProvider = scopedProvider.GetRequiredService<ITempDataProvider>();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = scopedProvider,
+            User = page.PageContext.HttpContext.User
+        };
+        var routeData = new RouteData();
+        routeData.Values["page"] = "/ActionTasks/Index";
+        var actionDescriptor = new ActionDescriptor();
+        actionDescriptor.RouteValues["page"] = "/ActionTasks/Index";
+        var actionContext = new ActionContext(httpContext, routeData, actionDescriptor);
+        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: "/Pages/ActionTasks/_SprintClosureReview.cshtml", isMainPage: false);
+        if (!viewResult.Success)
+        {
+            throw new InvalidOperationException("Unable to locate _SprintClosureReview partial view.");
+        }
+
+        var viewData = new ViewDataDictionary<IndexModel>(new EmptyModelMetadataProvider(), page.ModelState)
+        {
+            Model = page
+        };
+        var tempData = new TempDataDictionary(httpContext, tempDataProvider);
+        var viewContext = new ViewContext(actionContext, viewResult.View, viewData, tempData, writer, new HtmlHelperOptions());
+        await viewResult.View.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    private static ServiceProvider BuildRazorServiceProvider()
+    {
+        // SECTION: Minimal MVC services required to render Razor partials in tests.
+        var contentRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var webRoot = Path.Combine(contentRoot, "wwwroot");
+        var environment = new TestWebHostEnvironment
+        {
+            ApplicationName = typeof(Program).Assembly.GetName().Name!,
+            ContentRootPath = contentRoot,
+            WebRootPath = webRoot,
+            ContentRootFileProvider = new PhysicalFileProvider(contentRoot),
+            WebRootFileProvider = Directory.Exists(webRoot) ? new PhysicalFileProvider(webRoot) : new NullFileProvider(),
+            EnvironmentName = Environments.Development
+        };
+        var services = new ServiceCollection();
+        var diagnosticListener = new DiagnosticListener("Microsoft.AspNetCore");
+        services.AddSingleton<DiagnosticListener>(diagnosticListener);
+        services.AddSingleton<DiagnosticSource>(diagnosticListener);
+        services.AddSingleton<IWebHostEnvironment>(environment);
+        services.AddSingleton<IHostEnvironment>(environment);
+        services.AddLogging();
+        services.AddRouting();
+        services.AddRazorPages();
+        services.AddControllersWithViews();
+        return services.BuildServiceProvider();
     }
 
     private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync(string currentRole = RoleNames.HoD)
@@ -527,6 +647,17 @@ public class ActionTaskPageTests
             Status = status,
             SprintId = sprintId
         };
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        // SECTION: Test host environment for Razor partial rendering.
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
     }
 
     private sealed class StubCollabService : IActionTaskCollaborationService

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -285,8 +285,7 @@ public class ActionSprintService
 
         var oldValue = task.SprintId?.ToString();
         task.SprintId = null;
-        AddTaskSprintAudit(task.Id, "TaskRemovedFromSprint", userId, role, oldValue, null, "Removed from sprint and moved to backlog.");
-        AddTaskSprintAudit(task.Id, "TaskMovedToBacklog", userId, role, oldValue, null, "Moved to backlog.");
+        AddTaskSprintAudit(task.Id, "TaskMovedToBacklog", userId, role, oldValue, null, "Removed from sprint and moved to backlog.");
 
         await _context.SaveChangesAsync(cancellationToken);
         return task;

--- a/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionSprintWorkflowPolicy.cs
@@ -55,9 +55,9 @@ public class ActionSprintWorkflowPolicy
             throw new InvalidOperationException("Carry-forward target sprint must be different from the sprint being closed.");
         }
 
-        if (targetSprint.StartDate.Date <= sourceSprint.StartDate.Date)
+        if (targetSprint.StartDate.Date <= sourceSprint.EndDate.Date)
         {
-            throw new InvalidOperationException("Carry-forward target sprint must be later than the sprint being closed.");
+            throw new InvalidOperationException("Carry-forward target sprint must start after the sprint being closed ends.");
         }
 
         if (targetSprint.Status == ActionSprintStatus.Closed)

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -132,7 +132,7 @@ public sealed class ActionTaskQueryService
     {
         var unfinishedTasks = sprintTasks.Where(IsOpen).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
         var targetOptions = sprints
-            .Where(s => s.Id != sprint.Id && s.Status != ActionSprintStatus.Closed && s.StartDate.Date > sprint.StartDate.Date)
+            .Where(s => s.Id != sprint.Id && s.Status != ActionSprintStatus.Closed && s.StartDate.Date > sprint.EndDate.Date)
             .OrderBy(s => s.StartDate)
             .ThenBy(s => s.Id)
             .ToList();


### PR DESCRIPTION
### Motivation
- Clean up the Sprint Phase 1D closure review to remove nested forms and make the Create Next Sprint action post independently. 
- Strengthen validation so next-sprint creation from closure context cannot produce a sprint that overlaps or does not start after the source sprint. 
- Enforce a consistent carry-forward rule across workflow policy and UI read-model and remove duplicate audit noise for backlog moves. 
- Add tests to exercise the corrected behaviors and verify markup does not contain nested forms.

### Description
- Move the Create Next Sprint form out of the closure disposition form so it renders and posts independently in `Pages/ActionTasks/_SprintClosureReview.cshtml`.
- Add `ValidateNextSprintStartsAfterSourceSprintAsync()` and invoke it from `OnPostCreateNextSprintAsync()` in `Pages/ActionTasks/Index.cshtml.cs` to ensure `NextSprintInput.StartDate.Date > sourceSprint.EndDate.Date` and add a clear `ModelState` error when violated.
- Tighten carry-forward rules by updating `EnsureCanCarryForward` in `Services/ActionTasks/ActionSprintWorkflowPolicy.cs` to compare `targetSprint.StartDate.Date` against `sourceSprint.EndDate.Date` and update `ActionTaskQueryService.BuildClosureReview` to only list target sprints that start after the source sprint ends.
- Remove duplicate audit entries in `Services/ActionTasks/ActionSprintService.cs` so `MoveTaskToBacklogAsync` emits a single `TaskMovedToBacklog` audit event (previous duplicate `TaskRemovedFromSprint` removed) and keep an explanatory remark on the single event.
- Add and update unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` and `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` to cover: create-next-sprint rejecting start date on or before source sprint end, carry-forward rejecting overlapping/older targets, and verifying the closure-review partial renders the Create Next Sprint form outside the closure disposition form.

### Testing
- Static/markup checks: ran `git diff --check` and searched the closure partial to confirm independent `asp-page-handler="CreateNextSprint"` and `asp-page-handler="CloseSprintWithDisposition"` forms and no nesting; these checks succeeded.
- Local test execution: attempted `dotnet build` and `dotnet test` but the environment lacks the `dotnet` CLI so compilation and test runs were not executed here; tests were added/updated but not run in this environment.
- Behavioral verification in code: updated workflow and query logic so both policy (`EnsureCanCarryForward`) and UI read-model (`BuildClosureReview`) use the same "starts after source end" rule, and page-level validation surfaces a `ModelState` error when the next sprint start is not strictly later than the closed sprint end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb24fba9148329b79b5dc52bda6e49)