### PR TITLE
Enhance Action Tracker Reports filtering

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -76,6 +76,11 @@ public class IndexModel : PageModel
     public IReadOnlyList<CountSummary> StatusCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> CarryForwardBySprint { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public int ReportFilteredTaskCount { get; private set; }
+    public int ReportTotalTaskCount { get; private set; }
 
     [BindProperty(SupportsGet = true)]
     public string? ViewMode { get; set; } = "CommandCentre";
@@ -110,6 +115,24 @@ public class IndexModel : PageModel
     public string? SortBy { get; set; }
     [BindProperty(SupportsGet = true)]
     public string? SortDir { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? ReportSprintId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? ReportAssigneeUserId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public DateTime? ReportFromDate { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public DateTime? ReportToDate { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? ReportStatus { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? ReportPriority { get; set; }
 
     public string CurrentRole { get; private set; } = string.Empty;
     public string CurrentUserId { get; private set; } = string.Empty;
@@ -761,7 +784,7 @@ public class IndexModel : PageModel
         var activityByTaskId = await _service.GetLastActivityUtcByTaskIdsAsync(tasks.Select(t => t.Id).ToArray());
         var readModel = _queryService.BuildReadModel(
             tasks,
-            new ActionTaskQueryService.ActionTaskQueryRequest(CurrentUserId, IsMyTasksView, IsTaskListView, IsBacklogView, SelectedSprintId, sprints, FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir),
+            new ActionTaskQueryService.ActionTaskQueryRequest(CurrentUserId, IsMyTasksView, IsTaskListView, IsBacklogView, SelectedSprintId, sprints, FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir, ReportSprintId, ReportAssigneeUserId, ReportFromDate, ReportToDate, ReportStatus, ReportPriority),
             TaskAssigneeNames,
             activityByTaskId);
 
@@ -798,6 +821,11 @@ public class IndexModel : PageModel
         OpenAgeingBuckets = readModel.Reports.OpenAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         OverdueAgeingBuckets = readModel.Reports.OverdueAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         SubmittedPendingClosureAgeingBuckets = readModel.Reports.SubmittedPendingClosureAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        BacklogAgeingBuckets = readModel.Reports.BacklogAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        CarryForwardBySprint = readModel.Reports.CarryForwardBySprint.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        BlockedAgeingBuckets = readModel.Reports.BlockedAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        ReportFilteredTaskCount = readModel.Reports.FilteredTaskCount;
+        ReportTotalTaskCount = readModel.Reports.TotalTaskCount;
 
         // SECTION: Selected Task Resolution
         if (!TaskId.HasValue)
@@ -1081,6 +1109,9 @@ public class IndexModel : PageModel
     public int AssigneePendingCountsMax => AssigneePendingCounts.Count == 0 ? 0 : AssigneePendingCounts.Max(x => x.Count);
     public int OpenAgeingBucketsMax => OpenAgeingBuckets.Count == 0 ? 0 : OpenAgeingBuckets.Max(x => x.Count);
     public int OverdueAgeingBucketsMax => OverdueAgeingBuckets.Count == 0 ? 0 : OverdueAgeingBuckets.Max(x => x.Count);
+    public int BacklogAgeingBucketsMax => BacklogAgeingBuckets.Count == 0 ? 0 : BacklogAgeingBuckets.Max(x => x.Count);
+    public int CarryForwardBySprintMax => CarryForwardBySprint.Count == 0 ? 0 : CarryForwardBySprint.Max(x => x.Count);
+    public int BlockedAgeingBucketsMax => BlockedAgeingBuckets.Count == 0 ? 0 : BlockedAgeingBuckets.Max(x => x.Count);
     public int ActiveCriticalCount => Tasks.Count(t =>
         !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
         && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
@@ -1095,6 +1126,21 @@ public class IndexModel : PageModel
          || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
          || FilterDueDate.HasValue
          || !string.IsNullOrWhiteSpace(FilterSearch));
+
+
+    public bool HasReportFilters =>
+        IsReportsView &&
+        (ReportSprintId.HasValue
+         || !string.IsNullOrWhiteSpace(ReportAssigneeUserId)
+         || ReportFromDate.HasValue
+         || ReportToDate.HasValue
+         || !string.IsNullOrWhiteSpace(ReportStatus)
+         || !string.IsNullOrWhiteSpace(ReportPriority));
+
+    public string ReportFilterSummary =>
+        HasReportFilters
+            ? $"Showing {ReportFilteredTaskCount} of {ReportTotalTaskCount} tasks matching the selected report filters."
+            : $"Showing all {ReportTotalTaskCount} tasks available to the reports workspace.";
 
     // SECTION: Planning backlog disclosure mirrors every route value that can alter the backlog read model.
     public bool HasBacklogFilterRouteState => HasTaskFilterRouteState();

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -1,4 +1,9 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
+@{
+    // SECTION: Date filter display values are preformatted for CSP-safe server rendering.
+    var reportFromDateValue = Model.ReportFromDate?.ToString("yyyy-MM-dd");
+    var reportToDateValue = Model.ReportToDate?.ToString("yyyy-MM-dd");
+}
 
 @* SECTION: Reports introduction and scope. *@
 <section class="at-section-group">
@@ -11,6 +16,110 @@
         </div>
         <p class="at-empty-state-note">This page intentionally excludes the Command Centre KPI strip so reports remain focused on analysis rather than operational command cards.</p>
     </article>
+</section>
+
+@* SECTION: Compact reports filter bar for management analysis. *@
+<section class="at-section-group">
+    <form method="get" class="at-panel at-reports-filter-panel" aria-label="Reports filters">
+        <input type="hidden" name="ViewMode" value="Reports" />
+        <div class="at-reports-filter-heading">
+            <div>
+                <h2>Report Filters</h2>
+                <p class="at-panel-note">Narrow every report section by Sprint, responsible person, due-date range, workflow status and priority.</p>
+            </div>
+            <span class="at-report-filter-summary">@Model.ReportFilterSummary</span>
+        </div>
+        <div class="at-reports-filter-grid">
+            <label>
+                <span>Sprint</span>
+                <select class="form-select form-select-sm" name="ReportSprintId">
+                    <option value="">All Sprints &amp; Backlog</option>
+                    @if (Model.ReportSprintId == 0)
+                    {
+                        <option value="0" selected>Backlog only</option>
+                    }
+                    else
+                    {
+                        <option value="0">Backlog only</option>
+                    }
+                    @foreach (var sprint in Model.Sprints)
+                    {
+                        @if (Model.ReportSprintId == sprint.Id)
+                        {
+                            <option value="@sprint.Id" selected>@Model.DisplaySprintName(sprint)</option>
+                        }
+                        else
+                        {
+                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint)</option>
+                        }
+                    }
+                </select>
+            </label>
+            <label>
+                <span>Responsible Person</span>
+                <select class="form-select form-select-sm" name="ReportAssigneeUserId">
+                    <option value="">All people</option>
+                    @foreach (var user in Model.AssignableUsers)
+                    {
+                        @if (string.Equals(Model.ReportAssigneeUserId, user.UserId, StringComparison.Ordinal))
+                        {
+                            <option value="@user.UserId" selected>@user.DisplayName</option>
+                        }
+                        else
+                        {
+                            <option value="@user.UserId">@user.DisplayName</option>
+                        }
+                    }
+                </select>
+            </label>
+            <label>
+                <span>From</span>
+                <input class="form-control form-control-sm" type="date" name="ReportFromDate" value="@reportFromDateValue" />
+            </label>
+            <label>
+                <span>To</span>
+                <input class="form-control form-control-sm" type="date" name="ReportToDate" value="@reportToDateValue" />
+            </label>
+            <label>
+                <span>Status</span>
+                <select class="form-select form-select-sm" name="ReportStatus">
+                    <option value="">All statuses</option>
+                    @foreach (var status in Model.AllowedStatusOptions)
+                    {
+                        @if (string.Equals(Model.ReportStatus, status, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@status" selected>@status</option>
+                        }
+                        else
+                        {
+                            <option value="@status">@status</option>
+                        }
+                    }
+                </select>
+            </label>
+            <label>
+                <span>Priority</span>
+                <select class="form-select form-select-sm" name="ReportPriority">
+                    <option value="">All priorities</option>
+                    @foreach (var priority in Model.PriorityOptions)
+                    {
+                        @if (string.Equals(Model.ReportPriority, priority, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@priority" selected>@priority</option>
+                        }
+                        else
+                        {
+                            <option value="@priority">@priority</option>
+                        }
+                    }
+                </select>
+            </label>
+        </div>
+        <div class="at-reports-filter-actions">
+            <button type="submit" class="btn btn-sm btn-primary">Apply filters</button>
+            <a class="btn btn-sm btn-outline-secondary" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports">Reset / Clear all</a>
+        </div>
+    </form>
 </section>
 
 @* SECTION: Current-state analytical reports with proportional bars. *@
@@ -61,7 +170,7 @@
         </div>
         @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
         {
-            <p class="at-empty-state-note">No submitted tasks are awaiting closure.</p>
+            <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
         }
         else
         {
@@ -70,7 +179,7 @@
                 {
                     <div class="at-metric-row">
                         <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedCount == 0 ? 1 : Model.SubmittedCount)%"></div></div>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedPendingClosureAgeingBuckets.Max(x => x.Count))%"></div></div>
                         <strong>@item.Count</strong>
                     </div>
                 }
@@ -129,6 +238,71 @@
                 <div class="at-metric-row">
                     <span class="at-metric-label" title="@item.Name">@item.Name</span>
                     <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
+        </div>
+    </article>
+
+    @* SECTION: Decision-support summaries derived from the existing task and Sprint read model. *@
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Backlog Ageing Summary</h2>
+                <p class="at-panel-note">Highlights unscheduled open work by age so stale backlog items can be triaged.</p>
+            </div>
+        </div>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.BacklogAgeingBuckets)
+            {
+                <div class="at-metric-row">
+                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.BacklogAgeingBucketsMax)%"></div></div>
+                    <strong>@item.Count</strong>
+                </div>
+            }
+        </div>
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Carry-forward by Sprint</h2>
+                <p class="at-panel-note">Safely derived from unfinished tasks that remain assigned to non-closed Sprints.</p>
+            </div>
+        </div>
+        @if (Model.CarryForwardBySprint.All(item => item.Count == 0))
+        {
+            <p class="at-empty-state-note">No carry-forward candidates are visible in the selected report scope.</p>
+        }
+        else
+        {
+            <div class="at-metric-bars">
+                @foreach (var item in Model.CarryForwardBySprint)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.CarryForwardBySprintMax)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        }
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Blocked Task Ageing</h2>
+                <p class="at-panel-note">Ages blocked tasks by time since assignment to support unblock decisions without changing backend workflow.</p>
+            </div>
+        </div>
+        <div class="at-metric-bars">
+            @foreach (var item in Model.BlockedAgeingBuckets)
+            {
+                <div class="at-metric-row">
+                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.BlockedAgeingBucketsMax)%"></div></div>
                     <strong>@item.Count</strong>
                 </div>
             }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -778,6 +778,68 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("Backlog Queue", html, StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public async Task ReportsPartial_RendersCompactFilterBarAndSprintOptions()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Decision Sprint", ActionSprintStatus.Active);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Reports";
+        page.ReportSprintId = sprint.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskReports.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Report Filters", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
+        Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Reset / Clear all", html, StringComparison.Ordinal);
+        Assert.Contains("selected", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReportsFilters_PersistStateAndFilterSections()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Filtered Report Sprint", ActionSprintStatus.Active);
+        var matching = await setup.Db.ActionTasks.SingleAsync();
+        matching.SprintId = sprint.Id;
+        matching.Priority = "High";
+        matching.Status = ActionTaskStatuses.Blocked;
+        matching.AssignedOn = DateTime.UtcNow.Date.AddDays(-9);
+        matching.DueDate = DateTime.UtcNow.Date.AddDays(1);
+        setup.Db.ActionTasks.Add(NewTask("Outside report scope", ActionTaskStatuses.Assigned));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Reports";
+        page.ReportSprintId = sprint.Id;
+        page.ReportAssigneeUserId = "user-1";
+        page.ReportFromDate = DateTime.UtcNow.Date;
+        page.ReportToDate = DateTime.UtcNow.Date.AddDays(2);
+        page.ReportStatus = ActionTaskStatuses.Blocked;
+        page.ReportPriority = "High";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskReports.cshtml");
+
+        // SECTION: Assert
+        Assert.True(page.HasReportFilters);
+        Assert.Equal(1, page.ReportFilteredTaskCount);
+        Assert.Equal(1, page.StatusCounts.Single(x => x.Name == ActionTaskStatuses.Blocked).Count);
+        Assert.Equal(1, page.PriorityCounts.Single(x => x.Name == "High").Count);
+        Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8 to 14 days").Count);
+        Assert.Contains("Showing 1 of 2 tasks", html, StringComparison.Ordinal);
+        Assert.Contains(@"value=""High"" selected", html, StringComparison.Ordinal);
+        Assert.Contains(@"value=""user-1"" selected", html, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task SprintHistoryReadModel_ReturnsAuditEventsWithActorVisibility()
     {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -46,20 +46,80 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(nextSprint.Id, model.SprintReadModel.ClosureReview.TargetSprintOptions.Single().Id);
     }
 
+
+    [Fact]
+    public void BuildReadModel_AppliesReportsFiltersAcrossAnalyticalSections()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 21, Name = "Filtered Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var otherSprint = new ActionSprint { Id = 22, Name = "Other Sprint", Status = ActionSprintStatus.Planned, StartDate = today.AddDays(8), EndDate = today.AddDays(14) };
+        var tasks = new[]
+        {
+            NewTask(11, sprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "assignee", today.AddDays(-9)),
+            NewTask(12, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(4), "Normal", "assignee", today.AddDays(-1)),
+            NewTask(13, otherSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "other", today.AddDays(-16)),
+            NewTask(14, null, ActionTaskStatuses.Assigned, today.AddDays(2), "High", "assignee", today.AddDays(-5))
+        };
+        var service = new ActionTaskQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint, otherSprint }, null, null, null, null, null, null, null, sprint.Id, "assignee", today, today.AddDays(3), ActionTaskStatuses.Blocked, "High"),
+            new Dictionary<string, string> { ["assignee"] = "Responsible One", ["other"] = "Other Person" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(4, model.Reports.TotalTaskCount);
+        Assert.Equal(1, model.Reports.FilteredTaskCount);
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Responsible One", 1) }, model.Reports.AssigneePendingCounts);
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("High", 1) }, model.Reports.PriorityCounts);
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary(ActionTaskStatuses.Blocked, 1) }, model.Reports.StatusCounts);
+        Assert.Equal(1, model.Reports.BlockedAgeingBuckets.Single(x => x.Name == "8 to 14 days").Count);
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Filtered Sprint", 1) }, model.Reports.CarryForwardBySprint);
+    }
+
+    [Fact]
+    public void BuildReadModel_ReportBacklogSprintFilter_RendersBacklogAgeingOnly()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 31, Name = "Sprint Scope", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var tasks = new[]
+        {
+            NewTask(21, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-5)),
+            NewTask(22, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-12))
+        };
+        var service = new ActionTaskQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null, 0),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(1, model.Reports.FilteredTaskCount);
+        Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "4 to 7 days").Count);
+        Assert.All(model.Reports.CarryForwardBySprint, item => Assert.Equal(0, item.Count));
+    }
+
     // SECTION: Test data helper
-    private static ActionTaskItem NewTask(int id, int? sprintId, string status, DateTime dueDate)
+    private static ActionTaskItem NewTask(int id, int? sprintId, string status, DateTime dueDate, string priority = "Normal", string assignedToUserId = "assignee", DateTime? assignedOn = null)
         => new()
         {
             Id = id,
             Title = $"Task {id}",
             Description = "Task",
             CreatedByUserId = "creator",
-            AssignedToUserId = "assignee",
+            AssignedToUserId = assignedToUserId,
             CreatedByRole = "HoD",
             AssignedToRole = "TA",
-            AssignedOn = dueDate.AddDays(-2),
+            AssignedOn = assignedOn ?? dueDate.AddDays(-2),
             DueDate = dueDate,
-            Priority = "Normal",
+            Priority = priority,
             Status = status,
             SprintId = sprintId,
             ClosedOn = status == ActionTaskStatuses.Closed ? dueDate : null,

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -40,7 +40,7 @@ public sealed class ActionTaskQueryService
             KanbanSubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList(),
             KanbanClosedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).ToList(),
             DueBuckets = BuildDueBuckets(tasks),
-            Reports = BuildReportModel(tasks, assigneeNames)
+            Reports = BuildReportModel(tasks, request, assigneeNames)
         };
     }
 
@@ -201,22 +201,67 @@ public sealed class ActionTaskQueryService
         };
     }
 
-    private static ActionTaskReportReadModel BuildReportModel(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
+    // SECTION: Filter-aware report projection for management analysis without changing workflow rules.
+    private static ActionTaskReportReadModel BuildReportModel(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
     {
         var utcToday = DateTime.UtcNow.Date;
-        var openTasks = tasks.Where(IsOpen).ToList();
-        var submittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
+        var reportTasks = ApplyReportFilters(tasks, request).ToList();
+        var openTasks = reportTasks.Where(IsOpen).ToList();
+        var submittedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
+        var backlogOpenTasks = openTasks.Where(t => t.SprintId is null).ToList();
+        var blockedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
         string Assignee(string id) => assigneeNames.TryGetValue(id, out var name) ? name : "User";
 
         return new ActionTaskReportReadModel
         {
+            TotalTaskCount = tasks.Count,
+            FilteredTaskCount = reportTasks.Count,
             AssigneePendingCounts = openTasks.GroupBy(t => Assignee(t.AssignedToUserId)).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
-            PriorityCounts = tasks.GroupBy(t => t.Priority).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
-            StatusCounts = tasks.GroupBy(t => t.Status).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
-            OpenAgeingBuckets = new[] { new CountSummary("0 to 3 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)), new CountSummary("4 to 7 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)), new CountSummary("8 to 14 days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)), new CountSummary("15+ days", openTasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15)) },
+            PriorityCounts = openTasks.GroupBy(t => t.Priority).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
+            StatusCounts = reportTasks.GroupBy(t => t.Status).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new CountSummary(g.Key, g.Count())).ToList(),
+            OpenAgeingBuckets = BuildAssignedAgeingBuckets(openTasks, utcToday),
             OverdueAgeingBuckets = new[] { new CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)), new CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)), new CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8)) },
-            SubmittedPendingClosureAgeingBuckets = new[] { new CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)), new CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)), new CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4)) }
+            SubmittedPendingClosureAgeingBuckets = new[] { new CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)), new CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)), new CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4)) },
+            BacklogAgeingBuckets = BuildAssignedAgeingBuckets(backlogOpenTasks, utcToday),
+            BlockedAgeingBuckets = BuildAssignedAgeingBuckets(blockedTasks, utcToday),
+            CarryForwardBySprint = BuildCarryForwardBySprint(openTasks, request.Sprints)
         };
+    }
+
+    // SECTION: Reports filters are isolated from register/backlog filters to preserve other workspaces.
+    private static IEnumerable<ActionTaskItem> ApplyReportFilters(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request)
+    {
+        var query = tasks.AsEnumerable();
+        if (request.ReportSprintId.HasValue)
+        {
+            query = request.ReportSprintId.Value == 0
+                ? query.Where(t => t.SprintId is null)
+                : query.Where(t => t.SprintId == request.ReportSprintId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ReportAssigneeUserId)) query = query.Where(t => string.Equals(t.AssignedToUserId, request.ReportAssigneeUserId, StringComparison.Ordinal));
+        if (request.ReportFromDate.HasValue) { var d = request.ReportFromDate.Value.Date; query = query.Where(t => t.DueDate.Date >= d); }
+        if (request.ReportToDate.HasValue) { var d = request.ReportToDate.Value.Date; query = query.Where(t => t.DueDate.Date <= d); }
+        if (!string.IsNullOrWhiteSpace(request.ReportStatus)) query = query.Where(t => string.Equals(t.Status, request.ReportStatus, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(request.ReportPriority)) query = query.Where(t => string.Equals(t.Priority, request.ReportPriority, StringComparison.OrdinalIgnoreCase));
+        return query;
+    }
+
+    // SECTION: Shared assigned-age buckets used by open, backlog and blocked ageing reports.
+    private static IReadOnlyList<CountSummary> BuildAssignedAgeingBuckets(IReadOnlyList<ActionTaskItem> tasks, DateTime utcToday)
+        => new[] { new CountSummary("0 to 3 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)), new CountSummary("4 to 7 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)), new CountSummary("8 to 14 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)), new CountSummary("15+ days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15)) };
+
+    // SECTION: Safely-derived carry-forward candidates from unfinished tasks still associated with non-closed sprints.
+    private static IReadOnlyList<CountSummary> BuildCarryForwardBySprint(IReadOnlyList<ActionTaskItem> openTasks, IReadOnlyList<ActionSprint> sprints)
+    {
+        var sprintLookup = sprints.ToDictionary(s => s.Id);
+        return openTasks
+            .Where(t => t.SprintId.HasValue && sprintLookup.TryGetValue(t.SprintId.Value, out var sprint) && sprint.Status != ActionSprintStatus.Closed)
+            .GroupBy(t => sprintLookup[t.SprintId!.Value])
+            .OrderBy(g => g.Key.StartDate)
+            .ThenBy(g => g.Key.Id)
+            .Select(g => new CountSummary(g.Key.Name, g.Count()))
+            .ToList();
     }
 
     private static IEnumerable<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
@@ -269,7 +314,13 @@ public sealed class ActionTaskQueryService
         DateTime? FilterDueDate,
         string? FilterSearch,
         string? SortBy,
-        string? SortDir);
+        string? SortDir,
+        int? ReportSprintId = null,
+        string? ReportAssigneeUserId = null,
+        DateTime? ReportFromDate = null,
+        DateTime? ReportToDate = null,
+        string? ReportStatus = null,
+        string? ReportPriority = null);
 
     public sealed class ActionTaskReadModel
     {
@@ -362,6 +413,11 @@ public sealed class ActionTaskQueryService
         public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> CarryForwardBySprint { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public int TotalTaskCount { get; init; }
+        public int FilteredTaskCount { get; init; }
     }
     public sealed record CountSummary(string Name, int Count);
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3291,3 +3291,77 @@ html {
         margin-top: 0.35rem;
     }
 }
+
+/* SECTION: Phase 3D compact analytical Reports filters and decision-support cards. */
+.at-reports-filter-panel {
+    display: flex;
+    flex-direction: column;
+    gap: .85rem;
+}
+
+.at-reports-filter-heading {
+    align-items: flex-start;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+}
+
+.at-report-filter-summary {
+    background: rgba(15, 23, 42, .05);
+    border: 1px solid rgba(15, 23, 42, .08);
+    border-radius: 999px;
+    color: #475569;
+    font-size: .78rem;
+    font-weight: 700;
+    padding: .35rem .7rem;
+    white-space: nowrap;
+}
+
+.at-reports-filter-grid {
+    display: grid;
+    gap: .65rem;
+    grid-template-columns: minmax(13rem, 1.35fr) minmax(13rem, 1.35fr) repeat(4, minmax(8.5rem, 1fr));
+}
+
+.at-reports-filter-grid label {
+    color: #475569;
+    display: flex;
+    flex-direction: column;
+    font-size: .74rem;
+    font-weight: 800;
+    gap: .25rem;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+}
+
+.at-reports-filter-actions {
+    align-items: center;
+    display: flex;
+    gap: .5rem;
+    justify-content: flex-end;
+}
+
+@media (max-width: 1199.98px) {
+    .at-reports-filter-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-reports-filter-heading {
+        flex-direction: column;
+    }
+
+    .at-report-filter-summary {
+        white-space: normal;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .at-reports-filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-reports-filter-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a compact, management-focused Reports workspace with filter controls so analytical sections can be scoped for decision support without changing workflow, lifecycle, permission, audit or schema rules. 
- Keep Reports distinct from the Command Centre by avoiding KPI strip duplication and preserving existing behaviours for other workspaces and task inspector flows.

### Description
- Add a compact server-rendered Reports filter bar with controls for `Sprint` (including Backlog-only), `Responsible Person`, `From`/`To` date range, `Status`, `Priority`, and a `Reset / Clear all` action in `Pages/ActionTasks/_TaskReports.cshtml` and supporting CSS in `wwwroot/css/action-tracker.css`.
- Make report sections filter-aware by extending `ActionTaskQueryService.BuildReadModel` to call a new filter-aware `BuildReportModel(..., ActionTaskQueryRequest request, ...)` and adding `ApplyReportFilters`, `BuildAssignedAgeingBuckets`, and `BuildCarryForwardBySprint` helpers in `Services/ActionTasks/ActionTaskQueryService.cs`.
- Add decision-support report panels derived safely from the existing read model: `Backlog Ageing Summary`, `Carry-forward by Sprint`, and `Blocked Task Ageing`, and adapt existing sections (ageing, overdue ageing, pending-closure, assignee workload, priority exposure, workflow distribution) to reflect selected report filters in `Pages/ActionTasks/_TaskReports.cshtml`.
- Expose and persist report filter state via new bound properties on the page model (`ReportSprintId`, `ReportAssigneeUserId`, `ReportFromDate`, `ReportToDate`, `ReportStatus`, `ReportPriority`) and wire them into `IndexModel.LoadDataAsync` so filters survive GET route-state in `Pages/ActionTasks/Index.cshtml.cs`.
- Surface summary/count metadata (`ReportFilteredTaskCount`, `ReportTotalTaskCount`) and a short `ReportFilterSummary` to inform users of filtered scope without changing other read-models.
- Add tests to cover rendering and behaviour: updated `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` and `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` to validate filter bar rendering, filter persistence, and filtered read-model outputs.

### Testing
- JavaScript unit tests: ran `npm test` and all tests passed (13/13 passing). 
- Repository checks: `git diff --check` reported no whitespace/format issues. 
- Server-side tests: added and updated C# unit tests in `ProjectManagement.Tests/ActionTasks`; attempted to run `dotnet test` but the container environment does not have `dotnet` installed so those tests could not be executed here (they are included and should run in CI/Dev with .NET SDK available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbef547f588329ad90adc0e0dedaf7)