### PR TITLE
Avoid duplicate ActionTask workspace load

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -789,7 +789,7 @@ public class IndexModel : PageModel
         TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(sourceTasks);
 
         // SECTION: Workspace read-model orchestration boundary
-        var workspaceReadModel = await _workspaceBuilder.BuildAsync(BuildWorkspaceRequest(), TaskAssigneeNames);
+        var workspaceReadModel = await _workspaceBuilder.BuildAsync(BuildWorkspaceRequest(), sourceTasks, TaskAssigneeNames);
         var readModel = workspaceReadModel.ReadModel;
 
         // SECTION: Read-model projections assignment boundary

--- a/Services/ActionTasks/ActionTaskWorkspaceBuilder.cs
+++ b/Services/ActionTasks/ActionTaskWorkspaceBuilder.cs
@@ -19,12 +19,11 @@ public sealed class ActionTaskWorkspaceBuilder
         _queryService = queryService;
     }
 
-    // SECTION: Workspace composition boundary gathers task, sprint and activity inputs before read-model projection.
-    public async Task<ActionTaskWorkspaceReadModel> BuildAsync(ActionTaskWorkspaceRequest request, IReadOnlyDictionary<string, string> assigneeNames)
+    // SECTION: Workspace composition boundary uses the caller-provided task snapshot before read-model projection.
+    public async Task<ActionTaskWorkspaceReadModel> BuildAsync(ActionTaskWorkspaceRequest request, IReadOnlyList<ActionTaskItem> sourceTasks, IReadOnlyDictionary<string, string> assigneeNames)
     {
-        var tasks = await _taskService.GetTasksAsync(request.CurrentUserId, request.CurrentRole);
         var sprints = await _sprintService.GetSprintsAsync();
-        var activityByTaskId = await _taskService.GetLastActivityUtcByTaskIdsAsync(tasks.Select(t => t.Id).ToArray());
+        var activityByTaskId = await _taskService.GetLastActivityUtcByTaskIdsAsync(sourceTasks.Select(t => t.Id).ToArray());
         var queryRequest = new ActionTaskQueryService.ActionTaskQueryRequest(
             request.CurrentUserId,
             request.IsMyTasksView,
@@ -46,7 +45,7 @@ public sealed class ActionTaskWorkspaceBuilder
             request.ReportStatus,
             request.ReportPriority);
 
-        return new ActionTaskWorkspaceReadModel(tasks, _queryService.BuildReadModel(tasks, queryRequest, assigneeNames, activityByTaskId));
+        return new ActionTaskWorkspaceReadModel(sourceTasks, _queryService.BuildReadModel(sourceTasks, queryRequest, assigneeNames, activityByTaskId));
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a second full task fetch when building the workspace read model and ensure assignee-name resolution and read-model projection use the same task snapshot.
- Reduce risk of data races or inconsistencies between the page-provided `sourceTasks` and the workspace builder's internal fetch.

### Description
- Changed `ActionTaskWorkspaceBuilder.BuildAsync` to accept a caller-provided `IReadOnlyList<ActionTaskItem> sourceTasks` and `IReadOnlyDictionary<string, string> assigneeNames` instead of fetching tasks internally. 
- Updated `Pages/ActionTasks/Index.cshtml.cs` to pass the already-loaded `sourceTasks` to `BuildAsync` when building the workspace read model. 
- The workspace builder now uses `sourceTasks` for activity lookup (`GetLastActivityUtcByTaskIdsAsync`) and for read-model projection via `_queryService.BuildReadModel`.

### Testing
- Attempted to run `dotnet build --no-restore` but the environment does not have the `dotnet` CLI installed so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc03e1fbf48329a4ce433675121e8f)