### PR TITLE
Refine Action Tracker Sprints UX and Inspector (Phase 2A)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -910,6 +910,64 @@ public class IndexModel : PageModel
             .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
             .ToList());
 
+    // SECTION: Phase 2A layout helper projections for sprint, backlog, and dashboard UX.
+    public IReadOnlyList<ActionSprint> PlannedSprints =>
+        Sprints.Where(s => s.Status == ActionSprintStatus.Planned).OrderBy(s => s.StartDate).ThenBy(s => s.Id).ToList();
+
+    public IReadOnlyList<ActionSprint> ClosedSprints =>
+        Sprints.Where(s => s.Status == ActionSprintStatus.Closed).OrderByDescending(s => s.EndDate).ThenByDescending(s => s.Id).ToList();
+
+    public int SelectedSprintOverdueCount =>
+        SelectedSprintTasks.Count(IsTaskOverdue);
+
+    public IReadOnlyList<TaskDisplayItem> SprintAttentionOverdueTaskDisplays =>
+        ToDisplayItems(SelectedSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList());
+
+    public IReadOnlyList<TaskDisplayItem> SprintAttentionBlockedTaskDisplays =>
+        ToDisplayItems(SelectedSprintTasks
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id)
+            .ToList());
+
+    public IReadOnlyList<TaskDisplayItem> SprintAttentionSubmittedTaskDisplays =>
+        ToDisplayItems(SelectedSprintTasks
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.SubmittedOn ?? t.DueDate)
+            .ThenBy(t => t.Id)
+            .ToList());
+
+    public IReadOnlyList<TaskDisplayItem> SprintCarryForwardCandidateDisplays =>
+        ToDisplayItems(SprintClosureReview.UnfinishedTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList());
+
+    public int BacklogTotalCount => BacklogTasks.Count;
+
+    public int BacklogHighPriorityCount =>
+        BacklogTasks.Count(t => string.Equals(t.Priority, "High", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
+
+    public int BacklogOverdueCount =>
+        BacklogTasks.Count(IsTaskOverdue);
+
+    public IReadOnlyList<TaskDisplayItem> ActiveSprintOverdueTaskDisplays =>
+        ToDisplayItems(GetActiveSprintTasks().Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList());
+
+    public IReadOnlyList<TaskDisplayItem> ActiveSprintBlockedTaskDisplays =>
+        ToDisplayItems(GetActiveSprintTasks()
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id)
+            .Take(5)
+            .ToList());
+
+    public IReadOnlyList<TaskDisplayItem> ActiveSprintSubmittedTaskDisplays =>
+        ToDisplayItems(GetActiveSprintTasks()
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.SubmittedOn ?? t.DueDate)
+            .ThenBy(t => t.Id)
+            .Take(5)
+            .ToList());
+
     // SECTION: KPI helpers for dashboard and reports.
     public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
     public int OverdueCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < DateTime.UtcNow.Date);
@@ -1347,6 +1405,15 @@ public class IndexModel : PageModel
 
     private int CountByStatus(string status) =>
         Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
+
+    public bool IsTaskOverdue(ActionTaskItem task) =>
+        !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+        && task.DueDate.Date < DateTime.UtcNow.Date;
+
+    private IReadOnlyList<ActionTaskItem> GetActiveSprintTasks() =>
+        ActiveSprint is null
+            ? Array.Empty<ActionTaskItem>()
+            : Tasks.Where(t => t.SprintId == ActiveSprint.Id).ToList();
 
     private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>
         tasks.Select(task => new TaskDisplayItem

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -4,7 +4,7 @@
 @if (Model.SelectedSprint is not null && Model.CanReviewSprintClosure)
 {
     var review = Model.SprintClosureReview;
-    <section class="at-panel at-closure-review" data-at-closure-review="true">
+    <section id="sprint-closure-review" class="at-panel at-closure-review" data-at-closure-review="true">
         <div class="at-panel-heading">
             <div>
                 <h2>Sprint Closure Review</h2>

--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -10,6 +10,12 @@
         </div>
         <span class="at-count-chip">@Model.BacklogTaskDisplays.Count tasks</span>
     </div>
+    @* SECTION: Compact backlog planning signals preserve the SprintId == null backlog definition. *@
+    <div class="at-backlog-summary-grid" aria-label="Backlog summary">
+        <article><strong>@Model.BacklogTotalCount</strong><span>Total backlog</span></article>
+        <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
+        <article><strong>@Model.BacklogOverdueCount</strong><span>Overdue</span></article>
+    </div>
     <form method="get" class="row g-2" data-at-task-filter-form="true">
         <input type="hidden" name="viewMode" value="Backlog" />
         <div class="col-md-2">
@@ -115,12 +121,18 @@
                         <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
                             <td>
                                 <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Backlog">AT-@task.Id · @task.Title</a>
-                                <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
+                                <div class="at-backlog-task-meta">
+                                    <span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span>
+                                    @if (Model.IsTaskOverdue(task))
+                                    {
+                                        <span class="at-overdue-marker">Overdue</span>
+                                    }
+                                </div>
                             </td>
-                            <td>@item.AssigneeName</td>
+                            <td><span class="at-cell-primary">@item.AssigneeName</span></td>
                             <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
                             <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
-                            <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                            <td><span class="at-cell-primary">@task.DueDate.ToString("dd MMM yyyy")</span></td>
                             @if (Model.CanPlanSprints)
                             {
                                 <td>

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -27,14 +27,29 @@
             }
         </div>
     </div>
-    <div class="at-sprint-health-grid" aria-label="Active sprint health metrics">
-        <article><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong></article>
+    <div class="at-sprint-health-grid at-sprint-health-grid-readable" aria-label="Active sprint health metrics">
+        <article class="is-primary"><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong><span>Current execution scope</span></article>
         <article><h3>Completed</h3><strong>@Model.ActiveSprintMetrics.CompletedTasks</strong></article>
         <article><h3>In progress</h3><strong>@Model.ActiveSprintMetrics.InProgressTasks</strong></article>
         <article><h3>Blocked</h3><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></article>
         <article><h3>Overdue in sprint</h3><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></article>
         <article><h3>Backlog</h3><strong>@Model.ActiveSprintMetrics.BacklogTasks</strong></article>
         <article><h3>Carry-forward candidates</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong></article>
+    </div>
+    @* SECTION: Command attention grouping for active sprint exceptions. *@
+    <div class="at-dashboard-attention-grid" aria-label="Active sprint command attention">
+        <article class="at-attention-panel">
+            <div class="at-attention-heading"><span>Overdue</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, "No overdue tasks in the active sprint.")' />
+        </article>
+        <article class="at-attention-panel">
+            <div class="at-attention-heading"><span>Blocked</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, "No blocked tasks in the active sprint.")' />
+        </article>
+        <article class="at-attention-panel">
+            <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, "No submitted tasks pending closure in the active sprint.")' />
+        </article>
     </div>
 </section>
 

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -29,103 +29,93 @@
 
         @if (Model.SelectedTask is not null)
         {
-            @* SECTION: Scrollable body with unified activity timeline and collapsible details. *@
+            @* SECTION: Scrollable body prioritizes progress updates, with audit and long details collapsed by default. *@
             <div class="at-inspector-body">
-                <section class="at-inspector-section" aria-label="Activity Timeline">
-                    <h3>Activity</h3>
-                    @if (!Model.SelectedTaskUpdates.Any() && !Model.SelectedTaskLogs.Any())
+                <section class="at-inspector-section at-progress-timeline" aria-label="Progress Timeline">
+                    <div class="at-inspector-section-heading">
+                        <h3>Progress Timeline</h3>
+                        <span class="at-count-chip">@Model.SelectedTaskUpdates.Count</span>
+                    </div>
+                    @if (!Model.SelectedTaskUpdates.Any())
                     {
-                        <div class="at-empty-state at-empty-state-compact mt-2"><div>No activity recorded for this task yet.</div></div>
+                        <div class="at-empty-state at-empty-state-compact mt-2"><div>No progress updates recorded for this task yet.</div></div>
                     }
                     else
                     {
-                        // SECTION: Timeline projection keeps update/log payloads nullable by design.
-                        var updateEntries = Model.SelectedTaskUpdates
-                            .Select(update => new
-                            {
-                                Timestamp = update.CreatedAtUtc,
-                                EntryType = "Update",
-                                Update = (ProjectManagement.Models.ActionTaskUpdate?)update,
-                                Log = (ProjectManagement.Models.ActionTaskAuditLog?)null
-                            });
-
-                        var logEntries = Model.SelectedTaskLogs
-                            .Select(log => new
-                            {
-                                Timestamp = log.PerformedAt,
-                                EntryType = "Log",
-                                Update = (ProjectManagement.Models.ActionTaskUpdate?)null,
-                                Log = (ProjectManagement.Models.ActionTaskAuditLog?)log
-                            });
-
-                        var activityEntries = updateEntries
-                            .Concat(logEntries)
-                            .OrderByDescending(entry => entry.Timestamp)
-                            .ToList();
-
                         <div class="at-activity-stream mt-2">
-                            @foreach (var entry in activityEntries)
+                            @foreach (var update in Model.SelectedTaskUpdates.OrderByDescending(update => update.CreatedAtUtc))
                             {
-                                if (entry.Update is { } update)
-                                {
-                                    <article class="at-activity-update-card">
-                                        <div class="d-flex justify-content-between gap-2 flex-wrap">
-                                            <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong></div>
-                                            <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
-                                        </div>
-                                        <div class="at-audit-remarks at-remarks-text">@update.Body</div>
-                                        @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
-                                        {
-                                            <div class="at-update-files mt-2">
-                                                @foreach (var file in files)
+                                <article class="at-activity-update-card">
+                                    <div class="d-flex justify-content-between gap-2 flex-wrap">
+                                        <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong></div>
+                                        <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
+                                    </div>
+                                    <div class="at-audit-remarks at-remarks-text">@update.Body</div>
+                                    @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
+                                    {
+                                        <div class="at-update-files mt-2">
+                                            @foreach (var file in files)
+                                            {
+                                                var typeLabel = file.ContentType switch
                                                 {
-                                                    var typeLabel = file.ContentType switch
-                                                    {
-                                                        "application/pdf" => "PDF",
-                                                        "application/msword" => "DOC",
-                                                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "DOCX",
-                                                        "application/vnd.ms-excel" => "XLS",
-                                                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "XLSX",
-                                                        "image/jpeg" => "JPG",
-                                                        "image/png" => "PNG",
-                                                        "text/plain" => "TXT",
-                                                        _ => "FILE"
-                                                    };
-                                                    <div class="at-update-file-item">
-                                                        <span class="at-file-type">@typeLabel</span>
-                                                        <a class="at-file-name" href="@file.DownloadUrl" title="@file.FileName">@file.FileName</a>
-                                                        <span class="at-file-size">@ProjectManagement.Helpers.FileSizeFormatter.FormatFileSize(file.FileSize)</span>
-                                                        <a class="btn btn-outline-secondary btn-sm" href="@file.DownloadUrl">Download</a>
-                                                    </div>
-                                                }
-                                            </div>
-                                        }
-                                    </article>
-                                }
-                                else if (entry.Log is { } log)
-                                {
-                                    <article class="at-activity-system-row @(log.ActionType == "Task Created" ? "at-system-event-created" : "")">
-                                        <div class="d-flex justify-content-between gap-2 flex-wrap">
-                                            <div>
-                                                <strong>@log.ActionType</strong>
-                                                <span class="text-muted">by @Model.ResolveActorName(log.PerformedByUserId)</span>
-                                            </div>
-                                            <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
+                                                    "application/pdf" => "PDF",
+                                                    "application/msword" => "DOC",
+                                                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "DOCX",
+                                                    "application/vnd.ms-excel" => "XLS",
+                                                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "XLSX",
+                                                    "image/jpeg" => "JPG",
+                                                    "image/png" => "PNG",
+                                                    "text/plain" => "TXT",
+                                                    _ => "FILE"
+                                                };
+                                                <div class="at-update-file-item">
+                                                    <span class="at-file-type">@typeLabel</span>
+                                                    <a class="at-file-name" href="@file.DownloadUrl" title="@file.FileName">@file.FileName</a>
+                                                    <span class="at-file-size">@ProjectManagement.Helpers.FileSizeFormatter.FormatFileSize(file.FileSize)</span>
+                                                    <a class="btn btn-outline-secondary btn-sm" href="@file.DownloadUrl">Download</a>
+                                                </div>
+                                            }
                                         </div>
-                                        @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
-                                        {
-                                            <div class="small text-muted">@log.OldValue → @log.NewValue</div>
-                                        }
-                                        @if (!string.IsNullOrWhiteSpace(log.Remarks))
-                                        {
-                                            <div class="at-audit-remarks at-remarks-text">@log.Remarks</div>
-                                        }
-                                    </article>
-                                }
+                                    }
+                                </article>
                             }
                         </div>
                     }
                 </section>
+
+                @* SECTION: Audit trail remains available but collapsed by default to reduce inspector clutter. *@
+                <details class="at-inspector-section at-details-collapsible at-audit-collapsible">
+                    <summary>Audit Trail <span class="at-count-chip">@Model.SelectedTaskLogs.Count</span></summary>
+                    @if (!Model.SelectedTaskLogs.Any())
+                    {
+                        <div class="at-empty-inline mt-2">No audit entries recorded.</div>
+                    }
+                    else
+                    {
+                        <div class="at-audit-list mt-2">
+                            @foreach (var log in Model.SelectedTaskLogs.OrderByDescending(log => log.PerformedAt))
+                            {
+                                <article class="at-activity-system-row @(log.ActionType == "Task Created" ? "at-system-event-created" : "")">
+                                    <div class="d-flex justify-content-between gap-2 flex-wrap">
+                                        <div>
+                                            <strong>@log.ActionType</strong>
+                                            <span class="text-muted">by @Model.ResolveActorName(log.PerformedByUserId)</span>
+                                        </div>
+                                        <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
+                                    </div>
+                                    @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
+                                    {
+                                        <div class="small text-muted">@log.OldValue → @log.NewValue</div>
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(log.Remarks))
+                                    {
+                                        <div class="at-audit-remarks at-remarks-text">@log.Remarks</div>
+                                    }
+                                </article>
+                            }
+                        </div>
+                    }
+                </details>
 
                 <details class="at-inspector-section at-details-collapsible">
                     <summary>Task Details</summary>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -1,244 +1,316 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 
-@* SECTION: Sprint selector and metadata summary. *@
-<section class="at-sprint-layout">
-    <aside class="at-panel at-sprint-list-panel">
-        <div class="at-panel-heading">
-            <h2>Sprints</h2>
-            <span class="at-count-chip">@Model.Sprints.Count</span>
-        </div>
-        @if (Model.ActiveSprint is not null)
+@* SECTION: Sprint workspace uses a command strip, left sprint index, execution board, and attention lane. *@
+<section class="at-sprints-workspace">
+    @* SECTION: Selected sprint command strip with existing service-backed actions. *@
+    <section class="at-panel at-sprint-command-strip">
+        @if (Model.SelectedSprint is null)
         {
-            <div class="at-active-sprint-note">Active: @Model.ActiveSprint.Name</div>
-        }
-        @if (Model.CanPlanSprints)
-        {
-            <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
-                <summary class="btn btn-primary btn-sm">Create Sprint</summary>
-                <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
-                    <input type="hidden" name="ViewMode" value="Sprints" />
-                    <div asp-validation-summary="All" class="text-danger small"></div>
-                    <label class="form-label" asp-for="SprintInput.Name"></label>
-                    <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
-                    <label class="form-label" asp-for="SprintInput.StartDate"></label>
-                    <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
-                    <label class="form-label" asp-for="SprintInput.EndDate"></label>
-                    <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
-                    <label class="form-label" asp-for="SprintInput.Goal"></label>
-                    <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this planning window"></textarea>
-                    <button type="submit" class="btn btn-primary btn-sm">Create Planned Sprint</button>
-                </form>
-            </details>
-        }
-        @if (!Model.Sprints.Any())
-        {
-            <div class="at-empty-state at-empty-state-compact">No sprints are available yet.</div>
+            <div class="at-empty-state">Select a sprint to view sprint command details.</div>
         }
         else
         {
-            <form method="get" class="at-sprint-selector-form" data-at-sprint-selector="true">
-                <input type="hidden" name="viewMode" value="Sprints" />
-                <label class="form-label at-small" for="SelectedSprintId">Select Sprint</label>
-                <select class="form-select" id="SelectedSprintId" name="SelectedSprintId">
-                    @foreach (var sprint in Model.Sprints)
-                    {
-                        if (Model.SelectedSprint?.Id == sprint.Id)
-                        {
-                            <option value="@sprint.Id" selected>@sprint.Name (@sprint.Status)</option>
-                        }
-                        else
-                        {
-                            <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
-                        }
-                    }
-                </select>
-                <button type="submit" class="btn btn-outline-primary btn-sm">Open Sprint</button>
-            </form>
-        }
-    </aside>
+            <div class="at-sprint-command-main">
+                <div>
+                    <div class="at-section-eyebrow">Selected Sprint</div>
+                    <h2>@Model.SelectedSprint.Name</h2>
+                    <div class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</div>
+                </div>
+                <span class="at-sprint-status-pill">@Model.SelectedSprint.Status</span>
+                <div class="at-command-focus-strip at-sprint-command-focus">
+                    <strong>Command focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
+                </div>
+            </div>
 
-    <div class="at-sprint-main">
-        <section class="at-panel at-sprint-meta-panel">
-            @if (Model.SelectedSprint is null)
+            <div class="at-sprint-summary-grid at-sprint-summary-grid-compact" aria-label="Sprint summary">
+                <div><span>@Model.SprintSummary.TaskCount</span><small>Total</small></div>
+                <div><span>@Model.SprintSummary.OpenCount</span><small>Open</small></div>
+                <div><span>@Model.SprintSummary.ClosedCount</span><small>Closed</small></div>
+                <div><span>@Model.SprintSummary.BlockedCount</span><small>Blocked</small></div>
+                <div><span>@Model.SelectedSprintOverdueCount</span><small>Overdue</small></div>
+            </div>
+
+            @if (Model.CanPlanSprints || Model.CanEditSelectedSprint)
             {
-                <div class="at-empty-state">Select a sprint to view sprint tasks.</div>
+                @* SECTION: Sprint lifecycle and edit actions continue to post to existing handlers. *@
+                <div class="at-sprint-action-row at-sprint-action-row-strip">
+                    @if (Model.CanPlanSprints)
+                    {
+                        <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
+                            <summary class="btn btn-primary btn-sm">Create</summary>
+                            <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
+                                <input type="hidden" name="ViewMode" value="Sprints" />
+                                <div asp-validation-summary="All" class="text-danger small"></div>
+                                <label class="form-label" asp-for="SprintInput.Name"></label>
+                                <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
+                                <label class="form-label" asp-for="SprintInput.StartDate"></label>
+                                <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
+                                <label class="form-label" asp-for="SprintInput.EndDate"></label>
+                                <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
+                                <label class="form-label" asp-for="SprintInput.Goal"></label>
+                                <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this planning window"></textarea>
+                                <button type="submit" class="btn btn-primary btn-sm">Create Planned Sprint</button>
+                            </form>
+                        </details>
+                    }
+                    @if (Model.CanEditSelectedSprint)
+                    {
+                        <details class="at-sprint-form-disclosure" open="@Model.ShowEditSprintPanel">
+                            <summary class="btn btn-outline-primary btn-sm">Edit</summary>
+                            <form method="post" asp-page-handler="UpdateSprint" class="at-sprint-command-form">
+                                <input type="hidden" name="ViewMode" value="Sprints" />
+                                <input type="hidden" asp-for="SprintEditInput.SprintId" value="@Model.SelectedSprint.Id" />
+                                <input type="hidden" asp-for="SprintEditInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
+                                <div asp-validation-summary="All" class="text-danger small"></div>
+                                <label class="form-label" asp-for="SprintEditInput.Name"></label>
+                                <input class="form-control" asp-for="SprintEditInput.Name" maxlength="160" />
+                                <label class="form-label" asp-for="SprintEditInput.StartDate"></label>
+                                <input class="form-control" asp-for="SprintEditInput.StartDate" type="date" />
+                                <label class="form-label" asp-for="SprintEditInput.EndDate"></label>
+                                <input class="form-control" asp-for="SprintEditInput.EndDate" type="date" />
+                                <label class="form-label" asp-for="SprintEditInput.Goal"></label>
+                                <textarea class="form-control" asp-for="SprintEditInput.Goal" rows="3" maxlength="2000"></textarea>
+                                <button type="submit" class="btn btn-primary btn-sm">Save Sprint</button>
+                            </form>
+                        </details>
+                    }
+                    @if (Model.CanActivateSelectedSprint)
+                    {
+                        <form method="post" asp-page-handler="ActivateSprint">
+                            <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
+                            <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
+                            <button type="submit" class="btn btn-success btn-sm">Activate</button>
+                        </form>
+                    }
+                    @if (Model.CanCloseSelectedSprintDirectly)
+                    {
+                        <form method="post" asp-page-handler="CloseSprint">
+                            <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
+                            <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
+                            <button type="submit" class="btn btn-danger btn-sm">Close</button>
+                        </form>
+                    }
+                    else if (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any())
+                    {
+                        <a class="btn btn-outline-danger btn-sm" href="#sprint-closure-review">Review close</a>
+                    }
+                </div>
+            }
+        }
+    </section>
+
+    <div class="at-sprint-layout at-sprint-layout-refined">
+        @* SECTION: Left sprint list highlights active/selected sprints and subdues closed sprints. *@
+        <aside class="at-panel at-sprint-list-panel">
+            <div class="at-panel-heading">
+                <h2>Sprints</h2>
+                <span class="at-count-chip">@Model.Sprints.Count</span>
+            </div>
+            @if (!Model.Sprints.Any())
+            {
+                <div class="at-empty-state at-empty-state-compact">No sprints are available yet.</div>
             }
             else
             {
-                <div class="at-sprint-meta-header">
-                    <div>
-                        <div class="at-section-eyebrow">Selected Sprint</div>
-                        <h2>@Model.SelectedSprint.Name</h2>
-                        <div class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</div>
-                    </div>
-                    <span class="at-sprint-status-pill">@Model.SelectedSprint.Status</span>
-                </div>
-                @if (!string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal))
-                {
-                    <div class="at-command-focus-strip mt-2"><strong>Command focus:</strong> @Model.SelectedSprint.Goal</div>
-                }
-                <div class="at-sprint-summary-grid" aria-label="Sprint summary">
-                    <div><span>@Model.SprintSummary.TaskCount</span><small>Total tasks</small></div>
-                    <div><span>@Model.SprintSummary.OpenCount</span><small>Open</small></div>
-                    <div><span>@Model.SprintSummary.BlockedCount</span><small>Blocked</small></div>
-                    <div><span>@Model.SprintSummary.SubmittedCount</span><small>Submitted</small></div>
-                    <div><span>@Model.SprintSummary.BacklogCount</span><small>Backlog</small></div>
-                </div>
-
-                @if (Model.CanPlanSprints)
-                {
-                    @* SECTION: Sprint lifecycle actions remain service-backed through page handlers. *@
-                    <div class="at-sprint-action-row">
-                        @if (Model.CanActivateSelectedSprint)
+                <form method="get" class="at-sprint-selector-form at-sprint-selector-compact" data-at-sprint-selector="true">
+                    <input type="hidden" name="viewMode" value="Sprints" />
+                    <label class="form-label at-small" for="SelectedSprintId">Quick open</label>
+                    <select class="form-select form-select-sm" id="SelectedSprintId" name="SelectedSprintId">
+                        @foreach (var sprint in Model.Sprints)
                         {
-                            <form method="post" asp-page-handler="ActivateSprint">
-                                <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
-                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
-                                <button type="submit" class="btn btn-success btn-sm">Activate Sprint</button>
-                            </form>
-                        }
-                        @if (Model.CanCloseSelectedSprintDirectly)
-                        {
-                            <form method="post" asp-page-handler="CloseSprint">
-                                <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
-                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
-                                <button type="submit" class="btn btn-danger btn-sm">Close Sprint</button>
-                            </form>
-                        }
-                        else if (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any())
-                        {
-                            <span class="at-panel-note">Unfinished tasks require closure review before close.</span>
-                        }
-                    </div>
-                }
-
-                @if (Model.CanEditSelectedSprint)
-                {
-                    <details class="at-sprint-form-disclosure" open="@Model.ShowEditSprintPanel">
-                        <summary class="btn btn-outline-primary btn-sm">Edit Sprint Details</summary>
-                        <form method="post" asp-page-handler="UpdateSprint" class="at-sprint-command-form">
-                            <input type="hidden" name="ViewMode" value="Sprints" />
-                            <input type="hidden" asp-for="SprintEditInput.SprintId" value="@Model.SelectedSprint.Id" />
-                            <input type="hidden" asp-for="SprintEditInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
-                            <div asp-validation-summary="All" class="text-danger small"></div>
-                            <label class="form-label" asp-for="SprintEditInput.Name"></label>
-                            <input class="form-control" asp-for="SprintEditInput.Name" maxlength="160" />
-                            <label class="form-label" asp-for="SprintEditInput.StartDate"></label>
-                            <input class="form-control" asp-for="SprintEditInput.StartDate" type="date" />
-                            <label class="form-label" asp-for="SprintEditInput.EndDate"></label>
-                            <input class="form-control" asp-for="SprintEditInput.EndDate" type="date" />
-                            <label class="form-label" asp-for="SprintEditInput.Goal"></label>
-                            <textarea class="form-control" asp-for="SprintEditInput.Goal" rows="3" maxlength="2000"></textarea>
-                            <button type="submit" class="btn btn-primary btn-sm">Save Sprint</button>
-                        </form>
-                    </details>
-                }
-            }
-        </section>
-
-        @if (Model.CanModifySelectedSprint)
-        {
-            @* SECTION: Controlled backlog-to-sprint assignment without drag-and-drop planning. *@
-            <section class="at-panel at-sprint-planning-panel">
-                <div class="at-panel-heading">
-                    <h2>Add Backlog Task to Sprint</h2>
-                    <span class="at-panel-note">Available to Comdt and HoD only.</span>
-                </div>
-                <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
-                    <input type="hidden" name="ViewMode" value="Sprints" />
-                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint.Id" />
-                    <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
-                    <select class="form-select" name="id" aria-label="Select backlog task" required>
-                        <option value="">Select backlog task</option>
-                        @foreach (var item in Model.AssignableBacklogTaskDisplays)
-                        {
-                            <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
+                            if (Model.SelectedSprint?.Id == sprint.Id)
+                            {
+                                <option value="@sprint.Id" selected>@sprint.Name (@sprint.Status)</option>
+                            }
+                            else
+                            {
+                                <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
+                            }
                         }
                     </select>
-                    <button type="submit" class="btn btn-primary" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Sprint</button>
+                    <button type="submit" class="btn btn-outline-primary btn-sm">Open Sprint</button>
                 </form>
+
+                <div class="at-sprint-list-group">
+                    <div class="at-sprint-list-heading">Active</div>
+                    @if (Model.ActiveSprint is null)
+                    {
+                        <div class="at-empty-inline">No active sprint.</div>
+                    }
+                    else
+                    {
+                        <a class="at-sprint-list-item is-active @(Model.SelectedSprint?.Id == Model.ActiveSprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@Model.ActiveSprint.Id">
+                            <strong>@Model.ActiveSprint.Name</strong>
+                            <span>@Model.ActiveSprint.StartDate.ToString("dd MMM") – @Model.ActiveSprint.EndDate.ToString("dd MMM yyyy")</span>
+                        </a>
+                    }
+                </div>
+
+                <div class="at-sprint-list-group">
+                    <div class="at-sprint-list-heading">Planned</div>
+                    @if (!Model.PlannedSprints.Any())
+                    {
+                        <div class="at-empty-inline">No planned sprints.</div>
+                    }
+                    @foreach (var sprint in Model.PlannedSprints)
+                    {
+                        <a class="at-sprint-list-item @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@sprint.Id">
+                            <strong>@sprint.Name</strong>
+                            <span>@sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</span>
+                        </a>
+                    }
+                </div>
+
+                <div class="at-sprint-list-group is-closed">
+                    <div class="at-sprint-list-heading">Closed</div>
+                    @if (!Model.ClosedSprints.Any())
+                    {
+                        <div class="at-empty-inline">No closed sprints.</div>
+                    }
+                    @foreach (var sprint in Model.ClosedSprints.Take(8))
+                    {
+                        <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@sprint.Id">
+                            <strong>@sprint.Name</strong>
+                            <span>@sprint.EndDate.ToString("dd MMM yyyy")</span>
+                        </a>
+                    }
+                </div>
+            }
+        </aside>
+
+        @* SECTION: Centre sprint execution board groups tasks by workflow status without changing lifecycle rules. *@
+        <main class="at-sprint-execution-main">
+            @if (Model.CanModifySelectedSprint)
+            {
+                <section class="at-panel at-sprint-planning-panel">
+                    <div class="at-panel-heading">
+                        <h2>Add Backlog Task to Sprint</h2>
+                        <span class="at-panel-note">Available to Comdt and HoD only.</span>
+                    </div>
+                    <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
+                        <input type="hidden" name="ViewMode" value="Sprints" />
+                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint?.Id" />
+                        <input type="hidden" name="sprintId" value="@Model.SelectedSprint?.Id" />
+                        <select class="form-select" name="id" aria-label="Select backlog task" required>
+                            <option value="">Select backlog task</option>
+                            @foreach (var item in Model.AssignableBacklogTaskDisplays)
+                            {
+                                <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
+                            }
+                        </select>
+                        <button type="submit" class="btn btn-primary" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Sprint</button>
+                    </form>
+                </section>
+            }
+
+            <partial name="_SprintClosureReview" model="Model" />
+
+            <section class="at-board-scroll" aria-label="Selected sprint task board">
+                <div class="at-board-grid is-sprints">
+                    @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed })
+                    {
+                        var groupedTasks = Model.GetSprintTasksByStatus(status);
+                        <article class="at-panel at-board-column at-sprint-board-column">
+                            <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
+                            @if (!groupedTasks.Any())
+                            {
+                                <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
+                            }
+                            else
+                            {
+                                <div class="at-task-cards">
+                                    @foreach (var item in groupedTasks)
+                                    {
+                                        var task = item.Task;
+                                        <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                            <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
+                                                <div class="at-card-top-row">
+                                                    <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
+                                                    <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                                </div>
+                                                <dl class="at-card-facts">
+                                                    <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
+                                                    <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
+                                                </dl>
+                                                <div class="at-card-footer">
+                                                    <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                                                    @if (Model.IsTaskOverdue(task))
+                                                    {
+                                                        <span class="at-overdue-marker">Overdue</span>
+                                                    }
+                                                    <span class="at-open-details-label">Open details</span>
+                                                </div>
+                                            </a>
+                                            @if (Model.CanMoveTaskToBacklog(task))
+                                            {
+                                                <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
+                                                    <input type="hidden" name="ViewMode" value="Sprints" />
+                                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                                    <input type="hidden" name="id" value="@task.Id" />
+                                                    <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
+                                                </form>
+                                            }
+                                        </article>
+                                    }
+                                </div>
+                            }
+                        </article>
+                    }
+                </div>
             </section>
-        }
 
-        <partial name="_SprintClosureReview" model="Model" />
+            @if (Model.SelectedSprint is not null)
+            {
+                <details class="at-panel at-sprint-history-panel">
+                    <summary>Sprint History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>
+                    @if (!Model.SprintAuditHistory.Any())
+                    {
+                        <p class="at-empty-inline">No sprint lifecycle history is recorded yet.</p>
+                    }
+                    else
+                    {
+                        <ol class="at-sprint-history-list">
+                            @foreach (var entry in Model.SprintAuditHistory)
+                            {
+                                <li>
+                                    <div><strong>@entry.ActionType.Replace("Sprint", string.Empty)</strong> by @Model.ResolveSprintActorName(entry.PerformedByUserId)</div>
+                                    <small>@entry.PerformedAt.ToString("dd MMM yyyy HH:mm") UTC</small>
+                                    @if (!string.IsNullOrWhiteSpace(entry.Remarks))
+                                    {
+                                        <p>@entry.Remarks</p>
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(entry.OldValue) || !string.IsNullOrWhiteSpace(entry.NewValue))
+                                    {
+                                        <code>@entry.OldValue → @entry.NewValue</code>
+                                    }
+                                </li>
+                            }
+                        </ol>
+                    }
+                </details>
+            }
+        </main>
 
-        @* SECTION: Compact sprint lifecycle audit history. *@
-        @if (Model.SelectedSprint is not null)
-        {
-            <details class="at-panel at-sprint-history-panel">
-                <summary>Sprint History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>
-                @if (!Model.SprintAuditHistory.Any())
-                {
-                    <p class="at-empty-inline">No sprint lifecycle history is recorded yet.</p>
-                }
-                else
-                {
-                    <ol class="at-sprint-history-list">
-                        @foreach (var entry in Model.SprintAuditHistory)
-                        {
-                            <li>
-                                <div><strong>@entry.ActionType.Replace("Sprint", string.Empty)</strong> by @Model.ResolveSprintActorName(entry.PerformedByUserId)</div>
-                                <small>@entry.PerformedAt.ToString("dd MMM yyyy HH:mm") UTC</small>
-                                @if (!string.IsNullOrWhiteSpace(entry.Remarks))
-                                {
-                                    <p>@entry.Remarks</p>
-                                }
-                                @if (!string.IsNullOrWhiteSpace(entry.OldValue) || !string.IsNullOrWhiteSpace(entry.NewValue))
-                                {
-                                    <code>@entry.OldValue → @entry.NewValue</code>
-                                }
-                            </li>
-                        }
-                    </ol>
-                }
-            </details>
-        }
-
-        @* SECTION: Status-grouped sprint task board. *@
-        <section class="at-board-scroll" aria-label="Selected sprint task board">
-            <div class="at-board-grid is-sprints">
-                @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed })
-                {
-                    var groupedTasks = Model.GetSprintTasksByStatus(status);
-                    <article class="at-panel at-board-column">
-                        <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
-                        @if (!groupedTasks.Any())
-                        {
-                            <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
-                        }
-                        else
-                        {
-                            <div class="at-task-cards">
-                                @foreach (var item in groupedTasks)
-                                {
-                                    var task = item.Task;
-                                    <article class="at-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                                        <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
-                                            <div class="at-card-top-row">
-                                                <h3 class="at-card-subject">@task.Title</h3>
-                                                <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                                            </div>
-                                            <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
-                                            <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
-                                            <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
-                                        </a>
-                                        @if (Model.CanMoveTaskToBacklog(task))
-                                        {
-                                            <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
-                                                <input type="hidden" name="ViewMode" value="Sprints" />
-                                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                                <input type="hidden" name="id" value="@task.Id" />
-                                                <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
-                                            </form>
-                                        }
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </article>
-                }
+        @* SECTION: Right attention lane surfaces command exceptions and carry-forward candidates. *@
+        <aside class="at-panel at-sprint-attention-lane">
+            <div class="at-panel-heading"><h2>Attention Lane</h2></div>
+            <div class="at-attention-group">
+                <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue sprint tasks.")' />
             </div>
-        </section>
+            <div class="at-attention-group">
+                <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked sprint tasks.")' />
+            </div>
+            <div class="at-attention-group">
+                <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted sprint tasks.")' />
+            </div>
+            <div class="at-attention-group">
+                <div class="at-attention-heading"><span>Carry-forward candidates</span><strong>@Model.SprintCarryForwardCandidateDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
+            </div>
+        </aside>
     </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1443,3 +1443,362 @@ html {
     white-space: pre-wrap;
     word-break: break-word;
 }
+
+/* SECTION: Phase 2A refined sprint workspace layout */
+.at-sprints-workspace {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.at-sprint-command-strip {
+    display: grid;
+    grid-template-columns: minmax(280px, 1.3fr) minmax(360px, 1fr) auto;
+    gap: 0.85rem;
+    align-items: center;
+    padding: 0.85rem 1rem;
+}
+
+.at-sprint-command-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.65rem;
+    align-items: start;
+}
+
+.at-sprint-command-main h2 {
+    margin-bottom: 0.1rem;
+    font-size: 1.08rem;
+}
+
+.at-sprint-command-focus {
+    grid-column: 1 / -1;
+    margin: 0;
+    background: #f8fafc;
+    border: 1px solid var(--at-border);
+    border-radius: 10px;
+}
+
+.at-sprint-summary-grid-compact {
+    grid-template-columns: repeat(5, minmax(72px, 1fr));
+    margin-top: 0;
+}
+
+.at-sprint-summary-grid-compact div {
+    padding: 0.5rem 0.6rem;
+}
+
+.at-sprint-action-row-strip {
+    justify-content: flex-end;
+    margin-top: 0;
+}
+
+.at-sprint-layout-refined {
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr) minmax(240px, 300px);
+}
+
+.at-sprint-execution-main {
+    display: grid;
+    gap: 0.85rem;
+    min-width: 0;
+}
+
+.at-sprint-selector-compact {
+    border-bottom: 1px solid var(--at-border);
+    margin-bottom: 0.7rem;
+    padding-bottom: 0.75rem;
+}
+
+.at-sprint-list-group {
+    display: grid;
+    gap: 0.35rem;
+    margin-top: 0.7rem;
+}
+
+.at-sprint-list-heading {
+    color: var(--at-muted);
+    font-size: 0.72rem;
+    font-weight: 850;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.at-sprint-list-item {
+    display: grid;
+    gap: 0.1rem;
+    border: 1px solid var(--at-border);
+    border-radius: 10px;
+    color: var(--at-text);
+    padding: 0.55rem 0.65rem;
+    text-decoration: none;
+    background: #ffffff;
+}
+
+.at-sprint-list-item strong {
+    font-size: 0.82rem;
+    line-height: 1.25;
+}
+
+.at-sprint-list-item span {
+    color: var(--at-muted);
+    font-size: 0.76rem;
+    font-weight: 650;
+}
+
+.at-sprint-list-item.is-active {
+    border-color: #93c5fd;
+    background: #eff6ff;
+}
+
+.at-sprint-list-item.is-selected {
+    border-left: 4px solid var(--at-blue);
+}
+
+.at-sprint-list-group.is-closed .at-sprint-list-item,
+.at-sprint-list-item.is-closed {
+    opacity: 0.72;
+    background: #f8fafc;
+}
+
+.at-sprint-attention-lane {
+    position: sticky;
+    top: 5rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.at-attention-group,
+.at-attention-panel {
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #f8fafc;
+    padding: 0.65rem;
+}
+
+.at-attention-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.45rem;
+    color: var(--at-muted);
+    font-size: 0.78rem;
+    font-weight: 850;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.at-attention-heading strong {
+    min-width: 1.8rem;
+    border-radius: 999px;
+    background: #e2e8f0;
+    color: var(--at-text);
+    padding: 0.1rem 0.45rem;
+    text-align: center;
+}
+
+.at-sprint-board-column {
+    min-height: 12rem;
+}
+
+.at-sprint-task-card .at-card-subject {
+    font-size: 0.9rem;
+}
+
+.at-card-facts {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.45rem;
+    margin: 0.55rem 0;
+}
+
+.at-card-facts div {
+    min-width: 0;
+}
+
+.at-card-facts dt {
+    color: var(--at-muted);
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.at-card-facts dd {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 0.8rem;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+}
+
+.at-open-details-label {
+    color: var(--at-blue);
+    font-size: 0.74rem;
+    font-weight: 800;
+}
+
+.at-overdue-marker {
+    border: 1px solid #fecaca;
+    border-radius: 999px;
+    background: #fee2e2;
+    color: #991b1b;
+    padding: 0.12rem 0.45rem;
+    font-size: 0.72rem;
+    font-weight: 800;
+}
+
+/* SECTION: Phase 2A backlog planning summary and compact task metadata */
+.at-backlog-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+    gap: 0.65rem;
+    margin-bottom: 0.85rem;
+}
+
+.at-backlog-summary-grid article {
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #f8fafc;
+    padding: 0.65rem 0.75rem;
+}
+
+.at-backlog-summary-grid strong,
+.at-backlog-summary-grid span {
+    display: block;
+}
+
+.at-backlog-summary-grid strong {
+    color: var(--at-text);
+    font-size: 1.25rem;
+    font-weight: 850;
+}
+
+.at-backlog-summary-grid span {
+    color: var(--at-muted);
+    font-size: 0.78rem;
+    font-weight: 750;
+}
+
+.at-backlog-task-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.35rem;
+}
+
+.at-cell-primary {
+    color: var(--at-text);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+/* SECTION: Phase 2A task inspector prominence and collapsed audit affordances */
+.at-task-details-panel {
+    padding: 0;
+    overflow: hidden;
+}
+
+.at-inspector-shell {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    max-height: calc(100vh - 7rem);
+}
+
+.at-inspector-header {
+    margin-bottom: 0;
+    padding: 0.9rem 1rem;
+    border-bottom: 1px solid var(--at-border);
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.at-inspector-header .at-panel-title {
+    font-size: 1.08rem;
+    line-height: 1.25;
+}
+
+.at-inspector-body {
+    overflow: auto;
+    padding: 0.85rem 1rem;
+}
+
+.at-inspector-footer {
+    border-top: 1px solid var(--at-border);
+    background: #ffffff;
+    padding: 0.75rem 1rem;
+}
+
+.at-inspector-section-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.at-inspector-section-heading h3,
+.at-progress-timeline h3 {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 0.98rem;
+    font-weight: 800;
+}
+
+.at-progress-timeline {
+    margin-bottom: 0.8rem;
+}
+
+.at-audit-collapsible,
+.at-details-collapsible {
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #ffffff;
+    padding: 0.65rem 0.75rem;
+}
+
+.at-audit-list {
+    display: grid;
+    gap: 0.5rem;
+}
+
+/* SECTION: Phase 2A dashboard active sprint readability */
+.at-sprint-health-grid-readable article.is-primary {
+    border-color: #bfdbfe;
+    background: #eff6ff;
+}
+
+.at-sprint-health-grid-readable article span {
+    display: block;
+    color: var(--at-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    margin-top: 0.15rem;
+}
+
+.at-dashboard-attention-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-top: 0.9rem;
+}
+
+@media (max-width: 1200px) {
+    .at-sprint-command-strip,
+    .at-sprint-layout-refined,
+    .at-dashboard-attention-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-sprint-attention-lane {
+        position: static;
+    }
+}
+
+@media (max-width: 767px) {
+    .at-backlog-summary-grid,
+    .at-sprint-summary-grid-compact,
+    .at-card-facts {
+        grid-template-columns: 1fr;
+    }
+
+    .at-inspector-shell {
+        max-height: none;
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve Action Tracker usability and compactness for sprint planning/execution without changing business, sprint lifecycle, or permission rules.
- Make sprint command information and attention signals more prominent so commanders can quickly focus on overdue, blocked, and submitted items.
- Reduce inspector clutter by surfacing progress updates first and collapsing long details/audit trails by default.

### Description
- UI/layout: added a selected-sprint command strip, left sprint index (active/planned/closed grouping), centre execution board grouped by `Assigned`, `In Progress`, `Blocked`, `Submitted`, `Closed`, and a right attention lane (overdue, blocked, submitted, carry-forward) in `Pages/ActionTasks/_TaskSprints.cshtml` while preserving all existing handlers and lifecycle actions.
- Backlog: added compact backlog summary counts and clearer row metadata (assignee, due date, priority, overdue marker) while preserving the backlog definition (`SprintId == null`) and assign-to-sprint controls in `Pages/ActionTasks/_TaskBacklog.cshtml`.
- Inspector: promoted the progress/update timeline to the top, collapsed the audit trail and long task details by default, and kept sticky action controls in `Pages/ActionTasks/_TaskDetails.cshtml`.
- Dashboard: improved active sprint metric card readability and added command-attention panels for overdue/blocked/submitted groups in `Pages/ActionTasks/_TaskDashboard.cshtml`.
- View-model helpers: added read-only projections for planned/closed sprint lists, backlog counts, overdue detection, and sprint attention lists (no business-rule changes) in `Pages/ActionTasks/Index.cshtml.cs`.
- Minor: added an anchor id to the closure review section to support the command-strip "Review close" link in `Pages/ActionTasks/_SprintClosureReview.cshtml`.
- CSS: added compact, command-grade layout rules for the refined sprint workspace, backlog summary, inspector behaviour and dashboard attention panels to `wwwroot/css/action-tracker.css` following the existing visual language.
- Files modified: `Pages/ActionTasks/Index.cshtml.cs`, `Pages/ActionTasks/_TaskSprints.cshtml`, `Pages/ActionTasks/_TaskBacklog.cshtml`, `Pages/ActionTasks/_TaskDetails.cshtml`, `Pages/ActionTasks/_TaskDashboard.cshtml`, `Pages/ActionTasks/_SprintClosureReview.cshtml`, and `wwwroot/css/action-tracker.css`.

### Testing
- Ran `git diff --check` with no issues reported. (success)
- Attempted `dotnet build ProjectManagement.sln` but the `dotnet` CLI is not available in this environment, so build verification could not be run here. (not run)
- Attempted `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` but the `dotnet` CLI is not available in this environment, so tests could not be executed here. (not run)
- Commit created locally with message `Refine action tracker sprint UX` after changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2ab15bf48329942d6ec5a627d152)