### PR TITLE
Preserve selected sprint in mini-list links

### DIFF
--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -15,7 +15,8 @@ else
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode">
+            @* SECTION: Preserve contextual sprint selection when compact task links open the inspector. *@
+            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-route-SelectedSprintId="@pageModel.SelectedSprintId">
                 <div class="at-mini-title">AT-@task.Id · @task.Title</div>
                 <div class="at-mini-meta">
                     <span>@item.AssigneeName</span>


### PR DESCRIPTION
### Motivation
- Opening a task from compact attention lists dropped the currently selected sprint context and defaulted to the active sprint, so navigation needs to preserve the current `SelectedSprintId` for consistent UX.

### Description
- Add `asp-route-SelectedSprintId="@pageModel.SelectedSprintId"` to the compact task links in `Pages/ActionTasks/_TaskMiniList.cshtml` and include a section comment documenting the contextual sprint preservation.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors, and attempted `dotnet test` but it could not run because the `dotnet` CLI is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2f14f4608329a7e011cec9cb4eb7)