### PR TITLE
Polish Action Tracker reports filter auto-apply UX

### DIFF
--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -20,7 +20,7 @@
 
 @* SECTION: Compact reports filter bar for management analysis. *@
 <section class="at-section-group">
-    <form method="get" class="at-panel at-reports-filter-panel" aria-label="Reports filters">
+    <form method="get" class="at-panel at-reports-filter-panel" aria-label="Reports filters" data-at-reports-filter-form="true">
         <input type="hidden" name="ViewMode" value="Reports" />
         <div class="at-reports-filter-heading">
             <div>
@@ -32,7 +32,7 @@
         <div class="at-reports-filter-grid">
             <label>
                 <span>Sprint</span>
-                <select class="form-select form-select-sm" name="ReportSprintId">
+                <select class="form-select form-select-sm" name="ReportSprintId" data-at-reports-filter-control="true">
                     <option value="">All Sprints &amp; Backlog</option>
                     @if (Model.ReportSprintId == 0)
                     {
@@ -57,7 +57,7 @@
             </label>
             <label>
                 <span>Responsible Person</span>
-                <select class="form-select form-select-sm" name="ReportAssigneeUserId">
+                <select class="form-select form-select-sm" name="ReportAssigneeUserId" data-at-reports-filter-control="true">
                     <option value="">All people</option>
                     @foreach (var user in Model.AssignableUsers)
                     {
@@ -74,15 +74,15 @@
             </label>
             <label>
                 <span>From</span>
-                <input class="form-control form-control-sm" type="date" name="ReportFromDate" value="@reportFromDateValue" />
+                <input class="form-control form-control-sm" type="date" name="ReportFromDate" value="@reportFromDateValue" data-at-reports-date-filter="true" />
             </label>
             <label>
                 <span>To</span>
-                <input class="form-control form-control-sm" type="date" name="ReportToDate" value="@reportToDateValue" />
+                <input class="form-control form-control-sm" type="date" name="ReportToDate" value="@reportToDateValue" data-at-reports-date-filter="true" />
             </label>
             <label>
                 <span>Status</span>
-                <select class="form-select form-select-sm" name="ReportStatus">
+                <select class="form-select form-select-sm" name="ReportStatus" data-at-reports-filter-control="true">
                     <option value="">All statuses</option>
                     @foreach (var status in Model.AllowedStatusOptions)
                     {
@@ -99,7 +99,7 @@
             </label>
             <label>
                 <span>Priority</span>
-                <select class="form-select form-select-sm" name="ReportPriority">
+                <select class="form-select form-select-sm" name="ReportPriority" data-at-reports-filter-control="true">
                     <option value="">All priorities</option>
                     @foreach (var priority in Model.PriorityOptions)
                     {
@@ -116,7 +116,10 @@
             </label>
         </div>
         <div class="at-reports-filter-actions">
-            <button type="submit" class="btn btn-sm btn-primary">Apply filters</button>
+            <span class="at-reports-filter-loading" data-at-reports-filter-loading="true" role="status" aria-live="polite">
+                <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                <span>Updating reports...</span>
+            </span>
             <a class="btn btn-sm btn-outline-secondary" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports">Reset / Clear all</a>
         </div>
     </form>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -799,6 +799,11 @@ public class ActionTaskPageTests
         Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
         Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Reset / Clear all", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-reports-filter-form=""true""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-reports-filter-control=""true""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-reports-date-filter=""true""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-reports-filter-loading=""true""", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Apply filters", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("selected", html, StringComparison.Ordinal);
     }
 
@@ -836,8 +841,23 @@ public class ActionTaskPageTests
         Assert.Equal(1, page.PriorityCounts.Single(x => x.Name == "High").Count);
         Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8 to 14 days").Count);
         Assert.Contains("Showing 1 of 2 tasks", html, StringComparison.Ordinal);
+        Assert.Contains(@"method=""get""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ViewMode"" value=""Reports""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportAssigneeUserId""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportFromDate"" value=""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportToDate"" value=""", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""ReportStatus""", html, StringComparison.Ordinal);
         Assert.Contains(@"value=""High"" selected", html, StringComparison.Ordinal);
         Assert.Contains(@"value=""user-1"" selected", html, StringComparison.Ordinal);
+        Assert.Contains("Ageing Analysis", html, StringComparison.Ordinal);
+        Assert.Contains("Pending Closure Ageing", html, StringComparison.Ordinal);
+        Assert.Contains("Assignee Workload", html, StringComparison.Ordinal);
+        Assert.Contains("Priority Exposure", html, StringComparison.Ordinal);
+        Assert.Contains("Workflow Distribution", html, StringComparison.Ordinal);
+        Assert.Contains("Backlog Ageing Summary", html, StringComparison.Ordinal);
+        Assert.Contains("Carry-forward by Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Blocked Task Ageing", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node --test wwwroot/js/projects wwwroot/js/calendar.test.js",
+    "test": "node --test wwwroot/js/projects wwwroot/js/pages/action-tasks/index.test.js wwwroot/js/calendar.test.js",
     "lint:views": "./tools/check-views.sh"
   },
   "repository": {

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3341,6 +3341,25 @@ html {
     justify-content: flex-end;
 }
 
+.at-reports-filter-loading {
+    align-items: center;
+    color: #64748b;
+    display: none;
+    font-size: .78rem;
+    font-weight: 700;
+    gap: .4rem;
+}
+
+.at-reports-filter-loading.is-visible,
+.at-reports-filter-panel.is-loading .at-reports-filter-loading {
+    display: inline-flex;
+}
+
+.at-reports-filter-panel.is-loading .form-control,
+.at-reports-filter-panel.is-loading .form-select {
+    opacity: .72;
+}
+
 @media (max-width: 1199.98px) {
     .at-reports-filter-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -138,6 +138,63 @@
         });
     }
 
+    // SECTION: Reports filter auto-apply keeps management analysis low-friction.
+    function initReportsFilters() {
+        const form = document.querySelector("[data-at-reports-filter-form='true']");
+        if (!form) {
+            return;
+        }
+
+        let isSubmitting = false;
+        const loadingIndicator = form.querySelector("[data-at-reports-filter-loading='true']");
+
+        function showLoadingState() {
+            form.classList.add("is-loading");
+            form.setAttribute("aria-busy", "true");
+            if (loadingIndicator) {
+                loadingIndicator.classList.add("is-visible");
+            }
+        }
+
+        function submitReportsFilters() {
+            if (isSubmitting) {
+                return;
+            }
+
+            isSubmitting = true;
+            showLoadingState();
+            if (typeof form.requestSubmit === "function") {
+                form.requestSubmit();
+                return;
+            }
+
+            form.submit();
+        }
+
+        const dropdownControls = form.querySelectorAll("select[data-at-reports-filter-control='true']");
+        dropdownControls.forEach((control) => {
+            control.addEventListener("change", submitReportsFilters);
+        });
+
+        const dateControls = form.querySelectorAll("input[data-at-reports-date-filter='true']");
+        dateControls.forEach((control) => {
+            let lastAppliedValue = control.value || "";
+
+            function applyDateFilter() {
+                const currentValue = control.value || "";
+                if (currentValue === lastAppliedValue) {
+                    return;
+                }
+
+                lastAppliedValue = currentValue;
+                submitReportsFilters();
+            }
+
+            control.addEventListener("change", applyDateFilter);
+            control.addEventListener("blur", applyDateFilter);
+        });
+    }
+
     // SECTION: Sprint selector opens selected sprint through safe GET navigation.
     function initSprintSelector() {
         const form = document.querySelector("[data-at-sprint-selector='true']");
@@ -242,6 +299,7 @@
         initSearchableSelects();
         initStatusUpdateGuard();
         initTaskRegisterFilters();
+        initReportsFilters();
         initSprintSelector();
         initSprintClosureReview();
         initInspectorActionPanels();

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -1,0 +1,81 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const scriptPath = path.resolve(__dirname, 'index.js');
+const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+function createReportsFilterDom() {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+        <form method="get" data-at-reports-filter-form="true">
+            <input type="hidden" name="ViewMode" value="Reports" />
+            <select name="ReportSprintId" data-at-reports-filter-control="true">
+                <option value="">All</option>
+                <option value="1">Sprint 1</option>
+            </select>
+            <select name="ReportAssigneeUserId" data-at-reports-filter-control="true">
+                <option value="">All</option>
+                <option value="user-1">User One</option>
+            </select>
+            <input type="date" name="ReportFromDate" data-at-reports-date-filter="true" />
+            <input type="date" name="ReportToDate" value="2026-05-01" data-at-reports-date-filter="true" />
+            <select name="ReportStatus" data-at-reports-filter-control="true">
+                <option value="">All</option>
+                <option value="Blocked">Blocked</option>
+            </select>
+            <select name="ReportPriority" data-at-reports-filter-control="true">
+                <option value="">All</option>
+                <option value="High">High</option>
+            </select>
+            <span data-at-reports-filter-loading="true"></span>
+            <a href="/ActionTasks?ViewMode=Reports">Reset / Clear all</a>
+        </form>
+    </body></html>`, { url: 'https://example.test/ActionTasks?ViewMode=Reports', runScripts: 'dangerously' });
+
+    const { window } = dom;
+    const document = window.document;
+    const submissions = [];
+    const form = document.querySelector('[data-at-reports-filter-form]');
+    form.requestSubmit = () => {
+        submissions.push(new window.URLSearchParams(new window.FormData(form)).toString());
+    };
+
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+    document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+
+    return { window, document, form, submissions };
+}
+
+test('reports dropdown filters auto-submit with query-state fields intact', () => {
+    const { window, document, form, submissions } = createReportsFilterDom();
+    const sprint = document.querySelector('select[name="ReportSprintId"]');
+
+    sprint.value = '1';
+    sprint.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    assert.equal(submissions.length, 1);
+    assert.ok(form.classList.contains('is-loading'));
+    assert.equal(form.getAttribute('aria-busy'), 'true');
+    assert.ok(submissions[0].includes('ViewMode=Reports'));
+    assert.ok(submissions[0].includes('ReportSprintId=1'));
+});
+
+test('reports date filters submit on change or blur but not every typed input event', () => {
+    const { window, document, submissions } = createReportsFilterDom();
+    const fromDate = document.querySelector('input[name="ReportFromDate"]');
+
+    fromDate.value = '2026-05-07';
+    fromDate.dispatchEvent(new window.Event('input', { bubbles: true }));
+    assert.equal(submissions.length, 0);
+
+    fromDate.dispatchEvent(new window.Event('blur', { bubbles: true }));
+    assert.equal(submissions.length, 1);
+    assert.ok(submissions[0].includes('ReportFromDate=2026-05-07'));
+
+    fromDate.dispatchEvent(new window.Event('change', { bubbles: true }));
+    assert.equal(submissions.length, 1);
+});


### PR DESCRIPTION
### Motivation
- Make the Reports filter bar feel modern and low-friction by removing the explicit "Apply filters" button and auto-applying filter changes. 
- Preserve existing report calculations, query-string state, and the Reset / Clear all control while keeping the UI CSP-safe and offline-friendly. 

### Description
- Removed the explicit `Apply filters` button and added a loading affordance in the reports filter action area, while keeping the `Reset / Clear all` link intact. 
- Added CSP-safe data attributes to the Reports form and controls (`data-at-reports-filter-form`, `data-at-reports-filter-control`, `data-at-reports-date-filter`, `data-at-reports-filter-loading`) and wired a new `initReportsFilters()` initializer to auto-submit dropdowns on `change` and apply date filters on `change` or `blur` (debounced by value comparison to avoid submitting on every keystroke). 
- Implemented a minimal loading state (CSS + spinner markup) that marks the form `aria-busy` and subtly dims controls while submitting. 
- Updated server-side Razor partial markup to include the new data hooks and extended unit tests (Razor assertions) and JS tests to cover auto-submit behaviour and query-string preservation; also updated `package.json` to run the new JS test file. 

### Testing
- Ran `npm test` which executed the existing JS tests plus the new `wwwroot/js/pages/action-tasks/index.test.js` and all JS tests passed. 
- Ran `npm run lint:views` which surfaced pre-existing inline-style violations in several Razor files (including existing metric-bar `style="width:..."` usages); these are unrelated to this change and no new inline styles/scripts were introduced. 
- Intended `dotnet test` for the updated Razor/C# assertions could not be executed in this environment because the `dotnet` CLI was not available, so server-side test execution is pending in CI; the tests were updated in the repository to assert the new markup and report sections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf70afc28832988782731304c8b40)