### PR TITLE
Fix ActionTasks index compile errors

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
 
@@ -98,6 +99,7 @@ public class IndexModel : PageModel
     public int ReportTotalTaskCount { get; private set; }
     public ActionTaskMyWorkQueueReadModel MyWorkQueue { get; private set; } = EmptyMyWorkQueue;
     public ActionTaskCommandCentreSummary CommandCentreSummary { get; private set; } = ActionTaskCommandCentreSummary.Empty;
+    public ActionTaskSprintWorkspaceSummary SprintWorkspaceSummary { get; private set; } = ActionTaskSprintWorkspaceSummary.Empty;
 
 
     [BindProperty(SupportsGet = true)]
@@ -971,6 +973,30 @@ public class IndexModel : PageModel
         }
 
         return merged;
+    }
+
+    // SECTION: Person display formatting preserves rank-first names for locally merged actor dictionaries.
+    private static string BuildPersonDisplayName(string? rank, string? fullName, string? userName, string? email)
+    {
+        var trimmedRank = rank?.Trim();
+        var trimmedFullName = fullName?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(trimmedRank) && !string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return $"{trimmedRank} {trimmedFullName}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(trimmedFullName))
+        {
+            return trimmedFullName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(userName))
+        {
+            return userName;
+        }
+
+        return string.IsNullOrWhiteSpace(email) ? "User" : email;
     }
 
     // SECTION: Task display projections for richer UI cards and mini-lists.


### PR DESCRIPTION
### Motivation
- Resolve compilation errors in the Action Tasks page caused by missing EF Core async extensions and missing local helpers/read-model property used by sprint workspace projections.

### Description
- Added `using Microsoft.EntityFrameworkCore;` to enable `ToListAsync()` on `IQueryable` in `Pages/ActionTasks/Index.cshtml.cs`.
- Introduced a missing read-model property `SprintWorkspaceSummary` with the default `ActionTaskSprintWorkspaceSummary.Empty` to ensure sprint-related projections compile safely.
- Added a local `BuildPersonDisplayName(string? rank, string? fullName, string? userName, string? email)` helper to centralize actor/assignee display-name formatting used by actor-name dictionary merges.
- Changes are limited to `Pages/ActionTasks/Index.cshtml.cs` and preserve existing behavior and defaults from the service layer builders.

### Testing
- Attempted to run `dotnet build`, but the `dotnet` CLI is not available in the environment so a build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1b4a6efc832985ae2f76d79e4500)