### PR TITLE
Planning Board: exclusive Views, Due/Exceptions view, compact cards & Execute improvements

### DIFF
--- a/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml
+++ b/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml
@@ -1,0 +1,41 @@
+@model ProjectManagement.Pages.ActionTasks.IndexModel
+
+@{
+    // SECTION: Full Views tab due/exception view renders directly without the nested Planning Board disclosure.
+    var dueExceptionCount = Model.DueTodayTaskDisplays.Count
+        + Model.DueThisWeekTaskDisplays.Count
+        + Model.DueLaterTaskDisplays.Count
+        + Model.SprintOverdueTaskDisplays.Count;
+}
+
+@* SECTION: Due and exception buckets are selected-view content, not a secondary details block. *@
+<section class="at-panel at-planning-due-exceptions-view" aria-labelledby="planning-due-exceptions-heading">
+    <div class="at-panel-heading at-planning-due-exceptions-header">
+        <div>
+            <div class="at-section-eyebrow">Planning Board</div>
+            <h2 id="planning-due-exceptions-heading">Due / exceptions</h2>
+            <p class="at-panel-note">Review upcoming and overdue task buckets without leaving the Planning Board.</p>
+        </div>
+        <span class="at-count-chip">@dueExceptionCount</span>
+    </div>
+
+    @* SECTION: Due buckets remain responsive so this view does not create page-level horizontal scrolling. *@
+    <div class="at-planning-due-exceptions-grid" aria-label="Planning Board due and exceptions">
+        <article class="at-panel at-board-column at-due-exception-column">
+            <div class="at-panel-heading"><h2>Due Today</h2><span class="at-count-chip">@Model.DueTodayTaskDisplays.Count</span></div>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueTodayTaskDisplays, "No tasks due today.", false)' />
+        </article>
+        <article class="at-panel at-board-column at-due-exception-column">
+            <div class="at-panel-heading"><h2>Due This Week</h2><span class="at-count-chip">@Model.DueThisWeekTaskDisplays.Count</span></div>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueThisWeekTaskDisplays, "No tasks due this week.", false)' />
+        </article>
+        <article class="at-panel at-board-column at-due-exception-column">
+            <div class="at-panel-heading"><h2>Due Later</h2><span class="at-count-chip">@Model.DueLaterTaskDisplays.Count</span></div>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.DueLaterTaskDisplays, "No later tasks.", false)' />
+        </article>
+        <article class="at-panel at-board-column at-due-exception-column at-due-exception-column-overdue">
+            <div class="at-panel-heading"><h2>Overdue</h2><span class="at-count-chip">@Model.SprintOverdueTaskDisplays.Count</span></div>
+            <partial name="_TaskCards" model='@Tuple.Create(Model, Model.SprintOverdueTaskDisplays, "No overdue tasks.", false)' />
+        </article>
+    </div>
+</section>

--- a/Pages/ActionTasks/_PlanningExecuteTab.cshtml
+++ b/Pages/ActionTasks/_PlanningExecuteTab.cshtml
@@ -7,7 +7,7 @@
     var attentionCount = Model.SprintAttentionOverdueTaskDisplays.Count + Model.SprintAttentionBlockedTaskDisplays.Count + Model.SprintAttentionSubmittedTaskDisplays.Count;
 }
 
-@* SECTION: Execute tab makes the real execution board the first dominant content. *@
+@* SECTION: Execute tab starts with a compact board header before status work sections. *@
 <section class="at-planning-tab-panel at-sprint-execution-main at-planning-execute-panel" aria-label="Planning Board Execute tab">
     @if (Model.SelectedSprint is null)
     {
@@ -15,6 +15,61 @@
     }
     else
     {
+        <header class="at-panel at-execute-board-header" aria-label="Execution board header">
+            <div class="at-execute-board-title">
+                <span class="at-section-eyebrow">Execute</span>
+                <h2>Execution board</h2>
+            </div>
+            @if (Model.CanModifySelectedSprint)
+            {
+                @* SECTION: Add Backlog Task remains a secondary collapsed action, now discoverable at the top of Execute. *@
+                <details class="at-execute-quick-add at-execute-quick-add-inline">
+                    <summary>Add Backlog Task <span class="at-count-chip">@Model.AssignableBacklogTaskDisplays.Count</span></summary>
+                    <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
+                        <input type="hidden" name="ViewMode" value="Planning" />
+                        <input type="hidden" name="PlanningTab" value="Execute" />
+                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint?.Id" />
+                        <input type="hidden" name="sprintId" value="@Model.SelectedSprint?.Id" />
+                        <select class="form-select form-select-sm" name="id" aria-label="Select backlog task" required>
+                            <option value="">Select backlog task</option>
+                            @foreach (var item in Model.AssignableBacklogTaskDisplays)
+                            {
+                                <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
+                            }
+                        </select>
+                        <button type="submit" class="btn btn-primary btn-sm" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign</button>
+                    </form>
+                </details>
+            }
+        </header>
+
+        @* SECTION: Compact attention summary is default; task mini-lists stay inside the collapsed details panel. *@
+        <details class="at-panel at-sprint-attention-lane at-execute-attention">
+            <summary>
+                <span>Execution attention</span>
+                <span class="at-execute-attention-summary" aria-label="Execution attention counts">
+                    <span>Overdue <strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></span>
+                    <span>Blocked <strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></span>
+                    <span>Submitted pending closure <strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></span>
+                </span>
+                <span class="at-count-chip">@attentionCount</span>
+            </summary>
+            <div class="at-attention-grid">
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
+                </div>
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
+                </div>
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
+                </div>
+            </div>
+        </details>
+
         <section class="at-sprint-board-stack at-execute-status-board" aria-label="Selected Planning Board task board">
             <div class="at-execute-status-grid">
                 @foreach (var status in activeStatuses)
@@ -57,47 +112,5 @@
                 }
             </details>
         </section>
-
-        <div class="at-execute-toolbar" aria-label="Execute secondary actions and attention">
-            @if (Model.CanModifySelectedSprint)
-            {
-                @* SECTION: Add Backlog Task is secondary and collapsed below the execution board. *@
-                <details class="at-panel at-execute-quick-add">
-                    <summary>Add Backlog Task <span class="at-count-chip">@Model.AssignableBacklogTaskDisplays.Count</span></summary>
-                    <form method="post" asp-page-handler="AssignToSprint" class="at-sprint-add-form">
-                        <input type="hidden" name="ViewMode" value="Planning" />
-                        <input type="hidden" name="PlanningTab" value="Execute" />
-                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprint?.Id" />
-                        <input type="hidden" name="sprintId" value="@Model.SelectedSprint?.Id" />
-                        <select class="form-select form-select-sm" name="id" aria-label="Select backlog task" required>
-                            <option value="">Select backlog task</option>
-                            @foreach (var item in Model.AssignableBacklogTaskDisplays)
-                            {
-                                <option value="@item.Task.Id">AT-@item.Task.Id · @item.Task.Title (@item.AssigneeName)</option>
-                            }
-                        </select>
-                        <button type="submit" class="btn btn-primary btn-sm" @(Model.AssignableBacklogTaskDisplays.Any() ? null : "disabled")>Assign</button>
-                    </form>
-                </details>
-            }
-
-            <details class="at-panel at-sprint-attention-lane at-execute-attention" @(attentionCount > 0 ? "open" : null)>
-                <summary>Execution attention <span class="at-count-chip">@attentionCount</span></summary>
-                <div class="at-attention-grid">
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
-                    </div>
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
-                    </div>
-                    <div class="at-attention-group">
-                        <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
-                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
-                    </div>
-                </div>
-            </details>
-        </div>
     }
 </section>

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -14,10 +14,7 @@
             <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
             <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
         </div>
-        <dl class="at-card-facts">
-            <div><dt>Owner</dt><dd>@item.AssigneeName</dd></div>
-            <div><dt>Due</dt><dd>@task.DueDate.ToString("dd MMM yyyy")</dd></div>
-        </dl>
+        <div class="at-card-compact-meta">@item.AssigneeName <span aria-hidden="true">·</span> @task.DueDate.ToString("dd MMM yyyy")</div>
         <div class="at-card-footer">
             <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
             @if (pageModel.IsTaskOverdue(task))

--- a/Pages/ActionTasks/_PlanningViewsTab.cshtml
+++ b/Pages/ActionTasks/_PlanningViewsTab.cshtml
@@ -1,6 +1,6 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Views tab keeps due/exception and Kanban alternate views selectable instead of competing with execution. *@
+@* SECTION: Views tab exposes exactly one selected alternate view at a time. *@
 <section class="at-planning-tab-panel at-planning-views-panel" aria-label="Planning Board Views tab">
     <nav class="at-panel at-planning-view-toggle" aria-label="Planning Board alternate view selector">
         <span class="at-section-eyebrow">Alternate views</span>
@@ -13,17 +13,9 @@
     @if (string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase))
     {
         <partial name="_TaskKanban" model="Model" />
-        <details class="at-planning-secondary-view">
-            <summary>Due / exceptions <span class="at-count-chip">@(Model.DueTodayTaskDisplays.Count + Model.DueThisWeekTaskDisplays.Count + Model.DueLaterTaskDisplays.Count + Model.SprintOverdueTaskDisplays.Count)</span></summary>
-            <partial name="_TaskSprintBoard" model="Model" />
-        </details>
     }
     else
     {
-        <partial name="_TaskSprintBoard" model="Model" />
-        <details class="at-planning-secondary-view">
-            <summary>Kanban alternate view <span class="at-count-chip">@(Model.KanbanAssignedTaskDisplays.Count + Model.KanbanInProgressTaskDisplays.Count + Model.KanbanBlockedTaskDisplays.Count + Model.KanbanSubmittedTaskDisplays.Count + Model.KanbanClosedTaskDisplays.Count)</span></summary>
-            <p class="at-panel-note">Open Kanban from the selector above to review all workflow columns.</p>
-        </details>
+        <partial name="_PlanningDueExceptionsView" model="Model" />
     }
 </section>

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -25,9 +25,11 @@
         </div>
         <span class="at-count-chip">@kanbanTaskCount</span>
     </div>
+    <p class="at-panel-note at-kanban-view-note">Kanban is a wide alternate workflow view.</p>
 
-    @* SECTION: Existing Kanban columns continue to group tasks by current workflow status names. *@
-    <div class="at-board-grid is-kanban at-planning-secondary-grid" aria-label="Planning Board Kanban alternate view">
+    @* SECTION: Existing Kanban columns continue to group tasks by current workflow status names inside an internal scroll area. *@
+    <div class="at-kanban-scroll" tabindex="0">
+        <div class="at-board-grid is-kanban at-planning-secondary-grid" aria-label="Planning Board Kanban alternate view">
         @foreach (var column in kanbanColumns)
         {
             <article class="at-panel at-board-column">
@@ -64,6 +66,7 @@
                 }
             </article>
         }
+        </div>
     </div>
 </section>
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2593,3 +2593,182 @@ html {
         white-space: normal;
     }
 }
+
+/* SECTION: Phase 3A-3 exclusive Planning views and card-density refinement. */
+.at-planning-due-exceptions-view,
+.at-planning-kanban-view {
+    min-width: 0;
+    margin-top: 0;
+    overflow: hidden;
+}
+
+.at-planning-due-exceptions-header {
+    padding: 0.85rem 0.9rem 0;
+}
+
+.at-planning-due-exceptions-header .at-panel-note,
+.at-kanban-view-note {
+    margin: 0.15rem 0 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-planning-due-exceptions-view .at-planning-due-exceptions-grid {
+    border-top: 0;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    padding-top: 0.75rem;
+}
+
+.at-kanban-view-note {
+    padding: 0 0.9rem 0.7rem;
+}
+
+.at-kanban-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: visible;
+    padding: 0 0.9rem 0.9rem;
+}
+
+.at-kanban-scroll .at-planning-secondary-grid {
+    border-top: 1px solid var(--at-border);
+    padding: 0.9rem 0 0;
+}
+
+.at-shell.is-planning-board.has-selection .at-planning-kanban-view {
+    max-width: calc(100vw - 88px - 2rem);
+}
+
+.at-shell.is-planning-board.has-selection .at-kanban-scroll {
+    padding-right: min(29rem, calc(100vw - 1rem));
+}
+
+.at-sprint-task-card .at-task-card-link {
+    padding: 0.42rem 0.5rem;
+}
+
+.at-sprint-task-card .at-card-top-row {
+    align-items: flex-start;
+}
+
+.at-sprint-task-card .at-card-subject {
+    font-size: var(--at-font-sm);
+    line-height: 1.2;
+}
+
+.at-card-compact-meta {
+    margin-top: 0.25rem;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: 400;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.at-sprint-task-card .at-card-footer {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.35rem;
+    margin-top: 0.35rem;
+}
+
+.at-sprint-task-card .at-card-footer .at-open-details-label {
+    margin-left: auto;
+}
+
+.at-sprint-task-card .at-card-action-form {
+    padding: 0 0.5rem 0.5rem;
+}
+
+.at-sprint-task-card .at-card-action-form .btn-sm {
+    padding: 0.18rem 0.45rem;
+    font-size: var(--at-font-xs);
+}
+
+.at-execute-board-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-width: 0;
+    padding: 0.65rem 0.75rem;
+}
+
+.at-execute-board-title {
+    min-width: 0;
+}
+
+.at-execute-board-title h2 {
+    margin: 0.05rem 0 0;
+    font-size: 1rem;
+    line-height: 1.2;
+}
+
+.at-execute-quick-add-inline {
+    min-width: min(24rem, 100%);
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #ffffff;
+}
+
+.at-execute-attention > summary {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+}
+
+.at-execute-attention-summary {
+    display: inline-flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.at-execute-attention-summary span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border: 1px solid var(--at-border);
+    border-radius: 999px;
+    background: #f8fafc;
+    color: var(--at-muted);
+    padding: 0.12rem 0.45rem;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+    white-space: nowrap;
+}
+
+.at-execute-attention-summary strong {
+    color: var(--at-text);
+    font-weight: var(--at-weight-bold);
+}
+
+@media (max-width: 1200px) {
+    .at-planning-due-exceptions-view .at-planning-due-exceptions-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-shell.is-planning-board.has-selection .at-planning-kanban-view {
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 767px) {
+    .at-planning-due-exceptions-view .at-planning-due-exceptions-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-execute-board-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .at-execute-quick-add-inline {
+        min-width: 0;
+    }
+
+    .at-shell.is-planning-board.has-selection .at-kanban-scroll {
+        padding-right: 0.9rem;
+    }
+}


### PR DESCRIPTION
### Motivation
- Clean up the Planning Board Views area so only the selected alternate view renders, remove duplicated headings in Due / exceptions, and reduce card density after the Phase 3A-2 redesign. 
- Make Kanban an explicit wide alternate view that scrolls internally without introducing page-level horizontal scroll or colliding with the overlay inspector. 
- Improve discoverability and density of the Execute tab by surfacing a compact toolbar and attention summary while keeping existing workflows and handlers intact.

### Description
- Render only the selected view in `Pages/ActionTasks/_PlanningViewsTab.cshtml` and add a dedicated `Pages/ActionTasks/_PlanningDueExceptionsView.cshtml` for the full Views tab Due / Exceptions experience. 
- Keep `Pages/ActionTasks/_TaskKanban.cshtml` as the Kanban alternate view, add an explanatory note, and wrap the board in an internal horizontal scroll container to avoid page-level scrolling. 
- Compact task cards by replacing the Owner/Due `dl` with a single metadata line in `Pages/ActionTasks/_PlanningTaskCard.cshtml` and add corresponding density CSS rules in `wwwroot/css/action-tracker.css`. 
- Improve `Pages/ActionTasks/_PlanningExecuteTab.cshtml` by adding a compact execution header with an inline (still-collapsible) `Add Backlog Task` control and make Execution attention a compact summary strip with expandable mini-lists. 
- Preserve existing behaviour and handlers (sprint creation/editing/activation/closure, task assign/move/update/status changes, inspector/detail actions) and avoid any backend/workflow/schema changes.

### Testing
- Ran `git diff --check` to verify no whitespace or index errors and it passed. 
- Attempted `dotnet build ProjectManagement.sln` and `dotnet test ProjectManagement.sln`, but both could not run in this environment because the `dotnet` CLI is not installed (build/tests blocked). 
- Verified changes by inspecting modified files and committed the patch (`Refine Planning Board views and card density`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb729567ec8329830bd5f807c90f06)