### PR TITLE
Refocus ActionTasks dashboard into Command Centre (command-attention view)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -158,7 +158,7 @@ public class IndexModel : PageModel
         "MyWork" => "Tasks assigned to the logged-in user.",
         "Register" => "Filterable register of all visible tasks.",
         "Reports" => "Summary of pending, critical, blocked and closed tasks.",
-        _ => "Command-level visibility of active, delayed and critical tasks."
+        _ => "Command workspace for overdue, blocked, submitted and critical task action."
     };
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
@@ -1006,7 +1006,7 @@ public class IndexModel : PageModel
          || FilterDueDate.HasValue
          || !string.IsNullOrWhiteSpace(FilterSearch));
     public string DashboardCommandFocusSummary =>
-        $"{ActiveCount} active tasks. {CriticalOpenCount} critical. {OverdueCount} overdue. {InProgressCount} in progress. {SubmittedCount} pending closure.";
+        $"{OverdueCount} overdue. {BlockedCount} blocked. {SubmittedPendingClosureCount} submitted pending closure. {CriticalOpenCount} critical open. {ActiveSprintMetrics.CarryForwardCandidateTasks} carry-forward candidates.";
     public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<TaskDisplayItem> TopAttentionTaskDisplays => BuildTopAttentionItems();
 

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -1,15 +1,15 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Command overview KPI strip. *@
-<section class="at-kpis">
-    <article><h3>Active</h3><strong>@Model.ActiveCount</strong></article>
-    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong></article>
-    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong></article>
-    <article><h3>Submitted</h3><strong>@Model.SubmittedCount</strong></article>
-    <article><h3>Closed</h3><strong>@Model.ClosedCount</strong></article>
+@* SECTION: Command-attention strip for command-centre exceptions. *@
+<section class="at-kpis" aria-label="Command attention metrics">
+    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Past due and open</p></article>
+    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Needs unblock action</p></article>
+    <article><h3>Pending Closure</h3><strong>@Model.SubmittedPendingClosureCount</strong><p>Submitted for close-out</p></article>
+    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Critical priority, not closed</p></article>
+    <article><h3>Carry Forward</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong><p>Active sprint candidates</p></article>
 </section>
 <section class="at-panel at-command-focus-strip mb-3">
-    <strong>Command Focus:</strong> @Model.DashboardCommandFocusSummary
+    <strong>Command Attention:</strong> @Model.DashboardCommandFocusSummary
 </section>
 
 @* SECTION: Active sprint operational health metrics. *@
@@ -74,23 +74,25 @@
     </div>
 </section>
 
-@* SECTION: Recent activity panels with compact task rows. *@
+@* SECTION: Recent activity is secondary to command-critical work and collapsed by default. *@
 <section class="at-section-group">
-    <h2 class="at-section-title">Recent Activity</h2>
-    <div class="at-card-grid">
-        <article class="at-panel">
-            <div class="at-panel-heading">
-                <h3>Recently Submitted</h3>
-                <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
-            </div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No submitted tasks awaiting closure.")' />
-        </article>
-        <article class="at-panel">
-            <div class="at-panel-heading">
-                <h3>Recently Updated</h3>
-                <span class="at-count-chip">@Model.RecentlyUpdatedTaskDisplays.Count</span>
-            </div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlyUpdatedTaskDisplays, "No recently updated tasks.")' />
-        </article>
-    </div>
+    <details class="at-panel at-details-collapsible">
+        <summary>Recent Activity</summary>
+        <div class="at-card-grid mt-3">
+            <article class="at-panel">
+                <div class="at-panel-heading">
+                    <h3>Recently Submitted</h3>
+                    <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
+                </div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No submitted tasks awaiting closure.")' />
+            </article>
+            <article class="at-panel">
+                <div class="at-panel-heading">
+                    <h3>Recently Updated</h3>
+                    <span class="at-count-chip">@Model.RecentlyUpdatedTaskDisplays.Count</span>
+                </div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlyUpdatedTaskDisplays, "No recently updated tasks.")' />
+            </article>
+        </div>
+    </details>
 </section>


### PR DESCRIPTION
### Motivation
- Shift the Action Tasks dashboard from a broad KPI dashboard to a focused command workspace that surfaces command-critical exceptions (overdue, blocked, submitted pending closure, critical open, carry-forward candidates).
- Ensure operational sprint health remains prominent while deprioritising recent activity so commanders can act on exceptions quickly.
- Keep UX and security constraints intact by avoiding inline scripts and reusing existing partials and JS/CSS.

### Description
- Replaced the broad KPI strip in `Pages/ActionTasks/_TaskDashboard.cshtml` with a compact command-attention strip showing `Overdue`, `Blocked`, `Pending Closure`, `Critical Open` and `Carry Forward` metrics and short context notes.
- Kept the `Active Sprint Health` panel and active-sprint attention lists near the top and preserved the high-risk lists (`Critical Open Tasks`, `Overdue Tasks`) in their existing location.
- Moved the `Recently Submitted` and `Recently Updated` panels into a collapsed `<details>` section so recent activity is secondary to command-critical content, and used existing `_TaskMiniList` partials (no inline scripts added).
- Updated the page-level descriptive text in `Pages/ActionTasks/Index.cshtml.cs` by changing the default `PageSubtitle` and rebuilding `DashboardCommandFocusSummary` to reflect the command-centre focus.

### Testing
- Ran `git diff --check` which completed without issues.
- Attempted to run the automated unit test suite with `dotnet test ProjectManagement.sln` but the `dotnet` CLI was not available in the environment so the test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4bbd9b488329a1e92c383481c4fe)