### PR TITLE
Clarify backlog vs non‑sprint assigned work; add central task categorisation

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -91,6 +91,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> NonSprintAssignedWorkloadCounts { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> CarryForwardBySprint { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public int ReportFilteredTaskCount { get; private set; }
@@ -321,11 +322,24 @@ public class IndexModel : PageModel
             : name;
     }
 
+    // SECTION: Task scope badges use official Sprint / Backlog / Non-sprint categorisation.
     public string GetSprintBadgeText(ActionTaskItem task)
-        => task.SprintId.HasValue ? ResolveSprintName(task.SprintId) : "Backlog";
+        => ActionTaskCategorization.ResolveCategory(task) switch
+        {
+            ActionTaskWorkCategory.Sprint => ResolveSprintName(task.SprintId),
+            ActionTaskWorkCategory.NonSprint => "Non-sprint",
+            ActionTaskWorkCategory.Closed => "Closed",
+            _ => "Backlog"
+        };
 
     public string GetSprintBadgeClass(ActionTaskItem task)
-        => task.SprintId.HasValue ? "at-scope-badge at-scope-badge-sprint" : "at-scope-badge at-scope-badge-backlog";
+        => ActionTaskCategorization.ResolveCategory(task) switch
+        {
+            ActionTaskWorkCategory.Sprint => "at-scope-badge at-scope-badge-sprint",
+            ActionTaskWorkCategory.NonSprint => "at-scope-badge at-scope-badge-non-sprint",
+            ActionTaskWorkCategory.Closed => "at-scope-badge at-scope-badge-closed",
+            _ => "at-scope-badge at-scope-badge-backlog"
+        };
 
     public IReadOnlyList<TaskDisplayItem> GetSprintTasksByStatus(string status)
         => ToDisplayItems(SelectedSprintTasks.Where(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase)).ToList());
@@ -837,6 +851,7 @@ public class IndexModel : PageModel
         OverdueAgeingBuckets = readModel.Reports.OverdueAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         SubmittedPendingClosureAgeingBuckets = readModel.Reports.SubmittedPendingClosureAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         BacklogAgeingBuckets = readModel.Reports.BacklogAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        NonSprintAssignedWorkloadCounts = readModel.Reports.NonSprintAssignedWorkloadCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         CarryForwardBySprint = readModel.Reports.CarryForwardBySprint.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         BlockedAgeingBuckets = readModel.Reports.BlockedAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         ReportFilteredTaskCount = readModel.Reports.FilteredTaskCount;
@@ -1102,6 +1117,7 @@ public class IndexModel : PageModel
     public int OpenAgeingBucketsMax => OpenAgeingBuckets.Count == 0 ? 0 : OpenAgeingBuckets.Max(x => x.Count);
     public int OverdueAgeingBucketsMax => OverdueAgeingBuckets.Count == 0 ? 0 : OverdueAgeingBuckets.Max(x => x.Count);
     public int BacklogAgeingBucketsMax => BacklogAgeingBuckets.Count == 0 ? 0 : BacklogAgeingBuckets.Max(x => x.Count);
+    public int NonSprintAssignedWorkloadCountsMax => NonSprintAssignedWorkloadCounts.Count == 0 ? 0 : NonSprintAssignedWorkloadCounts.Max(x => x.Count);
     public int CarryForwardBySprintMax => CarryForwardBySprint.Count == 0 ? 0 : CarryForwardBySprint.Max(x => x.Count);
     public int BlockedAgeingBucketsMax => BlockedAgeingBuckets.Count == 0 ? 0 : BlockedAgeingBuckets.Max(x => x.Count);
     public int ActiveCriticalCount => CommandCentreSummary.ActiveCriticalCount;

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -109,13 +109,13 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Backlog Queue</h2>
-                <p class="at-panel-note">Filter backlog tasks and assign eligible work into a sprint.</p>
+                <p class="at-panel-note">Filter true backlog tasks and assign eligible work into a Sprint.</p>
             </div>
             <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
         </div>
         <div class="at-planning-backlog-body">
             <div class="at-backlog-summary-grid" aria-label="Backlog summary">
-                <article><strong>@Model.BacklogTotalCount</strong><span>Total backlog</span></article>
+                <article><strong>@Model.BacklogTotalCount</strong><span>True backlog</span></article>
                 <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
                 <article><strong>@Model.BacklogOverdueCount</strong><span>Overdue</span></article>
             </div>
@@ -124,7 +124,7 @@
             <details class="at-planning-backlog-filter-shell" open="@hasBacklogFilters">
                 <summary>
                     <span>Filter Backlog</span>
-                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All open backlog")</span>
+                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All true backlog")</span>
                 </summary>
                 <form method="get" class="at-planning-backlog-filter">
                     <input type="hidden" name="viewMode" value="Planning" />

--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -4,7 +4,7 @@
     <div class="at-panel-heading">
         <div>
             <h2>Sprint Board Backlog Filters</h2>
-            <p class="at-panel-note">Backlog queue shows only open tasks that are not assigned to a sprint.</p>
+            <p class="at-panel-note">Backlog queue shows only open tasks that are not in a Sprint and not assigned to a user.</p>
         </div>
         <span class="at-count-chip">@Model.BacklogTaskDisplays.Count tasks</span>
     </div>
@@ -87,7 +87,7 @@
         <h2>Sprint Board Backlog Queue</h2>
         @if (Model.CanPlanSprints)
         {
-            <span class="at-panel-note">Comdt and HoD can assign open backlog tasks into open sprints.</span>
+            <span class="at-panel-note">Comdt and HoD can assign true backlog tasks into open Sprints.</span>
         }
     </div>
 

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -133,7 +133,7 @@
                         <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
                         <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
                         <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
-                        <div><span class="text-muted">Sprint / Backlog</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
+                        <div><span class="text-muted">Work category</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
                     </div>
                 </details>
             </div>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -33,14 +33,14 @@
             <label>
                 <span>Sprint</span>
                 <select class="form-select form-select-sm" name="ReportSprintId" data-at-reports-filter-control="true">
-                    <option value="">All Sprints &amp; Backlog</option>
+                    <option value="">All Sprint, Backlog &amp; Non-sprint work</option>
                     @if (Model.ReportSprintId == 0)
                     {
-                        <option value="0" selected>Backlog only</option>
+                        <option value="0" selected>True backlog only</option>
                     }
                     else
                     {
-                        <option value="0">Backlog only</option>
+                        <option value="0">True backlog only</option>
                     }
                     @foreach (var sprint in Model.Sprints)
                     {
@@ -252,7 +252,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Backlog Ageing Summary</h2>
-                <p class="at-panel-note">Highlights unscheduled open work by age so stale backlog items can be triaged.</p>
+                <p class="at-panel-note">Highlights true backlog only: open, not in a Sprint, and not assigned to a user.</p>
             </div>
         </div>
         <div class="at-metric-bars">
@@ -265,6 +265,32 @@
                 </div>
             }
         </div>
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Non-sprint Assigned Workload</h2>
+                <p class="at-panel-note">Counts open assigned work that is not part of Sprint commitment and is excluded from backlog ageing.</p>
+            </div>
+        </div>
+        @if (!Model.NonSprintAssignedWorkloadCounts.Any())
+        {
+            <p class="at-empty-state-note">No open non-sprint assigned work is visible in the selected report scope.</p>
+        }
+        else
+        {
+            <div class="at-metric-bars at-metric-bars-tight">
+                @foreach (var item in Model.NonSprintAssignedWorkloadCounts)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.NonSprintAssignedWorkloadCountsMax)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        }
     </article>
 
     <article class="at-panel">

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -384,6 +384,9 @@ public class ActionTaskPageTests
         var sprint = AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
         await setup.Db.SaveChangesAsync();
         setup.Db.ActionTasks.Add(NewTask("Sprint task", ActionTaskStatuses.Assigned, sprint.Id));
+        var trueBacklog = NewTask("True backlog", ActionTaskStatuses.Assigned);
+        trueBacklog.AssignedToUserId = string.Empty;
+        setup.Db.ActionTasks.Add(trueBacklog);
         setup.Db.ActionTasks.Add(NewTask("Closed backlog", ActionTaskStatuses.Closed));
         await setup.Db.SaveChangesAsync();
         var page = setup.Page;
@@ -395,9 +398,40 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.NotEmpty(page.BacklogTasks);
         Assert.All(page.BacklogTasks, task => Assert.Null(task.SprintId));
-        Assert.Contains(page.BacklogTasks, task => task.Title == "Mine");
+        Assert.All(page.BacklogTasks, task => Assert.True(string.IsNullOrWhiteSpace(task.AssignedToUserId)));
+        Assert.Contains(page.BacklogTasks, task => task.Title == "True backlog");
+        Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Mine");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Closed backlog");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Sprint task");
+    }
+
+    [Fact]
+    public async Task TaskScopeBadges_UseSprintBacklogNonSprintAndClosedLabels()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Badge Sprint", ActionSprintStatus.Active);
+        var sprintTask = NewTask("Sprint scoped", ActionTaskStatuses.Assigned, sprint.Id);
+        var backlogTask = NewTask("Backlog scoped", ActionTaskStatuses.Assigned);
+        backlogTask.AssignedToUserId = string.Empty;
+        var nonSprintTask = NewTask("Non sprint scoped", ActionTaskStatuses.Assigned);
+        var closedTask = NewTask("Closed scoped", ActionTaskStatuses.Closed);
+        setup.Db.ActionTasks.AddRange(sprintTask, backlogTask, nonSprintTask, closedTask);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+
+        // SECTION: Act
+        await page.OnGetAsync();
+
+        // SECTION: Assert
+        Assert.Equal("Badge Sprint", page.GetSprintBadgeText(sprintTask));
+        Assert.Equal("Backlog", page.GetSprintBadgeText(backlogTask));
+        Assert.Equal("Non-sprint", page.GetSprintBadgeText(nonSprintTask));
+        Assert.Equal("Closed", page.GetSprintBadgeText(closedTask));
+        Assert.Contains("at-scope-badge-sprint", page.GetSprintBadgeClass(sprintTask), StringComparison.Ordinal);
+        Assert.Contains("at-scope-badge-backlog", page.GetSprintBadgeClass(backlogTask), StringComparison.Ordinal);
+        Assert.Contains("at-scope-badge-non-sprint", page.GetSprintBadgeClass(nonSprintTask), StringComparison.Ordinal);
+        Assert.Contains("at-scope-badge-closed", page.GetSprintBadgeClass(closedTask), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -857,6 +891,7 @@ public class ActionTaskPageTests
         Assert.Contains("Priority Exposure", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Distribution", html, StringComparison.Ordinal);
         Assert.Contains("Backlog Ageing Summary", html, StringComparison.Ordinal);
+        Assert.Contains("Non-sprint Assigned Workload", html, StringComparison.Ordinal);
         Assert.Contains("Carry-forward by Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Blocked Task Ageing", html, StringComparison.Ordinal);
     }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -21,8 +21,9 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(2, activeSprint.Id, ActionTaskStatuses.InProgress, today.AddDays(1)),
             NewTask(3, activeSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(-2)),
             NewTask(4, activeSprint.Id, ActionTaskStatuses.Submitted, today.AddDays(2)),
-            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3)),
-            NewTask(6, null, ActionTaskStatuses.Closed, today.AddDays(4))
+            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3), assignedToUserId: string.Empty),
+            NewTask(6, null, ActionTaskStatuses.Closed, today.AddDays(4)),
+            NewTask(7, null, ActionTaskStatuses.Assigned, today.AddDays(5))
         };
         var service = CreateQueryService();
 
@@ -44,6 +45,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(3, model.ActiveSprintMetrics.CarryForwardCandidateTasks);
         Assert.Equal(new[] { 5 }, model.BacklogTasks.Select(t => t.Id));
         Assert.Equal(new[] { 5 }, model.SprintReadModel.BacklogTasks.Select(t => t.Id));
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Assignee", 1) }, model.Reports.NonSprintAssignedWorkloadCounts);
         Assert.Equal(1, model.SprintReadModel.ClosureReview.CompletedTasks.Count);
         Assert.Equal(3, model.SprintReadModel.ClosureReview.UnfinishedTasks.Count);
         Assert.Equal(nextSprint.Id, model.SprintReadModel.ClosureReview.TargetSprintOptions.Single().Id);
@@ -62,7 +64,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(11, sprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "assignee", today.AddDays(-9)),
             NewTask(12, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(4), "Normal", "assignee", today.AddDays(-1)),
             NewTask(13, otherSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "other", today.AddDays(-16)),
-            NewTask(14, null, ActionTaskStatuses.Assigned, today.AddDays(2), "High", "assignee", today.AddDays(-5))
+            NewTask(14, null, ActionTaskStatuses.Assigned, today.AddDays(2), "High", string.Empty, today.AddDays(-5)),
+            NewTask(15, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-3))
         };
         var service = CreateQueryService();
 
@@ -74,7 +77,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
             new Dictionary<int, DateTime?>());
 
         // SECTION: Assert
-        Assert.Equal(4, model.Reports.TotalTaskCount);
+        Assert.Equal(5, model.Reports.TotalTaskCount);
         Assert.Equal(1, model.Reports.FilteredTaskCount);
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Responsible One", 1) }, model.Reports.AssigneePendingCounts);
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("High", 1) }, model.Reports.PriorityCounts);
@@ -91,9 +94,10 @@ public class ActionTaskQueryServiceSprintMetricsTests
         var sprint = new ActionSprint { Id = 31, Name = "Sprint Scope", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
         var tasks = new[]
         {
-            NewTask(21, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-5)),
+            NewTask(21, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", string.Empty, today.AddDays(-5)),
             NewTask(22, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-12)),
-            NewTask(23, null, ActionTaskStatuses.Closed, today.AddDays(2), "Normal", "assignee", today.AddDays(-20))
+            NewTask(23, null, ActionTaskStatuses.Closed, today.AddDays(2), "Normal", "assignee", today.AddDays(-20)),
+            NewTask(24, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-20))
         };
         var service = CreateQueryService();
 
@@ -109,6 +113,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.DoesNotContain(model.Reports.StatusCounts, item => string.Equals(item.Name, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
         Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "4 to 7 days").Count);
         Assert.Equal(0, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "15+ days").Count);
+        Assert.Empty(model.Reports.NonSprintAssignedWorkloadCounts);
         Assert.All(model.Reports.CarryForwardBySprint, item => Assert.Equal(0, item.Count));
     }
 

--- a/Services/ActionTasks/ActionTaskCategorization.cs
+++ b/Services/ActionTasks/ActionTaskCategorization.cs
@@ -1,0 +1,51 @@
+using System;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+public enum ActionTaskWorkCategory
+{
+    Sprint,
+    Backlog,
+    NonSprint,
+    Closed
+}
+
+public static class ActionTaskCategorization
+{
+    // SECTION: Official task category source of truth for sprint, backlog, non-sprint, and closed work.
+    public static ActionTaskWorkCategory ResolveCategory(ActionTaskItem task)
+    {
+        if (IsClosedTask(task))
+        {
+            return ActionTaskWorkCategory.Closed;
+        }
+
+        if (IsSprintTask(task))
+        {
+            return ActionTaskWorkCategory.Sprint;
+        }
+
+        return HasAssignedUser(task)
+            ? ActionTaskWorkCategory.NonSprint
+            : ActionTaskWorkCategory.Backlog;
+    }
+
+    public static bool IsSprintTask(ActionTaskItem task)
+        => task.SprintId.HasValue && IsOpenTask(task);
+
+    public static bool IsBacklogTask(ActionTaskItem task)
+        => task.SprintId is null && !HasAssignedUser(task) && IsOpenTask(task);
+
+    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
+        => task.SprintId is null && HasAssignedUser(task) && IsOpenTask(task);
+
+    public static bool IsClosedTask(ActionTaskItem task)
+        => string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsOpenTask(ActionTaskItem task)
+        => !IsClosedTask(task);
+
+    public static bool HasAssignedUser(ActionTaskItem task)
+        => !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+}

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -56,8 +56,8 @@ public sealed class ActionTaskQueryService
     public ActionTaskItem? SelectTask(IReadOnlyList<ActionTaskItem> visibleTasks, int? taskId)
         => !taskId.HasValue ? null : visibleTasks.FirstOrDefault(t => t.Id == taskId.Value);
 
-    private static bool IsOpen(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
-    private static bool IsActionableBacklog(ActionTaskItem task) => task.SprintId is null && IsOpen(task);
+    private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
+    private static bool IsBacklog(ActionTaskItem task) => ActionTaskCategorization.IsBacklogTask(task);
     private static bool IsCriticalOpen(ActionTaskItem task) => IsOpen(task) && string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
 
     private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
@@ -66,10 +66,10 @@ public sealed class ActionTaskQueryService
         return activityTimestampUtc ?? task.SubmittedOn ?? task.AssignedOn;
     }
 
-    // SECTION: Backlog read-model projection where null SprintId plus open status is the actionable backlog contract.
+    // SECTION: Backlog read-model projection uses the official open, unsprinted, unassigned backlog contract.
     private static IReadOnlyList<ActionTaskItem> BuildBacklogTasks(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
     {
-        var backlogTasks = tasks.Where(IsActionableBacklog).ToList();
+        var backlogTasks = tasks.Where(IsBacklog).ToList();
         return request.IsBacklogView
             ? ApplyTaskListFilters(backlogTasks, request, assigneeNames).ToList()
             : backlogTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
@@ -93,7 +93,7 @@ public sealed class ActionTaskQueryService
             ? new List<ActionTaskItem>()
             : tasks.Where(t => t.SprintId == selectedSprint.Id).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
-        var backlogTasks = tasks.Where(IsActionableBacklog).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+        var backlogTasks = tasks.Where(IsBacklog).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
         return new ActionSprintReadModel
         {
@@ -193,7 +193,7 @@ public sealed class ActionTaskQueryService
             InProgressTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)),
             BlockedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)),
             OverdueTasks = activeSprintTasks.Count(t => IsOpen(t) && t.DueDate.Date < today),
-            BacklogTasks = tasks.Count(IsActionableBacklog),
+            BacklogTasks = tasks.Count(IsBacklog),
             CarryForwardCandidateTasks = activeSprintTasks.Count(t => IsOpen(t))
         };
     }
@@ -361,6 +361,7 @@ public sealed class ActionTaskQueryService
         public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> NonSprintAssignedWorkloadCounts { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> CarryForwardBySprint { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public int TotalTaskCount { get; init; }

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -21,7 +21,8 @@ public sealed class ActionTaskReportBuilder
         var reportTasks = ApplyReportFilters(tasks, request).ToList();
         var openTasks = reportTasks.Where(IsOpen).ToList();
         var submittedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
-        var backlogOpenTasks = openTasks.Where(IsActionableBacklog).ToList();
+        var backlogOpenTasks = openTasks.Where(ActionTaskCategorization.IsBacklogTask).ToList();
+        var nonSprintOpenTasks = openTasks.Where(ActionTaskCategorization.IsAssignedNonSprintTask).ToList();
         var blockedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
         string Assignee(string id) => assigneeNames.TryGetValue(id, out var name) ? name : "User";
 
@@ -36,6 +37,7 @@ public sealed class ActionTaskReportBuilder
             OverdueAgeingBuckets = new[] { new ActionTaskQueryService.CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)), new ActionTaskQueryService.CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)), new ActionTaskQueryService.CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8)) },
             SubmittedPendingClosureAgeingBuckets = new[] { new ActionTaskQueryService.CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)), new ActionTaskQueryService.CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)), new ActionTaskQueryService.CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4)) },
             BacklogAgeingBuckets = BuildAssignedAgeingBuckets(backlogOpenTasks, utcToday),
+            NonSprintAssignedWorkloadCounts = BuildNonSprintAssignedWorkloadCounts(nonSprintOpenTasks, assigneeNames),
             BlockedAgeingBuckets = BuildAssignedAgeingBuckets(blockedTasks, utcToday),
             CarryForwardBySprint = BuildCarryForwardBySprint(openTasks, request.Sprints)
         };
@@ -48,7 +50,7 @@ public sealed class ActionTaskReportBuilder
         if (request.ReportSprintId.HasValue)
         {
             query = request.ReportSprintId.Value == 0
-                ? query.Where(IsActionableBacklog)
+                ? query.Where(ActionTaskCategorization.IsBacklogTask)
                 : query.Where(t => t.SprintId == request.ReportSprintId.Value);
         }
 
@@ -77,8 +79,14 @@ public sealed class ActionTaskReportBuilder
             .ToList();
     }
 
-    // SECTION: Backlog analytics use the actionable backlog definition without changing general reports.
-    private static bool IsActionableBacklog(ActionTaskItem task) => task.SprintId is null && IsOpen(task);
+    // SECTION: Non-sprint assigned workload remains separate from backlog ageing and sprint workload.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildNonSprintAssignedWorkloadCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
+        => tasks
+            .GroupBy(t => assigneeNames.TryGetValue(t.AssignedToUserId, out var name) ? name : "User")
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key)
+            .Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count()))
+            .ToList();
 
-    private static bool IsOpen(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1222,7 +1222,7 @@ html {
     background: #f1f5f9;
 }
 
-/* SECTION: Sprint and backlog scope badges */
+/* SECTION: Sprint, backlog, non-sprint, and closed scope badges */
 .at-scope-badge {
     display: inline-flex;
     align-items: center;
@@ -1244,6 +1244,18 @@ html {
 .at-scope-badge-backlog {
     color: #475569;
     background: #f1f5f9;
+    border-color: #cbd5e1;
+}
+
+.at-scope-badge-non-sprint {
+    color: #7c2d12;
+    background: #ffedd5;
+    border-color: #fed7aa;
+}
+
+.at-scope-badge-closed {
+    color: #334155;
+    background: #e2e8f0;
     border-color: #cbd5e1;
 }
 


### PR DESCRIPTION
### Motivation

- Backlog was previously inferred as `SprintId == null` which mixed unassigned future work with real assigned non‑sprint tasks, causing incorrect backlog queues, ageing and reports. 
- Introduce a single source of truth for categorisation so UI, reports and read‑models consistently treat sprint / backlog / non‑sprint / closed work.

### Description

- Added a central categorisation helper `ActionTaskCategorization` and `ActionTaskWorkCategory` with predicates `IsSprintTask`, `IsBacklogTask`, `IsAssignedNonSprintTask`, `IsClosedTask` and `HasAssignedUser` so category logic is centralized in `Services/ActionTasks/ActionTaskCategorization.cs`.
- Updated read‑model/query/report logic to use the new predicates: `ActionTaskQueryService` now uses the true backlog predicate for backlog projections and dashboard counts, and `ActionTaskReportBuilder` separates `NonSprintAssignedWorkloadCounts` from backlog ageing buckets; added `NonSprintAssignedWorkloadCounts` to the report read model.
- Updated UI and helpers to surface categories: `Pages/ActionTasks/Index.cshtml.cs` badge helpers now use `ActionTaskCategorization.ResolveCategory(task)` and render `Sprint` / `Backlog` / `Non‑sprint` / `Closed`; views updated include `_TaskReports.cshtml`, `_TaskBacklog.cshtml`, `_TaskDetails.cshtml`, `_PlanningPlanTab.cshtml` and related partials to clarify wording and show the new “Non‑sprint Assigned Workload” report panel; CSS added badge styles for `at-scope-badge-non-sprint` and `at-scope-badge-closed` in `wwwroot/css/action-tracker.css`.
- Kept constraints intact: no DB schema or permission/workflow changes, preserved URLs and existing handlers; behaviour change limited to read‑model/projection and UI labelling.

### Testing

- Updated/added unit tests to capture the new semantics: `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests` was adjusted to assert `NonSprintAssignedWorkloadCounts` and true backlog behaviour, and `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests` was updated and extended with a new `TaskScopeBadges_UseSprintBacklogNonSprintAndClosedLabels` test and backlog filtering assertions.
- Performed static checks via `git diff --check` which reported no problems. 
- Attempted to run the test suite with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTasks"` but this environment does not have `dotnet` installed, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1876b7ec8329af08fcf2a9ad8368)