### PR TITLE
Redesign sprint board workspace layout

### DIFF
--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -241,9 +241,10 @@
 
             <partial name="_SprintClosureReview" model="Model" />
 
-            <section class="at-board-scroll" aria-label="Selected sprint task board">
-                <div class="at-board-grid is-sprints">
-                    @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed })
+            @* SECTION: Primary execution board keeps active workflow statuses in the main row to avoid default horizontal scrolling. *@
+            <section class="at-sprint-board-stack" aria-label="Selected sprint task board">
+                <div class="at-board-grid is-sprints at-sprint-primary-statuses">
+                    @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted })
                     {
                         var groupedTasks = Model.GetSprintTasksByStatus(status);
                         <article class="at-panel at-board-column at-sprint-board-column">
@@ -293,7 +294,80 @@
                         </article>
                     }
                 </div>
+
+                @* SECTION: Closed work remains grouped but moves below active execution statuses to protect board width. *@
+                @{
+                    var closedTasks = Model.GetSprintTasksByStatus(ActionTaskStatuses.Closed);
+                }
+                <article class="at-panel at-board-column at-sprint-board-column at-sprint-closed-section">
+                    <div class="at-panel-heading"><h2>@(ActionTaskStatuses.Closed)</h2><span class="at-count-chip">@closedTasks.Count</span></div>
+                    @if (!closedTasks.Any())
+                    {
+                        <p class="at-empty-inline">No @(ActionTaskStatuses.Closed.ToLowerInvariant()) tasks.</p>
+                    }
+                    else
+                    {
+                        <div class="at-task-cards at-sprint-closed-cards">
+                            @foreach (var item in closedTasks)
+                            {
+                                var task = item.Task;
+                                <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                    <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Sprints" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
+                                        <div class="at-card-top-row">
+                                            <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
+                                            <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                        </div>
+                                        <dl class="at-card-facts">
+                                            <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
+                                            <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
+                                        </dl>
+                                        <div class="at-card-footer">
+                                            <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                                            @if (Model.IsTaskOverdue(task))
+                                            {
+                                                <span class="at-overdue-marker">Overdue</span>
+                                            }
+                                            <span class="at-open-details-label">Open details</span>
+                                        </div>
+                                    </a>
+                                    @if (Model.CanMoveTaskToBacklog(task))
+                                    {
+                                        <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
+                                            <input type="hidden" name="ViewMode" value="Sprints" />
+                                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                            <input type="hidden" name="id" value="@task.Id" />
+                                            <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
+                                        </form>
+                                    }
+                                </article>
+                            }
+                        </div>
+                    }
+                </article>
             </section>
+
+            @* SECTION: Attention lane sits below execution board so it remains visible without stealing board width. *@
+            <aside class="at-panel at-sprint-attention-lane">
+                <div class="at-panel-heading"><h2>Attention Lane</h2></div>
+                <div class="at-attention-grid">
+                    <div class="at-attention-group">
+                        <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue sprint tasks.")' />
+                    </div>
+                    <div class="at-attention-group">
+                        <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked sprint tasks.")' />
+                    </div>
+                    <div class="at-attention-group">
+                        <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted sprint tasks.")' />
+                    </div>
+                    <div class="at-attention-group">
+                        <div class="at-attention-heading"><span>Carry-forward candidates</span><strong>@Model.SprintCarryForwardCandidateDisplays.Count</strong></div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
+                    </div>
+                </div>
+            </aside>
 
             @if (Model.SelectedSprint is not null)
             {
@@ -327,25 +401,5 @@
             }
         </main>
 
-        @* SECTION: Right attention lane surfaces command exceptions and carry-forward candidates. *@
-        <aside class="at-panel at-sprint-attention-lane">
-            <div class="at-panel-heading"><h2>Attention Lane</h2></div>
-            <div class="at-attention-group">
-                <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue sprint tasks.")' />
-            </div>
-            <div class="at-attention-group">
-                <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked sprint tasks.")' />
-            </div>
-            <div class="at-attention-group">
-                <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted sprint tasks.")' />
-            </div>
-            <div class="at-attention-group">
-                <div class="at-attention-heading"><span>Carry-forward candidates</span><strong>@Model.SprintCarryForwardCandidateDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
-            </div>
-        </aside>
     </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1504,7 +1504,7 @@ html {
 }
 
 .at-sprint-layout-refined {
-    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr) minmax(240px, 300px);
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
 }
 
 .at-sprint-execution-main {
@@ -1571,10 +1571,14 @@ html {
 }
 
 .at-sprint-attention-lane {
-    position: sticky;
-    top: 5rem;
     display: grid;
     gap: 0.75rem;
+}
+
+.at-attention-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.65rem;
 }
 
 .at-attention-group,
@@ -1629,7 +1633,7 @@ html {
 .at-card-facts dt {
     color: var(--at-muted);
     font-size: var(--at-font-xs);
-    font-weight: var(--at-weight-bold);
+    font-weight: var(--at-weight-semibold);
     text-transform: uppercase;
 }
 
@@ -1637,14 +1641,14 @@ html {
     margin: 0;
     color: var(--at-text);
     font-size: var(--at-font-md);
-    font-weight: 700;
+    font-weight: var(--at-weight-medium);
     overflow-wrap: anywhere;
 }
 
 .at-open-details-label {
     color: var(--at-blue);
     font-size: var(--at-font-sm);
-    font-weight: var(--at-weight-bold);
+    font-weight: var(--at-weight-medium);
 }
 
 .at-overdue-marker {
@@ -1864,7 +1868,7 @@ html {
 
 .at-open-details-label {
     font-size: var(--at-font-xs);
-    font-weight: var(--at-weight-bold);
+    font-weight: var(--at-weight-medium);
 }
 
 /* SECTION: Phase 2A sprint workspace cleanup and inspector-safe board layout */
@@ -1915,16 +1919,33 @@ html {
     box-shadow: var(--at-shadow-sm);
 }
 
+.at-sprint-board-stack {
+    display: grid;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
 .at-board-grid.is-sprints {
-    grid-auto-columns: minmax(185px, 1fr);
-    grid-template-columns: repeat(5, minmax(185px, 1fr));
+    grid-auto-columns: initial;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.at-sprint-primary-statuses {
+    align-items: start;
+}
+
+.at-sprint-closed-section {
+    min-height: 0;
+}
+
+.at-sprint-closed-cards {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .at-sprint-execution-main .at-board-scroll {
     max-width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    overscroll-behavior-x: contain;
+    overflow-x: visible;
+    overflow-y: visible;
 }
 
 .at-sprint-task-card {
@@ -1940,8 +1961,7 @@ html {
 }
 
 .at-shell.has-selection .at-sprint-attention-lane {
-    grid-column: 2;
-    position: static;
+    grid-column: auto;
 }
 
 .at-shell.has-selection .at-sprint-board-column {
@@ -1949,8 +1969,8 @@ html {
 }
 
 .at-shell.has-selection .at-board-grid.is-sprints {
-    grid-auto-columns: minmax(175px, 1fr);
-    grid-template-columns: repeat(5, minmax(175px, 1fr));
+    grid-auto-columns: initial;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 @media (max-width: 1399px) {
@@ -1965,9 +1985,20 @@ html {
         grid-template-columns: 1fr;
         grid-column: auto;
     }
+
+    .at-board-grid.is-sprints {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 @media (max-width: 767px) {
+    .at-board-grid.is-sprints,
+    .at-shell.has-selection .at-board-grid.is-sprints,
+    .at-sprint-closed-cards,
+    .at-attention-grid {
+        grid-template-columns: 1fr;
+    }
+
     .at-sprint-empty-command {
         align-items: stretch;
         flex-direction: column;


### PR DESCRIPTION
### Motivation
- Reduce horizontal pressure on the primary sprint execution area so the default working mode does not require horizontal scrolling. 
- Reduce excessive visual emphasis in sprint task cards so metadata like Owner and Due are less prominent while keeping task titles semi-bold. 

### Description
- Updated the sprint workspace view in `Pages/ActionTasks/_TaskSprints.cshtml` to render the primary row with `Assigned`, `In Progress`, `Blocked`, and `Submitted`, and to move `Closed` tasks into a lower section so the main row does not force five columns. 
- Moved the Attention Lane below the execution board and made its groups responsive via a new `at-attention-grid` so it remains visible without stealing main board width, while preserving the existing attention groupings. 
- Adjusted layout CSS in `wwwroot/css/action-tracker.css` (including `.at-sprint-layout-refined`, `.at-board-grid.is-sprints`, `.at-sprint-board-stack`, and responsive rules) to prefer a multi-row / reduced-column layout and to avoid default horizontal overflow. 
- Reduced typographic emphasis for card metadata by changing `dt`/`dd` and the `Open details` label to medium/semibold weights while keeping task titles semi-bold and preserving all existing sprint/task actions and workflow handlers (e.g. Move to Backlog, Assign to Sprint, sprint create/edit/activate/close, closure review, carry-forward). 

### Testing
- `npm test` executed and passed (`13` tests, all passing). 
- `git diff --check` passed with no whitespace errors in the modified files. 
- `dotnet test ProjectManagement.sln` could not be executed because `dotnet` is not available in the environment. 
- `npm run lint:views` reported pre-existing inline-style issues in unrelated views, which are outside the scope of this change and did not originate from the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3ad38b60832992266ccccaa85259)