### PR TITLE
Add Planning Board view toggle (PlanningView=Default|DueExceptions|Kanban)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -3,8 +3,20 @@
 @{
     ViewData["Title"] = "Task Tracker";
     ViewData["UseFullWidth"] = true;
-}
 
+    // SECTION: Planning Board view-state normalization keeps Kanban out of primary navigation.
+    var requestedPlanningView = (Context.Request.Query["PlanningView"].ToString() ?? string.Empty).Trim();
+    var resolvedPlanningView = requestedPlanningView switch
+    {
+        var value when string.Equals(value, "DueExceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+        var value when string.Equals(value, "Due / exceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+        var value when string.Equals(value, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
+        _ => "Default"
+    };
+    var isDefaultPlanningView = string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase);
+    var isDueExceptionsPlanningView = string.Equals(resolvedPlanningView, "DueExceptions", StringComparison.OrdinalIgnoreCase);
+    var isKanbanPlanningView = string.Equals(resolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase);
+}
 @section Styles {
     <link rel="stylesheet" href="~/css/action-tracker.css" asp-append-version="true" />
 }
@@ -50,7 +62,45 @@
         }
         else if (Model.IsPlanningView)
         {
-            <partial name="_TaskSprints" model="Model" />
+            @* SECTION: Planning Board secondary view toggle uses PlanningView query state instead of a top-level Kanban navigation mode. *@
+            <nav class="at-panel at-planning-view-toggle" aria-label="Planning Board view toggle">
+                <span class="at-section-eyebrow">Planning Board view</span>
+                <div class="btn-group" role="group" aria-label="Planning Board view options">
+                    <a asp-page="/ActionTasks/Index"
+                       asp-route-viewMode="Planning"
+                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
+                       asp-route-taskId="@Model.TaskId"
+                       class="btn btn-sm @(isDefaultPlanningView ? "btn-primary" : "btn-outline-primary")"
+                       aria-current="@(isDefaultPlanningView ? "page" : null)">Default</a>
+                    <a asp-page="/ActionTasks/Index"
+                       asp-route-viewMode="Planning"
+                       asp-route-PlanningView="DueExceptions"
+                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
+                       asp-route-taskId="@Model.TaskId"
+                       class="btn btn-sm @(isDueExceptionsPlanningView ? "btn-primary" : "btn-outline-primary")"
+                       aria-current="@(isDueExceptionsPlanningView ? "page" : null)">Due / exceptions</a>
+                    <a asp-page="/ActionTasks/Index"
+                       asp-route-viewMode="Planning"
+                       asp-route-PlanningView="Kanban"
+                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
+                       asp-route-taskId="@Model.TaskId"
+                       class="btn btn-sm @(isKanbanPlanningView ? "btn-primary" : "btn-outline-primary")"
+                       aria-current="@(isKanbanPlanningView ? "page" : null)">Kanban</a>
+                </div>
+            </nav>
+
+            @if (isDueExceptionsPlanningView)
+            {
+                <partial name="_TaskSprintBoard" model="Model" />
+            }
+            else if (isKanbanPlanningView)
+            {
+                <partial name="_TaskKanban" model="Model" />
+            }
+            else
+            {
+                <partial name="_TaskSprints" model="Model" />
+            }
         }
         else if (Model.IsMyWorkView)
         {

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -1,31 +1,69 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Planning Board Kanban is an alternate review toggle, not the default primary work mode. *@
-<details class="at-panel at-planning-secondary-view at-planning-kanban-view">
-    <summary>
-        <span>Kanban Alternate View</span>
-        <span class="at-count-chip">@(Model.KanbanAssignedTaskDisplays.Count + Model.KanbanInProgressTaskDisplays.Count + Model.KanbanBlockedTaskDisplays.Count + Model.KanbanSubmittedTaskDisplays.Count + Model.KanbanClosedTaskDisplays.Count)</span>
-    </summary>
-    <div class="at-board-grid is-kanban at-planning-secondary-grid" aria-label="Planning Board Kanban alternate view">
-        <article class="at-panel at-board-column">
-            <div class="at-panel-heading"><h2>Assigned</h2><span class="at-count-chip">@Model.KanbanAssignedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanAssignedTaskDisplays, "No assigned tasks.", true)' />
-        </article>
-        <article class="at-panel at-board-column">
-            <div class="at-panel-heading"><h2>In Progress</h2><span class="at-count-chip">@Model.KanbanInProgressTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanInProgressTaskDisplays, "No in progress tasks.", true)' />
-        </article>
-        <article class="at-panel at-board-column">
-            <div class="at-panel-heading"><h2>Blocked</h2><span class="at-count-chip">@Model.KanbanBlockedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.", true)' />
-        </article>
-        <article class="at-panel at-board-column">
-            <div class="at-panel-heading"><h2>Submitted</h2><span class="at-count-chip">@Model.KanbanSubmittedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks.", true)' />
-        </article>
-        <article class="at-panel at-board-column">
-            <div class="at-panel-heading"><h2>Closed</h2><span class="at-count-chip">@Model.KanbanClosedTaskDisplays.Count</span></div>
-            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.KanbanClosedTaskDisplays, "No closed tasks.", true)' />
-        </article>
+@{
+    // SECTION: Kanban is scoped to the Planning Board view toggle and is not a primary navigation mode.
+    var isKanbanPlanningView = string.Equals(Context.Request.Query["PlanningView"].ToString(), "Kanban", StringComparison.OrdinalIgnoreCase);
+    var kanbanColumns = new[]
+    {
+        (Title: "Assigned", Tasks: Model.KanbanAssignedTaskDisplays, EmptyMessage: "No assigned tasks."),
+        (Title: "In Progress", Tasks: Model.KanbanInProgressTaskDisplays, EmptyMessage: "No in progress tasks."),
+        (Title: "Blocked", Tasks: Model.KanbanBlockedTaskDisplays, EmptyMessage: "No blocked tasks."),
+        (Title: "Submitted", Tasks: Model.KanbanSubmittedTaskDisplays, EmptyMessage: "No submitted tasks."),
+        (Title: "Closed", Tasks: Model.KanbanClosedTaskDisplays, EmptyMessage: "No closed tasks.")
+    };
+    var kanbanTaskCount = kanbanColumns.Sum(column => column.Tasks.Count);
+}
+
+@if (isKanbanPlanningView)
+{
+@* SECTION: Planning Board Kanban preserves existing workflow-status grouping without introducing a top-level Kanban mode. *@
+<section class="at-panel at-planning-secondary-view at-planning-kanban-view" aria-labelledby="planning-kanban-heading">
+    <div class="at-panel-heading">
+        <div>
+            <div class="at-section-eyebrow">Planning Board</div>
+            <h2 id="planning-kanban-heading">Kanban</h2>
+        </div>
+        <span class="at-count-chip">@kanbanTaskCount</span>
     </div>
-</details>
+
+    @* SECTION: Existing Kanban columns continue to group tasks by current workflow status names. *@
+    <div class="at-board-grid is-kanban at-planning-secondary-grid" aria-label="Planning Board Kanban alternate view">
+        @foreach (var column in kanbanColumns)
+        {
+            <article class="at-panel at-board-column">
+                <div class="at-panel-heading"><h2>@column.Title</h2><span class="at-count-chip">@column.Tasks.Count</span></div>
+                @if (!column.Tasks.Any())
+                {
+                    <p class="at-empty-inline">@column.EmptyMessage</p>
+                }
+                else
+                {
+                    <div class="at-task-cards">
+                        @foreach (var item in column.Tasks)
+                        {
+                            var task = item.Task;
+                            <article class="at-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                <a class="at-task-card-link"
+                                   asp-page="/ActionTasks/Index"
+                                   asp-route-taskId="@task.Id"
+                                   asp-route-viewMode="Planning"
+                                   asp-route-PlanningView="Kanban"
+                                   asp-route-SelectedSprintId="@Model.SelectedSprintId"
+                                   aria-label="Open task AT-@task.Id details">
+                                    <div class="at-card-top-row">
+                                        <h3 class="at-card-subject">@task.Title</h3>
+                                        <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                    </div>
+                                    <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
+                                    <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                                    <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
+                                </a>
+                            </article>
+                        }
+                    </div>
+                }
+            </article>
+        }
+    </div>
+</section>
+}


### PR DESCRIPTION
### Motivation
- Provide a Planning Board-level toggle so reviewers can switch between the default planning surface, a due/exceptions review, and the Kanban alternate view using query-string state rather than adding a top-level Kanban navigation mode. 
- Keep existing kanban grouping and task detail links intact and avoid changing workflow status names or transition permissions. 
- Preserve CSP rules and avoid inline scripts while keeping UI state scoped to the Planning Board.

### Description
- Added `PlanningView` query-string normalization and helper booleans to `Pages/ActionTasks/Index.cshtml` to resolve `Default`, `DueExceptions` (alias: `Due / exceptions`) and `Kanban` states and to compute `isDefaultPlanningView`, `isDueExceptionsPlanningView`, and `isKanbanPlanningView`.
- Introduced an in-page Planning Board view toggle (three buttons: Default, Due / exceptions, Kanban) rendered when `viewMode=Planning` that preserves `SelectedSprintId` and `TaskId` in the generated links.
- Changed Planning Board rendering to route to the appropriate partial based on `PlanningView` state: Default -> `_TaskSprints`, Due / exceptions -> `_TaskSprintBoard`, Kanban -> `_TaskKanban`.
- Refactored `Pages/ActionTasks/_TaskKanban.cshtml` so it only renders when `PlanningView=Kanban`, preserved the existing column groupings (Assigned, In Progress, Blocked, Submitted, Closed), preserved task detail links and passed `viewMode=Planning`, `PlanningView=Kanban`, and `SelectedSprintId` so selection and inspector behavior remain unchanged, and added section comments to clarify scoping.
- Ensured no workflow status names or status-transition permission logic were changed, and retained CSP-safe GET links/forms and no inline scripts.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it reported no problems. (succeeded)
- Attempted `dotnet build` but `dotnet` is not available in the environment so a full build could not be executed. (not run due to missing tool)
- Ran `bash tools/check-views.sh`, which surfaced pre-existing inline style attribute warnings unrelated to these changes; those warnings existed outside the modified files. (tool reported failures unrelated to this PR)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb50e2041483298ae7124d1129d93a)