### PR TITLE
Restore remaining My Work task visibility

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -938,6 +938,13 @@ public class IndexModel : PageModel
             .ThenBy(t => t.Id)
             .ToList());
 
+    public IReadOnlyList<TaskDisplayItem> MyRemainingAssignedTaskDisplays =>
+        ToDisplayItems(GetRemainingAssignedTasks()
+            .OrderBy(t => StatusOrder(t.Status))
+            .ThenBy(t => t.DueDate)
+            .ThenBy(t => t.Id)
+            .ToList());
+
     // SECTION: Legacy My Tasks display alias retained for older partial references.
     public IReadOnlyList<TaskDisplayItem> MyWorkOverdueTaskDisplays =>
         MyOverdueTaskDisplays;
@@ -1509,6 +1516,20 @@ public class IndexModel : PageModel
         ActiveSprint is null
             ? Array.Empty<ActionTaskItem>()
             : Tasks.Where(t => t.SprintId == ActiveSprint.Id).ToList();
+
+    // SECTION: Remaining personal work keeps assigned tasks visible when they do not fit a priority lane.
+    private IReadOnlyList<ActionTaskItem> GetRemainingAssignedTasks()
+    {
+        var activeSprintId = ActiveSprint?.Id;
+        return Tasks
+            .Where(IsOpenTask)
+            .Where(t => t.DueDate.Date != DateTime.UtcNow.Date)
+            .Where(t => !IsTaskOverdue(t))
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
+            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+            .Where(t => !activeSprintId.HasValue || t.SprintId != activeSprintId.Value)
+            .ToList();
+    }
 
     private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>
         tasks.Select(task => new TaskDisplayItem

--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -8,6 +8,7 @@
     var inProgressCount = Model.MyInProgressTaskDisplays.Count;
     var submittedCount = Model.MySubmittedTaskDisplays.Count;
     var activeSprintTaskCount = Model.MyActiveSprintTaskDisplays.Count;
+    var remainingAssignedTaskCount = Model.MyRemainingAssignedTaskDisplays.Count;
 }
 
 @* SECTION: Personal execution KPI strip. *@
@@ -97,6 +98,20 @@
             <span class="at-count-chip">@submittedCount</span>
         </div>
         <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.MySubmittedTaskDisplays, "No submitted tasks are awaiting closure.")' />
+    </article>
+</section>
+
+@* SECTION: Remaining assigned work keeps personal tasks reachable even when they do not belong to the priority lanes above. *@
+<section class="at-section-group">
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h3>Remaining assigned work</h3>
+                <p class="at-panel-note">Open assigned tasks outside today's, overdue, in-progress, submitted, and active sprint lanes.</p>
+            </div>
+            <span class="at-count-chip">@remainingAssignedTaskCount</span>
+        </div>
+        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.MyRemainingAssignedTaskDisplays, "No remaining assigned tasks outside the priority lanes.", false)' />
     </article>
 </section>
 

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -91,6 +91,25 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task MyWorkPartial_RendersAssignedTasksOutsidePriorityLanes()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Remaining assigned work", html, StringComparison.Ordinal);
+        Assert.Contains("Open task AT-", html, StringComparison.Ordinal);
+        Assert.Contains("Mine", html, StringComparison.Ordinal);
+        Assert.Single(page.MyRemainingAssignedTaskDisplays);
+    }
+
+    [Fact]
     public async Task TaskDetailsPartial_KanbanInspectorFormsCarryPlanningView()
     {
         // SECTION: Arrange


### PR DESCRIPTION
### Motivation
- Ensure assigned tasks that do not fit the existing priority lanes (due-today, overdue, in-progress, submitted, active-sprint) remain visible in the "My Work" view so users do not lose sight of assigned backlog/future tasks.

### Description
- Added a `MyRemainingAssignedTaskDisplays` projection to `Pages/ActionTasks/Index.cshtml.cs` that exposes remaining assigned tasks as `TaskDisplayItem`s using `ToDisplayItems`.
- Implemented `GetRemainingAssignedTasks()` in `Pages/ActionTasks/Index.cshtml.cs` which returns open tasks filtered to exclude today-due, overdue, in-progress, submitted, and active-sprint assignments.
- Rendered a new "Remaining assigned work" section in `Pages/ActionTasks/_TaskMyWork.cshtml` and reused the existing CSP-safe `_TaskCards` partial to list the tasks (no inline scripts introduced).
- Added a unit test `MyWorkPartial_RendersAssignedTasksOutsidePriorityLanes` in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert the new section renders and the expected item appears.

### Testing
- Added `MyWorkPartial_RendersAssignedTasksOutsidePriorityLanes` to the `ActionTaskPageTests` suite and committed the test; it has not been executed in this environment because the `dotnet` CLI is not available here, so automated test execution could not be performed (`dotnet test` returned "command not found").
- Changes were committed locally and a PR branch was prepared with the described diffs (`Pages/ActionTasks/Index.cshtml.cs`, `Pages/ActionTasks/_TaskMyWork.cshtml`, `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb562152388329b271ab2b61795a60)