### PR TITLE
Update Task Reports: defer historical trend messaging

### DIFF
--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -6,7 +6,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Task Analysis Reports</h2>
-                <p class="at-panel-note">Analytical views for ageing, closure latency, workload distribution, and priority exposure.</p>
+                <p class="at-panel-note">Analytical views computed from current task and sprint data, with historical trend reporting deferred until sprint metric snapshots exist.</p>
             </div>
         </div>
         <p class="at-empty-state-note">This page intentionally excludes the Command Centre KPI strip so reports remain focused on analysis rather than operational command cards.</p>
@@ -143,6 +143,6 @@
                 <p class="at-panel-note">Trend charts require dated snapshot data before they can show reliable movement over time.</p>
             </div>
         </div>
-        <p class="at-empty-state-note">Trend reporting is deferred for this phase. The current task read model only exposes the present state, so this page will not duplicate Command Centre cards as a substitute for missing history.</p>
+        <p class="at-empty-state-note">Trend reporting will be enabled after historical sprint metrics are available.</p>
     </article>
 </section>


### PR DESCRIPTION
### Motivation
- Provide a minimal deferred state for historical trend reports while preserving all analytical sections computed from existing task and sprint data and avoid any Phase 1 schema changes.

### Description
- Update `Pages/ActionTasks/_TaskReports.cshtml` to revise the reports introduction copy and replace the historical trend placeholder with the minimal message: `Trend reporting will be enabled after historical sprint metrics are available.`

### Testing
- Attempted to run `dotnet test ProjectManagement.sln` but the command could not execute in this environment because `dotnet` is not installed, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb60dc5a2c83298921b1ec10d2a4cb)