### PR TITLE
Exclude Closed tasks from actionable backlog and backlog reports

### DIFF
--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -1,12 +1,10 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
-@using ProjectManagement.Models
-
-@* SECTION: Sprint Board backlog queue filters reuse the module's controlled register-style filtering. *@
+@* SECTION: Sprint Board backlog queue filters reuse controlled open-status filtering for actionable unscheduled work. *@
 <section class="at-panel mb-3">
     <div class="at-panel-heading">
         <div>
             <h2>Sprint Board Backlog Filters</h2>
-            <p class="at-panel-note">Backlog queue shows only tasks that are not assigned to a sprint.</p>
+            <p class="at-panel-note">Backlog queue shows only open tasks that are not assigned to a sprint.</p>
         </div>
         <span class="at-count-chip">@Model.BacklogTaskDisplays.Count tasks</span>
     </div>
@@ -21,8 +19,8 @@
         <div class="col-md-2">
             <label class="form-label">Status</label>
             <select class="form-select" name="FilterStatus">
-                <option value="">All</option>
-                @foreach (var status in Model.AllowedStatusOptions.Append(ActionTaskStatuses.Closed))
+                <option value="">All open statuses</option>
+                @foreach (var status in Model.AllowedStatusOptions)
                 {
                     if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
                     {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -396,7 +396,7 @@ public class ActionTaskPageTests
         Assert.NotEmpty(page.BacklogTasks);
         Assert.All(page.BacklogTasks, task => Assert.Null(task.SprintId));
         Assert.Contains(page.BacklogTasks, task => task.Title == "Mine");
-        Assert.Contains(page.BacklogTasks, task => task.Title == "Closed backlog");
+        Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Closed backlog");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Sprint task");
     }
 
@@ -436,10 +436,11 @@ public class ActionTaskPageTests
         await page.OnGetAsync();
 
         // SECTION: Assert
-        Assert.Contains(page.SprintBacklogTasks, task => task.Title == "Closed backlog");
+        Assert.DoesNotContain(page.SprintBacklogTasks, task => task.Title == "Closed backlog");
         Assert.DoesNotContain(page.AssignableBacklogTaskDisplays, item => item.Task.Title == "Closed backlog");
         Assert.All(page.AssignableBacklogTaskDisplays, item => Assert.NotEqual(ActionTaskStatuses.Closed, item.Task.Status));
-        Assert.False(page.CanAssignTaskToSprint(page.SprintBacklogTasks.Single(task => task.Title == "Closed backlog")));
+        Assert.Contains(page.Tasks, task => task.Title == "Closed backlog");
+        Assert.False(page.CanAssignTaskToSprint(page.Tasks.Single(task => task.Title == "Closed backlog")));
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -21,7 +21,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(2, activeSprint.Id, ActionTaskStatuses.InProgress, today.AddDays(1)),
             NewTask(3, activeSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(-2)),
             NewTask(4, activeSprint.Id, ActionTaskStatuses.Submitted, today.AddDays(2)),
-            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3))
+            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3)),
+            NewTask(6, null, ActionTaskStatuses.Closed, today.AddDays(4))
         };
         var service = CreateQueryService();
 
@@ -41,6 +42,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(1, model.ActiveSprintMetrics.OverdueTasks);
         Assert.Equal(1, model.ActiveSprintMetrics.BacklogTasks);
         Assert.Equal(3, model.ActiveSprintMetrics.CarryForwardCandidateTasks);
+        Assert.Equal(new[] { 5 }, model.BacklogTasks.Select(t => t.Id));
+        Assert.Equal(new[] { 5 }, model.SprintReadModel.BacklogTasks.Select(t => t.Id));
         Assert.Equal(1, model.SprintReadModel.ClosureReview.CompletedTasks.Count);
         Assert.Equal(3, model.SprintReadModel.ClosureReview.UnfinishedTasks.Count);
         Assert.Equal(nextSprint.Id, model.SprintReadModel.ClosureReview.TargetSprintOptions.Single().Id);
@@ -89,7 +92,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
         var tasks = new[]
         {
             NewTask(21, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-5)),
-            NewTask(22, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-12))
+            NewTask(22, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-12)),
+            NewTask(23, null, ActionTaskStatuses.Closed, today.AddDays(2), "Normal", "assignee", today.AddDays(-20))
         };
         var service = CreateQueryService();
 
@@ -102,7 +106,9 @@ public class ActionTaskQueryServiceSprintMetricsTests
 
         // SECTION: Assert
         Assert.Equal(1, model.Reports.FilteredTaskCount);
+        Assert.DoesNotContain(model.Reports.StatusCounts, item => string.Equals(item.Name, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
         Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "4 to 7 days").Count);
+        Assert.Equal(0, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "15+ days").Count);
         Assert.All(model.Reports.CarryForwardBySprint, item => Assert.Equal(0, item.Count));
     }
 

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -57,6 +57,7 @@ public sealed class ActionTaskQueryService
         => !taskId.HasValue ? null : visibleTasks.FirstOrDefault(t => t.Id == taskId.Value);
 
     private static bool IsOpen(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    private static bool IsActionableBacklog(ActionTaskItem task) => task.SprintId is null && IsOpen(task);
     private static bool IsCriticalOpen(ActionTaskItem task) => IsOpen(task) && string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
 
     private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
@@ -65,10 +66,10 @@ public sealed class ActionTaskQueryService
         return activityTimestampUtc ?? task.SubmittedOn ?? task.AssignedOn;
     }
 
-    // SECTION: Backlog read-model projection where null SprintId is the backlog contract.
+    // SECTION: Backlog read-model projection where null SprintId plus open status is the actionable backlog contract.
     private static IReadOnlyList<ActionTaskItem> BuildBacklogTasks(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
     {
-        var backlogTasks = tasks.Where(t => t.SprintId is null).ToList();
+        var backlogTasks = tasks.Where(IsActionableBacklog).ToList();
         return request.IsBacklogView
             ? ApplyTaskListFilters(backlogTasks, request, assigneeNames).ToList()
             : backlogTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
@@ -92,7 +93,7 @@ public sealed class ActionTaskQueryService
             ? new List<ActionTaskItem>()
             : tasks.Where(t => t.SprintId == selectedSprint.Id).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
-        var backlogTasks = tasks.Where(t => t.SprintId is null).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+        var backlogTasks = tasks.Where(IsActionableBacklog).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
         return new ActionSprintReadModel
         {
@@ -192,7 +193,7 @@ public sealed class ActionTaskQueryService
             InProgressTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)),
             BlockedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)),
             OverdueTasks = activeSprintTasks.Count(t => IsOpen(t) && t.DueDate.Date < today),
-            BacklogTasks = tasks.Count(t => t.SprintId is null),
+            BacklogTasks = tasks.Count(IsActionableBacklog),
             CarryForwardCandidateTasks = activeSprintTasks.Count(t => IsOpen(t))
         };
     }

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -21,7 +21,7 @@ public sealed class ActionTaskReportBuilder
         var reportTasks = ApplyReportFilters(tasks, request).ToList();
         var openTasks = reportTasks.Where(IsOpen).ToList();
         var submittedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
-        var backlogOpenTasks = openTasks.Where(t => t.SprintId is null).ToList();
+        var backlogOpenTasks = openTasks.Where(IsActionableBacklog).ToList();
         var blockedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
         string Assignee(string id) => assigneeNames.TryGetValue(id, out var name) ? name : "User";
 
@@ -48,7 +48,7 @@ public sealed class ActionTaskReportBuilder
         if (request.ReportSprintId.HasValue)
         {
             query = request.ReportSprintId.Value == 0
-                ? query.Where(t => t.SprintId is null)
+                ? query.Where(IsActionableBacklog)
                 : query.Where(t => t.SprintId == request.ReportSprintId.Value);
         }
 
@@ -76,6 +76,9 @@ public sealed class ActionTaskReportBuilder
             .Select(g => new ActionTaskQueryService.CountSummary(g.Key.Name, g.Count()))
             .ToList();
     }
+
+    // SECTION: Backlog analytics use the actionable backlog definition without changing general reports.
+    private static bool IsActionableBacklog(ActionTaskItem task) => task.SprintId is null && IsOpen(task);
 
     private static bool IsOpen(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
### Motivation
- Backlog should represent unscheduled, actionable work only, so tasks with status `Closed` must not be counted or listed in backlog queues, planning lists or backlog ageing reports while remaining available in Register and other historical views.

### Description
- Introduced `IsActionableBacklog` and updated read-model projections to treat backlog as `SprintId == null && IsOpen(task)`; applied in `ActionTaskQueryService` to `BuildBacklogTasks`, sprint read-model backlog and active-sprint backlog counts. (see `Services/ActionTasks/ActionTaskQueryService.cs`)
- Updated reporting to build backlog ageing from open unscheduled tasks and to treat `ReportSprintId == 0` as the actionable backlog, preserving other report slices. (see `Services/ActionTasks/ActionTaskReportBuilder.cs`)
- Clarified UI wording and removed `Closed` from backlog status filter choices in the Sprint Board backlog partial. (see `Pages/ActionTasks/_TaskBacklog.cshtml`)
- Adjusted unit tests to assert closed unscheduled tasks are excluded from backlog lists and backlog ageing while remaining present in broader register/task scopes. (see `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` and `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs`)

### Testing
- Updated unit tests: `ActionTaskQueryServiceSprintMetricsTests` and `ActionTaskPageTests` were modified to reflect the actionable-backlog behaviour and to validate backlog counts/ageing exclude closed tasks; these tests were changed in this PR.
- Ran `git diff --check` successfully and committed the changes.
- Attempted to run `dotnet test --filter ActionTasks` but the `dotnet` CLI was not available in the execution environment so tests were not executed here; CI should run the full test-suite before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0258e5c88329bd57876b5f9fa520)