### PR TITLE
Add My Work partial and separate Register view

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -52,7 +52,11 @@
         {
             <partial name="_TaskSprints" model="Model" />
         }
-        else if (Model.IsMyWorkView || Model.IsRegisterView)
+        else if (Model.IsMyWorkView)
+        {
+            <partial name="_TaskMyWork" model="Model" />
+        }
+        else if (Model.IsRegisterView)
         {
             <partial name="_TaskRegister" model="Model" />
         }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -896,6 +896,9 @@ public class IndexModel : PageModel
     public IReadOnlyList<TaskDisplayItem> SprintOverdueTaskDisplays =>
         ToDisplayItems(SprintOverdueTasks);
 
+    public IReadOnlyList<TaskDisplayItem> MyWorkOverdueTaskDisplays =>
+        ToDisplayItems(SprintOverdueTasks);
+
     public IReadOnlyList<TaskDisplayItem> BacklogTaskDisplays =>
         ToDisplayItems(BacklogTasks);
 
@@ -904,6 +907,13 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<TaskDisplayItem> SprintBacklogTaskDisplays =>
         ToDisplayItems(SprintBacklogTasks);
+
+    public IReadOnlyList<TaskDisplayItem> ActiveSprintTaskDisplays =>
+        ToDisplayItems(GetActiveSprintTasks()
+            .OrderBy(t => StatusOrder(t.Status))
+            .ThenBy(t => t.DueDate)
+            .ThenBy(t => t.Id)
+            .ToList());
 
     public IReadOnlyList<TaskDisplayItem> AssignableBacklogTaskDisplays =>
         ToDisplayItems(SprintBacklogTasks
@@ -1401,6 +1411,17 @@ public class IndexModel : PageModel
 
     private int CountByStatus(string status) =>
         Tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
+
+    // SECTION: Reusable status ordering for page-level task projections.
+    private static int StatusOrder(string status) => status switch
+    {
+        ActionTaskStatuses.Assigned => 1,
+        ActionTaskStatuses.InProgress => 2,
+        ActionTaskStatuses.Blocked => 3,
+        ActionTaskStatuses.Submitted => 4,
+        ActionTaskStatuses.Closed => 5,
+        _ => 99
+    };
 
     public bool IsTaskOverdue(ActionTaskItem task) =>
         !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)

--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -1,0 +1,154 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+@using ProjectManagement.Models
+
+@{
+    // SECTION: My Work read-model aliases keep the Razor below focused on presentation.
+    var assignedTaskCount = Model.Tasks.Count;
+    var activeSprintTaskCount = Model.ActiveSprintTaskDisplays.Count;
+}
+
+@* SECTION: Personal execution KPI strip. *@
+<section class="at-kpis at-kpis-mywork" aria-label="My work task summary">
+    <article>
+        <h3>Assigned to me</h3>
+        <strong>@assignedTaskCount</strong>
+        <p>Visible tasks scoped by your assignment.</p>
+    </article>
+    <article>
+        <h3>Overdue</h3>
+        <strong>@Model.MyWorkOverdueTaskDisplays.Count</strong>
+        <p>Needs immediate attention.</p>
+    </article>
+    <article>
+        <h3>Due today</h3>
+        <strong>@Model.DueTodayTaskDisplays.Count</strong>
+        <p>Due by end of day.</p>
+    </article>
+    <article>
+        <h3>In progress</h3>
+        <strong>@Model.KanbanInProgressTaskDisplays.Count</strong>
+        <p>Currently underway.</p>
+    </article>
+    <article>
+        <h3>Submitted</h3>
+        <strong>@Model.KanbanSubmittedTaskDisplays.Count</strong>
+        <p>Awaiting closure review.</p>
+    </article>
+    <article>
+        <h3>Active sprint</h3>
+        <strong>@activeSprintTaskCount</strong>
+        <p>@(string.IsNullOrWhiteSpace(Model.ActiveSprintMetrics.ActiveSprintName) ? "No active sprint set." : Model.ActiveSprintMetrics.ActiveSprintName)</p>
+    </article>
+</section>
+
+@* SECTION: Personal priority lanes for time-sensitive work. *@
+<section class="at-section-group">
+    <h2 class="at-section-title">Today and overdue</h2>
+    <div class="at-card-grid">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Overdue tasks</h3>
+                <span class="at-count-chip">@Model.MyWorkOverdueTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.MyWorkOverdueTaskDisplays, "No overdue tasks assigned to you.")' />
+        </article>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Due today</h3>
+                <span class="at-count-chip">@Model.DueTodayTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.")' />
+        </article>
+    </div>
+</section>
+
+@* SECTION: Personal workflow lanes for execution and handoff. *@
+<section class="at-section-group">
+    <h2 class="at-section-title">Execution lanes</h2>
+    <div class="at-card-grid">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>In progress</h3>
+                <span class="at-count-chip">@Model.KanbanInProgressTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No in-progress tasks assigned to you.")' />
+        </article>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <h3>Submitted for closure</h3>
+                <span class="at-count-chip">@Model.KanbanSubmittedTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks are awaiting closure.")' />
+        </article>
+    </div>
+</section>
+
+@* SECTION: Active sprint context for assigned work. *@
+<section class="at-section-group">
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h3>My active sprint tasks</h3>
+                @if (!string.IsNullOrWhiteSpace(Model.ActiveSprintMetrics.ActiveSprintName))
+                {
+                    <p class="at-panel-note">@Model.ActiveSprintMetrics.ActiveSprintName · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
+                }
+                else
+                {
+                    <p class="at-panel-note">No active sprint is currently set.</p>
+                }
+            </div>
+            <span class="at-count-chip">@activeSprintTaskCount</span>
+        </div>
+        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintTaskDisplays, "No assigned tasks are in the active sprint.")' />
+    </article>
+</section>
+
+@* SECTION: Assigned task records provide a quick personal work list without replacing the auditable register. *@
+<section class="at-section-group">
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <h3>All assigned tasks</h3>
+            <span class="at-count-chip">@assignedTaskCount</span>
+        </div>
+        @if (!Model.Tasks.Any())
+        {
+            <div class="at-empty-state">
+                <div class="fw-semibold">No tasks are currently assigned to you.</div>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm at-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Task</th>
+                            <th>Due Date</th>
+                            <th>Status</th>
+                            <th>Priority</th>
+                            <th>Sprint</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var task in Model.Tasks)
+                        {
+                            <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="MyWork">AT-@task.Id</a></td>
+                                <td>
+                                    <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="MyWork">@task.Title</a>
+                                    <div class="at-task-desc-preview">@task.Description</div>
+                                </td>
+                                <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                                <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
+                                <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
+                                <td><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </article>
+</section>

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -1,13 +1,11 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 
-@* SECTION: Task-list specific filters. *@
-@if (Model.IsTaskListView)
-{
-    <section class="at-panel mb-3">
-        <h2>Task List Filters</h2>
-        <form id="taskFilterForm" method="get" class="row g-2" data-at-task-filter-form="true">
-            <input type="hidden" name="viewMode" value="TaskList" />
+@* SECTION: Register filters keep task records searchable and auditable. *@
+<section class="at-panel mb-3">
+    <h2>Register Filters</h2>
+    <form id="taskFilterForm" method="get" class="row g-2" data-at-task-filter-form="true">
+        <input type="hidden" name="viewMode" value="Register" />
             <div class="col-md-2">
                 <label class="form-label">Status</label>
                 <select class="form-select" name="FilterStatus">
@@ -89,12 +87,12 @@
                 <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
             </div>
             <div class="col-12 d-flex gap-2">
-                <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="btn btn-outline-secondary btn-sm">Reset</a>
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
             </div>
         </form>
 
-        @if (Model.HasActiveFilters)
-        {
+    @if (Model.HasActiveFilters)
+    {
             <div class="at-active-filters" aria-label="Active filters">
                 @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
                 {
@@ -116,20 +114,19 @@
                 {
                     <span class="at-filter-chip">Search: @Model.FilterSearch</span>
                 }
-                <a asp-page="/ActionTasks/Index" asp-route-viewMode="TaskList" class="at-filter-clear">Clear all</a>
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-filter-clear">Clear all</a>
             </div>
-        }
-    </section>
-}
+    }
+</section>
 
-@* SECTION: Shared register table for MyTasks and TaskList views. *@
+@* SECTION: Auditable task register table. *@
 <section class="at-panel">
-    <h2>@(Model.IsMyTasksView ? "My Tasks" : "Task Register")</h2>
+    <h2>Task Register</h2>
     @if (!Model.Tasks.Any())
     {
-            <div class="at-empty-state">
-                <div class="fw-semibold">No tasks found for the current filters.</div>
-            </div>
+        <div class="at-empty-state">
+            <div class="fw-semibold">No tasks found for the current filters.</div>
+        </div>
     }
     else
     {

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2010,3 +2010,20 @@ html {
         width: min(100%, calc(100vw - 2rem));
     }
 }
+
+/* SECTION: My Work focused execution workspace */
+.at-kpis-mywork {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+@media (max-width: 1399px) {
+    .at-kpis-mywork {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 767px) {
+    .at-kpis-mywork {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated, focused "My Work" workspace for users so the page can surface personal execution lanes (assigned, overdue, due-today, in-progress, submitted, active sprint) without turning the register into a personal view.
- Keep the `Register` view focused on searchable, filterable, auditable tabular records for reporting and bulk operations.
- Reuse existing read-model projections from the query service to avoid duplicating business logic or additional queries.

### Description
- Render the new partial `_TaskMyWork` when the resolved mode is `MyWork` and render `_TaskRegister` only when the resolved mode is `Register` by updating `Pages/ActionTasks/Index.cshtml`.
- Add `Pages/ActionTasks/_TaskMyWork.cshtml` which composes a personal KPI strip and lanes using existing display projections (assigned tasks, overdue, due-today, in-progress, submitted, active sprint) and a compact table of all assigned tasks.
- Refactor `Pages/ActionTasks/_TaskRegister.cshtml` so filters and reset/clear links target the `Register` view-mode and keep the partial focused on auditable tabular records.
- Add page-model projections and helpers in `Pages/ActionTasks/Index.cshtml.cs`: `MyWorkOverdueTaskDisplays`, `ActiveSprintTaskDisplays` (ordered by status/due/id) and a reusable `StatusOrder` helper, and reuse the existing `ToDisplayItems`/read-model values to populate the partials.
- Add responsive styling for the My Work KPI strip in `wwwroot/css/action-tracker.css` under the `.at-kpis-mywork` selector.

### Testing
- Ran static change check via `git diff --check`, which reported no issues (success).
- Attempted to run `dotnet build` and `dotnet --info` but the environment does not provide the .NET SDK, so build/test could not be executed here (blocked by missing `dotnet` CLI).
- Verified the rendered Razor condition and new files by inspecting diffs and file contents (scripted file updates and local checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb454856ac83299a8542ce3dcb4e3e)