### PR TITLE
Use shared route-state for Planning backlog disclosure and update label

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -1095,6 +1095,9 @@ public class IndexModel : PageModel
          || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
          || FilterDueDate.HasValue
          || !string.IsNullOrWhiteSpace(FilterSearch));
+
+    // SECTION: Planning backlog disclosure mirrors every route value that can alter the backlog read model.
+    public bool HasBacklogFilterRouteState => HasTaskFilterRouteState();
     public string DashboardCommandFocusSummary =>
         $"{OverdueCount} overdue. {BlockedCount} blocked. {SubmittedPendingClosureCount} submitted pending closure. {CriticalOpenCount} critical open. {ActiveSprintMetrics.CarryForwardCandidateTasks} carry-forward candidates.";
     public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -1,9 +1,7 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @{
-    // SECTION: Backlog filters are compact by default, expanding automatically when an active filter needs visibility.
-    var hasBacklogFilters = !string.IsNullOrWhiteSpace(Model.FilterStatus)
-        || !string.IsNullOrWhiteSpace(Model.FilterPriority)
-        || !string.IsNullOrWhiteSpace(Model.FilterSearch);
+    // SECTION: Backlog filters are compact by default, expanding automatically when any route filter or sort state changes the queue.
+    var hasBacklogFilters = Model.HasBacklogFilterRouteState;
 }
 
 @* SECTION: Plan tab contains planning-window list, backlog filters, backlog queue, and assignment. *@
@@ -126,7 +124,7 @@
             <details class="at-planning-backlog-filter-shell" open="@hasBacklogFilters">
                 <summary>
                     <span>Filter Backlog</span>
-                    <span class="at-filter-state">@(hasBacklogFilters ? "Filters active" : "All open backlog")</span>
+                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All open backlog")</span>
                 </summary>
                 <form method="get" class="at-planning-backlog-filter">
                     <input type="hidden" name="viewMode" value="Planning" />


### PR DESCRIPTION
### Motivation
- Ensure the Planning backlog filter disclosure expands when any backlog-affecting route state (including assignee, due date, or sort) is present, matching legacy Backlog URLs and preventing hidden filter confusion.
- Make the disclosure summary copy accurately reflect a customized backlog view rather than implying only visible compact filters are active.

### Description
- Added `HasBacklogFilterRouteState` to `Pages/ActionTasks/Index.cshtml.cs` which reuses the existing `HasTaskFilterRouteState()` helper to detect any backlog-related route state. 
- Updated `Pages/ActionTasks/_PlanningPlanTab.cshtml` to set `var hasBacklogFilters = Model.HasBacklogFilterRouteState;` so the panel opens for all backlog-affecting route values.
- Changed the disclosure label from `Filters active` to `Custom backlog view` to better describe non-visual or sort-only route states.

### Testing
- Attempted to run `dotnet test ProjectManagement.sln --no-restore` but the `dotnet` CLI is not installed in the environment so automated tests could not be executed.
- Verified repository changes via file inspection and committed the edits (`Pages/ActionTasks/Index.cshtml.cs`, `Pages/ActionTasks/_PlanningPlanTab.cshtml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb838536848329ad67a07d5799108f)