### PR TITLE
Update sprint modification guard

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -192,9 +192,7 @@ public class IndexModel : PageModel
     }
 
     public bool CanModifySelectedSprint =>
-        CanPlanSprints
-        && SelectedSprint is not null
-        && SelectedSprint.Status != ActionSprintStatus.Closed;
+        CanPlanSprints && SelectedSprint is not null && SelectedSprint.Status != ActionSprintStatus.Closed;
 
     public bool CanReviewSprintClosure =>
         CanPlanSprints


### PR DESCRIPTION
### Motivation
- Consolidate the sprint-modification guard into a single expression that requires sprint planning permission, a selected sprint, and that the selected sprint is not closed.

### Description
- Replace the multiline `public bool CanModifySelectedSprint =>` block in `Pages/ActionTasks/Index.cshtml.cs` with `CanPlanSprints && SelectedSprint is not null && SelectedSprint.Status != ActionSprintStatus.Closed;`.

### Testing
- Attempted `dotnet build ProjectManagement.sln` and `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter FullyQualifiedName~ActionTasks`, but both could not be executed because the `dotnet` SDK is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5e69c76c8329be3d2fe0c158f2a4)