### PR TITLE
Refactor Action Tracker page composition: extract user lookup and sprint workspace summary, centralise route/filter state

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
 
@@ -30,10 +29,12 @@ public class IndexModel : PageModel
     private readonly ActionTaskRouteStateHelper _routeStateHelper;
     private readonly ActionTaskMyWorkQueueBuilder _myWorkQueueBuilder;
     private readonly ActionTaskCommandCentreSummaryBuilder _commandCentreSummaryBuilder;
+    private readonly ActionTaskSprintWorkspaceSummaryBuilder _sprintWorkspaceSummaryBuilder;
     private readonly IActionTrackerClock _clock;
+    private readonly ActionTaskUserLookupService _userLookup;
     private readonly UserManager<ApplicationUser> _users;
 
-    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionSprintService sprintService, ActionTaskQueryService queryService, ActionTaskWorkspaceBuilder workspaceBuilder, ActionTaskWorkflowPolicy workflowPolicy, ActionTaskRouteStateHelper routeStateHelper, ActionTaskMyWorkQueueBuilder myWorkQueueBuilder, ActionTaskCommandCentreSummaryBuilder commandCentreSummaryBuilder, IActionTrackerClock clock, UserManager<ApplicationUser> users)
+    public IndexModel(IActionTaskService service, IActionTaskCollaborationService collaborationService, ActionTaskPermissionService permission, ActionSprintService sprintService, ActionTaskQueryService queryService, ActionTaskWorkspaceBuilder workspaceBuilder, ActionTaskWorkflowPolicy workflowPolicy, ActionTaskRouteStateHelper routeStateHelper, ActionTaskMyWorkQueueBuilder myWorkQueueBuilder, ActionTaskCommandCentreSummaryBuilder commandCentreSummaryBuilder, ActionTaskSprintWorkspaceSummaryBuilder sprintWorkspaceSummaryBuilder, ActionTaskUserLookupService userLookup, IActionTrackerClock clock, UserManager<ApplicationUser> users)
     {
         _service = service;
         _collaborationService = collaborationService;
@@ -45,6 +46,8 @@ public class IndexModel : PageModel
         _routeStateHelper = routeStateHelper;
         _myWorkQueueBuilder = myWorkQueueBuilder;
         _commandCentreSummaryBuilder = commandCentreSummaryBuilder;
+        _sprintWorkspaceSummaryBuilder = sprintWorkspaceSummaryBuilder;
+        _userLookup = userLookup;
         _clock = clock;
         _users = users;
         Input.DueDate = _clock.UtcToday.AddDays(7);
@@ -790,8 +793,8 @@ public class IndexModel : PageModel
         var sourceTasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
 
         // SECTION: Query read-model dependencies
-        AssignableUsers = await LoadAssignableUsersAsync();
-        TaskAssigneeNames = await LoadTaskAssigneeNamesAsync(sourceTasks);
+        AssignableUsers = await _userLookup.LoadAssignableUsersAsync(CurrentRole);
+        TaskAssigneeNames = await _userLookup.LoadTaskAssigneeNamesAsync(sourceTasks);
 
         // SECTION: Workspace read-model orchestration boundary
         var workspaceReadModel = await _workspaceBuilder.BuildAsync(BuildWorkspaceRequest(), sourceTasks, TaskAssigneeNames);
@@ -823,6 +826,7 @@ public class IndexModel : PageModel
         ActiveSprintMetrics = readModel.ActiveSprintMetrics;
         MyWorkQueue = _myWorkQueueBuilder.Build(Tasks, ActiveSprint);
         CommandCentreSummary = _commandCentreSummaryBuilder.Build(Tasks, CriticalOpenTasks.Count, ActiveSprintMetrics.CarryForwardCandidateTasks);
+        SprintWorkspaceSummary = _sprintWorkspaceSummaryBuilder.Build(new ActionTaskSprintWorkspaceSummaryRequest(Tasks, BacklogTasks, SelectedSprintTasks, SprintClosureReview.UnfinishedTasks, Sprints, ActiveSprint));
         DueTodayTasks = readModel.DueBuckets.Today;
         DueThisWeekTasks = readModel.DueBuckets.ThisWeek;
         DueLaterTasks = readModel.DueBuckets.Later;
@@ -861,8 +865,8 @@ public class IndexModel : PageModel
         SelectedTaskLogs = await _service.GetTaskLogsAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
         SelectedTaskUpdates = await _collaborationService.GetUpdatesAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
         UpdateAttachments = await _collaborationService.GetAttachmentMetadataByUpdateAsync(SelectedTask.Id, CurrentUserId, CurrentRole);
-        TaskActorNames = await LoadTaskActorNamesAsync(SelectedTaskLogs);
-        TaskActorNames = await MergeActorNamesAsync(TaskActorNames, SelectedTaskUpdates);
+        TaskActorNames = await _userLookup.LoadTaskActorNamesAsync(SelectedTaskLogs);
+        TaskActorNames = await _userLookup.MergeUpdateActorNamesAsync(TaskActorNames, SelectedTaskUpdates);
     }
 
     // SECTION: Workspace request isolates GET filter, report and sprint state before builder orchestration.
@@ -900,7 +904,7 @@ public class IndexModel : PageModel
         }
 
         SprintAuditHistory = await _sprintService.GetSprintAuditHistoryAsync(SelectedSprint.Id);
-        SprintActorNames = await LoadSprintActorNamesAsync(SprintAuditHistory);
+        SprintActorNames = await _userLookup.LoadSprintActorNamesAsync(SprintAuditHistory);
     }
 
     private void PrepareSprintForms()
@@ -1040,11 +1044,7 @@ public class IndexModel : PageModel
         ToDisplayItems(SprintBacklogTasks);
 
     public IReadOnlyList<TaskDisplayItem> ActiveSprintTaskDisplays =>
-        ToDisplayItems(GetActiveSprintTasks()
-            .OrderBy(t => StatusOrder(t.Status))
-            .ThenBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(SprintWorkspaceSummary.ActiveSprintTasks);
 
     public IReadOnlyList<TaskDisplayItem> AssignableBacklogTaskDisplays =>
         ToDisplayItems(SprintBacklogTasks
@@ -1053,61 +1053,40 @@ public class IndexModel : PageModel
 
     // SECTION: Phase 2A layout helper projections for sprint, backlog, and dashboard UX.
     public IReadOnlyList<ActionSprint> PlannedSprints =>
-        Sprints.Where(s => s.Status == ActionSprintStatus.Planned).OrderBy(s => s.StartDate).ThenBy(s => s.Id).ToList();
+        SprintWorkspaceSummary.PlannedSprints;
 
     public IReadOnlyList<ActionSprint> ClosedSprints =>
-        Sprints.Where(s => s.Status == ActionSprintStatus.Closed).OrderByDescending(s => s.EndDate).ThenByDescending(s => s.Id).ToList();
+        SprintWorkspaceSummary.ClosedSprints;
 
     public int SelectedSprintOverdueCount =>
-        SelectedSprintTasks.Count(IsTaskOverdue);
+        SprintWorkspaceSummary.SelectedSprintOverdueCount;
 
     public IReadOnlyList<TaskDisplayItem> SprintAttentionOverdueTaskDisplays =>
-        ToDisplayItems(SelectedSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList());
+        ToDisplayItems(SprintWorkspaceSummary.SprintAttentionOverdueTasks);
 
     public IReadOnlyList<TaskDisplayItem> SprintAttentionBlockedTaskDisplays =>
-        ToDisplayItems(SelectedSprintTasks
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(SprintWorkspaceSummary.SprintAttentionBlockedTasks);
 
     public IReadOnlyList<TaskDisplayItem> SprintAttentionSubmittedTaskDisplays =>
-        ToDisplayItems(SelectedSprintTasks
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.SubmittedOn ?? t.DueDate)
-            .ThenBy(t => t.Id)
-            .ToList());
+        ToDisplayItems(SprintWorkspaceSummary.SprintAttentionSubmittedTasks);
 
     public IReadOnlyList<TaskDisplayItem> SprintCarryForwardCandidateDisplays =>
-        ToDisplayItems(SprintClosureReview.UnfinishedTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList());
+        ToDisplayItems(SprintWorkspaceSummary.SprintCarryForwardCandidateTasks);
 
-    public int BacklogTotalCount => BacklogTasks.Count;
+    public int BacklogTotalCount => SprintWorkspaceSummary.BacklogTotalCount;
 
-    public int BacklogHighPriorityCount =>
-        BacklogTasks.Count(t => string.Equals(t.Priority, "High", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
+    public int BacklogHighPriorityCount => SprintWorkspaceSummary.BacklogHighPriorityCount;
 
-    public int BacklogOverdueCount =>
-        BacklogTasks.Count(IsTaskOverdue);
+    public int BacklogOverdueCount => SprintWorkspaceSummary.BacklogOverdueCount;
 
     public IReadOnlyList<TaskDisplayItem> ActiveSprintOverdueTaskDisplays =>
-        ToDisplayItems(GetActiveSprintTasks().Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList());
+        ToDisplayItems(SprintWorkspaceSummary.ActiveSprintOverdueTasks);
 
     public IReadOnlyList<TaskDisplayItem> ActiveSprintBlockedTaskDisplays =>
-        ToDisplayItems(GetActiveSprintTasks()
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.DueDate)
-            .ThenBy(t => t.Id)
-            .Take(5)
-            .ToList());
+        ToDisplayItems(SprintWorkspaceSummary.ActiveSprintBlockedTasks);
 
     public IReadOnlyList<TaskDisplayItem> ActiveSprintSubmittedTaskDisplays =>
-        ToDisplayItems(GetActiveSprintTasks()
-            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(t => t.SubmittedOn ?? t.DueDate)
-            .ThenBy(t => t.Id)
-            .Take(5)
-            .ToList());
+        ToDisplayItems(SprintWorkspaceSummary.ActiveSprintSubmittedTasks);
 
     // SECTION: KPI helpers for dashboard and reports.
     public int ActiveCount => CommandCentreSummary.ActiveCount;
@@ -1139,13 +1118,7 @@ public class IndexModel : PageModel
 
 
     public bool HasReportFilters =>
-        IsReportsView &&
-        (ReportSprintId.HasValue
-         || !string.IsNullOrWhiteSpace(ReportAssigneeUserId)
-         || ReportFromDate.HasValue
-         || ReportToDate.HasValue
-         || !string.IsNullOrWhiteSpace(ReportStatus)
-         || !string.IsNullOrWhiteSpace(ReportPriority));
+        IsReportsView && _routeStateHelper.HasReportFilterRouteState(BuildReportFilterRouteState());
 
     public string ReportFilterSummary =>
         HasReportFilters
@@ -1171,115 +1144,6 @@ public class IndexModel : PageModel
         CurrentRole = ActionTaskRoleResolver.Resolve(User) ?? string.Empty;
 
         await Task.CompletedTask;
-    }
-
-    private async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync()
-    {
-        // SECTION: Stabilize user snapshot to avoid overlapping data-reader operations
-        var utcNow = new DateTimeOffset(_clock.UtcNow, TimeSpan.Zero);
-        var users = await _users.Users
-            .Where(u => !u.IsDisabled)
-            .Where(u => !u.PendingDeletion)
-            .Where(u => !u.LockoutEnd.HasValue || u.LockoutEnd <= utcNow)
-            .OrderBy(u => u.Rank)
-            .ThenBy(u => u.FullName)
-            .ThenBy(u => u.UserName)
-            .Take(200)
-            .ToListAsync();
-
-        // SECTION: Resolve assignable users with role checks
-        var list = new List<UserOption>();
-        foreach (var user in users)
-        {
-            var roles = await _users.GetRolesAsync(user);
-            var matchedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(roles);
-            if (matchedRole is null || !_permission.CanAssign(CurrentRole, matchedRole))
-            {
-                continue;
-            }
-
-            list.Add(new UserOption(user.Id, BuildPersonDisplayName(user), matchedRole));
-        }
-
-        return list;
-    }
-
-    // SECTION: Resolve assignee display names for task register rendering
-    private async Task<IReadOnlyDictionary<string, string>> LoadTaskAssigneeNamesAsync(IReadOnlyList<ActionTaskItem> tasks)
-    {
-        var userIds = tasks
-            .Select(t => t.AssignedToUserId)
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-
-        if (userIds.Count == 0)
-        {
-            return new Dictionary<string, string>(StringComparer.Ordinal);
-        }
-
-        var users = await _users.Users
-            .Where(u => userIds.Contains(u.Id))
-            .Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email })
-            .ToListAsync();
-
-        return users.ToDictionary(
-            u => u.Id,
-            u => BuildPersonDisplayName(u.Rank, u.FullName, u.UserName, u.Email),
-            StringComparer.Ordinal);
-    }
-
-    // SECTION: Resolve inspector actor names for audit visibility.
-    private async Task<IReadOnlyDictionary<string, string>> LoadTaskActorNamesAsync(IReadOnlyList<ActionTaskAuditLog> logs)
-    {
-        var actorIds = logs
-            .Select(log => log.PerformedByUserId)
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-
-        if (actorIds.Count == 0)
-        {
-            return new Dictionary<string, string>(StringComparer.Ordinal);
-        }
-
-        var users = await _users.Users
-            .Where(u => actorIds.Contains(u.Id))
-            .Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email })
-            .ToListAsync();
-
-        return users.ToDictionary(
-            u => u.Id,
-            u => BuildPersonDisplayName(u.Rank, u.FullName, u.UserName, u.Email),
-            StringComparer.Ordinal);
-    }
-
-    // SECTION: Person display helper for rank and full-name-first rendering.
-    private static string BuildPersonDisplayName(ApplicationUser user) =>
-        BuildPersonDisplayName(user.Rank, user.FullName, user.UserName, user.Email);
-
-    // SECTION: Person display helper for query projections.
-    private static string BuildPersonDisplayName(string? rank, string? fullName, string? userName, string? email)
-    {
-        var trimmedRank = rank?.Trim();
-        var trimmedFullName = fullName?.Trim();
-
-        if (!string.IsNullOrWhiteSpace(trimmedRank) && !string.IsNullOrWhiteSpace(trimmedFullName))
-        {
-            return $"{trimmedRank} {trimmedFullName}";
-        }
-
-        if (!string.IsNullOrWhiteSpace(trimmedFullName))
-        {
-            return trimmedFullName;
-        }
-
-        if (!string.IsNullOrWhiteSpace(userName))
-        {
-            return userName;
-        }
-
-        return string.IsNullOrWhiteSpace(email) ? "User" : email;
     }
 
     // SECTION: Resolve a safe, standardized view mode value for postback and redirects
@@ -1394,11 +1258,12 @@ public class IndexModel : PageModel
     private ActionTaskFilterRouteState BuildFilterRouteState()
         => new(FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir);
 
+    private ActionTaskReportFilterRouteState BuildReportFilterRouteState()
+        => new(ReportSprintId, ReportAssigneeUserId, ReportFromDate, ReportToDate, ReportStatus, ReportPriority);
+
     // SECTION: Planning backlog filter detection keeps canonical Planning routes compatible with legacy Backlog filtered views.
     private bool IsPlanningBacklogFilterContext()
-        => IsPlanningView
-            && string.Equals(ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
-            && HasTaskFilterRouteState();
+        => _routeStateHelper.IsPlanningBacklogFilterContext(ResolvedViewMode, ResolvedPlanningView, BuildFilterRouteState());
 
     // SECTION: Shared filter-state detection is delegated to the shared route-state helper.
     private bool HasTaskFilterRouteState()
@@ -1546,25 +1411,12 @@ public class IndexModel : PageModel
         public List<IFormFile> Files { get; set; } = new();
     }
 
-    public sealed record UserOption(string UserId, string DisplayName, string Role);
     public sealed record CountSummary(string Name, int Count);
     public sealed class TaskDisplayItem
     {
         public ActionTaskItem Task { get; init; } = default!;
         public string AssigneeName { get; init; } = string.Empty;
     }
-
-
-    // SECTION: Reusable status ordering for page-level task projections.
-    private static int StatusOrder(string status) => status switch
-    {
-        ActionTaskStatuses.Assigned => 1,
-        ActionTaskStatuses.InProgress => 2,
-        ActionTaskStatuses.Blocked => 3,
-        ActionTaskStatuses.Submitted => 4,
-        ActionTaskStatuses.Closed => 5,
-        _ => 99
-    };
 
     public bool IsTaskOverdue(ActionTaskItem task) =>
         IsOpenTask(task)
@@ -1573,11 +1425,6 @@ public class IndexModel : PageModel
     // SECTION: Shared open-task predicate keeps personal and command projections aligned.
     private static bool IsOpenTask(ActionTaskItem task) =>
         !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
-
-    private IReadOnlyList<ActionTaskItem> GetActiveSprintTasks() =>
-        ActiveSprint is null
-            ? Array.Empty<ActionTaskItem>()
-            : Tasks.Where(t => t.SprintId == ActiveSprint.Id).ToList();
 
 
     private IReadOnlyList<TaskDisplayItem> ToDisplayItems(IReadOnlyList<ActionTaskItem> tasks) =>

--- a/Program.cs
+++ b/Program.cs
@@ -389,6 +389,8 @@ builder.Services.AddScoped<ActionTaskReportBuilder>();
 builder.Services.AddScoped<ActionTaskRouteStateHelper>();
 builder.Services.AddScoped<ActionTaskMyWorkQueueBuilder>();
 builder.Services.AddScoped<ActionTaskCommandCentreSummaryBuilder>();
+builder.Services.AddScoped<ActionTaskUserLookupService>();
+builder.Services.AddScoped<ActionTaskSprintWorkspaceSummaryBuilder>();
 builder.Services.AddScoped<ActionTaskQueryService>();
 builder.Services.AddScoped<ActionTaskWorkspaceBuilder>();
 builder.Services.AddScoped<ActionTaskWorkflowPolicy>();

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1058,7 +1058,8 @@ public class ActionTaskPageTests
         var sprintWorkflowPolicy = new ActionSprintWorkflowPolicy();
         var sprintService = new ActionSprintService(db, permission, sprintWorkflowPolicy);
         var workspaceBuilder = new ActionTaskWorkspaceBuilder(service, sprintService, queryService);
-        var page = new IndexModel(service, collab, permission, sprintService, queryService, workspaceBuilder, workflowPolicy, new ActionTaskRouteStateHelper(), new ActionTaskMyWorkQueueBuilder(clock), new ActionTaskCommandCentreSummaryBuilder(clock), clock, userManager);
+        var userLookup = new ActionTaskUserLookupService(userManager, permission, clock);
+        var page = new IndexModel(service, collab, permission, sprintService, queryService, workspaceBuilder, workflowPolicy, new ActionTaskRouteStateHelper(), new ActionTaskMyWorkQueueBuilder(clock), new ActionTaskCommandCentreSummaryBuilder(clock), new ActionTaskSprintWorkspaceSummaryBuilder(clock), userLookup, clock, userManager);
 
         var httpContext = new DefaultHttpContext
         {

--- a/Services/ActionTasks/ActionTaskRouteStateHelper.cs
+++ b/Services/ActionTasks/ActionTaskRouteStateHelper.cs
@@ -100,6 +100,22 @@ public sealed class ActionTaskRouteStateHelper
             || !string.IsNullOrWhiteSpace(state.SortBy)
             || !string.IsNullOrWhiteSpace(state.SortDir);
 
+
+    // SECTION: Planning backlog filter detection keeps canonical Planning routes compatible with legacy Backlog filtered views.
+    public bool IsPlanningBacklogFilterContext(string resolvedViewMode, string resolvedPlanningView, ActionTaskFilterRouteState filterState)
+        => string.Equals(resolvedViewMode, "Planning", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
+            && HasTaskFilterRouteState(filterState);
+
+    // SECTION: Shared report filter-state detection covers auto-applied report GET filters.
+    public bool HasReportFilterRouteState(ActionTaskReportFilterRouteState state)
+        => state.ReportSprintId.HasValue
+            || !string.IsNullOrWhiteSpace(state.ReportAssigneeUserId)
+            || state.ReportFromDate.HasValue
+            || state.ReportToDate.HasValue
+            || !string.IsNullOrWhiteSpace(state.ReportStatus)
+            || !string.IsNullOrWhiteSpace(state.ReportPriority);
+
     public bool IsLegacyViewMode(string? viewMode, string legacyViewMode)
         => string.Equals((viewMode ?? string.Empty).Trim(), legacyViewMode, StringComparison.OrdinalIgnoreCase);
 
@@ -185,3 +201,11 @@ public sealed record ActionTaskFilterRouteState(
     string? FilterSearch,
     string? SortBy,
     string? SortDir);
+
+public sealed record ActionTaskReportFilterRouteState(
+    int? ReportSprintId,
+    string? ReportAssigneeUserId,
+    DateTime? ReportFromDate,
+    DateTime? ReportToDate,
+    string? ReportStatus,
+    string? ReportPriority);

--- a/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskSprintWorkspaceSummaryBuilder
+{
+    private readonly IActionTrackerClock _clock;
+
+    public ActionTaskSprintWorkspaceSummaryBuilder(IActionTrackerClock clock)
+    {
+        _clock = clock;
+    }
+
+    // SECTION: Sprint workspace summary centralizes backlog, selected-sprint and active-sprint attention composition.
+    public ActionTaskSprintWorkspaceSummary Build(ActionTaskSprintWorkspaceSummaryRequest request)
+    {
+        var activeSprintTasks = GetActiveSprintTasks(request.Tasks, request.ActiveSprint);
+
+        return new ActionTaskSprintWorkspaceSummary(
+            request.Sprints.Where(s => s.Status == ActionSprintStatus.Planned).OrderBy(s => s.StartDate).ThenBy(s => s.Id).ToList(),
+            request.Sprints.Where(s => s.Status == ActionSprintStatus.Closed).OrderByDescending(s => s.EndDate).ThenByDescending(s => s.Id).ToList(),
+            request.SelectedSprintTasks.Count(IsTaskOverdue),
+            request.SelectedSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            request.SelectedSprintTasks.Where(IsBlocked).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            request.SelectedSprintTasks.Where(IsSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).ToList(),
+            request.UnfinishedClosureTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            request.BacklogTasks.Count,
+            request.BacklogTasks.Count(IsHighPriorityBacklogTask),
+            request.BacklogTasks.Count(IsTaskOverdue),
+            activeSprintTasks.OrderBy(t => StatusOrder(t.Status)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            activeSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
+            activeSprintTasks.Where(IsBlocked).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
+            activeSprintTasks.Where(IsSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).Take(5).ToList());
+    }
+
+    // SECTION: Sprint summary predicates preserve existing open-task and status semantics.
+    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
+    private static bool IsHighPriorityBacklogTask(ActionTaskItem task) => string.Equals(task.Priority, "High", StringComparison.OrdinalIgnoreCase) || string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
+    private static bool IsBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+    private static bool IsSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+    private static bool IsOpenTask(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<ActionTaskItem> GetActiveSprintTasks(IReadOnlyList<ActionTaskItem> tasks, ActionSprint? activeSprint)
+        => activeSprint is null ? Array.Empty<ActionTaskItem>() : tasks.Where(t => t.SprintId == activeSprint.Id).ToList();
+
+    private static int StatusOrder(string status) => status switch
+    {
+        ActionTaskStatuses.Assigned => 1,
+        ActionTaskStatuses.InProgress => 2,
+        ActionTaskStatuses.Blocked => 3,
+        ActionTaskStatuses.Submitted => 4,
+        ActionTaskStatuses.Closed => 5,
+        _ => 99
+    };
+}
+
+public sealed record ActionTaskSprintWorkspaceSummaryRequest(
+    IReadOnlyList<ActionTaskItem> Tasks,
+    IReadOnlyList<ActionTaskItem> BacklogTasks,
+    IReadOnlyList<ActionTaskItem> SelectedSprintTasks,
+    IReadOnlyList<ActionTaskItem> UnfinishedClosureTasks,
+    IReadOnlyList<ActionSprint> Sprints,
+    ActionSprint? ActiveSprint);
+
+public sealed record ActionTaskSprintWorkspaceSummary(
+    IReadOnlyList<ActionSprint> PlannedSprints,
+    IReadOnlyList<ActionSprint> ClosedSprints,
+    int SelectedSprintOverdueCount,
+    IReadOnlyList<ActionTaskItem> SprintAttentionOverdueTasks,
+    IReadOnlyList<ActionTaskItem> SprintAttentionBlockedTasks,
+    IReadOnlyList<ActionTaskItem> SprintAttentionSubmittedTasks,
+    IReadOnlyList<ActionTaskItem> SprintCarryForwardCandidateTasks,
+    int BacklogTotalCount,
+    int BacklogHighPriorityCount,
+    int BacklogOverdueCount,
+    IReadOnlyList<ActionTaskItem> ActiveSprintTasks,
+    IReadOnlyList<ActionTaskItem> ActiveSprintOverdueTasks,
+    IReadOnlyList<ActionTaskItem> ActiveSprintBlockedTasks,
+    IReadOnlyList<ActionTaskItem> ActiveSprintSubmittedTasks)
+{
+    public static ActionTaskSprintWorkspaceSummary Empty { get; } = new(
+        Array.Empty<ActionSprint>(),
+        Array.Empty<ActionSprint>(),
+        0,
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        0,
+        0,
+        0,
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>(),
+        Array.Empty<ActionTaskItem>());
+}

--- a/Services/ActionTasks/ActionTaskUserLookupService.cs
+++ b/Services/ActionTasks/ActionTaskUserLookupService.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public sealed class ActionTaskUserLookupService
+{
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly ActionTaskPermissionService _permission;
+    private readonly IActionTrackerClock _clock;
+
+    public ActionTaskUserLookupService(UserManager<ApplicationUser> users, ActionTaskPermissionService permission, IActionTrackerClock clock)
+    {
+        _users = users;
+        _permission = permission;
+        _clock = clock;
+    }
+
+    // SECTION: Assignable-user lookup centralizes active-account and role assignment filtering.
+    public async Task<IReadOnlyList<UserOption>> LoadAssignableUsersAsync(string currentRole)
+    {
+        var utcNow = new DateTimeOffset(_clock.UtcNow, TimeSpan.Zero);
+        var users = await _users.Users
+            .Where(u => !u.IsDisabled)
+            .Where(u => !u.PendingDeletion)
+            .Where(u => !u.LockoutEnd.HasValue || u.LockoutEnd <= utcNow)
+            .OrderBy(u => u.Rank)
+            .ThenBy(u => u.FullName)
+            .ThenBy(u => u.UserName)
+            .Take(200)
+            .ToListAsync();
+
+        var list = new List<UserOption>();
+        foreach (var user in users)
+        {
+            var roles = await _users.GetRolesAsync(user);
+            var matchedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(roles);
+            if (matchedRole is null || !_permission.CanAssign(currentRole, matchedRole))
+            {
+                continue;
+            }
+
+            list.Add(new UserOption(user.Id, BuildPersonDisplayName(user), matchedRole));
+        }
+
+        return list;
+    }
+
+    // SECTION: Task assignee display lookup keeps register and card projection names consistent.
+    public Task<IReadOnlyDictionary<string, string>> LoadTaskAssigneeNamesAsync(IReadOnlyList<ActionTaskItem> tasks)
+        => LoadUserDisplayNamesAsync(tasks.Select(t => t.AssignedToUserId));
+
+    // SECTION: Task audit actor display lookup keeps inspector history names consistent.
+    public Task<IReadOnlyDictionary<string, string>> LoadTaskActorNamesAsync(IReadOnlyList<ActionTaskAuditLog> logs)
+        => LoadUserDisplayNamesAsync(logs.Select(log => log.PerformedByUserId));
+
+    // SECTION: Sprint audit actor display lookup keeps lifecycle history names consistent.
+    public Task<IReadOnlyDictionary<string, string>> LoadSprintActorNamesAsync(IReadOnlyList<ActionSprintAuditLog> logs)
+        => LoadUserDisplayNamesAsync(logs.Select(log => log.PerformedByUserId));
+
+    // SECTION: Collaboration update actor merge fills names that are absent from audit actor lookups.
+    public async Task<IReadOnlyDictionary<string, string>> MergeUpdateActorNamesAsync(IReadOnlyDictionary<string, string> current, IReadOnlyList<ActionTaskUpdate> updates)
+    {
+        var updateNames = await LoadUserDisplayNamesAsync(updates.Select(update => update.CreatedByUserId));
+        if (updateNames.Count == 0)
+        {
+            return current;
+        }
+
+        var merged = new Dictionary<string, string>(current, StringComparer.Ordinal);
+        foreach (var name in updateNames)
+        {
+            merged.TryAdd(name.Key, name.Value);
+        }
+
+        return merged;
+    }
+
+    // SECTION: Shared user display-name query avoids duplicate actor and assignee projection logic.
+    private async Task<IReadOnlyDictionary<string, string>> LoadUserDisplayNamesAsync(IEnumerable<string?> userIds)
+    {
+        var ids = userIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (ids.Count == 0)
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var users = await _users.Users
+            .Where(u => ids.Contains(u.Id))
+            .Select(u => new { u.Id, u.Rank, u.FullName, u.UserName, u.Email })
+            .ToListAsync();
+
+        return users.ToDictionary(
+            u => u.Id,
+            u => BuildPersonDisplayName(u.Rank, u.FullName, u.UserName, u.Email),
+            StringComparer.Ordinal);
+    }
+
+    // SECTION: Person display helper preserves rank and full-name-first rendering across Action Tracker views.
+    private static string BuildPersonDisplayName(ApplicationUser user)
+        => BuildPersonDisplayName(user.Rank, user.FullName, user.UserName, user.Email);
+
+    private static string BuildPersonDisplayName(string? rank, string? fullName, string? userName, string? email)
+    {
+        var trimmedRank = rank?.Trim();
+        var trimmedFullName = fullName?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(trimmedRank) && !string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return $"{trimmedRank} {trimmedFullName}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return trimmedFullName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(userName))
+        {
+            return userName;
+        }
+
+        return string.IsNullOrWhiteSpace(email) ? "User" : email;
+    }
+}
+
+public sealed record UserOption(string UserId, string DisplayName, string Role);


### PR DESCRIPTION
### Motivation

- Reduce the size and responsibilities of `Pages/ActionTasks/Index.cshtml.cs` so the PageModel focuses on request state, orchestration and handlers rather than heavy composition logic.  
- Centralise user/actor name resolution and assignable-user filtering to avoid duplicated EF queries and to keep name-resolution semantics consistent.  
- Move sprint/backlog/active-sprint composition out of the page so sprint workspace concerns are easier to reason about and test.  
- Strengthen route/filter/report state handling in one helper and use the existing `IActionTrackerClock` consistently for date-bound logic.

### Description

- Extracted `ActionTaskUserLookupService` to own assignable-user lookup and all user display-name lookups/merging (`LoadAssignableUsersAsync`, `LoadTaskAssigneeNamesAsync`, `LoadTaskActorNamesAsync`, `LoadSprintActorNamesAsync`, `MergeUpdateActorNamesAsync`) and reused the existing display-name fallback logic.  
- Added `ActionTaskSprintWorkspaceSummaryBuilder` to compose sprint/backlog/active-sprint attention summaries (planned/closed sprint lists, selected-sprint attention sections, carry-forward candidates, backlog metrics and active sprint health lists) and moved related projections out of the page.  
- Extended `ActionTaskRouteStateHelper` to provide `IsPlanningBacklogFilterContext` and `HasReportFilterRouteState` and introduced `ActionTaskReportFilterRouteState` to centralise report-filter detection and keep canonical route-preservation logic in one place.  
- Updated `Pages/ActionTasks/Index.cshtml.cs` to inject and call the new services, remove in-page user lookup and sprint composition code, delegate sprint/read-model projections to the new summary model, and keep page handlers, query binding and orchestration responsibilities.  
- Registered new services in DI (`ActionTaskUserLookupService`, `ActionTaskSprintWorkspaceSummaryBuilder`) and adjusted `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to construct the page with the new dependencies while preserving test intent and fixtures.  

### Testing

- Updated page test construction to supply the new service dependencies; test sources were changed accordingly.  
- Ran repository checks such as `git diff --check` and verified the working tree and commit were created successfully.  
- Could not execute `dotnet test` in this environment because `dotnet` is not installed, so automated test execution was not performed here; the change only adjusts constructors/delegation and preserves existing public behaviour and read-model shapes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc110233ac83298cbf4e3c81ad3220)