### PR TITLE
Register: enterprise-grade grid polish (compact filters, Sprint column, sticky header)

### DIFF
--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -1,121 +1,150 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 
-@* SECTION: Register filters keep task records searchable and auditable. *@
-<section class="at-panel mb-3">
-    <h2>Register Filters</h2>
-    <form id="taskFilterForm" method="get" class="row g-2" data-at-task-filter-form="true">
-        <input type="hidden" name="viewMode" value="Register" />
-            <div class="col-md-2">
-                <label class="form-label">Status</label>
-                <select class="form-select" name="FilterStatus">
-                    <option value="">All</option>
-                    @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
-                    {
-                        @if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
-                        {
-                            <option value="@status" selected>@status</option>
-                        }
-                        else
-                        {
-                            <option value="@status">@status</option>
-                        }
-                    }
-                </select>
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Priority</label>
-                <select class="form-select" name="FilterPriority">
-                    <option value="">All</option>
-                    @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
-                    {
-                        @if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
-                        {
-                            <option value="@priority" selected>@priority</option>
-                        }
-                        else
-                        {
-                            <option value="@priority">@priority</option>
-                        }
-                    }
-                </select>
-            </div>
-            <div class="col-md-3">
-                <label class="form-label">Responsible Person</label>
-                <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
-                @{
-                    // SECTION: Build unique, user-readable datalist labels even when display names collide.
-                    var duplicateDisplayNames = Model.AssignableUsers
-                        .Where(u => !string.IsNullOrWhiteSpace(u.DisplayName))
-                        .GroupBy(u => u.DisplayName.Trim(), StringComparer.OrdinalIgnoreCase)
-                        .Where(g => g.Count() > 1)
-                        .Select(g => g.Key)
-                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+@{
+    // SECTION: Register sort affordances keep active ordering visible without changing query behavior.
+    string SortIndicator(string sortKey)
+    {
+        if (!string.Equals(Model.SortBy, sortKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
 
-                    var selectedAssignee = string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId)
-                        ? null
-                        : Model.AssignableUsers.FirstOrDefault(u => string.Equals(u.UserId, Model.FilterAssigneeUserId, StringComparison.Ordinal));
-                    var selectedDisplayName = (selectedAssignee?.DisplayName ?? string.Empty).Trim();
-                    var selectedUserId = (selectedAssignee?.UserId ?? string.Empty).Trim();
-                    var selectedAssigneeLabel = string.IsNullOrWhiteSpace(selectedDisplayName)
-                        ? selectedUserId
-                        : (duplicateDisplayNames.Contains(selectedDisplayName) ? $"{selectedDisplayName} ({selectedUserId})" : selectedDisplayName);
-                }
-                <input
-                    type="search"
-                    class="form-control"
-                    id="FilterAssigneePicker"
-                    list="FilterAssigneeOptions"
-                    autocomplete="off"
-                    placeholder="All Responsible Persons"
-                    value="@selectedAssigneeLabel"
-                    data-at-assignee-picker="true"
-                    data-at-assignee-target="FilterAssigneeUserId" />
-                <datalist id="FilterAssigneeOptions">
-                    @foreach (var assignee in Model.AssignableUsers)
+        return string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "↓" : "↑";
+    }
+
+    string SortLinkClass(string sortKey)
+        => string.Equals(Model.SortBy, sortKey, StringComparison.OrdinalIgnoreCase) ? "at-sort-link is-active" : "at-sort-link";
+
+    string SortAriaSort(string sortKey)
+    {
+        if (!string.Equals(Model.SortBy, sortKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return "none";
+        }
+
+        return string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "descending" : "ascending";
+    }
+}
+
+@* SECTION: Register filters keep task records searchable and auditable. *@
+<section class="at-panel at-register-filter-panel mb-3">
+    <div class="at-register-filter-heading">
+        <div>
+            <h2>Register Filters</h2>
+            <p class="at-panel-note">Refine the master task register without leaving the workspace.</p>
+        </div>
+        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
+    </div>
+    <form id="taskFilterForm" method="get" class="at-register-filter-toolbar" data-at-task-filter-form="true">
+        <input type="hidden" name="viewMode" value="Register" />
+        <div class="at-register-filter-field at-register-filter-field-narrow">
+            <label class="form-label" for="RegisterFilterStatus">Status</label>
+            <select class="form-select form-select-sm" id="RegisterFilterStatus" name="FilterStatus">
+                <option value="">All</option>
+                @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
+                {
+                    @if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
                     {
-                        <option value="@((duplicateDisplayNames.Contains((assignee.DisplayName ?? string.Empty).Trim()) ? $"{assignee.DisplayName} ({assignee.UserId})" : assignee.DisplayName) ?? assignee.UserId)" data-user-id="@assignee.UserId"></option>
+                        <option value="@status" selected>@status</option>
                     }
-                </datalist>
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Due Date</label>
-                <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
-            </div>
-            <div class="col-md-3">
-                <label class="form-label">Search by title</label>
-                <input type="text" class="form-control" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
-            </div>
-            <div class="col-12 d-flex gap-2">
-                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
-            </div>
-        </form>
+                    else
+                    {
+                        <option value="@status">@status</option>
+                    }
+                }
+            </select>
+        </div>
+        <div class="at-register-filter-field at-register-filter-field-narrow">
+            <label class="form-label" for="RegisterFilterPriority">Priority</label>
+            <select class="form-select form-select-sm" id="RegisterFilterPriority" name="FilterPriority">
+                <option value="">All</option>
+                @foreach (var priority in new[] { "Low", "Normal", "High", "Critical" })
+                {
+                    @if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
+                    {
+                        <option value="@priority" selected>@priority</option>
+                    }
+                    else
+                    {
+                        <option value="@priority">@priority</option>
+                    }
+                }
+            </select>
+        </div>
+        <div class="at-register-filter-field at-register-filter-field-person">
+            <label class="form-label" for="FilterAssigneePicker">Responsible Person</label>
+            <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
+            @{
+                // SECTION: Build unique, user-readable datalist labels even when display names collide.
+                var duplicateDisplayNames = Model.AssignableUsers
+                    .Where(u => !string.IsNullOrWhiteSpace(u.DisplayName))
+                    .GroupBy(u => u.DisplayName.Trim(), StringComparer.OrdinalIgnoreCase)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                var selectedAssignee = string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId)
+                    ? null
+                    : Model.AssignableUsers.FirstOrDefault(u => string.Equals(u.UserId, Model.FilterAssigneeUserId, StringComparison.Ordinal));
+                var selectedDisplayName = (selectedAssignee?.DisplayName ?? string.Empty).Trim();
+                var selectedUserId = (selectedAssignee?.UserId ?? string.Empty).Trim();
+                var selectedAssigneeLabel = string.IsNullOrWhiteSpace(selectedDisplayName)
+                    ? selectedUserId
+                    : (duplicateDisplayNames.Contains(selectedDisplayName) ? $"{selectedDisplayName} ({selectedUserId})" : selectedDisplayName);
+            }
+            <input
+                type="search"
+                class="form-control form-control-sm"
+                id="FilterAssigneePicker"
+                list="FilterAssigneeOptions"
+                autocomplete="off"
+                placeholder="All Responsible Persons"
+                value="@selectedAssigneeLabel"
+                data-at-assignee-picker="true"
+                data-at-assignee-target="FilterAssigneeUserId" />
+            <datalist id="FilterAssigneeOptions">
+                @foreach (var assignee in Model.AssignableUsers)
+                {
+                    <option value="@((duplicateDisplayNames.Contains((assignee.DisplayName ?? string.Empty).Trim()) ? $"{assignee.DisplayName} ({assignee.UserId})" : assignee.DisplayName) ?? assignee.UserId)" data-user-id="@assignee.UserId"></option>
+                }
+            </datalist>
+        </div>
+        <div class="at-register-filter-field at-register-filter-field-date">
+            <label class="form-label" for="RegisterFilterDueDate">Due Date</label>
+            <input type="date" class="form-control form-control-sm" id="RegisterFilterDueDate" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
+        </div>
+        <div class="at-register-filter-field at-register-filter-field-search">
+            <label class="form-label" for="RegisterFilterSearch">Search by title</label>
+            <input type="text" class="form-control form-control-sm" id="RegisterFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
+        </div>
+    </form>
 
     @if (Model.HasActiveFilters)
     {
-            <div class="at-active-filters" aria-label="Active filters">
-                @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
-                {
-                    <span class="at-filter-chip">Status: @Model.FilterStatus</span>
-                }
-                @if (!string.IsNullOrWhiteSpace(Model.FilterPriority))
-                {
-                    <span class="at-filter-chip">Priority: @Model.FilterPriority</span>
-                }
-                @if (!string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId))
-                {
-                    <span class="at-filter-chip">Responsible Person: @Model.ResolveAssigneeName(Model.FilterAssigneeUserId)</span>
-                }
-                @if (Model.FilterDueDate.HasValue)
-                {
-                    <span class="at-filter-chip">Due: @Model.FilterDueDate.Value.ToString("dd MMM yyyy")</span>
-                }
-                @if (!string.IsNullOrWhiteSpace(Model.FilterSearch))
-                {
-                    <span class="at-filter-chip">Search: @Model.FilterSearch</span>
-                }
-                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-filter-clear">Clear all</a>
-            </div>
+        <div class="at-active-filters at-register-active-filters" aria-label="Active filters">
+            @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
+            {
+                <span class="at-filter-chip">Status: @Model.FilterStatus</span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Model.FilterPriority))
+            {
+                <span class="at-filter-chip">Priority: @Model.FilterPriority</span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId))
+            {
+                <span class="at-filter-chip">Responsible Person: @Model.ResolveAssigneeName(Model.FilterAssigneeUserId)</span>
+            }
+            @if (Model.FilterDueDate.HasValue)
+            {
+                <span class="at-filter-chip">Due: @Model.FilterDueDate.Value.ToString("dd MMM yyyy")</span>
+            }
+            @if (!string.IsNullOrWhiteSpace(Model.FilterSearch))
+            {
+                <span class="at-filter-chip">Search: @Model.FilterSearch</span>
+            }
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-filter-clear">Clear all</a>
+        </div>
     }
 </section>
 
@@ -130,17 +159,18 @@
     }
     else
     {
-        <div class="table-responsive">
-            <table class="table table-sm at-table">
+        <div class="table-responsive at-register-table-scroll">
+            <table class="table table-sm at-table at-register-table align-middle">
                 <thead>
                     <tr>
                         @* SECTION: Register sorting links preserve active filters for audit-friendly review. *@
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID</a></th>
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task</a></th>
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person</a></th>
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due Date</a></th>
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status</a></th>
-                        <th><a class="at-sort-link" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority</a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("id")'><a class='@SortLinkClass("id")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("id")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("title")'><a class='@SortLinkClass("title")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("title")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("assignee")'><a class='@SortLinkClass("assignee")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("assignee")</span></a></th>
+                        <th scope="col" class="at-register-sprint-heading">Sprint</th>
+                        <th scope="col" aria-sort='@SortAriaSort("due")'><a class='@SortLinkClass("due")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due Date<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("due")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("status")'><a class='@SortLinkClass("status")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("status")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("priority")'><a class='@SortLinkClass("priority")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("priority")</span></a></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -148,15 +178,13 @@
                     {
                         <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
                             <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">AT-@task.Id</a></td>
-                            <td>
+                            <td class="at-register-task-cell">
                                 <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">@task.Title</a>
                                 <div class="at-task-desc-preview">@task.Description</div>
-                                <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
                             </td>
-                            <td>
-                                <div class="fw-semibold">@Model.ResolveAssigneeName(task.AssignedToUserId)</div>
-                            </td>
-                            <td>@task.DueDate.ToString("dd MMM yyyy")</td>
+                            <td class="at-register-person-cell">@Model.ResolveAssigneeName(task.AssignedToUserId)</td>
+                            <td class="at-register-sprint-cell"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></td>
+                            <td class="at-register-date-cell">@task.DueDate.ToString("dd MMM yyyy")</td>
                             <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
                             <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
                         </tr>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -273,6 +273,65 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task RegisterPartial_RendersDedicatedSprintColumn()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Enterprise Sprint", ActionSprintStatus.Active);
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.SprintId = sprint.Id;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Register";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskRegister.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("<th scope=\"col\" class=\"at-register-sprint-heading\">Sprint</th>", html, StringComparison.Ordinal);
+        Assert.Contains("at-register-sprint-cell", html, StringComparison.Ordinal);
+        Assert.Contains("Enterprise Sprint", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RegisterPartial_ActiveFiltersRemainVisibleAndSortLinksPreserveFilters()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var taskDueDate = (await setup.Db.ActionTasks.SingleAsync()).DueDate.Date;
+        var page = setup.Page;
+        page.ViewMode = "Register";
+        page.FilterStatus = ActionTaskStatuses.Assigned;
+        page.FilterPriority = "Normal";
+        page.FilterAssigneeUserId = "user-1";
+        page.FilterDueDate = taskDueDate;
+        page.FilterSearch = "Mine";
+        page.SortBy = "due";
+        page.SortDir = "desc";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskRegister.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("at-register-active-filters", html, StringComparison.Ordinal);
+        Assert.Contains("Status: Assigned", html, StringComparison.Ordinal);
+        Assert.Contains("Priority: Normal", html, StringComparison.Ordinal);
+        Assert.Contains("Responsible Person: User One", html, StringComparison.Ordinal);
+        Assert.Contains($"Due: {taskDueDate:dd MMM yyyy}", html, StringComparison.Ordinal);
+        Assert.Contains("Search: Mine", html, StringComparison.Ordinal);
+        Assert.Contains("FilterStatus=Assigned", html, StringComparison.Ordinal);
+        Assert.Contains("FilterPriority=Normal", html, StringComparison.Ordinal);
+        Assert.Contains("FilterAssigneeUserId=user-1", html, StringComparison.Ordinal);
+        Assert.Contains($"FilterDueDate={taskDueDate:yyyy-MM-dd}", html, StringComparison.Ordinal);
+        Assert.Contains("FilterSearch=Mine", html, StringComparison.Ordinal);
+        Assert.Contains("SortBy=id", html, StringComparison.Ordinal);
+        Assert.Contains("class=\"at-sort-link is-active\"", html, StringComparison.Ordinal);
+        Assert.Contains("aria-sort=\"descending\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CreateValidationFailure_ReopensPanel()
     {
         // SECTION: Arrange

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -605,6 +605,158 @@ html {
     text-decoration: underline;
 }
 
+
+/* SECTION: Register enterprise grid polish */
+.at-register-filter-panel {
+    padding: 0.75rem 0.85rem;
+}
+
+.at-register-filter-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.55rem;
+}
+
+.at-register-filter-heading h2 {
+    margin-bottom: 0.1rem;
+}
+
+.at-register-filter-heading .at-panel-note {
+    margin: 0;
+}
+
+.at-register-filter-toolbar {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.75fr) minmax(8rem, 0.75fr) minmax(13rem, 1.25fr) minmax(9rem, 0.8fr) minmax(15rem, 1.5fr);
+    gap: 0.5rem;
+    align-items: end;
+}
+
+.at-register-filter-field .form-label {
+    margin-bottom: 0.2rem;
+    color: #64748b;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-register-filter-field .form-control,
+.at-register-filter-field .form-select {
+    min-height: 2rem;
+    font-size: var(--at-font-md);
+}
+
+.at-register-active-filters {
+    margin-top: 0.55rem;
+    gap: 0.35rem;
+}
+
+.at-register-active-filters .at-filter-chip {
+    padding: 0.12rem 0.5rem;
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-register-table-scroll {
+    max-height: min(64vh, 42rem);
+    overflow: auto;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+}
+
+.at-register-table {
+    min-width: 980px;
+    font-size: var(--at-font-md);
+}
+
+.at-register-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    box-shadow: inset 0 -1px 0 var(--at-border);
+    padding: 0.45rem 0.55rem;
+    white-space: nowrap;
+}
+
+.at-register-table td {
+    padding: 0.38rem 0.55rem;
+}
+
+.at-register-table tbody tr:hover td {
+    background: #f8fafc;
+}
+
+.at-register-task-cell {
+    min-width: 18rem;
+    max-width: 30rem;
+}
+
+.at-register-person-cell,
+.at-register-date-cell {
+    color: #334155;
+    font-weight: 400;
+    white-space: nowrap;
+}
+
+.at-register-sprint-cell {
+    min-width: 9.5rem;
+    max-width: 13.5rem;
+}
+
+.at-register-sprint-cell .at-scope-badge {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.at-register-table .at-task-title {
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-register-table .at-task-desc-preview {
+    -webkit-line-clamp: 1;
+    font-size: var(--at-font-sm);
+}
+
+.at-register-table tbody tr.is-selected td {
+    background: #eef6ff;
+}
+
+.at-register-table tbody tr.is-selected:hover td {
+    background: #e8f2ff;
+}
+
+.at-sort-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+}
+
+.at-sort-link.is-active {
+    color: #1d4ed8;
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-sort-indicator {
+    min-width: 0.75rem;
+    color: #64748b;
+    font-size: 0.72rem;
+    line-height: 1;
+}
+
+@media (max-width: 1199.98px) {
+    .at-register-filter-toolbar {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-register-filter-field-person,
+    .at-register-filter-field-search {
+        grid-column: span 2;
+    }
+}
+
 /* SECTION: Badge system */
 .at-badge {
     border-radius: 999px;


### PR DESCRIPTION
### Motivation
- Improve the Register workspace visual density and readability so it behaves like an ERP-grade master task record while preserving all backend behaviour and workflows.
- Keep existing filters, sorting, task links and selection behaviour intact while making the UI more compact and audit-friendly.

### Description
- Compact filter toolbar: replaced the tall filter form with a compact, toolbar-like filter panel and preserved all existing fields (Status, Priority, Responsible Person, Due Date, Title search), Reset and Clear-all actions, and visible active filter chips; added small helper Razor functions for active sort affordances. (Pages/ActionTasks/_TaskRegister.cshtml)
- Table structure: added a dedicated Sprint column and moved the sprint/backlog badge out of the Task cell, preserved the task ID/title links and selected-row behaviour, and adjusted table column order to: ID, Task, Responsible Person, Sprint, Due Date, Status, Priority. (Pages/ActionTasks/_TaskRegister.cshtml)
- Visual polish & accessibility: introduced compact row density, sticky table header inside a scroll container, subtler hover and selected states, lighter typography for Responsible Person and Due Date, visible but subtle sort indicators and `aria-sort` state, and ellipsized sprint badges. (wwwroot/css/action-tracker.css)
- Tests: updated/added Razor partial tests to assert the Sprint column renders, active filter chips remain visible, and sort links preserve filter route values and indicate active sort. (ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs)

### Testing
- Ran `npm test` (JavaScript unit tests) and they passed.
- Ran the repository view linter (`npm run lint:views`) which reported failures due to pre-existing inline style attributes in unrelated views; these are outside the scope of this change and pre-existed the PR.
- Attempted to run the .NET unit tests for the modified ActionTasks tests but the `dotnet` SDK is not available in this environment, so the full test run could not be executed here; the newly added partial-render unit tests are included in the test project and should be run in CI or a local environment with the .NET SDK installed.
- No backend services, workflow rules, permissions, audit logic, database schema, task services or sprint services were changed during this UI/readability polish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8a86437c8329a7d911839e8ef67a)