### PR TITLE
Sprint workspace cleanup: expose Create Sprint, relabel actions, and inspector-safe layout

### DIFF
--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -7,7 +7,42 @@
     <section class="at-panel at-sprint-command-strip">
         @if (Model.SelectedSprint is null)
         {
-            <div class="at-empty-state">Select a sprint to view sprint command details.</div>
+            @* SECTION: First-sprint empty state keeps sprint creation independent of any selected sprint. *@
+            <div class="at-sprint-empty-command">
+                <div class="at-empty-state">
+                    @if (!Model.Sprints.Any())
+                    {
+                        <strong>No sprint has been created yet.</strong>
+                        <span>Create the first sprint to start planning task execution from this workspace.</span>
+                    }
+                    else
+                    {
+                        <strong>No sprint is selected.</strong>
+                        <span>Select an existing sprint, or create another sprint for a new planning window.</span>
+                    }
+                </div>
+                @if (Model.CanPlanSprints)
+                {
+                    <div class="at-sprint-action-row at-sprint-action-row-strip">
+                        <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
+                            <summary class="btn btn-primary btn-sm">Create Sprint</summary>
+                            <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
+                                <input type="hidden" name="ViewMode" value="Sprints" />
+                                <div asp-validation-summary="All" class="text-danger small"></div>
+                                <label class="form-label" asp-for="SprintInput.Name"></label>
+                                <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
+                                <label class="form-label" asp-for="SprintInput.StartDate"></label>
+                                <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
+                                <label class="form-label" asp-for="SprintInput.EndDate"></label>
+                                <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
+                                <label class="form-label" asp-for="SprintInput.Goal"></label>
+                                <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this planning window"></textarea>
+                                <button type="submit" class="btn btn-primary btn-sm">Create Sprint</button>
+                            </form>
+                        </details>
+                    </div>
+                }
+            </div>
         }
         else
         {
@@ -38,7 +73,7 @@
                     @if (Model.CanPlanSprints)
                     {
                         <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
-                            <summary class="btn btn-primary btn-sm">Create</summary>
+                            <summary class="btn btn-primary btn-sm">Create Sprint</summary>
                             <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
                                 <input type="hidden" name="ViewMode" value="Sprints" />
                                 <div asp-validation-summary="All" class="text-danger small"></div>
@@ -50,14 +85,14 @@
                                 <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
                                 <label class="form-label" asp-for="SprintInput.Goal"></label>
                                 <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this planning window"></textarea>
-                                <button type="submit" class="btn btn-primary btn-sm">Create Planned Sprint</button>
+                                <button type="submit" class="btn btn-primary btn-sm">Create Sprint</button>
                             </form>
                         </details>
                     }
                     @if (Model.CanEditSelectedSprint)
                     {
                         <details class="at-sprint-form-disclosure" open="@Model.ShowEditSprintPanel">
-                            <summary class="btn btn-outline-primary btn-sm">Edit</summary>
+                            <summary class="btn btn-outline-primary btn-sm">Edit Sprint</summary>
                             <form method="post" asp-page-handler="UpdateSprint" class="at-sprint-command-form">
                                 <input type="hidden" name="ViewMode" value="Sprints" />
                                 <input type="hidden" asp-for="SprintEditInput.SprintId" value="@Model.SelectedSprint.Id" />
@@ -109,7 +144,7 @@
             </div>
             @if (!Model.Sprints.Any())
             {
-                <div class="at-empty-state at-empty-state-compact">No sprints are available yet.</div>
+                <div class="at-empty-state at-empty-state-compact">No sprint has been created yet. Use Create Sprint to create the first sprint.</div>
             }
             else
             {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -448,7 +448,7 @@ public class ActionTaskPageTests
         await page.OnGetAsync();
 
         // SECTION: Act
-        var html = await RenderSprintClosureReviewAsync(page);
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_SprintClosureReview.cshtml");
 
         // SECTION: Assert
         var createFormStart = html.IndexOf("at-sprint-command-form", StringComparison.Ordinal);
@@ -458,6 +458,73 @@ public class ActionTaskPageTests
         Assert.True(createFormStart >= 0, "Create next sprint form should render.");
         Assert.True(closureFormStart >= 0, "Closure disposition form should render.");
         Assert.True(createFormStart < closureFormStart || createFormStart > closureFormEnd, "Create next sprint form must not be nested inside the closure disposition form.");
+    }
+
+
+    [Fact]
+    public async Task SprintsPartial_NoSprints_ExposesCreateSprintForAuthorisedUsers()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskSprints.cshtml");
+
+        // SECTION: Assert
+        Assert.Null(page.SelectedSprint);
+        Assert.Contains("No sprint has been created yet", html, StringComparison.Ordinal);
+        Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("handler=CreateSprint", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Select a sprint to view sprint command details.", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SprintsPartial_SelectedSprint_UsesExplicitSprintActionLabels()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.Comdt);
+        var sprint = AddSprint(setup.Db, "Command Sprint", ActionSprintStatus.Planned);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+        page.SelectedSprintId = sprint.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskSprints.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Edit Sprint", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(">Create</summary>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(">Edit</summary>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SprintsPartial_SelectedSprint_RendersSprintAndTaskBoard()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var sprint = AddSprint(setup.Db, "Execution Sprint", ActionSprintStatus.Active);
+        setup.Db.ActionTasks.Add(NewTask("Sprint board task", ActionTaskStatuses.InProgress, sprint.Id));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Sprints";
+        page.SelectedSprintId = sprint.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskSprints.cshtml");
+
+        // SECTION: Assert
+        Assert.NotNull(page.SelectedSprint);
+        Assert.Contains("Execution Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Selected sprint task board", html, StringComparison.Ordinal);
+        Assert.Contains("Sprint board task", html, StringComparison.Ordinal);
+        Assert.Contains("at-board-grid is-sprints", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -503,9 +570,9 @@ public class ActionTaskPageTests
         Assert.Single(entityType.GetForeignKeys().Where(fk => fk.PrincipalEntityType.ClrType == typeof(ActionTaskItem)));
     }
 
-    private static async Task<string> RenderSprintClosureReviewAsync(IndexModel page)
+    private static async Task<string> RenderPartialAsync(IndexModel page, string viewPath)
     {
-        // SECTION: Razor partial rendering helper for closure-review markup checks.
+        // SECTION: Razor partial rendering helper for sprint workspace markup checks.
         await using var writer = new StringWriter();
         using var provider = BuildRazorServiceProvider();
         using var scope = provider.CreateScope();
@@ -522,10 +589,10 @@ public class ActionTaskPageTests
         var actionDescriptor = new ActionDescriptor();
         actionDescriptor.RouteValues["page"] = "/ActionTasks/Index";
         var actionContext = new ActionContext(httpContext, routeData, actionDescriptor);
-        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: "/Pages/ActionTasks/_SprintClosureReview.cshtml", isMainPage: false);
+        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: viewPath, isMainPage: false);
         if (!viewResult.Success)
         {
-            throw new InvalidOperationException("Unable to locate _SprintClosureReview partial view.");
+            throw new InvalidOperationException($"Unable to locate {viewPath} partial view.");
         }
 
         var viewData = new ViewDataDictionary<IndexModel>(new EmptyModelMetadataProvider(), page.ModelState)

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1802,3 +1802,116 @@ html {
         max-height: none;
     }
 }
+
+/* SECTION: Phase 2A sprint workspace cleanup and inspector-safe board layout */
+.at-sprint-empty-command {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.85rem;
+}
+
+.at-sprint-empty-command .at-empty-state {
+    display: grid;
+    gap: 0.2rem;
+    margin: 0;
+    text-align: left;
+}
+
+.at-sprint-empty-command .at-empty-state strong,
+.at-sprint-empty-command .at-empty-state span {
+    display: block;
+}
+
+.at-sprint-command-strip,
+.at-sprint-layout-refined,
+.at-sprint-execution-main,
+.at-board-scroll {
+    min-width: 0;
+}
+
+.at-sprint-action-row-strip {
+    align-items: flex-start;
+}
+
+.at-sprint-action-row-strip .at-sprint-form-disclosure {
+    position: relative;
+    margin: 0;
+}
+
+.at-sprint-action-row-strip .at-sprint-command-form {
+    display: grid;
+    position: absolute;
+    top: calc(100% + 0.45rem);
+    right: 0;
+    z-index: 5;
+    width: min(24rem, calc(100vw - 2rem));
+    box-shadow: var(--at-shadow-sm);
+}
+
+.at-board-grid.is-sprints {
+    grid-auto-columns: minmax(220px, 1fr);
+    grid-template-columns: repeat(5, minmax(220px, 1fr));
+}
+
+.at-sprint-execution-main .at-board-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+}
+
+.at-sprint-task-card {
+    min-width: 0;
+}
+
+.at-sprint-task-card .at-card-footer {
+    gap: 0.35rem;
+}
+
+.at-shell.has-selection .at-sprint-layout-refined {
+    grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
+}
+
+.at-shell.has-selection .at-sprint-attention-lane {
+    grid-column: 2;
+    position: static;
+}
+
+.at-shell.has-selection .at-sprint-board-column {
+    min-width: 0;
+}
+
+.at-shell.has-selection .at-board-grid.is-sprints {
+    grid-auto-columns: minmax(205px, 1fr);
+    grid-template-columns: repeat(5, minmax(205px, 1fr));
+}
+
+@media (max-width: 1399px) {
+    .at-shell.has-selection .at-sprint-layout-refined {
+        grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+    }
+}
+
+@media (max-width: 1200px) {
+    .at-shell.has-selection .at-sprint-layout-refined,
+    .at-shell.has-selection .at-sprint-attention-lane {
+        grid-template-columns: 1fr;
+        grid-column: auto;
+    }
+}
+
+@media (max-width: 767px) {
+    .at-sprint-empty-command {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .at-sprint-action-row-strip .at-sprint-command-form {
+        left: 0;
+        right: auto;
+        width: min(100%, calc(100vw - 2rem));
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the Sprints workspace usable when no sprint exists by exposing a service-backed Create Sprint action and clear empty-state messaging without requiring a selected sprint. 
- Remove ambiguous button labels to improve command readability and avoid confusion with the global Create Task action. 
- Reduce horizontal layout pressure and keep the sprint board usable when the task inspector is open while preserving existing lifecycle, permission, and backend rules.

### Description
- Update `Pages/ActionTasks/_TaskSprints.cshtml` to render a first-sprint empty state and a `Create Sprint` details/form when `Model.SelectedSprint` is null, and to change the command-strip labels from `Create`/`Edit` to `Create Sprint`/`Edit Sprint` while keeping existing page handlers. 
- Add compact prompt text for the sprint list empty state and preserve service-backed POST handlers for creating/updating/activating/closing sprints. 
- Add Phase 2A CSS in `wwwroot/css/action-tracker.css` introducing `.at-sprint-empty-command`, inspector-safe two-column layout rules when `.at-shell.has-selection` is present, reduced sprint-board column minimums, internal horizontal scrolling for the board, and responsive safeguards so cards and the attention lane are not visually cut off by the inspector. 
- Add/modify Razor-based tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` including a new `RenderPartialAsync` helper and tests: `SprintsPartial_NoSprints_ExposesCreateSprintForAuthorisedUsers`, `SprintsPartial_SelectedSprint_UsesExplicitSprintActionLabels`, and `SprintsPartial_SelectedSprint_RendersSprintAndTaskBoard` to assert markup and labels; no existing tests removed.

### Testing
- New and updated unit tests were added to the test project (see `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`) but were not executed in this environment. 
- Ran a whitespace/check (`git diff --check`) to validate patch formatting and it reported no issues. 
- Attempted to run `dotnet test --no-restore` but the `dotnet` CLI is not installed in the current environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb32e707e083298e98fceb7b518158)