### PR TITLE
Redesign My Work personal queue: compact KPI strip, priority queue and de-duplication

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -970,11 +970,20 @@ public class IndexModel : PageModel
             .ToList());
 
     public IReadOnlyList<TaskDisplayItem> MyRemainingAssignedTaskDisplays =>
-        ToDisplayItems(GetRemainingAssignedTasks()
-            .OrderBy(t => StatusOrder(t.Status))
-            .ThenBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        MyWorkAllMyTasksDisplays;
+
+    // SECTION: My Work queue projections de-duplicate tasks by urgency before rendering primary workspace sections.
+    public IReadOnlyList<TaskDisplayItem> MyWorkActionRequiredDisplays =>
+        ToDisplayItems(BuildMyWorkQueueSection(MyWorkQueueSection.ActionRequired));
+
+    public IReadOnlyList<TaskDisplayItem> MyWorkCurrentWorkDisplays =>
+        ToDisplayItems(BuildMyWorkQueueSection(MyWorkQueueSection.CurrentWork));
+
+    public IReadOnlyList<TaskDisplayItem> MyWorkSubmittedAwaitingClosureDisplays =>
+        ToDisplayItems(BuildMyWorkQueueSection(MyWorkQueueSection.SubmittedAwaitingClosure));
+
+    public IReadOnlyList<TaskDisplayItem> MyWorkAllMyTasksDisplays =>
+        ToDisplayItems(BuildMyWorkQueueSection(MyWorkQueueSection.AllMyTasks));
 
     // SECTION: Legacy My Tasks display alias retained for older partial references.
     public IReadOnlyList<TaskDisplayItem> MyWorkOverdueTaskDisplays =>
@@ -1685,19 +1694,76 @@ public class IndexModel : PageModel
             ? Array.Empty<ActionTaskItem>()
             : Tasks.Where(t => t.SprintId == ActiveSprint.Id).ToList();
 
-    // SECTION: Remaining personal work keeps assigned tasks visible when they do not fit a priority lane.
-    private IReadOnlyList<ActionTaskItem> GetRemainingAssignedTasks()
+    // SECTION: My Work queue section identifiers keep the presentation grouping explicit and replaceable.
+    private enum MyWorkQueueSection
     {
-        var activeSprintId = ActiveSprint?.Id;
-        return Tasks
-            .Where(IsOpenTask)
-            .Where(t => t.DueDate.Date != DateTime.UtcNow.Date)
-            .Where(t => !IsTaskOverdue(t))
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
-            .Where(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-            .Where(t => !activeSprintId.HasValue || t.SprintId != activeSprintId.Value)
-            .ToList();
+        ActionRequired,
+        CurrentWork,
+        SubmittedAwaitingClosure,
+        AllMyTasks
     }
+
+    // SECTION: Remaining personal work keeps assigned tasks visible when they do not fit a priority lane.
+    private IReadOnlyList<ActionTaskItem> GetRemainingAssignedTasks() =>
+        BuildMyWorkQueueSection(MyWorkQueueSection.AllMyTasks);
+
+    // SECTION: Priority-based My Work queue assigns each task to exactly one primary section.
+    private IReadOnlyList<ActionTaskItem> BuildMyWorkQueueSection(MyWorkQueueSection section) =>
+        Tasks
+            .Select(task => new { Task = task, Section = ResolveMyWorkQueueSection(task) })
+            .Where(item => item.Section == section)
+            .Select(item => item.Task)
+            .OrderBy(task => ResolveMyWorkPriorityRank(task))
+            .ThenBy(task => StatusOrder(task.Status))
+            .ThenBy(task => task.DueDate)
+            .ThenBy(task => task.Id)
+            .ToList();
+
+    // SECTION: My Work precedence prevents repeated cards across action, execution, submitted, and remaining sections.
+    private MyWorkQueueSection ResolveMyWorkQueueSection(ActionTaskItem task)
+    {
+        if (IsTaskOverdue(task) || IsTaskDueToday(task) || IsTaskBlocked(task))
+        {
+            return MyWorkQueueSection.ActionRequired;
+        }
+
+        if (IsTaskInProgress(task))
+        {
+            return MyWorkQueueSection.CurrentWork;
+        }
+
+        if (IsTaskSubmitted(task))
+        {
+            return MyWorkQueueSection.SubmittedAwaitingClosure;
+        }
+
+        return MyWorkQueueSection.AllMyTasks;
+    }
+
+    // SECTION: My Work row ordering follows the required urgency precedence inside compact sections.
+    private int ResolveMyWorkPriorityRank(ActionTaskItem task)
+    {
+        if (IsTaskOverdue(task)) return 1;
+        if (IsTaskDueToday(task)) return 2;
+        if (IsTaskBlocked(task)) return 3;
+        if (IsTaskInProgress(task)) return 4;
+        if (IsTaskSubmitted(task)) return 5;
+        return 6;
+    }
+
+    // SECTION: My Work status predicates keep grouping readable without changing workflow rules.
+    private static bool IsTaskBlocked(ActionTaskItem task) =>
+        string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTaskInProgress(ActionTaskItem task) =>
+        string.Equals(task.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTaskSubmitted(ActionTaskItem task) =>
+        string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTaskDueToday(ActionTaskItem task) =>
+        IsOpenTask(task)
+        && task.DueDate.Date == DateTime.UtcNow.Date;
 
     private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>
         tasks.Select(task => new TaskDisplayItem

--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -3,25 +3,28 @@
 @{
     // SECTION: My Work read-model aliases keep personal task presentation consistent and CSP-safe.
     var assignedTaskCount = Model.Tasks.Count;
-    var dueTodayCount = Model.MyDueTodayTaskDisplays.Count;
+    var actionRequiredTasks = Model.MyWorkActionRequiredDisplays;
+    var currentWorkTasks = Model.MyWorkCurrentWorkDisplays;
+    var submittedTasks = Model.MyWorkSubmittedAwaitingClosureDisplays;
+    var allMyTaskDisplays = Model.MyWorkAllMyTasksDisplays;
+    var actionRequiredCount = actionRequiredTasks.Count;
     var overdueCount = Model.MyOverdueTaskDisplays.Count;
     var inProgressCount = Model.MyInProgressTaskDisplays.Count;
     var submittedCount = Model.MySubmittedTaskDisplays.Count;
     var activeSprintTaskCount = Model.MyActiveSprintTaskDisplays.Count;
-    var remainingAssignedTaskCount = Model.MyRemainingAssignedTaskDisplays.Count;
 }
 
-@* SECTION: Personal execution KPI strip. *@
+@* SECTION: Compact personal execution KPI strip. *@
 <section class="at-kpis at-kpis-mywork" aria-label="My work task summary">
     <article>
         <h3>Assigned to me</h3>
         <strong>@assignedTaskCount</strong>
-        <p>Visible tasks scoped by your assignment.</p>
+        <p>Total tasks in your personal queue.</p>
     </article>
     <article>
         <h3>Needs action now</h3>
-        <strong>@dueTodayCount</strong>
-        <p>Assigned tasks due today.</p>
+        <strong>@actionRequiredCount</strong>
+        <p>Overdue, due today, or blocked.</p>
     </article>
     <article>
         <h3>Overdue</h3>
@@ -45,93 +48,10 @@
     </article>
 </section>
 
-@* SECTION: Needs action now is intentionally first so the user sees today's required work before other lanes. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>Needs action now</h3>
-                <p class="at-panel-note">Tasks assigned to you that are due today.</p>
-            </div>
-            <span class="at-count-chip">@dueTodayCount</span>
-        </div>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.MyDueTodayTaskDisplays, "No tasks assigned to you are due today.", false)' />
-    </article>
-</section>
-
-@* SECTION: Overdue work follows today's commitments to keep time exceptions visible. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>Overdue</h3>
-                <p class="at-panel-note">Open assigned tasks with due dates before today.</p>
-            </div>
-            <span class="at-count-chip">@overdueCount</span>
-        </div>
-        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.MyOverdueTaskDisplays, "No overdue tasks assigned to you.")' />
-    </article>
-</section>
-
-@* SECTION: In-progress work highlights tasks currently being executed. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>In progress</h3>
-                <p class="at-panel-note">Assigned tasks currently underway.</p>
-            </div>
-            <span class="at-count-chip">@inProgressCount</span>
-        </div>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.MyInProgressTaskDisplays, "No in-progress tasks assigned to you.", true)' />
-    </article>
-</section>
-
-@* SECTION: Submitted handoffs remain visible while pending manager closure. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>Submitted pending closure</h3>
-                <p class="at-panel-note">Submitted tasks awaiting closure review.</p>
-            </div>
-            <span class="at-count-chip">@submittedCount</span>
-        </div>
-        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.MySubmittedTaskDisplays, "No submitted tasks are awaiting closure.")' />
-    </article>
-</section>
-
-@* SECTION: Remaining assigned work keeps personal tasks reachable even when they do not belong to the priority lanes above. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>Remaining assigned work</h3>
-                <p class="at-panel-note">Open assigned tasks outside today's, overdue, in-progress, submitted, and active Planning Window lanes.</p>
-            </div>
-            <span class="at-count-chip">@remainingAssignedTaskCount</span>
-        </div>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.MyRemainingAssignedTaskDisplays, "No remaining assigned tasks outside the priority lanes.", false)' />
-    </article>
-</section>
-
-@* SECTION: Active Planning Window context shows assigned work in the current Planning Window without moving workflow actions out of the inspector. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h3>My active Planning Window</h3>
-                @if (Model.ActiveSprint is not null)
-                {
-                    <p class="at-panel-note">@Model.DisplayPlanningWindowName(Model.ActiveSprint) · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
-                }
-                else
-                {
-                    <p class="at-panel-note">No active Planning Window is currently set.</p>
-                }
-            </div>
-            <span class="at-count-chip">@activeSprintTaskCount</span>
-        </div>
-        <partial name="_TaskCards" model='@Tuple.Create(Model, Model.MyActiveSprintTaskDisplays, "No assigned tasks are in the active Planning Window.", false)' />
-    </article>
+@* SECTION: Priority-based personal work queue avoids repeated tasks and oversized empty panels. *@
+<section class="at-mywork-queue" aria-label="Priority-based personal work queue">
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, actionRequiredTasks, "Action Required", "Overdue, due today, and blocked work that needs attention before other assignments.", "No action-required tasks right now.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, currentWorkTasks, "Current Work", "In-progress tasks that are already underway after urgent exceptions are removed.", "No current work in progress.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, submittedTasks, "Submitted / Awaiting Closure", "Submitted work waiting for closure review.", "No submitted tasks are awaiting closure.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, allMyTaskDisplays, "All My Tasks", "Remaining assigned tasks not already shown above.", "No remaining assigned tasks.")' />
 </section>

--- a/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
+++ b/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
@@ -1,0 +1,30 @@
+@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>>
+@{
+    var pageModel = Model.Item1;
+    var tasks = Model.Item2;
+}
+
+@* SECTION: Compact My Work rows preserve inspector routing without large task-card bodies. *@
+<div class="at-mywork-rows">
+    @foreach (var item in tasks)
+    {
+        var task = item.Task;
+        <a class="at-mywork-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)"
+           asp-page="/ActionTasks/Index"
+           asp-route-taskId="@task.Id"
+           asp-route-viewMode="@pageModel.ResolvedViewMode"
+           aria-label="Open task AT-@task.Id details">
+            <div class="at-mywork-row-main">
+                <span class="at-mywork-task-id">AT-@task.Id</span>
+                <span class="at-mywork-title">@task.Title</span>
+            </div>
+            <div class="at-mywork-row-meta" aria-label="Task metadata">
+                <span>Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                <span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span>
+                <span class="at-mywork-open-action">Open details</span>
+            </div>
+        </a>
+    }
+</div>

--- a/Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml
+++ b/Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml
@@ -1,0 +1,28 @@
+@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>, string, string, string>
+@{
+    var pageModel = Model.Item1;
+    var tasks = Model.Item2;
+    var title = Model.Item3;
+    var description = Model.Item4;
+    var emptyMessage = Model.Item5;
+}
+
+@* SECTION: Compact queue section keeps empty My Work groups from dominating the page. *@
+<article class="at-panel at-mywork-section @(tasks.Any() ? string.Empty : "is-empty")">
+    <div class="at-mywork-section-heading">
+        <div>
+            <h3>@title</h3>
+            <p class="at-panel-note">@description</p>
+        </div>
+        <span class="at-count-chip">@tasks.Count</span>
+    </div>
+
+    @if (!tasks.Any())
+    {
+        <p class="at-empty-inline at-mywork-empty-line">@emptyMessage</p>
+    }
+    else
+    {
+        <partial name="_TaskMyWorkQueueRows" model='@Tuple.Create(pageModel, tasks)' />
+    }
+</article>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -91,7 +91,7 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task MyWorkPartial_RendersAssignedTasksOutsidePriorityLanes()
+    public async Task MyWorkPartial_RendersRedesignedPersonalQueueSections()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
@@ -103,10 +103,79 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("Remaining assigned work", html, StringComparison.Ordinal);
-        Assert.Contains("Open task AT-", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned to me", html, StringComparison.Ordinal);
+        Assert.Contains("Needs action now", html, StringComparison.Ordinal);
+        Assert.Contains("Active Planning Window", html, StringComparison.Ordinal);
+        Assert.Contains("Action Required", html, StringComparison.Ordinal);
+        Assert.Contains("Current Work", html, StringComparison.Ordinal);
+        Assert.Contains("Submitted / Awaiting Closure", html, StringComparison.Ordinal);
+        Assert.Contains("All My Tasks", html, StringComparison.Ordinal);
+        Assert.Contains("Open details", html, StringComparison.Ordinal);
         Assert.Contains("Mine", html, StringComparison.Ordinal);
-        Assert.Single(page.MyRemainingAssignedTaskDisplays);
+        Assert.Single(page.MyWorkAllMyTasksDisplays);
+    }
+
+    [Fact]
+    public async Task MyWorkQueue_TaskAppearsOnlyInHighestPrioritySection()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var overlappingTask = await setup.Db.ActionTasks.SingleAsync();
+        overlappingTask.Title = "Overdue in progress";
+        overlappingTask.Status = ActionTaskStatuses.InProgress;
+        overlappingTask.DueDate = DateTime.UtcNow.Date.AddDays(-1);
+        setup.Db.ActionTasks.Add(NewTask("Later in progress", ActionTaskStatuses.InProgress));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains(page.MyWorkActionRequiredDisplays, item => item.Task.Title == "Overdue in progress");
+        Assert.DoesNotContain(page.MyWorkCurrentWorkDisplays, item => item.Task.Title == "Overdue in progress");
+        Assert.Contains(page.MyWorkCurrentWorkDisplays, item => item.Task.Title == "Later in progress");
+        Assert.Equal(1, CountOccurrences(html, "Overdue in progress"));
+    }
+
+    [Fact]
+    public async Task MyWorkPartial_EmptySectionsRenderCompactly()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("at-mywork-empty-line", html, StringComparison.Ordinal);
+        Assert.Contains("No action-required tasks right now.", html, StringComparison.Ordinal);
+        Assert.Contains("at-panel at-mywork-section is-empty", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("No tasks assigned to you are due today.", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MyWorkTaskLink_PreservesRouteStateWhenOpeningInspector()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains($"taskId={task.Id}", html, StringComparison.Ordinal);
+        Assert.Contains("viewMode=MyWork", html, StringComparison.Ordinal);
+        Assert.Contains($"Open task AT-{task.Id} details", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -704,6 +773,21 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Null(taskId1);
         Assert.Single(entityType.GetForeignKeys().Where(fk => fk.PrincipalEntityType.ClrType == typeof(ActionTaskItem)));
+    }
+
+
+    private static int CountOccurrences(string value, string searchTerm)
+    {
+        // SECTION: HTML assertion helper avoids regex dependencies for simple rendered-text counts.
+        var count = 0;
+        var startIndex = 0;
+        while ((startIndex = value.IndexOf(searchTerm, startIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            startIndex += searchTerm.Length;
+        }
+
+        return count;
     }
 
     private static async Task<string> RenderPartialAsync(IndexModel page, string viewPath)

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2014,6 +2014,136 @@ html {
 /* SECTION: My Work focused execution workspace */
 .at-kpis-mywork {
     grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0.65rem;
+}
+
+.at-kpis-mywork article {
+    min-height: 0;
+    padding: 0.75rem 0.85rem;
+}
+
+.at-kpis-mywork h3 {
+    margin-bottom: 0.25rem;
+    font-size: 0.72rem;
+}
+
+.at-kpis-mywork strong {
+    font-size: 1.4rem;
+    line-height: 1.05;
+}
+
+.at-kpis-mywork p {
+    margin-top: 0.25rem;
+    font-size: 0.72rem;
+    line-height: 1.25;
+}
+
+.at-mywork-queue {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.at-mywork-section {
+    padding: 0.85rem;
+}
+
+.at-mywork-section.is-empty {
+    padding: 0.65rem 0.85rem;
+}
+
+.at-mywork-section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: start;
+    margin-bottom: 0.65rem;
+}
+
+.at-mywork-section.is-empty .at-mywork-section-heading {
+    margin-bottom: 0.25rem;
+}
+
+.at-mywork-section-heading h3 {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 1rem;
+    font-weight: var(--at-weight-bold);
+}
+
+.at-mywork-empty-line {
+    margin: 0;
+}
+
+.at-mywork-rows {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.at-mywork-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 1.4fr);
+    gap: 0.65rem;
+    align-items: center;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #fff;
+    color: inherit;
+    text-decoration: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.at-mywork-row:hover,
+.at-mywork-row:focus {
+    border-color: rgba(37, 99, 235, 0.45);
+    box-shadow: var(--at-shadow-sm);
+    color: inherit;
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+.at-mywork-row.is-selected {
+    border-color: var(--at-primary);
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.16);
+}
+
+.at-mywork-row-main {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    min-width: 0;
+}
+
+.at-mywork-task-id {
+    color: var(--at-primary);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    white-space: nowrap;
+}
+
+.at-mywork-title {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--at-text);
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.at-mywork-row-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: flex-end;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+}
+
+.at-mywork-open-action {
+    color: var(--at-primary);
+    font-weight: 800;
+    white-space: nowrap;
 }
 
 @media (max-width: 1399px) {
@@ -2025,6 +2155,14 @@ html {
 @media (max-width: 767px) {
     .at-kpis-mywork {
         grid-template-columns: 1fr;
+    }
+
+    .at-mywork-row {
+        grid-template-columns: 1fr;
+    }
+
+    .at-mywork-row-meta {
+        justify-content: flex-start;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Replace a sparse, repetitive My Work layout with a compact personal execution workspace that surfaces what requires action, what is in progress, what is submitted, and what remains assigned while preserving existing workflow, permissions and DB schema.
- Ensure tasks appear only once by priority so the user has a single, ordered personal work queue with clear urgency precedence.

### Description
- Added priority-based My Work projections in `Index.cshtml.cs` including `BuildMyWorkQueueSection`, `ResolveMyWorkQueueSection`, `ResolveMyWorkPriorityRank` and predicates (`IsTaskDueToday`, `IsTaskBlocked`, `IsTaskInProgress`, `IsTaskSubmitted`) to assign each task to exactly one section (Action Required, Current Work, Submitted / Awaiting Closure, All My Tasks). 
- Reworked the My Work Razor into a compact KPI strip and a priority queue in `Pages/ActionTasks/_TaskMyWork.cshtml` and introduced two partials: `_TaskMyWorkQueueSection.cshtml` and `_TaskMyWorkQueueRows.cshtml` to render compact rows and compact empty states while preserving inspector routing via `asp-route-taskId` and `asp-route-viewMode`.
- Added CSS rules in `wwwroot/css/action-tracker.css` to reduce KPI/card heights, style compact task rows, and ensure empty sections render as small inline lines instead of large panels, with responsive adjustments.
- Updated tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to validate the redesigned sections (`MyWorkPartial_RendersRedesignedPersonalQueueSections`), de-duplication precedence (`MyWorkQueue_TaskAppearsOnlyInHighestPrioritySection`), compact empty rendering (`MyWorkPartial_EmptySectionsRenderCompactly`) and route/state preservation when opening a task from My Work (`MyWorkTaskLink_PreservesRouteStateWhenOpeningInspector`).
- Preserved existing behaviour: task inspector, update/status/submit lifecycle, route state and permission usage remain unchanged because only read-model projections and view markup/CSS were altered.

### Testing
- Ran `git diff --check` to validate formatting and whitespace checks and it reported no issues.
- Added/updated unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` covering UI projections, de-duplication precedence, empty section rendering and route preservation; these tests are runnable with `dotnet test` in a suitable environment.
- Attempted to run `dotnet test` in this environment but `dotnet` is not installed here, so automated test execution could not be completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb81fdffd88329b4dbc74245c756a5)