### PR TITLE
Preserve Planning Board sub-view in task inspector

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -5,14 +5,7 @@
     ViewData["UseFullWidth"] = true;
 
     // SECTION: Planning Board view-state normalization keeps Kanban out of primary navigation.
-    var requestedPlanningView = (Context.Request.Query["PlanningView"].ToString() ?? string.Empty).Trim();
-    var resolvedPlanningView = requestedPlanningView switch
-    {
-        var value when string.Equals(value, "DueExceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-        var value when string.Equals(value, "Due / exceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-        var value when string.Equals(value, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
-        _ => "Default"
-    };
+    var resolvedPlanningView = Model.ResolvedPlanningView;
     var isDefaultPlanningView = string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase);
     var isDueExceptionsPlanningView = string.Equals(resolvedPlanningView, "DueExceptions", StringComparison.OrdinalIgnoreCase);
     var isKanbanPlanningView = string.Equals(resolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase);

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
@@ -83,6 +84,9 @@ public class IndexModel : PageModel
     public int? SelectedSprintId { get; set; }
 
     [BindProperty(SupportsGet = true)]
+    public string? PlanningView { get; set; }
+
+    [BindProperty(SupportsGet = true)]
     public string? FilterStatus { get; set; }
 
     [BindProperty(SupportsGet = true)]
@@ -130,6 +134,7 @@ public class IndexModel : PageModel
     public bool CanCreate => _permission.CanCreate(CurrentRole);
     public bool CanClose => _permission.CanClose(CurrentRole);
     public string ResolvedViewMode => ResolveViewMode();
+    public string ResolvedPlanningView => ResolvePlanningView();
     public bool IsCommandCentreView => string.Equals(ResolvedViewMode, "CommandCentre", StringComparison.OrdinalIgnoreCase);
     public bool IsPlanningView => string.Equals(ResolvedViewMode, "Planning", StringComparison.OrdinalIgnoreCase);
     public bool IsMyWorkView => string.Equals(ResolvedViewMode, "MyWork", StringComparison.OrdinalIgnoreCase);
@@ -541,7 +546,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+        return RedirectToTaskPage(id, SelectedSprintId);
     }
 
     // SECTION: Close task by command role
@@ -562,7 +567,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+        return RedirectToTaskPage(id, SelectedSprintId);
     }
 
     // SECTION: Update in-flight status
@@ -576,14 +581,14 @@ public class IndexModel : PageModel
             if (task is null)
             {
                 TempData["ToastError"] = "Task not found.";
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+                return RedirectToTaskPage(id, SelectedSprintId);
             }
 
             // SECTION: Preserve permission enforcement even for status no-op submissions.
             if (!_permission.CanUpdateTask(CurrentRole, CurrentUserId, task.AssignedToUserId))
             {
                 TempData["ToastError"] = "You are not authorized to update this task.";
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+                return RedirectToTaskPage(id, SelectedSprintId);
             }
 
             // SECTION: Keep no-op handling for user-friendly messaging after permission validation.
@@ -591,7 +596,7 @@ public class IndexModel : PageModel
             if (!string.IsNullOrWhiteSpace(noOpMessage))
             {
                 TempData["ToastMessage"] = noOpMessage;
-                return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+                return RedirectToTaskPage(id, SelectedSprintId);
             }
 
             await _service.UpdateStatusAsync(id, DecodeRowVersion(rowVersion), status, CurrentUserId, CurrentRole, remarks);
@@ -606,7 +611,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+        return RedirectToTaskPage(id, SelectedSprintId);
     }
 
     // SECTION: Assign backlog or visible task into an available sprint.
@@ -624,7 +629,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId = sprintId });
+        return RedirectToTaskPage(id, sprintId);
     }
 
     // SECTION: Move a sprint task back to backlog without altering task lifecycle state.
@@ -642,7 +647,7 @@ public class IndexModel : PageModel
             TempData["ToastError"] = ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = id, SelectedSprintId });
+        return RedirectToTaskPage(id, SelectedSprintId);
     }
 
     // SECTION: Close active sprint after explicit closure review disposition.
@@ -688,7 +693,7 @@ public class IndexModel : PageModel
         if (!ModelState.IsValid)
         {
             TempData["ToastError"] = "Unable to post update. Please check the entered details and try again.";
-            return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId, SelectedSprintId });
+            return RedirectToTaskPage(UpdateInput.TaskId, SelectedSprintId);
         }
 
         try
@@ -706,7 +711,7 @@ public class IndexModel : PageModel
                 : ex.Message;
         }
 
-        return RedirectToPage(new { ViewMode = ResolveViewMode(), TaskId = UpdateInput.TaskId, SelectedSprintId });
+        return RedirectToTaskPage(UpdateInput.TaskId, SelectedSprintId);
     }
 
     // SECTION: Shared data loading
@@ -1285,6 +1290,37 @@ public class IndexModel : PageModel
         {
             throw new InvalidOperationException("Sprint version is invalid. Please reload and try again.");
         }
+    }
+
+    // SECTION: Planning Board sub-view normalization keeps secondary view state safe across links and postbacks.
+    private string ResolvePlanningView()
+    {
+        var normalized = (PlanningView ?? string.Empty).Trim();
+        return normalized switch
+        {
+            _ when string.Equals(normalized, "DueExceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+            _ when string.Equals(normalized, "Due / exceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+            _ when string.Equals(normalized, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
+            _ => "Default"
+        };
+    }
+
+    // SECTION: Shared task redirect route preserves Planning Board sub-view state from inspector actions.
+    private RedirectToPageResult RedirectToTaskPage(int? taskId, int? selectedSprintId)
+    {
+        var routeValues = new RouteValueDictionary
+        {
+            [nameof(ViewMode)] = ResolveViewMode(),
+            [nameof(TaskId)] = taskId,
+            [nameof(SelectedSprintId)] = selectedSprintId
+        };
+
+        if (IsPlanningView && !string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase))
+        {
+            routeValues[nameof(PlanningView)] = ResolvedPlanningView;
+        }
+
+        return RedirectToPage(routeValues);
     }
 
     private string ResolveViewMode()

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -24,7 +24,7 @@
                     </div>
                 }
             </div>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-PlanningView="@Model.ResolvedPlanningView" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
         </header>
 
         @if (Model.SelectedTask is not null)
@@ -138,6 +138,7 @@
                             <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
                             <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                             <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                            <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                             <div class="at-action-title">Add Update</div>
                             <div class="mb-2">
                                 <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
@@ -161,7 +162,8 @@
                             <summary class="visually-hidden">Open status panel</summary>
                             <form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
@@ -200,7 +202,8 @@
                             <summary class="visually-hidden">Open submit panel</summary>
                             <form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
@@ -223,7 +226,8 @@
                             <summary class="visually-hidden">Open close panel</summary>
                             <form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -2,7 +2,7 @@
 
 @{
     // SECTION: Kanban is scoped to the Planning Board view toggle and is not a primary navigation mode.
-    var isKanbanPlanningView = string.Equals(Context.Request.Query["PlanningView"].ToString(), "Kanban", StringComparison.OrdinalIgnoreCase);
+    var isKanbanPlanningView = string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase);
     var kanbanColumns = new[]
     {
         (Title: "Assigned", Tasks: Model.KanbanAssignedTaskDisplays, EmptyMessage: "No assigned tasks."),

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -66,6 +66,51 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task PlanningKanban_StatusNoOpRedirect_PreservesPlanningView()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        var sprint = AddSprint(setup.Db, "Kanban Sprint", ActionSprintStatus.Active);
+        task.SprintId = sprint.Id;
+        await setup.Db.SaveChangesAsync();
+        page.ViewMode = "Planning";
+        page.PlanningView = "Kanban";
+        page.SelectedSprintId = sprint.Id;
+
+        // SECTION: Act
+        var result = await page.OnPostUpdateStatusAsync(task.Id, Convert.ToBase64String(task.RowVersion), task.Status, "No status change");
+
+        // SECTION: Assert
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("Planning", redirect.RouteValues![nameof(IndexModel.ViewMode)]);
+        Assert.Equal("Kanban", redirect.RouteValues[nameof(IndexModel.PlanningView)]);
+        Assert.Equal(sprint.Id, redirect.RouteValues[nameof(IndexModel.SelectedSprintId)]);
+        Assert.Equal(task.Id, redirect.RouteValues[nameof(IndexModel.TaskId)]);
+    }
+
+    [Fact]
+    public async Task TaskDetailsPartial_KanbanInspectorFormsCarryPlanningView()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        page.ViewMode = "Planning";
+        page.PlanningView = "Kanban";
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("name=\"PlanningView\" value=\"Kanban\"", html, StringComparison.Ordinal);
+        Assert.Contains("PlanningView=Kanban", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task TaskList_SelectedTaskLoadsWhenFilteredOutOfRegister()
     {
         // SECTION: Arrange


### PR DESCRIPTION
### Motivation
- Users reported that when interacting with a task inspector while using the Planning Board secondary view (e.g. `Kanban`), postback actions dropped the secondary view and returned the Planning Board to `Default` instead of preserving the selected sub-view.
- The change centralizes Planning Board sub-view normalization and ensures the selected `PlanningView` round-trips through links and POST handlers so inspector actions do not unexpectedly change the UI state.

### Description
- Bind the `PlanningView` query/form state on the page model with `public string? PlanningView { get; set; }` and add `ResolvedPlanningView` backed by a new `ResolvePlanningView()` normalization helper.
- Add a shared redirect helper `RedirectToTaskPage(int? taskId, int? selectedSprintId)` that preserves non-default `PlanningView` when returning from task inspector POST handlers and replace inline `RedirectToPage(new { ViewMode = ResolveViewMode(), ... })` calls with the helper across status/submit/close/assign/update handlers.
- Update Razor views to use the normalized planning state (use `Model.ResolvedPlanningView` in `Index.cshtml` and `_TaskKanban.cshtml`) and include `PlanningView` in the inspector close link and as hidden form fields in inspector POST forms (`_TaskDetails.cshtml`) so sub-view state round-trips without client scripts.
- Add two regression tests to `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`: `PlanningKanban_StatusNoOpRedirect_PreservesPlanningView` and `TaskDetailsPartial_KanbanInspectorFormsCarryPlanningView` to cover redirect route values and rendered inspector fields.

### Testing
- Ran `git diff --check` to validate no whitespace/merge errors and it passed successfully. 
- Attempted to run `dotnet format` and `dotnet test --filter ActionTaskPageTests` but the environment does not have the `dotnet` SDK installed so formatting and unit test execution could not be performed here. 
- Added unit tests covering the new behavior; they were included in the commit and should be green when run in a CI environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb53ec664c832998359511736bc638)