### PR TITLE
Preserve planning view state in task inspectors

### DIFF
--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -4,6 +4,12 @@
     var tasks = Model.Item2;
     var emptyMessage = Model.Item3;
     var hideStatusBadge = Model.Item4;
+    // SECTION: Planning Board task cards preserve the selected internal tab, alternate view, and Planning Window when opening the inspector.
+    var planningTabRouteValue = pageModel.IsPlanningView ? pageModel.ResolvedPlanningTab : null;
+    var planningViewRouteValue = pageModel.IsPlanningView && !string.Equals(pageModel.ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
+        ? pageModel.ResolvedPlanningView
+        : null;
+    var selectedSprintRouteValue = pageModel.IsPlanningView ? pageModel.SelectedSprintId : null;
 }
 
 @if (!tasks.Any())
@@ -17,7 +23,14 @@ else
         {
             var task = item.Task;
             <article class="at-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" aria-label="Open task AT-@task.Id details">
+                <a class="at-task-card-link"
+                   asp-page="/ActionTasks/Index"
+                   asp-route-taskId="@task.Id"
+                   asp-route-viewMode="@pageModel.ResolvedViewMode"
+                   asp-route-PlanningTab="@planningTabRouteValue"
+                   asp-route-PlanningView="@planningViewRouteValue"
+                   asp-route-SelectedSprintId="@selectedSprintRouteValue"
+                   aria-label="Open task AT-@task.Id details">
                     <div class="at-card-top-row">
                         <h3 class="at-card-subject">@task.Title</h3>
                         <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -1,5 +1,14 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
+@{
+    // SECTION: Inspector actions preserve the active Planning Board tab, alternate view, and Planning Window route state.
+    var planningTabRouteValue = Model.IsPlanningView ? Model.ResolvedPlanningTab : null;
+    var planningViewRouteValue = Model.IsPlanningView && !string.Equals(Model.ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
+        ? Model.ResolvedPlanningView
+        : null;
+    var selectedSprintRouteValue = Model.IsPlanningView ? Model.SelectedSprintId : null;
+}
+
 @* SECTION: Right-side task inspector drawer content. *@
 <section id="task-details" class="at-panel at-task-details-panel" tabindex="-1">
     @* SECTION: Inspector shell organizes fixed header, scrollable body, and sticky action rail. *@
@@ -24,7 +33,7 @@
                     </div>
                 }
             </div>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-PlanningView="@Model.ResolvedPlanningView" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="@Model.ResolvedViewMode" asp-route-SelectedSprintId="@selectedSprintRouteValue" asp-route-PlanningTab="@planningTabRouteValue" asp-route-PlanningView="@planningViewRouteValue" class="btn btn-light btn-sm at-inspector-close" aria-label="Close inspector"><i class="bi bi-x-lg" aria-hidden="true"></i></a>
         </header>
 
         @if (Model.SelectedTask is not null)
@@ -138,6 +147,7 @@
                             <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
                             <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                             <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                            <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
                             <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                             <div class="at-action-title">Add Update</div>
                             <div class="mb-2">
@@ -163,6 +173,7 @@
                             <form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
                                 <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
@@ -203,6 +214,7 @@
                             <form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
                                 <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
@@ -227,6 +239,7 @@
                             <form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact">
                                 <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
                                 <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -49,6 +49,7 @@
                                    asp-page="/ActionTasks/Index"
                                    asp-route-taskId="@task.Id"
                                    asp-route-viewMode="Planning"
+                                   asp-route-PlanningTab="Views"
                                    asp-route-PlanningView="Kanban"
                                    asp-route-SelectedSprintId="@Model.SelectedSprintId"
                                    aria-label="Open task AT-@task.Id details">

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -125,8 +125,36 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
 
         // SECTION: Assert
+        Assert.Contains("name=\"PlanningTab\" value=\"Views\"", html, StringComparison.Ordinal);
         Assert.Contains("name=\"PlanningView\" value=\"Kanban\"", html, StringComparison.Ordinal);
+        Assert.Contains("PlanningTab=Views", html, StringComparison.Ordinal);
         Assert.Contains("PlanningView=Kanban", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlanningDueExceptionsTaskCards_PreserveViewsRouteState()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Due Exceptions Sprint", ActionSprintStatus.Active);
+        await setup.Db.SaveChangesAsync();
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.SprintId = sprint.Id;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Views";
+        page.PlanningView = "DueExceptions";
+        page.SelectedSprintId = sprint.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("PlanningTab=Views", html, StringComparison.Ordinal);
+        Assert.Contains("PlanningView=DueExceptions", html, StringComparison.Ordinal);
+        Assert.Contains($"SelectedSprintId={sprint.Id}", html, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Keep Planning Board context (internal tab, alternate view and selected sprint) when users open the shared task inspector so navigation and postbacks return the user to the same Planning view instead of falling back to defaults.

### Description

- Preserve and propagate `PlanningTab`, `PlanningView` and `SelectedSprintId` route values from task cards into inspector links by adding scoped route parameters in `Pages/ActionTasks/_TaskCards.cshtml`.
- Make inspector close links and all inspector postback forms carry `PlanningTab` plus the existing `PlanningView` and `SelectedSprintId` by adding hidden inputs and local route variables in `Pages/ActionTasks/_TaskDetails.cshtml`.
- Anchor Kanban card links to the Views tab so Kanban task opens keep the alternate view context in `Pages/ActionTasks/_TaskKanban.cshtml`.
- Add regression tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert that inspector forms and Due/Exceptions task-card markup preserve the Planning tab/view and selected sprint route state.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff issues and it succeeded.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTaskPageTests"` but `dotnet` is not available in this environment so the new tests were added but not executed here.
- Verified Razor partials and the changed templates render the new hidden inputs and route attributes via the repository diffs and local file inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7a74781483299bce2a3786d7078c)