### PR TITLE
Add PriorityOptions to workflow policy and expose to ActionTasks index (fix _TaskSprints compile error)

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -168,6 +168,7 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
+    public IReadOnlyList<string> PriorityOptions => _workflowPolicy.PriorityOptions;
     public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
     public IReadOnlyList<ActionSprint> AssignableSprints => Sprints.Where(s => s.Status != ActionSprintStatus.Closed).ToList();
     public IReadOnlyList<ActionSprint> ClosureTargetSprints => SprintClosureReview.TargetSprintOptions;

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -13,13 +13,21 @@ public sealed class ActionTaskWorkflowPolicy
         _permission = permission;
     }
 
-    // SECTION: Supported transition targets for in-flight status updates.
+    // SECTION: Supported option lists for task forms and filters.
     public IReadOnlyList<string> AllowedStatusOptions => new[]
     {
         ActionTaskStatuses.Assigned,
         ActionTaskStatuses.InProgress,
         ActionTaskStatuses.Blocked,
         ActionTaskStatuses.Submitted
+    };
+
+    public IReadOnlyList<string> PriorityOptions => new[]
+    {
+        "Low",
+        "Normal",
+        "High",
+        "Critical"
     };
 
     // SECTION: Action availability guards.


### PR DESCRIPTION
### Motivation
- Fix a compile/runtime error in the planning backlog partial where `Model.PriorityOptions` was referenced but not exposed from the page model, and centralise priority option values for forms and filters.

### Description
- Added a shared `PriorityOptions` list to `Services/ActionTasks/ActionTaskWorkflowPolicy` and exposed it via `Pages/ActionTasks/Index.cshtml.cs` as `PriorityOptions` so the `_TaskSprints.cshtml` partial can render the priority filter.

### Testing
- Verified code references with `rg` to confirm `PriorityOptions` is present where used and ran `git diff --check`; attempted `dotnet build --no-restore` but the `dotnet` CLI is not available in this environment so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb61c639c48329a0d7ce8c521b570f)