### PR TITLE
Nest Due/Exceptions into Planning Board as a collapsible section

### DIFF
--- a/Pages/ActionTasks/_TaskSprintBoard.cshtml
+++ b/Pages/ActionTasks/_TaskSprintBoard.cshtml
@@ -1,25 +1,35 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Planning Board due-and-exception review is a secondary toggle, not the primary work mode. *@
-<details class="at-panel at-planning-secondary-view at-planning-due-exceptions-view">
-    <summary>
-        <span>Due / Exceptions View</span>
-        <span class="at-count-chip">@(Model.DueTodayTaskDisplays.Count + Model.DueThisWeekTaskDisplays.Count + Model.DueLaterTaskDisplays.Count + Model.SprintOverdueTaskDisplays.Count)</span>
+@{
+    var dueExceptionCount = Model.DueTodayTaskDisplays.Count
+        + Model.DueThisWeekTaskDisplays.Count
+        + Model.DueLaterTaskDisplays.Count
+        + Model.SprintOverdueTaskDisplays.Count;
+}
+
+@* SECTION: Collapsible Planning Board due and exception review stays nested below the primary sprint workflow. *@
+<details class="at-planning-due-exceptions-section">
+    <summary class="at-planning-due-exceptions-summary">
+        <span class="at-planning-due-exceptions-title">Due / exceptions</span>
+        <span class="at-planning-due-exceptions-meta">Review upcoming and overdue task buckets without leaving the Planning Board.</span>
+        <span class="at-count-chip">@dueExceptionCount</span>
     </summary>
-    <div class="at-board-grid at-board-grid-sprint at-planning-secondary-grid" aria-label="Planning Board due and exceptions">
-        <article class="at-panel at-board-column">
+
+    @* SECTION: Due buckets stack by default and only become lateral review columns on wider screens. *@
+    <div class="at-planning-due-exceptions-grid" aria-label="Planning Board due and exceptions">
+        <article class="at-panel at-board-column at-due-exception-column">
             <div class="at-panel-heading"><h2>Due Today</h2><span class="at-count-chip">@Model.DueTodayTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks", false)' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.", false)' />
         </article>
-        <article class="at-panel at-board-column">
+        <article class="at-panel at-board-column at-due-exception-column">
             <div class="at-panel-heading"><h2>Due This Week</h2><span class="at-count-chip">@Model.DueThisWeekTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks", false)' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.", false)' />
         </article>
-        <article class="at-panel at-board-column">
+        <article class="at-panel at-board-column at-due-exception-column">
             <div class="at-panel-heading"><h2>Due Later</h2><span class="at-count-chip">@Model.DueLaterTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No tasks", false)' />
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No later tasks.", false)' />
         </article>
-        <article class="at-panel at-board-column">
+        <article class="at-panel at-board-column at-due-exception-column at-due-exception-column-overdue">
             <div class="at-panel-heading"><h2>Overdue</h2><span class="at-count-chip">@Model.SprintOverdueTaskDisplays.Count</span></div>
             <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.", false)' />
         </article>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -481,7 +481,7 @@
                 </div>
             </aside>
 
-            @* SECTION: Planning Board alternate review toggles keep due exceptions and Kanban views secondary to the default work mode. *@
+            @* SECTION: Collapsible due/exception review remains nested in Planning Board; Kanban stays an alternate secondary view. *@
             <partial name="_TaskSprintBoard" model="Model" />
             <partial name="_TaskKanban" model="Model" />
 

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2028,6 +2028,79 @@ html {
     }
 }
 
+
+/* SECTION: Planning Board due/exception section stays nested and avoids horizontal-first interaction. */
+.at-planning-due-exceptions-section {
+    display: grid;
+    gap: 0;
+    margin-top: 1rem;
+    border: 1px solid var(--at-border);
+    border-radius: 14px;
+    background: var(--at-surface);
+    box-shadow: var(--at-shadow-sm);
+}
+
+.at-planning-due-exceptions-summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.25rem 0.75rem;
+    cursor: pointer;
+    padding: 0.75rem 0.9rem;
+}
+
+.at-planning-due-exceptions-title {
+    color: var(--at-text);
+    font-weight: var(--at-weight-bold);
+}
+
+.at-planning-due-exceptions-meta {
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: 600;
+}
+
+.at-planning-due-exceptions-summary .at-count-chip {
+    grid-row: 1 / span 2;
+    grid-column: 2;
+}
+
+.at-planning-due-exceptions-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    min-width: 0;
+    padding: 0.9rem;
+    border-top: 1px solid var(--at-border);
+}
+
+.at-due-exception-column {
+    min-width: 0;
+}
+
+.at-due-exception-column-overdue {
+    border-color: #fecaca;
+}
+
+@media (min-width: 992px) {
+    .at-planning-due-exceptions-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        align-items: start;
+    }
+}
+
+@media (max-width: 767px) {
+    .at-planning-due-exceptions-summary {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .at-planning-due-exceptions-summary .at-count-chip {
+        grid-row: auto;
+        grid-column: auto;
+        width: fit-content;
+    }
+}
+
 /* SECTION: Planning Board integrated backlog and alternate views */
 .at-planning-backlog-queue,
 .at-planning-secondary-view {
@@ -2098,4 +2171,5 @@ html {
 .at-planning-secondary-grid {
     grid-auto-columns: initial;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    min-width: 0;
 }


### PR DESCRIPTION
### Motivation
- Reduce the due-board surface from a top-level/alternate page into a secondary, non-intrusive review inside the Planning Board so the primary planning workflow remains the default interaction. 
- Preserve the same due buckets (Due Today, Due This Week, Due Later, Overdue) and keep the visualization responsive so narrow screens stack cards and wide screens optionally show lateral columns. 
- Avoid introducing horizontal-scroll-as-default and keep the UI CSP-safe with no inline scripts while maintaining existing task card rendering.

### Description
- Converted `Pages/ActionTasks/_TaskSprintBoard.cshtml` into a nested collapsible `details` section titled "Due / exceptions" and added an aggregate count badge computed from the model.  
- Kept the four requested buckets and updated their empty messages; each bucket now renders the existing `_TaskCards` partial to preserve current card markup and behavior.  
- Updated `Pages/ActionTasks/_TaskSprints.cshtml` to render the new collapsible section inside the Planning Board (left as a nested partial) and clarified the surrounding comment.  
- Added responsive styles to `wwwroot/css/action-tracker.css` to make the due buckets stack by default and switch to a 4-column lateral layout at larger breakpoints, and added `min-width: 0` tweaks to reduce horizontal overflow risk.

### Testing
- Ran repository scans with `rg` to verify references to the due buckets and affected partials and to confirm the board remains rendered only as the nested partial (searches completed successfully).  
- Ran `git diff --check` to ensure no whitespace/merge markers or obvious diff-check errors (no issues found).  
- Attempted `dotnet build` in the environment but it could not be run because `dotnet` is not installed in this container, so a full compile/test run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4fce509483299ca40e25af06614b)