### PR TITLE
Refactor Action Tracker: extract My Work & Command Centre builders and centralize route/filter state

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -29,10 +29,12 @@ public class IndexModel : PageModel
     private readonly ActionTaskWorkflowPolicy _workflowPolicy;
     private readonly ActionTaskRouteStateHelper _routeStateHelper;
     private readonly ActionTaskDisplayBuilder _displayBuilder;
+    private readonly ActionTaskMyWorkBuilder _myWorkBuilder;
+    private readonly ActionTaskCommandCentreBuilder _commandCentreBuilder;
     private readonly IActionTrackerClock _clock;
     private readonly UserManager<ApplicationUser> _users;
 
-    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionSprintService sprintService, ActionTaskQueryService queryService, ActionTaskWorkspaceBuilder workspaceBuilder, ActionTaskWorkflowPolicy workflowPolicy, ActionTaskRouteStateHelper routeStateHelper, ActionTaskDisplayBuilder displayBuilder, IActionTrackerClock clock, UserManager<ApplicationUser> users)
+    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionSprintService sprintService, ActionTaskQueryService queryService, ActionTaskWorkspaceBuilder workspaceBuilder, ActionTaskWorkflowPolicy workflowPolicy, ActionTaskRouteStateHelper routeStateHelper, ActionTaskDisplayBuilder displayBuilder, ActionTaskMyWorkBuilder myWorkBuilder, ActionTaskCommandCentreBuilder commandCentreBuilder, IActionTrackerClock clock, UserManager<ApplicationUser> users)
     {
         _service = service;
         _collaborationService = collaborationService;
@@ -43,6 +45,8 @@ public class IndexModel : PageModel
         _workflowPolicy = workflowPolicy;
         _routeStateHelper = routeStateHelper;
         _displayBuilder = displayBuilder;
+        _myWorkBuilder = myWorkBuilder;
+        _commandCentreBuilder = commandCentreBuilder;
         _clock = clock;
         _users = users;
         Input.DueDate = _clock.UtcToday.AddDays(7);
@@ -88,6 +92,8 @@ public class IndexModel : PageModel
     public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> CarryForwardBySprint { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public ActionTaskMyWorkQueues MyWorkQueues { get; private set; } = ActionTaskMyWorkQueues.Empty;
+    public ActionTaskCommandCentreSummary CommandCentreSummary { get; private set; } = ActionTaskCommandCentreSummary.Empty;
     public int ReportFilteredTaskCount { get; private set; }
     public int ReportTotalTaskCount { get; private set; }
 
@@ -816,6 +822,8 @@ public class IndexModel : PageModel
         PrepareSprintForms();
         await LoadSprintAuditHistoryAsync();
         ActiveSprintMetrics = readModel.ActiveSprintMetrics;
+        MyWorkQueues = _myWorkBuilder.Build(Tasks, ActiveSprint);
+        CommandCentreSummary = _commandCentreBuilder.Build(Tasks, CriticalOpenTasks.Count, ActiveSprintMetrics.CarryForwardCandidateTasks);
         DueTodayTasks = readModel.DueBuckets.Today;
         DueThisWeekTasks = readModel.DueBuckets.ThisWeek;
         DueLaterTasks = readModel.DueBuckets.Later;
@@ -987,58 +995,37 @@ public class IndexModel : PageModel
     public IReadOnlyList<TaskDisplayItem> SprintOverdueTaskDisplays =>
         ToDisplayItems(SprintOverdueTasks);
 
-    // SECTION: My Work display projections keep the personal workspace independent from dashboard limits.
+    // SECTION: My Work display projections are composed by a focused queue builder and rendered by the page.
     public IReadOnlyList<TaskDisplayItem> MyOverdueTaskDisplays =>
-        ToDisplayItems(Tasks
-            .Where(IsTaskOverdue)
-            .OrderBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(MyWorkQueues.Overdue);
 
     public IReadOnlyList<TaskDisplayItem> MyDueTodayTaskDisplays =>
-        ToDisplayItems(Tasks
-            .Where(t => IsOpenTask(t) && t.DueDate.Date == _clock.UtcToday)
-            .OrderBy(t => StatusOrder(t.Status))
-            .ThenBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(MyWorkQueues.DueToday);
 
     public IReadOnlyList<TaskDisplayItem> MyInProgressTaskDisplays =>
-        ToDisplayItems(Tasks
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(MyWorkQueues.InProgress);
 
     public IReadOnlyList<TaskDisplayItem> MySubmittedTaskDisplays =>
-        ToDisplayItems(Tasks
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.SubmittedOn ?? t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(MyWorkQueues.Submitted);
 
     public IReadOnlyList<TaskDisplayItem> MyActiveSprintTaskDisplays =>
-        ToDisplayItems(GetActiveSprintTasks()
-            .OrderBy(t => StatusOrder(t.Status))
-            .ThenBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(MyWorkQueues.ActiveSprint);
 
     public IReadOnlyList<TaskDisplayItem> MyRemainingAssignedTaskDisplays =>
         MyWorkAllMyTasksDisplays;
 
-    // SECTION: My Work queue projections de-duplicate tasks by urgency before rendering primary workspace sections.
+    // SECTION: My Work primary queues preserve service-owned precedence and de-duplication.
     public IReadOnlyList<TaskDisplayItem> MyWorkActionRequiredDisplays =>
-        ToDisplayItems(BuildMyWorkQueueSection(ActionTaskMyWorkQueueSection.ActionRequired));
+        ToDisplayItems(MyWorkQueues.ActionRequired);
 
     public IReadOnlyList<TaskDisplayItem> MyWorkCurrentWorkDisplays =>
-        ToDisplayItems(BuildMyWorkQueueSection(ActionTaskMyWorkQueueSection.CurrentWork));
+        ToDisplayItems(MyWorkQueues.CurrentWork);
 
     public IReadOnlyList<TaskDisplayItem> MyWorkSubmittedAwaitingClosureDisplays =>
-        ToDisplayItems(BuildMyWorkQueueSection(ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure));
+        ToDisplayItems(MyWorkQueues.SubmittedAwaitingClosure);
 
     public IReadOnlyList<TaskDisplayItem> MyWorkAllMyTasksDisplays =>
-        ToDisplayItems(BuildMyWorkQueueSection(ActionTaskMyWorkQueueSection.AllMyTasks));
+        ToDisplayItems(MyWorkQueues.AllMyTasks);
 
     // SECTION: Legacy My Tasks display alias retained for older partial references.
     public IReadOnlyList<TaskDisplayItem> MyWorkOverdueTaskDisplays =>
@@ -1124,13 +1111,13 @@ public class IndexModel : PageModel
             .ToList());
 
     // SECTION: KPI helpers for dashboard and reports.
-    public int ActiveCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
-    public int OverdueCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && t.DueDate.Date < _clock.UtcToday);
+    public int ActiveCount => CommandCentreSummary.ActiveCount;
+    public int OverdueCount => CommandCentreSummary.OverdueCount;
     public int InProgressCount => CountByStatus(ActionTaskStatuses.InProgress);
     public int SubmittedCount => CountByStatus(ActionTaskStatuses.Submitted);
-    public int BlockedCount => CountByStatus(ActionTaskStatuses.Blocked);
+    public int BlockedCount => CommandCentreSummary.BlockedCount;
     public int ClosedCount => CountByStatus(ActionTaskStatuses.Closed);
-    public int CriticalOpenCount => CriticalOpenTasks.Count;
+    public int CriticalOpenCount => CommandCentreSummary.CriticalOpenCount;
     public int StatusCountsMax => StatusCounts.Count == 0 ? 0 : StatusCounts.Max(x => x.Count);
     public int PriorityCountsMax => PriorityCounts.Count == 0 ? 0 : PriorityCounts.Max(x => x.Count);
     public int AssigneePendingCountsMax => AssigneePendingCounts.Count == 0 ? 0 : AssigneePendingCounts.Max(x => x.Count);
@@ -1139,30 +1126,15 @@ public class IndexModel : PageModel
     public int BacklogAgeingBucketsMax => BacklogAgeingBuckets.Count == 0 ? 0 : BacklogAgeingBuckets.Max(x => x.Count);
     public int CarryForwardBySprintMax => CarryForwardBySprint.Count == 0 ? 0 : CarryForwardBySprint.Max(x => x.Count);
     public int BlockedAgeingBucketsMax => BlockedAgeingBuckets.Count == 0 ? 0 : BlockedAgeingBuckets.Max(x => x.Count);
-    public int ActiveCriticalCount => Tasks.Count(t =>
-        !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-        && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
+    public int ActiveCriticalCount => CommandCentreSummary.ActiveCriticalCount;
 
-    public int SubmittedPendingClosureCount => Tasks.Count(t =>
-        string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase));
+    public int SubmittedPendingClosureCount => CommandCentreSummary.SubmittedPendingClosureCount;
 
     public bool HasActiveFilters =>
-        (IsTaskListView || IsBacklogView) &&
-        (!string.IsNullOrWhiteSpace(FilterStatus)
-         || !string.IsNullOrWhiteSpace(FilterPriority)
-         || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
-         || FilterDueDate.HasValue
-         || !string.IsNullOrWhiteSpace(FilterSearch));
-
+        _routeStateHelper.HasActiveTaskFilters(BuildRouteInputs(), ResolvedViewMode, IsBacklogView);
 
     public bool HasReportFilters =>
-        IsReportsView &&
-        (ReportSprintId.HasValue
-         || !string.IsNullOrWhiteSpace(ReportAssigneeUserId)
-         || ReportFromDate.HasValue
-         || ReportToDate.HasValue
-         || !string.IsNullOrWhiteSpace(ReportStatus)
-         || !string.IsNullOrWhiteSpace(ReportPriority));
+        _routeStateHelper.HasReportFilters(BuildRouteInputs(), ResolvedViewMode);
 
     public string ReportFilterSummary =>
         HasReportFilters
@@ -1172,33 +1144,12 @@ public class IndexModel : PageModel
     // SECTION: Planning backlog disclosure mirrors every route value that can alter the backlog read model.
     public bool HasBacklogFilterRouteState => HasTaskFilterRouteState();
     public string DashboardCommandFocusSummary =>
-        $"{OverdueCount} overdue. {BlockedCount} blocked. {SubmittedPendingClosureCount} submitted pending closure. {CriticalOpenCount} critical open. {ActiveSprintMetrics.CarryForwardCandidateTasks} carry-forward candidates.";
+        CommandCentreSummary.DashboardCommandFocusSummary;
     public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<TaskDisplayItem> TopAttentionTaskDisplays => BuildTopAttentionItems();
 
-    public string CommandSummary
-    {
-        get
-        {
-            var activeTasksText = $"There {(ActiveCount == 1 ? "is" : "are")} {ActiveCount} active {(ActiveCount == 1 ? "task" : "tasks")}";
-            var criticalText = $", including {ActiveCriticalCount} critical {(ActiveCriticalCount == 1 ? "task" : "tasks")}.";
-            var overdueText = OverdueCount switch
-            {
-                0 => "No tasks are overdue.",
-                1 => "1 task is overdue.",
-                _ => $"{OverdueCount} tasks are overdue."
-            };
-
-            var submittedPendingText = SubmittedPendingClosureCount switch
-            {
-                0 => "No submitted task is pending closure.",
-                1 => "1 submitted task is pending closure.",
-                _ => $"{SubmittedPendingClosureCount} submitted tasks are pending closure."
-            };
-
-            return $"{activeTasksText}{criticalText} {overdueText} {submittedPendingText}";
-        }
-    }
+    public string CommandSummary =>
+        CommandCentreSummary.CommandSummary;
 
     // SECTION: Percentage helper for CSS bar-width calculations.
     public int ToPercent(int value, int max) =>
@@ -1388,73 +1339,6 @@ public class IndexModel : PageModel
         }
     }
 
-    // SECTION: Sprint Board sub-view normalization keeps secondary view state safe across links and postbacks.
-    private string ResolvePlanningView()
-    {
-        var normalized = (PlanningView ?? string.Empty).Trim();
-        if (!string.IsNullOrWhiteSpace(normalized))
-        {
-            return normalized switch
-            {
-                _ when string.Equals(normalized, "DueExceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-                _ when string.Equals(normalized, "Due / exceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-                _ when string.Equals(normalized, "Due Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-                _ when string.Equals(normalized, "Sprint Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-                _ when string.Equals(normalized, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
-                _ => "Default"
-            };
-        }
-
-        // SECTION: Promote legacy top-level planning aliases to their closest secondary Planning view.
-        return (ViewMode ?? string.Empty).Trim() switch
-        {
-            var legacyView when string.Equals(legacyView, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
-            var legacyView when string.Equals(legacyView, "Due Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-            var legacyView when string.Equals(legacyView, "SprintBoard", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-            var legacyView when string.Equals(legacyView, "Sprint Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
-            _ => "Default"
-        };
-    }
-
-
-    // SECTION: Sprint Board internal tab normalization keeps planning, execution, closure, and alternate views separated.
-    private string ResolvePlanningTab()
-    {
-        var normalized = (PlanningTab ?? string.Empty).Trim();
-        if (!string.IsNullOrWhiteSpace(normalized))
-        {
-            return normalized switch
-            {
-                _ when string.Equals(normalized, "Plan", StringComparison.OrdinalIgnoreCase) => "Plan",
-                _ when string.Equals(normalized, "Planning", StringComparison.OrdinalIgnoreCase) => "Plan",
-                _ when string.Equals(normalized, "Backlog", StringComparison.OrdinalIgnoreCase) => "Plan",
-                _ when string.Equals(normalized, "Execute", StringComparison.OrdinalIgnoreCase) => "Execute",
-                _ when string.Equals(normalized, "Execution", StringComparison.OrdinalIgnoreCase) => "Execute",
-                _ when string.Equals(normalized, "Close", StringComparison.OrdinalIgnoreCase) => "Close",
-                _ when string.Equals(normalized, "Closure", StringComparison.OrdinalIgnoreCase) => "Close",
-                _ when string.Equals(normalized, "Views", StringComparison.OrdinalIgnoreCase) => "Views",
-                _ when string.Equals(normalized, "View", StringComparison.OrdinalIgnoreCase) => "Views",
-                _ => GetDefaultPlanningTab()
-            };
-        }
-
-        // SECTION: Legacy PlanningView aliases open the new Views tab while keeping old links functional.
-        if (!string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase))
-        {
-            return "Views";
-        }
-
-        return GetDefaultPlanningTab();
-    }
-
-    // SECTION: Planning tab default follows selected sprint availability.
-    private string GetDefaultPlanningTab()
-    {
-        return SelectedSprintId.HasValue || SelectedSprint is not null || ActiveSprint is not null
-            ? "Execute"
-            : "Plan";
-    }
-
     // SECTION: Shared task redirect route preserves workspace, selection, and relevant list state from inspector actions.
     private RedirectToPageResult RedirectToTaskPage(int? taskId, int? selectedSprintId)
     {
@@ -1466,87 +1350,50 @@ public class IndexModel : PageModel
     private object BuildTaskWorkspaceRouteValues(int? taskId, int? selectedSprintId)
         => _routeStateHelper.BuildTaskWorkspaceRouteValues(BuildRouteState(), taskId, selectedSprintId);
 
-    // SECTION: Task-list filter route preservation supports legacy Register and Backlog bookmarks after postback redirects.
+    // SECTION: Route/filter inputs isolate query-string state before centralized route helper decisions.
     private ActionTaskRouteState BuildRouteState()
+        => _routeStateHelper.BuildRouteState(BuildRouteInputs(), TaskId, SelectedSprintId, SelectedSprint, ActiveSprint);
+
+    private ActionTaskRouteInputs BuildRouteInputs()
         => new(
-            ResolveViewMode(),
-            ResolvedPlanningTab,
-            ResolvedPlanningView,
-            GetDefaultPlanningTab(),
-            IsPlanningView,
-            IsTaskListView || IsBacklogView,
-            TaskId,
-            SelectedSprintId,
+            ViewMode,
+            PlanningView,
+            PlanningTab,
             FilterStatus,
             FilterPriority,
             FilterAssigneeUserId,
             FilterDueDate,
             FilterSearch,
             SortBy,
-            SortDir);
+            SortDir,
+            ReportSprintId,
+            ReportAssigneeUserId,
+            ReportFromDate,
+            ReportToDate,
+            ReportStatus,
+            ReportPriority);
 
-    // SECTION: Planning backlog filter detection keeps canonical Planning routes compatible with legacy Backlog filtered views.
-    private bool IsPlanningBacklogFilterContext()
-    {
-        return IsPlanningView
-            && string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
-            && HasTaskFilterRouteState();
-    }
+    private string ResolvePlanningView()
+        => _routeStateHelper.ResolvePlanningView(ViewMode, PlanningView);
 
-    // SECTION: Shared filter-state detection covers GET bookmarks and required postback route preservation.
+    private string ResolvePlanningTab()
+        => _routeStateHelper.ResolvePlanningTab(PlanningTab, ResolvedPlanningView, GetDefaultPlanningTab());
+
+    private string GetDefaultPlanningTab()
+        => _routeStateHelper.GetDefaultPlanningTab(SelectedSprintId, SelectedSprint, ActiveSprint);
+
     private bool HasTaskFilterRouteState()
-    {
-        return !string.IsNullOrWhiteSpace(FilterStatus)
-            || !string.IsNullOrWhiteSpace(FilterPriority)
-            || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
-            || FilterDueDate.HasValue
-            || !string.IsNullOrWhiteSpace(FilterSearch)
-            || !string.IsNullOrWhiteSpace(SortBy)
-            || !string.IsNullOrWhiteSpace(SortDir);
-    }
+        => _routeStateHelper.HasTaskFilterRouteState(BuildRouteInputs());
 
-    // SECTION: Legacy view-state matching isolates backward-compatible aliases from canonical workspace names.
+    private bool IsPlanningBacklogFilterContext()
+        => _routeStateHelper.IsBacklogView(BuildRouteInputs(), ResolvedViewMode, ResolvedPlanningView)
+            && !IsLegacyViewMode("Backlog");
+
     private bool IsLegacyViewMode(string legacyViewMode)
-    {
-        return string.Equals((ViewMode ?? string.Empty).Trim(), legacyViewMode, StringComparison.OrdinalIgnoreCase);
-    }
+        => _routeStateHelper.IsLegacyViewMode(ViewMode, legacyViewMode);
 
     private string ResolveViewMode()
-    {
-        var normalized = (ViewMode ?? string.Empty).Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            return "CommandCentre";
-        }
-
-        // SECTION: Normalize known aliases in-place so legacy links render the correct modern workspace without GET redirects.
-        return normalized switch
-        {
-            _ when IsViewModeAlias(normalized, "Dashboard") => "CommandCentre",
-            _ when IsViewModeAlias(normalized, "Sprints") => "Planning",
-            _ when IsViewModeAlias(normalized, "Backlog") => "Planning",
-            _ when IsViewModeAlias(normalized, "Sprint") => "Planning",
-            _ when IsViewModeAlias(normalized, "Due Board") => "Planning",
-            _ when IsViewModeAlias(normalized, "SprintBoard") => "Planning",
-            _ when IsViewModeAlias(normalized, "Sprint Board") => "Planning",
-            _ when IsViewModeAlias(normalized, "Kanban") => "Planning",
-            _ when IsViewModeAlias(normalized, "MyTasks") => "MyWork",
-            _ when IsViewModeAlias(normalized, "My Tasks") => "MyWork",
-            _ when IsViewModeAlias(normalized, "TaskList") => "Register",
-            _ when IsViewModeAlias(normalized, "CommandCentre") => "CommandCentre",
-            _ when IsViewModeAlias(normalized, "Planning") => "Planning",
-            _ when IsViewModeAlias(normalized, "MyWork") => "MyWork",
-            _ when IsViewModeAlias(normalized, "Register") => "Register",
-            _ when IsViewModeAlias(normalized, "Reports") => "Reports",
-            _ => "CommandCentre"
-        };
-    }
-
-    // SECTION: Alias comparison centralizes case-insensitive matching for old and canonical view modes.
-    private static bool IsViewModeAlias(string normalizedViewMode, string candidate)
-    {
-        return string.Equals(normalizedViewMode, candidate, StringComparison.OrdinalIgnoreCase);
-    }
+        => _routeStateHelper.ResolveViewMode(ViewMode);
 
     public sealed class CreateTaskInput
     {
@@ -1705,10 +1552,6 @@ public class IndexModel : PageModel
         ActiveSprint is null
             ? Array.Empty<ActionTaskItem>()
             : Tasks.Where(t => t.SprintId == ActiveSprint.Id).ToList();
-
-    // SECTION: My Work queue sections are delegated to the display builder for reusable presentation grouping.
-    private IReadOnlyList<ActionTaskItem> BuildMyWorkQueueSection(ActionTaskMyWorkQueueSection section)
-        => _displayBuilder.BuildMyWorkQueueSection(Tasks, section);
 
     private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>
         tasks.Select(task => new TaskDisplayItem

--- a/Program.cs
+++ b/Program.cs
@@ -388,6 +388,8 @@ builder.Services.AddScoped<ActionTaskPermissionService>();
 builder.Services.AddScoped<ActionTaskReportBuilder>();
 builder.Services.AddScoped<ActionTaskRouteStateHelper>();
 builder.Services.AddScoped<ActionTaskDisplayBuilder>();
+builder.Services.AddScoped<ActionTaskMyWorkBuilder>();
+builder.Services.AddScoped<ActionTaskCommandCentreBuilder>();
 builder.Services.AddScoped<ActionTaskQueryService>();
 builder.Services.AddScoped<ActionTaskWorkspaceBuilder>();
 builder.Services.AddScoped<ActionTaskWorkflowPolicy>();

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
@@ -1,0 +1,93 @@
+using ProjectManagement.Models;
+using ProjectManagement.Services.ActionTasks;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskCompositionBuilderTests
+{
+    [Fact]
+    public void MyWorkBuilder_PreservesPrimarySectionPrecedenceAndDeduplication()
+    {
+        // SECTION: Arrange
+        var today = new DateTime(2026, 5, 7);
+        var sprint = new ActionSprint { Id = 10, Name = "Active", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(14) };
+        var tasks = new[]
+        {
+            NewTask(1, ActionTaskStatuses.Blocked, today.AddDays(-1), sprint.Id),
+            NewTask(2, ActionTaskStatuses.InProgress, today.AddDays(2), sprint.Id),
+            NewTask(3, ActionTaskStatuses.Submitted, today.AddDays(3)),
+            NewTask(4, ActionTaskStatuses.Assigned, today.AddDays(5)),
+            NewTask(5, ActionTaskStatuses.Closed, today.AddDays(-5))
+        };
+        var builder = new ActionTaskMyWorkBuilder(new FixedActionTrackerClock(today));
+
+        // SECTION: Act
+        var queues = builder.Build(tasks, sprint);
+
+        // SECTION: Assert
+        Assert.Equal(new[] { 1 }, queues.ActionRequired.Select(t => t.Id));
+        Assert.Equal(new[] { 2 }, queues.CurrentWork.Select(t => t.Id));
+        Assert.Equal(new[] { 3 }, queues.SubmittedAwaitingClosure.Select(t => t.Id));
+        Assert.Equal(new[] { 4, 5 }, queues.AllMyTasks.Select(t => t.Id));
+        Assert.Equal(tasks.Select(t => t.Id).OrderBy(id => id), queues.ActionRequired.Concat(queues.CurrentWork).Concat(queues.SubmittedAwaitingClosure).Concat(queues.AllMyTasks).Select(t => t.Id).OrderBy(id => id));
+        Assert.Equal(new[] { 1, 2 }, queues.ActiveSprint.Select(t => t.Id));
+    }
+
+    [Fact]
+    public void CommandCentreBuilder_PreservesSummaryWordingAndDateCounts()
+    {
+        // SECTION: Arrange
+        var today = new DateTime(2026, 5, 7);
+        var tasks = new[]
+        {
+            NewTask(1, ActionTaskStatuses.Assigned, today.AddDays(-1), priority: "Critical"),
+            NewTask(2, ActionTaskStatuses.Blocked, today.AddDays(2)),
+            NewTask(3, ActionTaskStatuses.Submitted, today.AddDays(3)),
+            NewTask(4, ActionTaskStatuses.Closed, today.AddDays(-2), priority: "Critical")
+        };
+        var builder = new ActionTaskCommandCentreBuilder(new FixedActionTrackerClock(today));
+
+        // SECTION: Act
+        var summary = builder.Build(tasks, criticalOpenCount: 1, carryForwardCandidateTasks: 2);
+
+        // SECTION: Assert
+        Assert.Equal(3, summary.ActiveCount);
+        Assert.Equal(1, summary.OverdueCount);
+        Assert.Equal(1, summary.BlockedCount);
+        Assert.Equal(1, summary.SubmittedPendingClosureCount);
+        Assert.Equal("1 overdue. 1 blocked. 1 submitted pending closure. 1 critical open. 2 carry-forward candidates.", summary.DashboardCommandFocusSummary);
+        Assert.Equal("There are 3 active tasks, including 1 critical task. 1 task is overdue. 1 submitted task is pending closure.", summary.CommandSummary);
+    }
+
+    // SECTION: Test data helper keeps builder tests focused on composition behaviour.
+    private static ActionTaskItem NewTask(int id, string status, DateTime dueDate, int? sprintId = null, string priority = "Normal")
+        => new()
+        {
+            Id = id,
+            Title = $"Task {id}",
+            Description = "Task",
+            CreatedByUserId = "creator",
+            AssignedToUserId = "assignee",
+            CreatedByRole = "HoD",
+            AssignedToRole = "TA",
+            AssignedOn = dueDate.AddDays(-2),
+            DueDate = dueDate,
+            Priority = priority,
+            Status = status,
+            SprintId = sprintId,
+            ClosedOn = status == ActionTaskStatuses.Closed ? dueDate : null,
+            SubmittedOn = status == ActionTaskStatuses.Submitted ? dueDate.AddDays(-1) : null
+        };
+
+    private sealed class FixedActionTrackerClock : IActionTrackerClock
+    {
+        public FixedActionTrackerClock(DateTime today)
+        {
+            UtcToday = today.Date;
+            UtcNow = today.Date.AddHours(12);
+        }
+
+        public DateTime UtcNow { get; }
+        public DateTime UtcToday { get; }
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1057,7 +1057,7 @@ public class ActionTaskPageTests
         var sprintWorkflowPolicy = new ActionSprintWorkflowPolicy();
         var sprintService = new ActionSprintService(db, permission, sprintWorkflowPolicy);
         var workspaceBuilder = new ActionTaskWorkspaceBuilder(service, sprintService, queryService);
-        var page = new IndexModel(service, collab, permission, sprintService, queryService, workspaceBuilder, workflowPolicy, new ActionTaskRouteStateHelper(), new ActionTaskDisplayBuilder(clock), clock, userManager);
+        var page = new IndexModel(service, collab, permission, sprintService, queryService, workspaceBuilder, workflowPolicy, new ActionTaskRouteStateHelper(), new ActionTaskDisplayBuilder(clock), new ActionTaskMyWorkBuilder(clock), new ActionTaskCommandCentreBuilder(clock), clock, userManager);
 
         var httpContext = new DefaultHttpContext
         {

--- a/Services/ActionTasks/ActionTaskCommandCentreBuilder.cs
+++ b/Services/ActionTasks/ActionTaskCommandCentreBuilder.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskCommandCentreBuilder
+{
+    private readonly IActionTrackerClock _clock;
+
+    public ActionTaskCommandCentreBuilder(IActionTrackerClock clock)
+    {
+        _clock = clock;
+    }
+
+    // SECTION: Compose Command Centre KPI text and counts outside the Razor Page model.
+    public ActionTaskCommandCentreSummary Build(IReadOnlyList<ActionTaskItem> tasks, int criticalOpenCount, int carryForwardCandidateTasks)
+    {
+        var activeCount = tasks.Count(IsOpenTask);
+        var overdueCount = tasks.Count(IsOverdue);
+        var blockedCount = CountByStatus(tasks, ActionTaskStatuses.Blocked);
+        var submittedPendingClosureCount = CountByStatus(tasks, ActionTaskStatuses.Submitted);
+        var activeCriticalCount = tasks.Count(t => IsOpenTask(t) && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
+
+        return new ActionTaskCommandCentreSummary(
+            ActiveCount: activeCount,
+            OverdueCount: overdueCount,
+            BlockedCount: blockedCount,
+            CriticalOpenCount: criticalOpenCount,
+            ActiveCriticalCount: activeCriticalCount,
+            SubmittedPendingClosureCount: submittedPendingClosureCount,
+            DashboardCommandFocusSummary: BuildDashboardCommandFocusSummary(overdueCount, blockedCount, submittedPendingClosureCount, criticalOpenCount, carryForwardCandidateTasks),
+            CommandSummary: BuildCommandSummary(activeCount, activeCriticalCount, overdueCount, submittedPendingClosureCount));
+    }
+
+    // SECTION: Existing Command Centre focus summary wording is preserved for stable dashboard UX.
+    private static string BuildDashboardCommandFocusSummary(int overdueCount, int blockedCount, int submittedPendingClosureCount, int criticalOpenCount, int carryForwardCandidateTasks)
+        => $"{overdueCount} overdue. {blockedCount} blocked. {submittedPendingClosureCount} submitted pending closure. {criticalOpenCount} critical open. {carryForwardCandidateTasks} carry-forward candidates.";
+
+    // SECTION: Existing Command Centre narrative wording is preserved for stable dashboard UX.
+    private static string BuildCommandSummary(int activeCount, int activeCriticalCount, int overdueCount, int submittedPendingClosureCount)
+    {
+        var activeTasksText = $"There {(activeCount == 1 ? "is" : "are")} {activeCount} active {(activeCount == 1 ? "task" : "tasks")}";
+        var criticalText = $", including {activeCriticalCount} critical {(activeCriticalCount == 1 ? "task" : "tasks")}.";
+        var overdueText = overdueCount switch
+        {
+            0 => "No tasks are overdue.",
+            1 => "1 task is overdue.",
+            _ => $"{overdueCount} tasks are overdue."
+        };
+
+        var submittedPendingText = submittedPendingClosureCount switch
+        {
+            0 => "No submitted task is pending closure.",
+            1 => "1 submitted task is pending closure.",
+            _ => $"{submittedPendingClosureCount} submitted tasks are pending closure."
+        };
+
+        return $"{activeTasksText}{criticalText} {overdueText} {submittedPendingText}";
+    }
+
+    // SECTION: Date-sensitive Command Centre checks use the Action Tracker clock consistently.
+    private bool IsOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
+    private static bool IsOpenTask(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    private static int CountByStatus(IReadOnlyList<ActionTaskItem> tasks, string status) => tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
+}
+
+public sealed record ActionTaskCommandCentreSummary(
+    int ActiveCount,
+    int OverdueCount,
+    int BlockedCount,
+    int CriticalOpenCount,
+    int ActiveCriticalCount,
+    int SubmittedPendingClosureCount,
+    string DashboardCommandFocusSummary,
+    string CommandSummary)
+{
+    public static ActionTaskCommandCentreSummary Empty { get; } = new(
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        "0 overdue. 0 blocked. 0 submitted pending closure. 0 critical open. 0 carry-forward candidates.",
+        "There are 0 active tasks, including 0 critical tasks. No tasks are overdue. No submitted task is pending closure.");
+}

--- a/Services/ActionTasks/ActionTaskDisplayBuilder.cs
+++ b/Services/ActionTasks/ActionTaskDisplayBuilder.cs
@@ -14,18 +14,6 @@ public sealed class ActionTaskDisplayBuilder
         _clock = clock;
     }
 
-    // SECTION: Priority-based My Work queue assigns each task to exactly one primary section.
-    public IReadOnlyList<ActionTaskItem> BuildMyWorkQueueSection(IReadOnlyList<ActionTaskItem> tasks, ActionTaskMyWorkQueueSection section)
-        => tasks
-            .Select(task => new { Task = task, Section = ResolveMyWorkQueueSection(task) })
-            .Where(item => item.Section == section)
-            .Select(item => item.Task)
-            .OrderBy(ResolveMyWorkPriorityRank)
-            .ThenBy(task => StatusOrder(task.Status))
-            .ThenBy(task => task.DueDate)
-            .ThenBy(task => task.Id)
-            .ToList();
-
     // SECTION: Report top-attention prioritization is reusable outside the page model.
     public IReadOnlyList<ActionTaskItem> BuildTopAttentionItems(IReadOnlyList<ActionTaskItem> tasks)
     {
@@ -45,38 +33,6 @@ public sealed class ActionTaskDisplayBuilder
             .ToList();
     }
 
-    // SECTION: My Work precedence prevents repeated cards across action, execution, submitted, and remaining sections.
-    private ActionTaskMyWorkQueueSection ResolveMyWorkQueueSection(ActionTaskItem task)
-    {
-        if (IsTaskOverdue(task) || IsTaskDueToday(task) || IsTaskBlocked(task))
-        {
-            return ActionTaskMyWorkQueueSection.ActionRequired;
-        }
-
-        if (IsTaskInProgress(task))
-        {
-            return ActionTaskMyWorkQueueSection.CurrentWork;
-        }
-
-        if (IsTaskSubmitted(task))
-        {
-            return ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure;
-        }
-
-        return ActionTaskMyWorkQueueSection.AllMyTasks;
-    }
-
-    // SECTION: My Work row ordering follows the required urgency precedence inside compact sections.
-    private int ResolveMyWorkPriorityRank(ActionTaskItem task)
-    {
-        if (IsTaskOverdue(task)) return 1;
-        if (IsTaskDueToday(task)) return 2;
-        if (IsTaskBlocked(task)) return 3;
-        if (IsTaskInProgress(task)) return 4;
-        if (IsTaskSubmitted(task)) return 5;
-        return 6;
-    }
-
     // SECTION: Report top-attention score keeps urgent overdue and critical work first.
     private static int GetAttentionScore(ActionTaskItem task, DateTime today)
     {
@@ -90,30 +46,4 @@ public sealed class ActionTaskDisplayBuilder
         return 6;
     }
 
-    // SECTION: My Work status predicates keep grouping readable without changing workflow rules.
-    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
-    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date == _clock.UtcToday;
-    private static bool IsTaskBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
-    private static bool IsTaskInProgress(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
-    private static bool IsTaskSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
-    private static bool IsOpenTask(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
-
-    // SECTION: Reusable status ordering mirrors page-level operational list ordering.
-    private static int StatusOrder(string status) => status switch
-    {
-        ActionTaskStatuses.Assigned => 1,
-        ActionTaskStatuses.InProgress => 2,
-        ActionTaskStatuses.Blocked => 3,
-        ActionTaskStatuses.Submitted => 4,
-        ActionTaskStatuses.Closed => 5,
-        _ => 99
-    };
-}
-
-public enum ActionTaskMyWorkQueueSection
-{
-    ActionRequired,
-    CurrentWork,
-    SubmittedAwaitingClosure,
-    AllMyTasks
 }

--- a/Services/ActionTasks/ActionTaskMyWorkBuilder.cs
+++ b/Services/ActionTasks/ActionTaskMyWorkBuilder.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskMyWorkBuilder
+{
+    private readonly IActionTrackerClock _clock;
+
+    public ActionTaskMyWorkBuilder(IActionTrackerClock clock)
+    {
+        _clock = clock;
+    }
+
+    // SECTION: Compose My Work queues in one place so page rendering cannot accidentally duplicate cards.
+    public ActionTaskMyWorkQueues Build(IReadOnlyList<ActionTaskItem> tasks, ActionSprint? activeSprint)
+    {
+        var activeSprintTasks = activeSprint is null
+            ? Array.Empty<ActionTaskItem>()
+            : tasks.Where(t => t.SprintId == activeSprint.Id).ToArray();
+
+        return new ActionTaskMyWorkQueues(
+            Overdue: tasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            DueToday: tasks.Where(t => IsOpenTask(t) && t.DueDate.Date == _clock.UtcToday).OrderBy(t => StatusOrder(t.Status)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            InProgress: tasks.Where(IsTaskInProgress).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            Submitted: tasks.Where(IsTaskSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).ToList(),
+            ActiveSprint: activeSprintTasks.OrderBy(t => StatusOrder(t.Status)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            ActionRequired: BuildPrimarySection(tasks, ActionTaskMyWorkQueueSection.ActionRequired),
+            CurrentWork: BuildPrimarySection(tasks, ActionTaskMyWorkQueueSection.CurrentWork),
+            SubmittedAwaitingClosure: BuildPrimarySection(tasks, ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure),
+            AllMyTasks: BuildPrimarySection(tasks, ActionTaskMyWorkQueueSection.AllMyTasks));
+    }
+
+    // SECTION: Priority-based My Work queue assigns each task to exactly one primary section.
+    private IReadOnlyList<ActionTaskItem> BuildPrimarySection(IReadOnlyList<ActionTaskItem> tasks, ActionTaskMyWorkQueueSection section)
+        => tasks
+            .Select(task => new { Task = task, Section = ResolvePrimarySection(task) })
+            .Where(item => item.Section == section)
+            .Select(item => item.Task)
+            .OrderBy(ResolvePriorityRank)
+            .ThenBy(task => StatusOrder(task.Status))
+            .ThenBy(task => task.DueDate)
+            .ThenBy(task => task.Id)
+            .ToList();
+
+    // SECTION: My Work precedence preserves historical de-duplication across urgent, current, submitted and remaining queues.
+    private ActionTaskMyWorkQueueSection ResolvePrimarySection(ActionTaskItem task)
+    {
+        if (IsTaskOverdue(task) || IsTaskDueToday(task) || IsTaskBlocked(task))
+        {
+            return ActionTaskMyWorkQueueSection.ActionRequired;
+        }
+
+        if (IsTaskInProgress(task))
+        {
+            return ActionTaskMyWorkQueueSection.CurrentWork;
+        }
+
+        if (IsTaskSubmitted(task))
+        {
+            return ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure;
+        }
+
+        return ActionTaskMyWorkQueueSection.AllMyTasks;
+    }
+
+    // SECTION: My Work ordering keeps urgent work first inside compact workspace sections.
+    private int ResolvePriorityRank(ActionTaskItem task)
+    {
+        if (IsTaskOverdue(task)) return 1;
+        if (IsTaskDueToday(task)) return 2;
+        if (IsTaskBlocked(task)) return 3;
+        if (IsTaskInProgress(task)) return 4;
+        if (IsTaskSubmitted(task)) return 5;
+        return 6;
+    }
+
+    // SECTION: Shared My Work predicates centralize date and lifecycle checks behind the Action Tracker clock.
+    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
+    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date == _clock.UtcToday;
+    private static bool IsTaskBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+    private static bool IsTaskInProgress(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
+    private static bool IsTaskSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+    private static bool IsOpenTask(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+
+    // SECTION: Status ordering mirrors the existing page-level operational list ordering.
+    private static int StatusOrder(string status) => status switch
+    {
+        ActionTaskStatuses.Assigned => 1,
+        ActionTaskStatuses.InProgress => 2,
+        ActionTaskStatuses.Blocked => 3,
+        ActionTaskStatuses.Submitted => 4,
+        ActionTaskStatuses.Closed => 5,
+        _ => 99
+    };
+}
+
+public sealed record ActionTaskMyWorkQueues(
+    IReadOnlyList<ActionTaskItem> Overdue,
+    IReadOnlyList<ActionTaskItem> DueToday,
+    IReadOnlyList<ActionTaskItem> InProgress,
+    IReadOnlyList<ActionTaskItem> Submitted,
+    IReadOnlyList<ActionTaskItem> ActiveSprint,
+    IReadOnlyList<ActionTaskItem> ActionRequired,
+    IReadOnlyList<ActionTaskItem> CurrentWork,
+    IReadOnlyList<ActionTaskItem> SubmittedAwaitingClosure,
+    IReadOnlyList<ActionTaskItem> AllMyTasks)
+{
+    public static ActionTaskMyWorkQueues Empty { get; } = new(
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>());
+}
+
+public enum ActionTaskMyWorkQueueSection
+{
+    ActionRequired,
+    CurrentWork,
+    SubmittedAwaitingClosure,
+    AllMyTasks
+}

--- a/Services/ActionTasks/ActionTaskRouteStateHelper.cs
+++ b/Services/ActionTasks/ActionTaskRouteStateHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Routing;
+using ProjectManagement.Models;
 
 namespace ProjectManagement.Services.ActionTasks;
 
@@ -33,6 +34,161 @@ public sealed class ActionTaskRouteStateHelper
         return routeValues;
     }
 
+    // SECTION: Canonical route state composition keeps query-string preservation outside the page model.
+    public ActionTaskRouteState BuildRouteState(ActionTaskRouteInputs inputs, int? taskId, int? selectedSprintId, ActionSprint? selectedSprint, ActionSprint? activeSprint)
+    {
+        var viewMode = ResolveViewMode(inputs.ViewMode);
+        var planningView = ResolvePlanningView(inputs.ViewMode, inputs.PlanningView);
+        var defaultPlanningTab = GetDefaultPlanningTab(selectedSprintId, selectedSprint, activeSprint);
+        var planningTab = ResolvePlanningTab(inputs.PlanningTab, planningView, defaultPlanningTab);
+        var isPlanningView = string.Equals(viewMode, "Planning", StringComparison.OrdinalIgnoreCase);
+        var isBacklogView = IsBacklogView(inputs, viewMode, planningView);
+        var shouldPreserveTaskFilters = string.Equals(viewMode, "Register", StringComparison.OrdinalIgnoreCase) || isBacklogView;
+
+        return new ActionTaskRouteState(
+            viewMode,
+            planningTab,
+            planningView,
+            defaultPlanningTab,
+            isPlanningView,
+            shouldPreserveTaskFilters,
+            taskId,
+            selectedSprintId,
+            inputs.FilterStatus,
+            inputs.FilterPriority,
+            inputs.FilterAssigneeUserId,
+            inputs.FilterDueDate,
+            inputs.FilterSearch,
+            inputs.SortBy,
+            inputs.SortDir);
+    }
+
+    // SECTION: View-mode checks centralize canonical and legacy workspace aliases for page projections.
+    public bool IsBacklogView(ActionTaskRouteInputs inputs, string resolvedViewMode, string resolvedPlanningView)
+        => IsLegacyViewMode(inputs.ViewMode, "Backlog")
+            || (string.Equals(resolvedViewMode, "Planning", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
+                && HasTaskFilterRouteState(inputs));
+
+    // SECTION: Task-list filter detection covers GET bookmarks and required postback route preservation.
+    public bool HasTaskFilterRouteState(ActionTaskRouteInputs inputs)
+        => !string.IsNullOrWhiteSpace(inputs.FilterStatus)
+            || !string.IsNullOrWhiteSpace(inputs.FilterPriority)
+            || !string.IsNullOrWhiteSpace(inputs.FilterAssigneeUserId)
+            || inputs.FilterDueDate.HasValue
+            || !string.IsNullOrWhiteSpace(inputs.FilterSearch)
+            || !string.IsNullOrWhiteSpace(inputs.SortBy)
+            || !string.IsNullOrWhiteSpace(inputs.SortDir);
+
+    // SECTION: Register and legacy backlog filters auto-apply without moving query logic into the page model.
+    public bool HasActiveTaskFilters(ActionTaskRouteInputs inputs, string resolvedViewMode, bool isBacklogView)
+        => (string.Equals(resolvedViewMode, "Register", StringComparison.OrdinalIgnoreCase) || isBacklogView)
+            && HasTaskFilterRouteState(inputs with { SortBy = null, SortDir = null });
+
+    // SECTION: Reports filter-state detection preserves auto-apply query-string behavior.
+    public bool HasReportFilters(ActionTaskRouteInputs inputs, string resolvedViewMode)
+        => string.Equals(resolvedViewMode, "Reports", StringComparison.OrdinalIgnoreCase)
+            && (inputs.ReportSprintId.HasValue
+                || !string.IsNullOrWhiteSpace(inputs.ReportAssigneeUserId)
+                || inputs.ReportFromDate.HasValue
+                || inputs.ReportToDate.HasValue
+                || !string.IsNullOrWhiteSpace(inputs.ReportStatus)
+                || !string.IsNullOrWhiteSpace(inputs.ReportPriority));
+
+    // SECTION: View-mode normalization keeps old bookmarks rendering modern workspaces without GET redirects.
+    public string ResolveViewMode(string? viewMode)
+    {
+        var normalized = (viewMode ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return "CommandCentre";
+        }
+
+        return normalized switch
+        {
+            _ when IsViewModeAlias(normalized, "Dashboard") => "CommandCentre",
+            _ when IsViewModeAlias(normalized, "Sprints") => "Planning",
+            _ when IsViewModeAlias(normalized, "Backlog") => "Planning",
+            _ when IsViewModeAlias(normalized, "Sprint") => "Planning",
+            _ when IsViewModeAlias(normalized, "Due Board") => "Planning",
+            _ when IsViewModeAlias(normalized, "SprintBoard") => "Planning",
+            _ when IsViewModeAlias(normalized, "Sprint Board") => "Planning",
+            _ when IsViewModeAlias(normalized, "Kanban") => "Planning",
+            _ when IsViewModeAlias(normalized, "MyTasks") => "MyWork",
+            _ when IsViewModeAlias(normalized, "My Tasks") => "MyWork",
+            _ when IsViewModeAlias(normalized, "TaskList") => "Register",
+            _ when IsViewModeAlias(normalized, "CommandCentre") => "CommandCentre",
+            _ when IsViewModeAlias(normalized, "Planning") => "Planning",
+            _ when IsViewModeAlias(normalized, "MyWork") => "MyWork",
+            _ when IsViewModeAlias(normalized, "Register") => "Register",
+            _ when IsViewModeAlias(normalized, "Reports") => "Reports",
+            _ => "CommandCentre"
+        };
+    }
+
+    // SECTION: Sprint Board sub-view normalization keeps secondary view state safe across links and postbacks.
+    public string ResolvePlanningView(string? viewMode, string? planningView)
+    {
+        var normalized = (planningView ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            return normalized switch
+            {
+                _ when string.Equals(normalized, "DueExceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+                _ when string.Equals(normalized, "Due / exceptions", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+                _ when string.Equals(normalized, "Due Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+                _ when string.Equals(normalized, "Sprint Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+                _ when string.Equals(normalized, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
+                _ => "Default"
+            };
+        }
+
+        return (viewMode ?? string.Empty).Trim() switch
+        {
+            var legacyView when string.Equals(legacyView, "Kanban", StringComparison.OrdinalIgnoreCase) => "Kanban",
+            var legacyView when string.Equals(legacyView, "Due Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+            var legacyView when string.Equals(legacyView, "SprintBoard", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+            var legacyView when string.Equals(legacyView, "Sprint Board", StringComparison.OrdinalIgnoreCase) => "DueExceptions",
+            _ => "Default"
+        };
+    }
+
+    // SECTION: Sprint Board internal tab normalization keeps planning, execution, closure, and alternate views separated.
+    public string ResolvePlanningTab(string? planningTab, string resolvedPlanningView, string defaultPlanningTab)
+    {
+        var normalized = (planningTab ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            return normalized switch
+            {
+                _ when string.Equals(normalized, "Plan", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Planning", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Backlog", StringComparison.OrdinalIgnoreCase) => "Plan",
+                _ when string.Equals(normalized, "Execute", StringComparison.OrdinalIgnoreCase) => "Execute",
+                _ when string.Equals(normalized, "Execution", StringComparison.OrdinalIgnoreCase) => "Execute",
+                _ when string.Equals(normalized, "Close", StringComparison.OrdinalIgnoreCase) => "Close",
+                _ when string.Equals(normalized, "Closure", StringComparison.OrdinalIgnoreCase) => "Close",
+                _ when string.Equals(normalized, "Views", StringComparison.OrdinalIgnoreCase) => "Views",
+                _ when string.Equals(normalized, "View", StringComparison.OrdinalIgnoreCase) => "Views",
+                _ => defaultPlanningTab
+            };
+        }
+
+        return !string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
+            ? "Views"
+            : defaultPlanningTab;
+    }
+
+    // SECTION: Planning tab default follows selected sprint availability.
+    public string GetDefaultPlanningTab(int? selectedSprintId, ActionSprint? selectedSprint, ActionSprint? activeSprint)
+        => selectedSprintId.HasValue || selectedSprint is not null || activeSprint is not null
+            ? "Execute"
+            : "Plan";
+
+    // SECTION: Legacy view-state matching isolates backward-compatible aliases from canonical workspace names.
+    public bool IsLegacyViewMode(string? viewMode, string legacyViewMode)
+        => string.Equals((viewMode ?? string.Empty).Trim(), legacyViewMode, StringComparison.OrdinalIgnoreCase);
+
     // SECTION: Filter route values are added only when populated so canonical links stay compact.
     private static void AddTaskFilterRouteValues(RouteValueDictionary routeValues, ActionTaskRouteState state)
     {
@@ -57,7 +213,29 @@ public sealed class ActionTaskRouteStateHelper
             routeValues[key] = value.Trim();
         }
     }
+
+    // SECTION: Alias comparison centralizes case-insensitive matching for old and canonical view modes.
+    private static bool IsViewModeAlias(string normalizedViewMode, string candidate)
+        => string.Equals(normalizedViewMode, candidate, StringComparison.OrdinalIgnoreCase);
 }
+
+public sealed record ActionTaskRouteInputs(
+    string? ViewMode,
+    string? PlanningView,
+    string? PlanningTab,
+    string? FilterStatus,
+    string? FilterPriority,
+    string? FilterAssigneeUserId,
+    DateTime? FilterDueDate,
+    string? FilterSearch,
+    string? SortBy,
+    string? SortDir,
+    int? ReportSprintId,
+    string? ReportAssigneeUserId,
+    DateTime? ReportFromDate,
+    DateTime? ReportToDate,
+    string? ReportStatus,
+    string? ReportPriority);
 
 public sealed record ActionTaskRouteState(
     string ViewMode,


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibility of `Pages/ActionTasks/Index.cshtml.cs` by moving non-trivial workspace composition and query/filter handling into focused services.
- Make My Work queue composition and Command Centre/KPI projection reusable, easier to test, and consistent with `IActionTrackerClock` usage.
- Centralize route and query-string state normalization so the page model remains focused on request handling and presentation bridging.

### Description
- Introduced `ActionTaskMyWorkBuilder` to own My Work queue composition, section precedence, de-duplication and ordering, and to use `IActionTrackerClock` for date logic; the page now consumes `ActionTaskMyWorkQueues` for all My Work projections.
- Introduced `ActionTaskCommandCentreBuilder` to compute dashboard KPI counts and summary strings consistently with the existing wording and clock semantics; the page reads `ActionTaskCommandCentreSummary` for Command Centre projections.
- Expanded `ActionTaskRouteStateHelper` to provide canonical route state composition and richer helpers (`ActionTaskRouteInputs`, `BuildRouteState`, `HasActiveTaskFilters`, `HasReportFilters`, `ResolveViewMode/PlanningView/PlanningTab`, etc.) so query/filter preservation and auto-apply behaviours live outside the page model.
- Reduced `ActionTaskDisplayBuilder` to the display-only responsibilities (kept `BuildTopAttentionItems`) and removed My Work composition from it; the My Work builder now owns all My Work logic.
- Updated `Pages/ActionTasks/Index.cshtml.cs` to inject the new builders, call them inside `LoadDataAsync`, and delegate display/KPI properties to the builders' outputs while preserving all visible behaviour and existing helper APIs.
- Registered the new builders in DI (`Program.cs`) and updated tests and test setup to supply the new constructor dependencies.
- Added unit tests `ActionTaskCompositionBuilderTests` that validate My Work queue precedence/de-duplication and Command Centre summary output/date counts.

### Testing
- Added `ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs` covering `ActionTaskMyWorkBuilder` and `ActionTaskCommandCentreBuilder` behaviour, and updated `ActionTaskPageTests` setup to provide the new builders; unit tests compile in-source but were not executed in this environment.
- Ran automated checks: `git diff --check` passed locally in the workspace; attempted `dotnet test ProjectManagement.sln --no-restore` but the `dotnet` SDK was not available in the container so the full test suite could not be executed here.
- Existing production behaviour was preserved by keeping the same routing, filter, permission and workflow logic, and by ensuring builders mirror the prior page logic; tests were added/updated only where constructor or composition responsibilities changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbffa1a0c88329a2d8f438d7763f3d)