### PR TITLE
Planning Board: add internal Plan/Execute/Close/Views tabs and simplify layout

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -3,12 +3,6 @@
 @{
     ViewData["Title"] = "Task Tracker";
     ViewData["UseFullWidth"] = true;
-
-    // SECTION: Planning Board view-state normalization keeps Kanban out of primary navigation.
-    var resolvedPlanningView = Model.ResolvedPlanningView;
-    var isDefaultPlanningView = string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase);
-    var isDueExceptionsPlanningView = string.Equals(resolvedPlanningView, "DueExceptions", StringComparison.OrdinalIgnoreCase);
-    var isKanbanPlanningView = string.Equals(resolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase);
 }
 @section Styles {
     <link rel="stylesheet" href="~/css/action-tracker.css" asp-append-version="true" />
@@ -55,45 +49,8 @@
         }
         else if (Model.IsPlanningView)
         {
-            @* SECTION: Planning Board secondary view toggle uses PlanningView query state instead of a top-level Kanban navigation mode. *@
-            <nav class="at-panel at-planning-view-toggle" aria-label="Planning Board view toggle">
-                <span class="at-section-eyebrow">Planning Board view</span>
-                <div class="btn-group" role="group" aria-label="Planning Board view options">
-                    <a asp-page="/ActionTasks/Index"
-                       asp-route-viewMode="Planning"
-                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
-                       asp-route-taskId="@Model.TaskId"
-                       class="btn btn-sm @(isDefaultPlanningView ? "btn-primary" : "btn-outline-primary")"
-                       aria-current="@(isDefaultPlanningView ? "page" : null)">Default</a>
-                    <a asp-page="/ActionTasks/Index"
-                       asp-route-viewMode="Planning"
-                       asp-route-PlanningView="DueExceptions"
-                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
-                       asp-route-taskId="@Model.TaskId"
-                       class="btn btn-sm @(isDueExceptionsPlanningView ? "btn-primary" : "btn-outline-primary")"
-                       aria-current="@(isDueExceptionsPlanningView ? "page" : null)">Due / exceptions</a>
-                    <a asp-page="/ActionTasks/Index"
-                       asp-route-viewMode="Planning"
-                       asp-route-PlanningView="Kanban"
-                       asp-route-SelectedSprintId="@Model.SelectedSprintId"
-                       asp-route-taskId="@Model.TaskId"
-                       class="btn btn-sm @(isKanbanPlanningView ? "btn-primary" : "btn-outline-primary")"
-                       aria-current="@(isKanbanPlanningView ? "page" : null)">Kanban</a>
-                </div>
-            </nav>
-
-            @if (isDueExceptionsPlanningView)
-            {
-                <partial name="_TaskSprintBoard" model="Model" />
-            }
-            else if (isKanbanPlanningView)
-            {
-                <partial name="_TaskKanban" model="Model" />
-            }
-            else
-            {
-                <partial name="_TaskSprints" model="Model" />
-            }
+            @* SECTION: Planning Board internal tabs are rendered inside the board partial to avoid competing major sections. *@
+            <partial name="_TaskSprints" model="Model" />
         }
         else if (Model.IsMyWorkView)
         {

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -87,6 +87,9 @@ public class IndexModel : PageModel
     public string? PlanningView { get; set; }
 
     [BindProperty(SupportsGet = true)]
+    public string? PlanningTab { get; set; }
+
+    [BindProperty(SupportsGet = true)]
     public string? FilterStatus { get; set; }
 
     [BindProperty(SupportsGet = true)]
@@ -135,6 +138,7 @@ public class IndexModel : PageModel
     public bool CanClose => _permission.CanClose(CurrentRole);
     public string ResolvedViewMode => ResolveViewMode();
     public string ResolvedPlanningView => ResolvePlanningView();
+    public string ResolvedPlanningTab => ResolvePlanningTab();
     public bool IsCommandCentreView => string.Equals(ResolvedViewMode, "CommandCentre", StringComparison.OrdinalIgnoreCase);
     public bool IsPlanningView => string.Equals(ResolvedViewMode, "Planning", StringComparison.OrdinalIgnoreCase);
     public bool IsMyWorkView => string.Equals(ResolvedViewMode, "MyWork", StringComparison.OrdinalIgnoreCase);
@@ -147,6 +151,10 @@ public class IndexModel : PageModel
     public bool IsTaskListView => IsRegisterView;
     public bool IsKanbanView => IsPlanningView && string.Equals(ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase);
     public bool IsSprintBoardView => IsPlanningView && string.Equals(ResolvedPlanningView, "DueExceptions", StringComparison.OrdinalIgnoreCase);
+    public bool IsPlanningPlanTab => IsPlanningView && string.Equals(ResolvedPlanningTab, "Plan", StringComparison.OrdinalIgnoreCase);
+    public bool IsPlanningExecuteTab => IsPlanningView && string.Equals(ResolvedPlanningTab, "Execute", StringComparison.OrdinalIgnoreCase);
+    public bool IsPlanningCloseTab => IsPlanningView && string.Equals(ResolvedPlanningTab, "Close", StringComparison.OrdinalIgnoreCase);
+    public bool IsPlanningViewsTab => IsPlanningView && string.Equals(ResolvedPlanningTab, "Views", StringComparison.OrdinalIgnoreCase);
     public bool IsBacklogView => IsLegacyViewMode("Backlog") || IsPlanningBacklogFilterContext();
     public bool IsSprintsView => IsPlanningView;
     public string PageHeading => ResolvedViewMode switch
@@ -1326,6 +1334,45 @@ public class IndexModel : PageModel
         };
     }
 
+
+    // SECTION: Planning Board internal tab normalization keeps planning, execution, closure, and alternate views separated.
+    private string ResolvePlanningTab()
+    {
+        var normalized = (PlanningTab ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            return normalized switch
+            {
+                _ when string.Equals(normalized, "Plan", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Planning", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Backlog", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Execute", StringComparison.OrdinalIgnoreCase) => "Execute",
+                _ when string.Equals(normalized, "Execution", StringComparison.OrdinalIgnoreCase) => "Execute",
+                _ when string.Equals(normalized, "Close", StringComparison.OrdinalIgnoreCase) => "Close",
+                _ when string.Equals(normalized, "Closure", StringComparison.OrdinalIgnoreCase) => "Close",
+                _ when string.Equals(normalized, "Views", StringComparison.OrdinalIgnoreCase) => "Views",
+                _ when string.Equals(normalized, "View", StringComparison.OrdinalIgnoreCase) => "Views",
+                _ => GetDefaultPlanningTab()
+            };
+        }
+
+        // SECTION: Legacy PlanningView aliases open the new Views tab while keeping old links functional.
+        if (!string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Views";
+        }
+
+        return GetDefaultPlanningTab();
+    }
+
+    // SECTION: Planning tab default follows selected planning window availability.
+    private string GetDefaultPlanningTab()
+    {
+        return SelectedSprintId.HasValue || SelectedSprint is not null || ActiveSprint is not null
+            ? "Execute"
+            : "Plan";
+    }
+
     // SECTION: Shared task redirect route preserves workspace, selection, and relevant list state from inspector actions.
     private RedirectToPageResult RedirectToTaskPage(int? taskId, int? selectedSprintId)
     {
@@ -1342,6 +1389,11 @@ public class IndexModel : PageModel
             [nameof(TaskId)] = taskId,
             [nameof(SelectedSprintId)] = selectedSprintId
         };
+
+        if (IsPlanningView && !string.Equals(ResolvedPlanningTab, GetDefaultPlanningTab(), StringComparison.OrdinalIgnoreCase))
+        {
+            routeValues[nameof(PlanningTab)] = ResolvedPlanningTab;
+        }
 
         if (IsPlanningView && !string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase))
         {

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -1,7 +1,20 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 
-@* SECTION: Planning Board workspace uses a command strip, left planning index, backlog queue, execution board, and attention lane. *@
+@{
+    // SECTION: Planning Board Phase 3A-1 tab state and execution group projections.
+    var planningTab = Model.ResolvedPlanningTab;
+    var isPlanTab = string.Equals(planningTab, "Plan", StringComparison.OrdinalIgnoreCase);
+    var isExecuteTab = string.Equals(planningTab, "Execute", StringComparison.OrdinalIgnoreCase);
+    var isCloseTab = string.Equals(planningTab, "Close", StringComparison.OrdinalIgnoreCase);
+    var isViewsTab = string.Equals(planningTab, "Views", StringComparison.OrdinalIgnoreCase);
+    var activeStatuses = new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted };
+    var closedTasks = Model.GetSprintTasksByStatus(ActionTaskStatuses.Closed);
+    var attentionCount = Model.SprintAttentionOverdueTaskDisplays.Count + Model.SprintAttentionBlockedTaskDisplays.Count + Model.SprintAttentionSubmittedTaskDisplays.Count;
+    var viewsPlanningView = string.Equals(Model.ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase) ? "DueExceptions" : Model.ResolvedPlanningView;
+}
+
+@* SECTION: Planning Board workspace separates planning, execution, closure, and alternate views into internal tabs. *@
 <section class="at-sprints-workspace at-planning-board-workspace">
     @* SECTION: Selected planning window command strip with existing service-backed sprint actions. *@
     <section class="at-panel at-sprint-command-strip">
@@ -13,12 +26,12 @@
                     @if (!Model.Sprints.Any())
                     {
                         <strong>No planning window has been created yet.</strong>
-                        <span>Create the first planning window to start planning task execution from this workspace.</span>
+                        <span>Create the first planning window from Plan to start execution planning.</span>
                     }
                     else
                     {
                         <strong>No planning window is selected.</strong>
-                        <span>Select an existing planning window, or create another planning window.</span>
+                        <span>Select an existing planning window from Plan to open Execute.</span>
                     }
                 </div>
                 @if (Model.CanPlanSprints)
@@ -28,6 +41,7 @@
                             <summary class="btn btn-primary btn-sm">Create Planning Window</summary>
                             <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
                                 <input type="hidden" name="ViewMode" value="Planning" />
+                                <input type="hidden" name="PlanningTab" value="Plan" />
                                 <div asp-validation-summary="All" class="text-danger small"></div>
                                 <label class="form-label" asp-for="SprintInput.Name"></label>
                                 <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
@@ -76,6 +90,7 @@
                             <summary class="btn btn-primary btn-sm">Create Planning Window</summary>
                             <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
                                 <input type="hidden" name="ViewMode" value="Planning" />
+                                <input type="hidden" name="PlanningTab" value="Plan" />
                                 <div asp-validation-summary="All" class="text-danger small"></div>
                                 <label class="form-label" asp-for="SprintInput.Name"></label>
                                 <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
@@ -92,11 +107,12 @@
                     @if (Model.CanEditSelectedSprint)
                     {
                         <details class="at-sprint-form-disclosure" open="@Model.ShowEditSprintPanel">
-                            <summary class="btn btn-outline-primary btn-sm">Edit Planning Window</summary>
+                            <summary class="btn btn-outline-primary btn-sm">Edit Window</summary>
                             <form method="post" asp-page-handler="UpdateSprint" class="at-sprint-command-form">
                                 <input type="hidden" name="ViewMode" value="Planning" />
-                                <input type="hidden" asp-for="SprintEditInput.SprintId" value="@Model.SelectedSprint.Id" />
-                                <input type="hidden" asp-for="SprintEditInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
+                                <input type="hidden" name="PlanningTab" value="Plan" />
+                                <input type="hidden" asp-for="SprintEditInput.SprintId" />
+                                <input type="hidden" asp-for="SprintEditInput.RowVersion" />
                                 <div asp-validation-summary="All" class="text-danger small"></div>
                                 <label class="form-label" asp-for="SprintEditInput.Name"></label>
                                 <input class="form-control" asp-for="SprintEditInput.Name" maxlength="160" />
@@ -113,6 +129,7 @@
                     @if (Model.CanActivateSelectedSprint)
                     {
                         <form method="post" asp-page-handler="ActivateSprint">
+                            <input type="hidden" name="PlanningTab" value="Execute" />
                             <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
                             <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
                             <button type="submit" class="btn btn-success btn-sm">Activate</button>
@@ -121,6 +138,7 @@
                     @if (Model.CanCloseSelectedSprintDirectly)
                     {
                         <form method="post" asp-page-handler="CloseSprint">
+                            <input type="hidden" name="PlanningTab" value="Close" />
                             <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
                             <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
                             <button type="submit" class="btn btn-danger btn-sm">Close</button>
@@ -128,97 +146,132 @@
                     }
                     else if (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any())
                     {
-                        <a class="btn btn-outline-danger btn-sm" href="#sprint-closure-review">Review close</a>
+                        <a class="btn btn-outline-danger btn-sm" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@Model.SelectedSprintId">Review close</a>
                     }
                 </div>
             }
         }
     </section>
 
-    <div class="at-sprint-layout at-sprint-layout-refined">
-        @* SECTION: Left planning pane highlights active/selected planning windows and hosts the expandable backlog queue. *@
-        <aside class="at-panel at-sprint-list-panel">
-            <div class="at-panel-heading">
-                <h2>Planning Board</h2>
-                <span class="at-count-chip">@Model.Sprints.Count</span>
-            </div>
-            @if (!Model.Sprints.Any())
-            {
-                <div class="at-empty-state at-empty-state-compact">No planning window has been created yet. Use Create Planning Window to create the first planning window.</div>
-            }
-            else
-            {
-                <form method="get" class="at-sprint-selector-form at-sprint-selector-compact" data-at-sprint-selector="true">
-                    <input type="hidden" name="viewMode" value="Planning" />
-                    <label class="form-label at-small" for="SelectedSprintId">Quick open</label>
-                    <select class="form-select form-select-sm" id="SelectedSprintId" name="SelectedSprintId">
-                        @foreach (var sprint in Model.Sprints)
+    @* SECTION: Planning Board internal tabs prevent all major sections from rendering at once. *@
+    <nav class="at-panel at-planning-tabs" aria-label="Planning Board tabs">
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(isPlanTab ? "active" : string.Empty)" aria-current="@(isPlanTab ? "page" : null)"><span>Plan</span><small>Windows & backlog</small></a>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(isExecuteTab ? "active" : string.Empty)" aria-current="@(isExecuteTab ? "page" : null)"><span>Execute</span><small>Status board</small></a>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(isCloseTab ? "active" : string.Empty)" aria-current="@(isCloseTab ? "page" : null)"><span>Close</span><small>Review & history</small></a>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="@viewsPlanningView" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(isViewsTab ? "active" : string.Empty)" aria-current="@(isViewsTab ? "page" : null)"><span>Views</span><small>Due & Kanban</small></a>
+    </nav>
+
+    @if (isPlanTab)
+    {
+        @* SECTION: Plan tab contains planning-window list, backlog filters, backlog queue, and assignment. *@
+        <section class="at-planning-tab-panel at-planning-plan-grid" aria-label="Planning Board Plan tab">
+            <aside class="at-panel at-sprint-list-panel at-planning-plan-card">
+                <div class="at-panel-heading">
+                    <h2>Planning Windows</h2>
+                    <span class="at-count-chip">@Model.Sprints.Count</span>
+                </div>
+                @if (!Model.Sprints.Any())
+                {
+                    <div class="at-empty-state at-empty-state-compact">No planning window has been created yet.</div>
+                }
+                else
+                {
+                    <form method="get" class="at-sprint-selector-form at-sprint-selector-compact" data-at-sprint-selector="true">
+                        <input type="hidden" name="viewMode" value="Planning" />
+                        <input type="hidden" name="PlanningTab" value="Execute" />
+                        <label class="form-label at-small" for="SelectedSprintId">Quick open</label>
+                        <select class="form-select form-select-sm" id="SelectedSprintId" name="SelectedSprintId">
+                            @foreach (var sprint in Model.Sprints)
+                            {
+                                if (Model.SelectedSprint?.Id == sprint.Id)
+                                {
+                                    <option value="@sprint.Id" selected>@sprint.Name (@sprint.Status)</option>
+                                }
+                                else
+                                {
+                                    <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
+                                }
+                            }
+                        </select>
+                        <button type="submit" class="btn btn-outline-primary btn-sm">Open Planning Window</button>
+                    </form>
+
+                    <div class="at-sprint-list-group">
+                        <div class="at-sprint-list-heading">Active</div>
+                        @if (Model.ActiveSprint is null)
                         {
-                            if (Model.SelectedSprint?.Id == sprint.Id)
-                            {
-                                <option value="@sprint.Id" selected>@sprint.Name (@sprint.Status)</option>
-                            }
-                            else
-                            {
-                                <option value="@sprint.Id">@sprint.Name (@sprint.Status)</option>
-                            }
+                            <div class="at-empty-inline">No active planning window.</div>
                         }
-                    </select>
-                    <button type="submit" class="btn btn-outline-primary btn-sm">Open Planning Window</button>
-                </form>
+                        else
+                        {
+                            <a class="at-sprint-list-item is-active @(Model.SelectedSprint?.Id == Model.ActiveSprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@Model.ActiveSprint.Id">
+                                <strong>@Model.ActiveSprint.Name</strong>
+                                <span>@Model.ActiveSprint.StartDate.ToString("dd MMM") – @Model.ActiveSprint.EndDate.ToString("dd MMM yyyy")</span>
+                            </a>
+                        }
+                    </div>
 
-                <div class="at-sprint-list-group">
-                    <div class="at-sprint-list-heading">Active</div>
-                    @if (Model.ActiveSprint is null)
-                    {
-                        <div class="at-empty-inline">No active planning window.</div>
-                    }
-                    else
-                    {
-                        <a class="at-sprint-list-item is-active @(Model.SelectedSprint?.Id == Model.ActiveSprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@Model.ActiveSprint.Id">
-                            <strong>@Model.ActiveSprint.Name</strong>
-                            <span>@Model.ActiveSprint.StartDate.ToString("dd MMM") – @Model.ActiveSprint.EndDate.ToString("dd MMM yyyy")</span>
-                        </a>
-                    }
-                </div>
+                    <div class="at-sprint-list-group">
+                        <div class="at-sprint-list-heading">Planned</div>
+                        @if (!Model.PlannedSprints.Any())
+                        {
+                            <div class="at-empty-inline">No planned windows.</div>
+                        }
+                        @foreach (var sprint in Model.PlannedSprints)
+                        {
+                            <a class="at-sprint-list-item @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@sprint.Id">
+                                <strong>@sprint.Name</strong>
+                                <span>@sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</span>
+                            </a>
+                        }
+                    </div>
 
-                <div class="at-sprint-list-group">
-                    <div class="at-sprint-list-heading">Planned</div>
-                    @if (!Model.PlannedSprints.Any())
-                    {
-                        <div class="at-empty-inline">No planned windows.</div>
-                    }
-                    @foreach (var sprint in Model.PlannedSprints)
-                    {
-                        <a class="at-sprint-list-item @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@sprint.Id">
-                            <strong>@sprint.Name</strong>
-                            <span>@sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</span>
-                        </a>
-                    }
-                </div>
+                    <details class="at-sprint-list-group is-closed">
+                        <summary class="at-sprint-list-heading">Closed <span class="at-count-chip">@Model.ClosedSprints.Count</span></summary>
+                        @if (!Model.ClosedSprints.Any())
+                        {
+                            <div class="at-empty-inline">No closed windows.</div>
+                        }
+                        @foreach (var sprint in Model.ClosedSprints.Take(8))
+                        {
+                            <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@sprint.Id">
+                                <strong>@sprint.Name</strong>
+                                <span>@sprint.EndDate.ToString("dd MMM yyyy")</span>
+                            </a>
+                        }
+                    </details>
+                }
 
-                <div class="at-sprint-list-group is-closed">
-                    <div class="at-sprint-list-heading">Closed</div>
-                    @if (!Model.ClosedSprints.Any())
-                    {
-                        <div class="at-empty-inline">No closed windows.</div>
-                    }
-                    @foreach (var sprint in Model.ClosedSprints.Take(8))
-                    {
-                        <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@sprint.Id">
-                            <strong>@sprint.Name</strong>
-                            <span>@sprint.EndDate.ToString("dd MMM yyyy")</span>
-                        </a>
-                    }
-                </div>
-            }
+                @if (Model.CanPlanSprints)
+                {
+                    <details class="at-sprint-form-disclosure at-plan-create-panel" open="@Model.ShowCreateSprintPanel">
+                        <summary class="btn btn-primary btn-sm">Create Planning Window</summary>
+                        <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form at-sprint-command-form-static">
+                            <input type="hidden" name="ViewMode" value="Planning" />
+                            <input type="hidden" name="PlanningTab" value="Plan" />
+                            <div asp-validation-summary="All" class="text-danger small"></div>
+                            <label class="form-label" asp-for="SprintInput.Name"></label>
+                            <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
+                            <label class="form-label" asp-for="SprintInput.StartDate"></label>
+                            <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
+                            <label class="form-label" asp-for="SprintInput.EndDate"></label>
+                            <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
+                            <label class="form-label" asp-for="SprintInput.Goal"></label>
+                            <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this planning window"></textarea>
+                            <button type="submit" class="btn btn-primary btn-sm">Create Planning Window</button>
+                        </form>
+                    </details>
+                }
+            </aside>
 
-            @* SECTION: Expandable backlog queue brings backlog triage and AssignToSprint posts into the Planning Board. *@
-            <details class="at-planning-backlog-queue" open>
-                <summary>
-                    <span>Backlog Queue</span>
+            <section class="at-panel at-planning-backlog-queue at-planning-plan-card">
+                <div class="at-panel-heading">
+                    <div>
+                        <h2>Backlog Queue</h2>
+                        <p class="at-panel-note">Filter backlog tasks and assign eligible work into a planning window.</p>
+                    </div>
                     <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
-                </summary>
+                </div>
                 <div class="at-planning-backlog-body">
                     <div class="at-backlog-summary-grid" aria-label="Backlog summary">
                         <article><strong>@Model.BacklogTotalCount</strong><span>Total backlog</span></article>
@@ -229,6 +282,7 @@
                     @* SECTION: Backlog filters remain GET-based and CSP-safe with no inline scripts. *@
                     <form method="get" class="at-planning-backlog-filter">
                         <input type="hidden" name="viewMode" value="Planning" />
+                        <input type="hidden" name="PlanningTab" value="Plan" />
                         <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                         <label class="form-label at-small" for="PlanningFilterStatus">Status</label>
                         <select class="form-select form-select-sm" id="PlanningFilterStatus" name="FilterStatus">
@@ -266,7 +320,7 @@
                         <input type="text" class="form-control form-control-sm" id="PlanningFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
                         <div class="at-planning-backlog-filter-actions">
                             <button type="submit" class="btn btn-outline-primary btn-sm">Apply</button>
-                            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-outline-secondary btn-sm">Reset</a>
+                            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-outline-secondary btn-sm">Reset</a>
                         </div>
                     </form>
 
@@ -282,7 +336,7 @@
                             {
                                 var task = item.Task;
                                 <article class="at-planning-backlog-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                                    <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
+                                    <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
                                     <div class="at-backlog-task-meta">
                                         <span class="at-cell-primary">@item.AssigneeName</span>
                                         <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
@@ -301,6 +355,7 @@
                                         {
                                             <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
                                                 <input type="hidden" name="ViewMode" value="Planning" />
+                                                <input type="hidden" name="PlanningTab" value="Execute" />
                                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                                 <input type="hidden" name="id" value="@task.Id" />
                                                 <select class="form-select form-select-sm" name="sprintId" aria-label="Select planning window for AT-@task.Id" required>
@@ -323,199 +378,229 @@
                         </div>
                     }
                 </div>
-            </details>
-        </aside>
-
-        @* SECTION: Centre Planning Board execution surface groups tasks by workflow status without changing lifecycle rules. *@
-        <main class="at-sprint-execution-main">
-            @if (Model.CanModifySelectedSprint)
+            </section>
+        </section>
+    }
+    else if (isExecuteTab)
+    {
+        @* SECTION: Execute tab keeps service-backed task cards focused on active execution statuses. *@
+        <section class="at-planning-tab-panel at-sprint-execution-main" aria-label="Planning Board Execute tab">
+            @if (Model.SelectedSprint is null)
             {
-                <section class="at-panel at-sprint-planning-panel">
-                    <div class="at-panel-heading">
-                        <h2>Add Backlog Task to Planning Window</h2>
-                        <span class="at-panel-note">Available to Comdt and HoD only.</span>
+                <div class="at-panel at-empty-state at-empty-state-compact">Select or create a planning window in Plan before using Execute.</div>
+            }
+            else
+            {
+                @if (Model.CanModifySelectedSprint)
+                {
+                    <section class="at-panel at-sprint-planning-panel at-execute-compact-assignment">
+                        <div class="at-panel-heading">
+                            <h2>Add Backlog Task</h2>
+                            <span class="at-panel-note">Backlog queue stays in Plan; use this compact assignment for quick additions.</span>
+                        </div>
+                        <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
+                            <input type="hidden" name="ViewMode" value="Planning" />
+                            <input type="hidden" name="PlanningTab" value="Execute" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint?.Id" />
+                            <input type="hidden" name="sprintId" value="@Model.SelectedSprint?.Id" />
+                            <select class="form-select" name="id" aria-label="Select backlog task" required>
+                                <option value="">Select backlog task</option>
+                                @foreach (var item in Model.AssignableBacklogTaskDisplays)
+                                {
+                                    <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
+                                }
+                            </select>
+                            <button type="submit" class="btn btn-primary" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign</button>
+                        </form>
+                    </section>
+                }
+
+                <details class="at-panel at-sprint-attention-lane at-execute-attention" @(attentionCount > 0 ? "open" : null)>
+                    <summary>Execution attention <span class="at-count-chip">@attentionCount</span></summary>
+                    <div class="at-attention-grid">
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
+                        </div>
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
+                        </div>
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
+                        </div>
                     </div>
-                    <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
-                        <input type="hidden" name="ViewMode" value="Planning" />
-                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint?.Id" />
-                        <input type="hidden" name="sprintId" value="@Model.SelectedSprint?.Id" />
-                        <select class="form-select" name="id" aria-label="Select backlog task" required>
-                            <option value="">Select backlog task</option>
-                            @foreach (var item in Model.AssignableBacklogTaskDisplays)
-                            {
-                                <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
-                            }
-                        </select>
-                        <button type="submit" class="btn btn-primary" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign to Planning Window</button>
-                    </form>
+                </details>
+
+                <section class="at-sprint-board-stack" aria-label="Selected Planning Board task board">
+                    <div class="at-board-grid is-sprints at-sprint-primary-statuses">
+                        @foreach (var status in activeStatuses)
+                        {
+                            var groupedTasks = Model.GetSprintTasksByStatus(status);
+                            <article class="at-panel at-board-column at-sprint-board-column">
+                                <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
+                                @if (!groupedTasks.Any())
+                                {
+                                    <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
+                                }
+                                else
+                                {
+                                    <div class="at-task-cards">
+                                        @foreach (var item in groupedTasks)
+                                        {
+                                            var task = item.Task;
+                                            <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                                <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
+                                                    <div class="at-card-top-row">
+                                                        <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
+                                                        <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                                    </div>
+                                                    <dl class="at-card-facts">
+                                                        <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
+                                                        <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
+                                                    </dl>
+                                                    <div class="at-card-footer">
+                                                        <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                                                        @if (Model.IsTaskOverdue(task))
+                                                        {
+                                                            <span class="at-overdue-marker">Overdue</span>
+                                                        }
+                                                        <span class="at-open-details-label">Open details</span>
+                                                    </div>
+                                                </a>
+                                                @if (Model.CanMoveTaskToBacklog(task))
+                                                {
+                                                    <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
+                                                        <input type="hidden" name="ViewMode" value="Planning" />
+                                                        <input type="hidden" name="PlanningTab" value="Execute" />
+                                                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                                        <input type="hidden" name="id" value="@task.Id" />
+                                                        <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
+                                                    </form>
+                                                }
+                                            </article>
+                                        }
+                                    </div>
+                                }
+                            </article>
+                        }
+                    </div>
+
+                    <details class="at-panel at-board-column at-sprint-board-column at-sprint-closed-section">
+                        <summary>@(ActionTaskStatuses.Closed) <span class="at-count-chip">@closedTasks.Count</span></summary>
+                        @if (!closedTasks.Any())
+                        {
+                            <p class="at-empty-inline">No @(ActionTaskStatuses.Closed.ToLowerInvariant()) tasks.</p>
+                        }
+                        else
+                        {
+                            <div class="at-task-cards at-sprint-closed-cards">
+                                @foreach (var item in closedTasks)
+                                {
+                                    var task = item.Task;
+                                    <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                                        <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
+                                            <div class="at-card-top-row">
+                                                <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
+                                                <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                                            </div>
+                                            <dl class="at-card-facts">
+                                                <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
+                                                <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
+                                            </dl>
+                                            <div class="at-card-footer">
+                                                <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                                                <span class="at-open-details-label">Open details</span>
+                                            </div>
+                                        </a>
+                                    </article>
+                                }
+                            </div>
+                        }
+                    </details>
                 </section>
             }
-
-            <partial name="_SprintClosureReview" model="Model" />
-
-            @* SECTION: Primary Planning Board keeps active workflow statuses in the main row to avoid default horizontal scrolling. *@
-            <section class="at-sprint-board-stack" aria-label="Selected Planning Board task board">
-                <div class="at-board-grid is-sprints at-sprint-primary-statuses">
-                    @foreach (var status in new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted })
-                    {
-                        var groupedTasks = Model.GetSprintTasksByStatus(status);
-                        <article class="at-panel at-board-column at-sprint-board-column">
-                            <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
-                            @if (!groupedTasks.Any())
-                            {
-                                <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
-                            }
-                            else
-                            {
-                                <div class="at-task-cards">
-                                    @foreach (var item in groupedTasks)
-                                    {
-                                        var task = item.Task;
-                                        <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                                            <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
-                                                <div class="at-card-top-row">
-                                                    <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
-                                                    <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                                                </div>
-                                                <dl class="at-card-facts">
-                                                    <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
-                                                    <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
-                                                </dl>
-                                                <div class="at-card-footer">
-                                                    <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
-                                                    @if (Model.IsTaskOverdue(task))
-                                                    {
-                                                        <span class="at-overdue-marker">Overdue</span>
-                                                    }
-                                                    <span class="at-open-details-label">Open details</span>
-                                                </div>
-                                            </a>
-                                            @if (Model.CanMoveTaskToBacklog(task))
-                                            {
-                                                <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
-                                                    <input type="hidden" name="ViewMode" value="Planning" />
-                                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                                    <input type="hidden" name="id" value="@task.Id" />
-                                                    <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
-                                                </form>
-                                            }
-                                        </article>
-                                    }
-                                </div>
-                            }
-                        </article>
-                    }
-                </div>
-
-                @* SECTION: Closed work remains grouped but moves below active execution statuses to protect board width. *@
-                @{
-                    var closedTasks = Model.GetSprintTasksByStatus(ActionTaskStatuses.Closed);
-                }
-                <article class="at-panel at-board-column at-sprint-board-column at-sprint-closed-section">
-                    <div class="at-panel-heading"><h2>@(ActionTaskStatuses.Closed)</h2><span class="at-count-chip">@closedTasks.Count</span></div>
-                    @if (!closedTasks.Any())
-                    {
-                        <p class="at-empty-inline">No @(ActionTaskStatuses.Closed.ToLowerInvariant()) tasks.</p>
-                    }
-                    else
-                    {
-                        <div class="at-task-cards at-sprint-closed-cards">
-                            @foreach (var item in closedTasks)
-                            {
-                                var task = item.Task;
-                                <article class="at-task-card at-sprint-task-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                                    <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-SelectedSprintId="@Model.SelectedSprintId" aria-label="Open task AT-@task.Id details">
-                                        <div class="at-card-top-row">
-                                            <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
-                                            <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                                        </div>
-                                        <dl class="at-card-facts">
-                                            <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
-                                            <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
-                                        </dl>
-                                        <div class="at-card-footer">
-                                            <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
-                                            @if (Model.IsTaskOverdue(task))
-                                            {
-                                                <span class="at-overdue-marker">Overdue</span>
-                                            }
-                                            <span class="at-open-details-label">Open details</span>
-                                        </div>
-                                    </a>
-                                    @if (Model.CanMoveTaskToBacklog(task))
-                                    {
-                                        <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
-                                            <input type="hidden" name="ViewMode" value="Planning" />
-                                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                            <input type="hidden" name="id" value="@task.Id" />
-                                            <button type="submit" class="btn btn-outline-secondary btn-sm">Move to Backlog</button>
-                                        </form>
-                                    }
-                                </article>
-                            }
-                        </div>
-                    }
-                </article>
-            </section>
-
-            @* SECTION: Attention lane sits below execution board so it remains visible without stealing board width. *@
-            <aside class="at-panel at-sprint-attention-lane">
-                <div class="at-panel-heading"><h2>Attention Lane</h2></div>
-                <div class="at-attention-grid">
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
-                    </div>
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
-                    </div>
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
-                    </div>
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Carry-forward candidates</span><strong>@Model.SprintCarryForwardCandidateDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
-                    </div>
-                </div>
-            </aside>
-
-            @* SECTION: Collapsible due/exception review remains nested in Planning Board; Kanban stays an alternate secondary view. *@
-            <partial name="_TaskSprintBoard" model="Model" />
-            <partial name="_TaskKanban" model="Model" />
-
-            @if (Model.SelectedSprint is not null)
+        </section>
+    }
+    else if (isCloseTab)
+    {
+        @* SECTION: Close tab groups closure review, carry-forward, next-window creation, and history. *@
+        <section class="at-planning-tab-panel at-sprint-execution-main" aria-label="Planning Board Close tab">
+            @if (Model.SelectedSprint is null)
             {
-                <details class="at-panel at-sprint-history-panel">
-                    <summary>Planning Window History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>
-                    @if (!Model.SprintAuditHistory.Any())
-                    {
-                        <p class="at-empty-inline">No planning lifecycle history is recorded yet.</p>
-                    }
-                    else
-                    {
-                        <ol class="at-sprint-history-list">
-                            @foreach (var entry in Model.SprintAuditHistory)
-                            {
-                                <li>
-                                    <div><strong>@entry.ActionType.Replace("Sprint", string.Empty)</strong> by @Model.ResolveSprintActorName(entry.PerformedByUserId)</div>
-                                    <small>@entry.PerformedAt.ToString("dd MMM yyyy HH:mm") UTC</small>
-                                    @if (!string.IsNullOrWhiteSpace(entry.Remarks))
-                                    {
-                                        <p>@entry.Remarks</p>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(entry.OldValue) || !string.IsNullOrWhiteSpace(entry.NewValue))
-                                    {
-                                        <code>@entry.OldValue → @entry.NewValue</code>
-                                    }
-                                </li>
-                            }
-                        </ol>
-                    }
+                <div class="at-panel at-empty-state at-empty-state-compact">Select a planning window in Plan before reviewing closure.</div>
+            }
+            else
+            {
+                <partial name="_SprintClosureReview" model="Model" />
+
+                <section class="at-panel at-sprint-attention-lane">
+                    <div class="at-panel-heading"><h2>Carry-forward candidates</h2><span class="at-count-chip">@Model.SprintCarryForwardCandidateDisplays.Count</span></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
+                </section>
+
+                @if (Model.SelectedSprint is not null)
+                {
+                    <details class="at-panel at-sprint-history-panel" open>
+                        <summary>Planning Window History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>
+                        @if (!Model.SprintAuditHistory.Any())
+                        {
+                            <p class="at-empty-inline">No planning lifecycle history is recorded yet.</p>
+                        }
+                        else
+                        {
+                            <ol class="at-sprint-history-list">
+                                @foreach (var entry in Model.SprintAuditHistory)
+                                {
+                                    <li>
+                                        <div><strong>@entry.ActionType.Replace("Sprint", string.Empty)</strong> by @Model.ResolveSprintActorName(entry.PerformedByUserId)</div>
+                                        <small>@entry.PerformedAt.ToString("dd MMM yyyy HH:mm") UTC</small>
+                                        @if (!string.IsNullOrWhiteSpace(entry.Remarks))
+                                        {
+                                            <p>@entry.Remarks</p>
+                                        }
+                                        @if (!string.IsNullOrWhiteSpace(entry.OldValue) || !string.IsNullOrWhiteSpace(entry.NewValue))
+                                        {
+                                            <code>@entry.OldValue → @entry.NewValue</code>
+                                        }
+                                    </li>
+                                }
+                            </ol>
+                        }
+                    </details>
+                }
+            }
+        </section>
+    }
+    else if (isViewsTab)
+    {
+        @* SECTION: Views tab keeps due/exception and Kanban alternate views selectable instead of competing with execution. *@
+        <section class="at-planning-tab-panel at-planning-views-panel" aria-label="Planning Board Views tab">
+            <nav class="at-panel at-planning-view-toggle" aria-label="Planning Board alternate view selector">
+                <span class="at-section-eyebrow">Alternate views</span>
+                <div class="btn-group" role="group" aria-label="Planning Board view options">
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="DueExceptions" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-outline-primary" : "btn-primary")">Due / exceptions</a>
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="Kanban" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")">Kanban</a>
+                </div>
+            </nav>
+
+            @if (string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase))
+            {
+                <partial name="_TaskKanban" model="Model" />
+                <details class="at-planning-secondary-view">
+                    <summary>Due / exceptions <span class="at-count-chip">@(Model.DueTodayTaskDisplays.Count + Model.DueThisWeekTaskDisplays.Count + Model.DueLaterTaskDisplays.Count + Model.SprintOverdueTaskDisplays.Count)</span></summary>
+                    <partial name="_TaskSprintBoard" model="Model" />
                 </details>
             }
-        </main>
-
-    </div>
+            else
+            {
+                <partial name="_TaskSprintBoard" model="Model" />
+                <details class="at-planning-secondary-view">
+                    <summary>Kanban alternate view <span class="at-count-chip">@(Model.KanbanAssignedTaskDisplays.Count + Model.KanbanInProgressTaskDisplays.Count + Model.KanbanBlockedTaskDisplays.Count + Model.KanbanSubmittedTaskDisplays.Count + Model.KanbanClosedTaskDisplays.Count)</span></summary>
+                    <p class="at-panel-note">Open Kanban from the selector above to review all workflow columns.</p>
+                </details>
+            }
+        </section>
+    }
 </section>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -539,8 +539,8 @@ public class ActionTaskPageTests
 
         // SECTION: Assert
         Assert.Null(page.SelectedSprint);
-        Assert.Contains("No sprint has been created yet", html, StringComparison.Ordinal);
-        Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("No planning window has been created yet", html, StringComparison.Ordinal);
+        Assert.Contains("Create Planning Window", html, StringComparison.Ordinal);
         Assert.Contains("handler=CreateSprint", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Select a sprint to view sprint command details.", html, StringComparison.Ordinal);
     }
@@ -561,8 +561,8 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskSprints.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Edit Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Create Planning Window", html, StringComparison.Ordinal);
+        Assert.Contains("Edit Window", html, StringComparison.Ordinal);
         Assert.DoesNotContain(">Create</summary>", html, StringComparison.Ordinal);
         Assert.DoesNotContain(">Edit</summary>", html, StringComparison.Ordinal);
     }
@@ -589,6 +589,7 @@ public class ActionTaskPageTests
         Assert.Contains("Selected Planning Board task board", html, StringComparison.Ordinal);
         Assert.Contains("Sprint board task", html, StringComparison.Ordinal);
         Assert.Contains("at-board-grid is-sprints", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Backlog Queue", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2173,3 +2173,172 @@ html {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     min-width: 0;
 }
+
+/* SECTION: Phase 3A-1 Planning Board internal tabs and simplified panes */
+.at-planning-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem;
+    padding: 0.55rem;
+}
+
+.at-planning-tabs a {
+    display: grid;
+    gap: 0.1rem;
+    border: 1px solid transparent;
+    border-radius: 12px;
+    color: var(--at-muted);
+    padding: 0.55rem 0.7rem;
+    text-decoration: none;
+    background: #f8fafc;
+}
+
+.at-planning-tabs a span {
+    color: var(--at-text);
+    font-size: var(--at-font-base);
+    font-weight: var(--at-weight-bold);
+}
+
+.at-planning-tabs a small {
+    color: var(--at-muted);
+    font-size: var(--at-font-xs);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-planning-tabs a.active {
+    border-color: #93c5fd;
+    background: #eff6ff;
+    box-shadow: inset 0 -3px 0 var(--at-blue);
+}
+
+.at-planning-tab-panel {
+    min-width: 0;
+}
+
+.at-planning-plan-grid {
+    display: grid;
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+    gap: 0.85rem;
+    align-items: start;
+}
+
+.at-planning-plan-card {
+    min-width: 0;
+}
+
+.at-planning-plan-grid .at-sprint-list-panel {
+    position: static;
+}
+
+.at-plan-create-panel {
+    display: grid;
+    gap: 0.6rem;
+    margin-top: 0.85rem;
+}
+
+.at-sprint-command-form-static {
+    display: grid;
+    gap: 0.5rem;
+    margin-top: 0.65rem;
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    padding: 0.75rem;
+    background: #ffffff;
+}
+
+.at-execute-compact-assignment {
+    padding: 0.75rem 0.85rem;
+}
+
+.at-execute-compact-assignment .at-panel-heading {
+    margin-bottom: 0.55rem;
+}
+
+.at-execute-attention {
+    padding: 0.75rem 0.85rem;
+}
+
+.at-execute-attention > summary,
+.at-sprint-closed-section > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    cursor: pointer;
+    color: var(--at-text);
+    font-weight: var(--at-weight-bold);
+}
+
+.at-execute-attention .at-attention-grid {
+    margin-top: 0.75rem;
+}
+
+.at-sprint-closed-section {
+    background: #f8fafc;
+    opacity: 0.92;
+}
+
+.at-sprint-closed-section[open] {
+    background: var(--at-surface);
+    opacity: 1;
+}
+
+.at-sprint-closed-section .at-sprint-closed-cards {
+    margin-top: 0.75rem;
+}
+
+.at-planning-views-panel {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.at-planning-view-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.7rem 0.85rem;
+}
+
+.at-planning-secondary-view .at-panel-note {
+    padding: 0 0.9rem 0.9rem;
+}
+
+.at-planning-plan-grid .at-planning-backlog-queue {
+    margin-top: 0;
+}
+
+.at-planning-plan-grid .at-planning-backlog-body {
+    border-top: 1px solid var(--at-border);
+}
+
+@media (max-width: 1200px) {
+    .at-planning-plan-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 767px) {
+    .at-planning-tabs {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-planning-view-toggle,
+    .at-planning-backlog-filter-actions,
+    .at-planning-backlog-assign-form {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .at-planning-view-toggle .btn-group {
+        display: grid;
+        grid-template-columns: 1fr;
+        width: 100%;
+    }
+}
+
+/* SECTION: Phase 3A-1 execution board uses intrinsic-width-safe columns instead of horizontal-first scrolling. */
+.at-sprint-board-stack .at-board-grid,
+.at-planning-views-panel .at-board-grid {
+    min-width: 0;
+}


### PR DESCRIPTION
### Motivation
- Reduce visual overload on the Planning Board by separating planning, execution, closure and alternate views into internal tabs so not all major sections render at once.
- Preserve existing services, post handlers, workflow, permissions and audit logic while keeping legacy `PlanningView` aliases functional.
- Make the Execute surface the default when a planning window is selected and Plan the default when none exists to improve discoverability.

### Description
- Introduced a new `PlanningTab` route/query property and `ResolvePlanningTab`/`GetDefaultPlanningTab` helpers in `Pages/ActionTasks/Index.cshtml.cs` to normalize the internal tab state and preserve legacy `PlanningView` behavior.
- Moved the Planning Board render into the `_TaskSprints` partial and rewrote that partial to expose four internal tabs: `Plan`, `Execute`, `Close`, and `Views`, with the Plan tab hosting the sprint list and backlog filters/assignment, Execute showing service-backed status columns (Assigned, In Progress, Blocked, Submitted) with Closed collapsed, Close handling closure review/carry-forward/history, and Views containing Due/Exceptions and Kanban as selectable alternates.
- Kept all existing form handlers and server-side postbacks (create/update/activate/close sprints, assign/move tasks, closure disposition, updates) unchanged and added `PlanningTab` hidden inputs where appropriate so postbacks continue to preserve workspace state.
- Added CSS in `wwwroot/css/action-tracker.css` to render compact tab controls, Plan grid, Execute attention styling and to prevent horizontal-first board scrolling; updated a handful of user-facing labels in tests and partials (`Create Planning Window`, `Edit Window`) to match the new UI copy.

### Testing
- Ran a repository check with `git diff --check`, which reported no whitespace/merge errors for the change set.
- Attempted to run automated tests with `dotnet test` but the execution environment did not provide the `dotnet` CLI, so unit tests in `ProjectManagement.Tests` were not executed here.
- Updated `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert the new Planning Board tab behaviour and wording; these tests were modified but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb66074b38832984e33608d718fdeb)