### PR TITLE
Preserve Planning Board tab from mini task links

### DIFF
--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -3,6 +3,8 @@
     var pageModel = Model.Item1;
     var tasks = Model.Item2;
     var emptyMessage = Model.Item3;
+    // SECTION: Preserve Planning Board tab context when compact links open the task inspector.
+    var planningTabRouteValue = pageModel.IsPlanningView ? pageModel.ResolvedPlanningTab : null;
 }
 
 @if (!tasks.Any())
@@ -15,8 +17,8 @@ else
         @foreach (var item in tasks)
         {
             var task = item.Task;
-            @* SECTION: Preserve contextual sprint selection when compact task links open the inspector. *@
-            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-route-SelectedSprintId="@pageModel.SelectedSprintId">
+            @* SECTION: Preserve contextual sprint and Planning Board tab selection when compact task links open the inspector. *@
+            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-route-PlanningTab="@planningTabRouteValue" asp-route-SelectedSprintId="@pageModel.SelectedSprintId">
                 <div class="at-mini-title">AT-@task.Id · @task.Title</div>
                 <div class="at-mini-meta">
                     <span>@item.AssigneeName</span>


### PR DESCRIPTION
### Motivation
- Ensure mini-list task links keep the current Planning Board context so opening the task inspector preserves the active Planning tab and sprint selection.

### Description
- Modified `Pages/ActionTasks/_TaskMiniList.cshtml` to compute `planningTabRouteValue = pageModel.IsPlanningView ? pageModel.ResolvedPlanningTab : null` and added `asp-route-PlanningTab="@planningTabRouteValue"` to the mini-list task anchor so the PlanningTab route value is included only when in the Planning workspace.

### Testing
- Attempted to run `dotnet test ProjectManagement.sln` but the `dotnet` CLI is not available in the environment, so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb73ed269c83299113fd1c9c9e044d)