### PR TITLE
Refactor Sprint Board into cockpit layout and tighten task-card density

### DIFF
--- a/Pages/ActionTasks/_PlanningCloseTab.cshtml
+++ b/Pages/ActionTasks/_PlanningCloseTab.cshtml
@@ -1,26 +1,32 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Close tab groups closure review, carry-forward, next-window creation, and history. *@
-<section class="at-planning-tab-panel at-sprint-execution-main" aria-label="Sprint Board Close tab">
+@* SECTION: Close tab cockpit makes closure review and carry-forward resolution the dominant review surface. *@
+<section class="at-planning-tab-panel at-cockpit-tab at-sprint-execution-main at-planning-close-panel" aria-label="Sprint Board Close tab">
     @if (Model.SelectedSprint is null)
     {
         <div class="at-panel at-empty-state at-empty-state-compact">Select a sprint in Plan before reviewing closure.</div>
     }
     else
     {
-        <partial name="_SprintClosureReview" model="Model" />
+        @* SECTION: Close main zone contains the existing closure review workflow and disposition form. *@
+        <section class="at-cockpit-main at-close-review-surface">
+            <partial name="_SprintClosureReview" model="Model" />
+        </section>
 
-        <details class="at-panel at-sprint-attention-lane at-close-carry-forward-panel">
-            <summary>
-                <span>Carry-forward candidates</span>
-                <span class="at-count-chip">@Model.SprintCarryForwardCandidateDisplays.Count</span>
-            </summary>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
-        </details>
+        @* SECTION: Close support zone highlights carry-forward candidates and closure warnings. *@
+        <aside class="at-cockpit-support at-close-warning-rail">
+            <details class="at-panel at-sprint-attention-lane at-close-carry-forward-panel" open>
+                <summary>
+                    <span>Carry-forward candidates</span>
+                    <span class="at-count-chip">@Model.SprintCarryForwardCandidateDisplays.Count</span>
+                </summary>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
+            </details>
+        </aside>
 
-        @if (Model.SelectedSprint is not null)
-        {
-            <details class="at-panel at-sprint-history-panel">
+        @* SECTION: Close secondary zone keeps sprint history collapsed and visually subordinate. *@
+        <aside class="at-cockpit-secondary at-close-history-rail">
+            <details class="at-panel at-sprint-history-panel at-sprint-history-secondary">
                 <summary>Sprint History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>
                 @if (!Model.SprintAuditHistory.Any())
                 {
@@ -47,6 +53,6 @@
                     </ol>
                 }
             </details>
-        }
+        </aside>
     }
 </section>

--- a/Pages/ActionTasks/_PlanningCommandStrip.cshtml
+++ b/Pages/ActionTasks/_PlanningCommandStrip.cshtml
@@ -1,11 +1,48 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
+@{
+    // SECTION: Sprint Board top-band signal math is presentation-only and keeps existing handlers untouched.
+    var completedCount = Model.SelectedSprint is null ? 0 : Model.SprintSummary.ClosedCount;
+    var totalCount = Model.SelectedSprint is null ? 0 : Model.SprintSummary.TaskCount;
+    var completionPercent = totalCount == 0 ? 0 : (int)Math.Round((double)completedCount / totalCount * 100);
+    var nextActionLabel = "Plan sprint scope";
+    var nextActionDetail = "Create or select a sprint, then shape backlog into a realistic commitment.";
 
-@* SECTION: Compact selected sprint command strip keeps existing sprint handlers intact. *@
-<section class="at-panel at-sprint-command-strip at-planning-command-strip">
+    if (Model.SelectedSprint is not null)
+    {
+        if (Model.CanActivateSelectedSprint)
+        {
+            nextActionLabel = "Activate sprint";
+            nextActionDetail = "Scope is planned; activation will move the sprint into execution.";
+        }
+        else if (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any())
+        {
+            nextActionLabel = "Resolve closure";
+            nextActionDetail = "Review unfinished work and choose carry-forward or backlog disposition.";
+        }
+        else if (Model.CanCloseSelectedSprintDirectly)
+        {
+            nextActionLabel = "Close sprint";
+            nextActionDetail = "All required work is ready for closure review completion.";
+        }
+        else if (Model.SprintSummary.BlockedCount > 0 || Model.SelectedSprintOverdueCount > 0)
+        {
+            nextActionLabel = "Intervene now";
+            nextActionDetail = "Clear blocked or overdue work before it threatens the sprint outcome.";
+        }
+        else
+        {
+            nextActionLabel = "Drive execution";
+            nextActionDetail = string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "Keep status movement visible and record a command focus when available." : Model.SelectedSprint.Goal;
+        }
+    }
+}
+
+@* SECTION: Sprint Board top command band summarizes identity, health signals, and the dominant next action. *@
+<section class="at-panel at-sprint-command-strip at-planning-command-strip at-sprint-top-band" aria-label="Selected sprint command band">
     @if (Model.SelectedSprint is null)
     {
-        @* SECTION: First-sprint empty command line preserves the existing create action. *@
-        <div class="at-sprint-empty-command at-planning-empty-command">
+        @* SECTION: Empty top-band state keeps first-sprint creation route-driven and handler-compatible. *@
+        <div class="at-sprint-empty-command at-planning-empty-command at-sprint-top-band-empty">
             <div class="at-empty-state at-empty-state-compact">
                 @if (!Model.Sprints.Any())
                 {
@@ -17,6 +54,11 @@
                     <strong>No sprint is selected.</strong>
                     <span>Select an existing sprint from Plan to open Execute.</span>
                 }
+            </div>
+            <div class="at-sprint-next-action">
+                <span class="at-section-eyebrow">Next action</span>
+                <strong>@nextActionLabel</strong>
+                <span>@nextActionDetail</span>
             </div>
             @if (Model.CanPlanSprints)
             {
@@ -44,29 +86,38 @@
     }
     else
     {
-        @* SECTION: Single-line command summary reduces visual load while retaining counts and actions. *@
-        <div class="at-planning-command-main">
-            <div class="at-planning-command-title">
-                <span class="at-section-eyebrow">Selected Sprint</span>
+        @* SECTION: Selected-sprint identity block presents name, lifecycle status, dates, and command focus. *@
+        <div class="at-sprint-top-band-identity">
+            <span class="at-section-eyebrow">Selected Sprint</span>
+            <div class="at-sprint-top-band-title">
                 <h2>@Model.DisplaySprintName(Model.SelectedSprint)</h2>
                 <span class="at-sprint-status-pill">@Model.SelectedSprint.Status</span>
-                <span class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</span>
             </div>
-            <div class="at-planning-command-pills" aria-label="Sprint summary">
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.OpenCount</strong> Open</span>
-                <span class="at-compact-counter"><strong>@Model.SelectedSprintOverdueCount</strong> Overdue</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.BlockedCount</strong> Blocked</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.ClosedCount</strong> Closed</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.TaskCount</strong> Total</span>
-            </div>
-            <div class="at-command-focus-strip at-sprint-command-focus at-planning-command-focus">
-                <strong>Command focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
-            </div>
+            <span class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</span>
+            <p class="at-command-focus-strip at-sprint-command-focus at-planning-command-focus">
+                <strong>Focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
+            </p>
+        </div>
+
+        @* SECTION: Top-band signal counters expose completion, open, blocked, overdue, and carry-forward risk at a glance. *@
+        <div class="at-sprint-top-band-signals" aria-label="Sprint health signals">
+            <span class="at-sprint-signal is-completion"><strong>@completionPercent%</strong><small>Complete</small></span>
+            <span class="at-sprint-signal"><strong>@Model.SprintSummary.OpenCount</strong><small>Open</small></span>
+            <span class="at-sprint-signal @(Model.SprintSummary.BlockedCount > 0 ? "is-risk" : string.Empty)"><strong>@Model.SprintSummary.BlockedCount</strong><small>Blocked</small></span>
+            <span class="at-sprint-signal @(Model.SelectedSprintOverdueCount > 0 ? "is-danger" : string.Empty)"><strong>@Model.SelectedSprintOverdueCount</strong><small>Overdue</small></span>
+            <span class="at-sprint-signal @(Model.SprintCarryForwardCandidateDisplays.Any() ? "is-warning" : string.Empty)"><strong>@Model.SprintCarryForwardCandidateDisplays.Count</strong><small>Carry-forward</small></span>
+        </div>
+
+        @* SECTION: Command focus keeps one dominant next-action summary above the detailed tab content. *@
+        <div class="at-sprint-next-action">
+            <span class="at-section-eyebrow">Next action</span>
+            <strong>@nextActionLabel</strong>
+            <span>@nextActionDetail</span>
         </div>
 
         @if (Model.CanPlanSprints || Model.CanEditSelectedSprint)
         {
-            @* SECTION: Lifecycle and edit actions continue to post to existing handlers. *@
+            @* SECTION: Lifecycle and edit actions continue to post to existing sprint handlers. *@
             <div class="at-sprint-action-row at-sprint-action-row-strip at-planning-command-actions">
                 @if (Model.CanPlanSprints)
                 {

--- a/Pages/ActionTasks/_PlanningExecuteTab.cshtml
+++ b/Pages/ActionTasks/_PlanningExecuteTab.cshtml
@@ -1,29 +1,100 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @using ProjectManagement.Models
 @{
-    // SECTION: Execute tab status sections intentionally avoid the old horizontal primary board class.
+    // SECTION: Execute tab keeps active status grouping presentation-only and handler-neutral.
     var activeStatuses = new[] { ActionTaskStatuses.Assigned, ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked, ActionTaskStatuses.Submitted };
     var closedTasks = Model.GetSprintTasksByStatus(ActionTaskStatuses.Closed);
     var attentionCount = Model.SprintAttentionOverdueTaskDisplays.Count + Model.SprintAttentionBlockedTaskDisplays.Count + Model.SprintAttentionSubmittedTaskDisplays.Count;
 }
 
-@* SECTION: Execute tab starts with a compact board header before status work sections. *@
-<section class="at-planning-tab-panel at-sprint-execution-main at-planning-execute-panel" aria-label="Sprint Board Execute tab">
+@* SECTION: Execute tab cockpit makes the active execution board dominant with interventions on the right rail. *@
+<section class="at-planning-tab-panel at-cockpit-tab at-sprint-execution-main at-planning-execute-panel" aria-label="Sprint Board Execute tab">
     @if (Model.SelectedSprint is null)
     {
         <div class="at-panel at-empty-state at-empty-state-compact">Select or create a sprint in Plan before using Execute.</div>
     }
     else
     {
-        <header class="at-panel at-execute-board-header" aria-label="Execution board header">
-            <div class="at-execute-board-title">
-                <span class="at-section-eyebrow">Execute</span>
-                <h2>Execution board</h2>
+        @* SECTION: Execute main zone renders the selected sprint status board as the dominant surface. *@
+        <section class="at-cockpit-main at-execute-status-board" aria-label="Selected Sprint Board task board">
+            <header class="at-panel at-execute-board-header" aria-label="Execution board header">
+                <div class="at-execute-board-title">
+                    <span class="at-section-eyebrow">Main zone</span>
+                    <h2>Active execution board</h2>
+                    <p class="at-panel-note">Move attention through assigned, in-progress, blocked, and submitted work.</p>
+                </div>
+            </header>
+            <div class="at-execute-status-grid">
+                @foreach (var status in activeStatuses)
+                {
+                    var groupedTasks = Model.GetSprintTasksByStatus(status);
+                    var statusSectionClass = status.ToLowerInvariant().Replace(" ", "-");
+                    <article class="at-panel at-board-column at-sprint-board-column at-execute-status-section at-execute-status-@statusSectionClass @(groupedTasks.Any() ? string.Empty : "is-empty")">
+                        <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
+                        @if (!groupedTasks.Any())
+                        {
+                            <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
+                        }
+                        else
+                        {
+                            <div class="at-task-cards">
+                                @foreach (var item in groupedTasks)
+                                {
+                                    <partial name="_PlanningTaskCard" model='@Tuple.Create(Model, item, "Execute", true)' />
+                                }
+                            </div>
+                        }
+                    </article>
+                }
             </div>
+            <details class="at-panel at-board-column at-sprint-board-column at-sprint-closed-section at-execute-closed-section @(closedTasks.Any() ? string.Empty : "is-empty")">
+                <summary>@(ActionTaskStatuses.Closed) <span class="at-count-chip">@closedTasks.Count</span></summary>
+                @if (!closedTasks.Any())
+                {
+                    <p class="at-empty-inline">No @(ActionTaskStatuses.Closed.ToLowerInvariant()) tasks.</p>
+                }
+                else
+                {
+                    <div class="at-task-cards at-sprint-closed-cards">
+                        @foreach (var item in closedTasks)
+                        {
+                            <partial name="_PlanningTaskCard" model='@Tuple.Create(Model, item, "Execute", false)' />
+                        }
+                    </div>
+                }
+            </details>
+        </section>
+
+        @* SECTION: Execute support zone is an intervention rail for overdue, blocked, and submitted-pending-closure lists. *@
+        <aside class="at-cockpit-support at-panel at-sprint-attention-lane at-execute-intervention-rail">
+            <div class="at-panel-heading">
+                <div>
+                    <span class="at-section-eyebrow">Support zone</span>
+                    <h2>Intervention rail</h2>
+                </div>
+                <span class="at-count-chip">@attentionCount</span>
+            </div>
+            <div class="at-attention-grid at-execute-rail-groups">
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
+                </div>
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
+                </div>
+                <div class="at-attention-group">
+                    <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
+                </div>
+            </div>
+        </aside>
+
+        @* SECTION: Execute secondary zone keeps backlog pull-in collapsed and secondary to active delivery. *@
+        <aside class="at-cockpit-secondary at-execute-secondary-rail">
             @if (Model.CanModifySelectedSprint)
             {
-                @* SECTION: Pull from Backlog remains a secondary collapsed action, discoverable at the top of Execute. *@
-                <details class="at-execute-quick-add at-execute-quick-add-inline @(Model.AssignableBacklogTaskDisplays.Any() ? string.Empty : "is-empty")">
+                <details class="at-panel at-execute-quick-add at-execute-quick-add-inline @(Model.AssignableBacklogTaskDisplays.Any() ? string.Empty : "is-empty")">
                     <summary>Pull from Backlog <span class="at-count-chip">@Model.AssignableBacklogTaskDisplays.Count</span></summary>
                     @if (!Model.AssignableBacklogTaskDisplays.Any())
                     {
@@ -48,76 +119,6 @@
                     }
                 </details>
             }
-        </header>
-
-        @* SECTION: Compact attention summary is default; task mini-lists stay inside the collapsed details panel. *@
-        <details class="at-panel at-sprint-attention-lane at-execute-attention">
-            <summary>
-                <span>Execution attention</span>
-                <span class="at-execute-attention-summary" aria-label="Execution attention counts">
-                    <span>Overdue <strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></span>
-                    <span>Blocked <strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></span>
-                    <span>Submitted pending closure <strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></span>
-                </span>
-                <span class="at-count-chip">@attentionCount</span>
-            </summary>
-            <div class="at-attention-grid">
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
-                </div>
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
-                </div>
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
-                </div>
-            </div>
-        </details>
-
-        <section class="at-sprint-board-stack at-execute-status-board" aria-label="Selected Sprint Board task board">
-            <div class="at-execute-status-grid">
-                @foreach (var status in activeStatuses)
-                {
-                    var groupedTasks = Model.GetSprintTasksByStatus(status);
-                    var statusSectionClass = status.ToLowerInvariant().Replace(" ", "-");
-                    <article class="at-panel at-board-column at-sprint-board-column at-execute-status-section at-execute-status-@statusSectionClass @(groupedTasks.Any() ? string.Empty : "is-empty")">
-                        <div class="at-panel-heading"><h2>@status</h2><span class="at-count-chip">@groupedTasks.Count</span></div>
-                        @if (!groupedTasks.Any())
-                        {
-                            <p class="at-empty-inline">No @status.ToLowerInvariant() tasks.</p>
-                        }
-                        else
-                        {
-                            <div class="at-task-cards">
-                                @foreach (var item in groupedTasks)
-                                {
-                                    <partial name="_PlanningTaskCard" model='@Tuple.Create(Model, item, "Execute", true)' />
-                                }
-                            </div>
-                        }
-                    </article>
-                }
-            </div>
-
-            <details class="at-panel at-board-column at-sprint-board-column at-sprint-closed-section at-execute-closed-section @(closedTasks.Any() ? string.Empty : "is-empty")">
-                <summary>@(ActionTaskStatuses.Closed) <span class="at-count-chip">@closedTasks.Count</span></summary>
-                @if (!closedTasks.Any())
-                {
-                    <p class="at-empty-inline">No @(ActionTaskStatuses.Closed.ToLowerInvariant()) tasks.</p>
-                }
-                else
-                {
-                    <div class="at-task-cards at-sprint-closed-cards">
-                        @foreach (var item in closedTasks)
-                        {
-                            <partial name="_PlanningTaskCard" model='@Tuple.Create(Model, item, "Execute", false)' />
-                        }
-                    </div>
-                }
-            </details>
-        </section>
+        </aside>
     }
 </section>

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -1,14 +1,87 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @{
-    // SECTION: Backlog filters are compact by default, expanding automatically when any route filter or sort state changes the queue.
+    // SECTION: Plan tab keeps backlog filters route-driven while prioritizing sprint scope shaping.
     var hasBacklogFilters = Model.HasBacklogFilterRouteState;
 }
 
-@* SECTION: Plan tab contains sprint list, backlog filters, backlog queue, and assignment. *@
-<section class="at-planning-tab-panel at-planning-plan-grid" aria-label="Sprint Board Plan tab">
-    <aside class="at-panel at-sprint-list-panel at-planning-plan-card">
+@* SECTION: Plan tab cockpit makes scope shaping and assignment the primary planning activity. *@
+<section class="at-planning-tab-panel at-cockpit-tab at-planning-plan-grid" aria-label="Sprint Board Plan tab">
+    @* SECTION: Plan main zone focuses on backlog intake and sprint assignment decisions. *@
+    <section class="at-cockpit-main at-panel at-planning-backlog-queue at-plan-scope-board">
         <div class="at-panel-heading">
-            <h2>Sprints</h2>
+            <div>
+                <span class="at-section-eyebrow">Main zone</span>
+                <h2>Shape sprint scope</h2>
+                <p class="at-panel-note">Filter true backlog tasks and assign eligible work into a Sprint.</p>
+            </div>
+            <span class="at-count-chip">@Model.BacklogTaskDisplays.Count backlog</span>
+        </div>
+        <div class="at-backlog-summary-grid" aria-label="Backlog summary">
+            <article><strong>@Model.BacklogTotalCount</strong><span>True backlog</span></article>
+            <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
+            <article><strong>@Model.BacklogOverdueCount</strong><span>Overdue</span></article>
+        </div>
+
+        @* SECTION: Backlog cards use the existing AssignToSprint handler and retain per-task assignability checks. *@
+        @if (!Model.BacklogTaskDisplays.Any())
+        {
+            <div class="at-empty-state at-empty-state-compact">No backlog tasks match the current filter.</div>
+        }
+        else
+        {
+            <div class="at-planning-backlog-list at-plan-scope-list">
+                @foreach (var item in Model.BacklogTaskDisplays)
+                {
+                    var task = item.Task;
+                    <article class="at-planning-backlog-card at-plan-scope-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                        <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
+                        <div class="at-backlog-task-meta">
+                            <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                            <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
+                            <span class="at-cell-primary">@item.AssigneeName</span>
+                            <span class="at-cell-primary">Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                            @if (Model.IsTaskOverdue(task))
+                            {
+                                <span class="at-overdue-marker">Overdue</span>
+                            }
+                        </div>
+                        @if (Model.CanPlanSprints)
+                        {
+                            @if (Model.CanAssignTaskToSprint(task))
+                            {
+                                <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
+                                    <input type="hidden" name="ViewMode" value="Planning" />
+                                    <input type="hidden" name="PlanningTab" value="Execute" />
+                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                    <input type="hidden" name="id" value="@task.Id" />
+                                    <select class="form-select form-select-sm" name="sprintId" aria-label="Select Sprint for AT-@task.Id" required>
+                                        <option value="">Select Sprint</option>
+                                        @foreach (var sprint in Model.AssignableSprints)
+                                        {
+                                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
+                                        }
+                                    </select>
+                                    <button type="submit" class="btn btn-primary btn-sm">Assign</button>
+                                </form>
+                            }
+                            else
+                            {
+                                <span class="text-muted small">Not assignable</span>
+                            }
+                        }
+                    </article>
+                }
+            </div>
+        }
+    </section>
+
+    @* SECTION: Plan support zone keeps sprint selection and creation slim beside scope shaping. *@
+    <aside class="at-cockpit-support at-panel at-sprint-list-panel at-plan-sprint-rail">
+        <div class="at-panel-heading">
+            <div>
+                <span class="at-section-eyebrow">Support zone</span>
+                <h2>Sprints</h2>
+            </div>
             <span class="at-count-chip">@Model.Sprints.Count</span>
         </div>
         @if (!Model.Sprints.Any())
@@ -36,7 +109,6 @@
                 </select>
                 <button type="submit" class="btn btn-outline-primary btn-sm">Open Sprint</button>
             </form>
-
             <div class="at-sprint-list-group">
                 <div class="at-sprint-list-heading">Active</div>
                 @if (Model.ActiveSprint is null)
@@ -51,7 +123,6 @@
                     </a>
                 }
             </div>
-
             <div class="at-sprint-list-group">
                 <div class="at-sprint-list-heading">Planned</div>
                 @if (!Model.PlannedSprints.Any())
@@ -66,23 +137,7 @@
                     </a>
                 }
             </div>
-
-            <details class="at-sprint-list-group is-closed">
-                <summary class="at-sprint-list-heading">Closed <span class="at-count-chip">@Model.ClosedSprints.Count</span></summary>
-                @if (!Model.ClosedSprints.Any())
-                {
-                    <div class="at-empty-inline">No closed sprints.</div>
-                }
-                @foreach (var sprint in Model.ClosedSprints.Take(8))
-                {
-                    <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@sprint.Id">
-                        <strong>@Model.DisplaySprintName(sprint)</strong>
-                        <span>@sprint.EndDate.ToString("dd MMM yyyy")</span>
-                    </a>
-                }
-            </details>
         }
-
         @if (Model.CanPlanSprints)
         {
             <details class="at-sprint-form-disclosure at-plan-create-panel" open="@Model.ShowCreateSprintPanel">
@@ -105,126 +160,68 @@
         }
     </aside>
 
-    <section class="at-panel at-planning-backlog-queue at-planning-plan-card">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Backlog Queue</h2>
-                <p class="at-panel-note">Filter true backlog tasks and assign eligible work into a Sprint.</p>
-                <p class="at-panel-note">Non-sprint means assigned work outside sprint commitment.</p>
-            </div>
-            <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
-        </div>
-        <div class="at-planning-backlog-body">
-            <div class="at-backlog-summary-grid" aria-label="Backlog summary">
-                <article><strong>@Model.BacklogTotalCount</strong><span>True backlog</span></article>
-                <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
-                <article><strong>@Model.BacklogOverdueCount</strong><span>Overdue</span></article>
-            </div>
-
-            @* SECTION: Backlog filters remain GET-based, CSP-safe, and collapsed so low counts keep the queue prominent. *@
-            <details class="at-planning-backlog-filter-shell" open="@hasBacklogFilters">
-                <summary>
-                    <span>Filter Backlog</span>
-                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All true backlog")</span>
-                </summary>
-                <form method="get" class="at-planning-backlog-filter">
-                    <input type="hidden" name="viewMode" value="Planning" />
-                    <input type="hidden" name="PlanningTab" value="Plan" />
-                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                    <label class="form-label at-small" for="PlanningFilterStatus">Status</label>
-                    <select class="form-select form-select-sm" id="PlanningFilterStatus" name="FilterStatus">
-                        <option value="">All open statuses</option>
-                        @foreach (var status in Model.AllowedStatusOptions)
-                        {
-                            if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
-                            {
-                                <option value="@status" selected>@status</option>
-                            }
-                            else
-                            {
-                                <option value="@status">@status</option>
-                            }
-                        }
-                    </select>
-
-                    <label class="form-label at-small" for="PlanningFilterPriority">Priority</label>
-                    <select class="form-select form-select-sm" id="PlanningFilterPriority" name="FilterPriority">
-                        <option value="">All priorities</option>
-                        @foreach (var priority in Model.PriorityOptions)
-                        {
-                            if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
-                            {
-                                <option value="@priority" selected>@priority</option>
-                            }
-                            else
-                            {
-                                <option value="@priority">@priority</option>
-                            }
-                        }
-                    </select>
-
-                    <label class="form-label at-small" for="PlanningFilterSearch">Search by title</label>
-                    <input type="text" class="form-control form-control-sm" id="PlanningFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
-                    <div class="at-planning-backlog-filter-actions">
-                        <button type="submit" class="btn btn-outline-primary btn-sm">Apply</button>
-                        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-outline-secondary btn-sm">Reset</a>
-                    </div>
-                </form>
-            </details>
-
-            @* SECTION: Backlog cards use the existing AssignToSprint handler and retain per-task assignability checks. *@
-            @if (!Model.BacklogTaskDisplays.Any())
-            {
-                <div class="at-empty-state at-empty-state-compact">No backlog tasks match the current filter.</div>
-            }
-            else
-            {
-                <div class="at-planning-backlog-list">
-                    @foreach (var item in Model.BacklogTaskDisplays)
+    @* SECTION: Plan secondary zone holds filters and closed sprint context so they do not compete with assignment. *@
+    <aside class="at-cockpit-secondary at-plan-secondary-rail">
+        <details class="at-panel at-planning-backlog-filter-shell" open="@hasBacklogFilters">
+            <summary>
+                <span>Filter backlog intake</span>
+                <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All true backlog")</span>
+            </summary>
+            <form method="get" class="at-planning-backlog-filter">
+                <input type="hidden" name="viewMode" value="Planning" />
+                <input type="hidden" name="PlanningTab" value="Plan" />
+                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                <label class="form-label at-small" for="PlanningFilterStatus">Status</label>
+                <select class="form-select form-select-sm" id="PlanningFilterStatus" name="FilterStatus">
+                    <option value="">All open statuses</option>
+                    @foreach (var status in Model.AllowedStatusOptions)
                     {
-                        var task = item.Task;
-                        <article class="at-planning-backlog-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                            <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
-                            <div class="at-backlog-task-meta">
-                                <span class="at-cell-primary">@item.AssigneeName</span>
-                                <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                                @if (Model.IsTaskOverdue(task))
-                                {
-                                    <span class="at-overdue-marker">Overdue</span>
-                                }
-                            </div>
-                            <div class="at-backlog-task-meta">
-                                <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
-                                <span class="at-cell-primary">Due @task.DueDate.ToString("dd MMM yyyy")</span>
-                            </div>
-                            @if (Model.CanPlanSprints)
-                            {
-                                @if (Model.CanAssignTaskToSprint(task))
-                                {
-                                    <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
-                                        <input type="hidden" name="ViewMode" value="Planning" />
-                                        <input type="hidden" name="PlanningTab" value="Execute" />
-                                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                        <input type="hidden" name="id" value="@task.Id" />
-                                        <select class="form-select form-select-sm" name="sprintId" aria-label="Select Sprint for AT-@task.Id" required>
-                                            <option value="">Select Sprint</option>
-                                            @foreach (var sprint in Model.AssignableSprints)
-                                            {
-                                                <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
-                                            }
-                                        </select>
-                                        <button type="submit" class="btn btn-primary btn-sm">Assign</button>
-                                    </form>
-                                }
-                                else
-                                {
-                                    <span class="text-muted small">Not assignable</span>
-                                }
-                            }
-                        </article>
+                        if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@status" selected>@status</option>
+                        }
+                        else
+                        {
+                            <option value="@status">@status</option>
+                        }
                     }
+                </select>
+                <label class="form-label at-small" for="PlanningFilterPriority">Priority</label>
+                <select class="form-select form-select-sm" id="PlanningFilterPriority" name="FilterPriority">
+                    <option value="">All priorities</option>
+                    @foreach (var priority in Model.PriorityOptions)
+                    {
+                        if (string.Equals(Model.FilterPriority, priority, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <option value="@priority" selected>@priority</option>
+                        }
+                        else
+                        {
+                            <option value="@priority">@priority</option>
+                        }
+                    }
+                </select>
+                <label class="form-label at-small" for="PlanningFilterSearch">Search by title</label>
+                <input type="text" class="form-control form-control-sm" id="PlanningFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
+                <div class="at-planning-backlog-filter-actions">
+                    <button type="submit" class="btn btn-outline-primary btn-sm">Apply</button>
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId" class="btn btn-outline-secondary btn-sm">Reset</a>
                 </div>
+            </form>
+        </details>
+        <details class="at-panel at-sprint-list-group is-closed at-plan-history-lite">
+            <summary class="at-sprint-list-heading">Closed sprints <span class="at-count-chip">@Model.ClosedSprints.Count</span></summary>
+            @if (!Model.ClosedSprints.Any())
+            {
+                <div class="at-empty-inline">No closed sprints.</div>
             }
-        </div>
-    </section>
+            @foreach (var sprint in Model.ClosedSprints.Take(8))
+            {
+                <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@sprint.Id">
+                    <strong>@Model.DisplaySprintName(sprint)</strong>
+                    <span>@sprint.EndDate.ToString("dd MMM yyyy")</span>
+                </a>
+            }
+        </details>
+    </aside>
 </section>

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -1,6 +1,6 @@
 @model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem, string, bool>
 @{
-    // SECTION: Shared Sprint Board task card keeps Execute and closed-section card behaviour consistent.
+    // SECTION: Dense Sprint Board task card keeps status, priority, due state, assignee, sprint context, and title scannable.
     var pageModel = Model.Item1;
     var item = Model.Item2;
     var planningTab = Model.Item3;
@@ -8,20 +8,26 @@
     var task = item.Task;
 }
 
-<article class="at-task-card at-sprint-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+@* SECTION: Compact card chrome avoids repeated heavy panels inside dense sprint columns. *@
+<article class="at-task-card at-sprint-task-card at-sprint-task-card-dense @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
     <a class="at-task-card-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="@planningTab" asp-route-SelectedSprintId="@pageModel.SelectedSprintId" aria-label="Open task AT-@task.Id details">
-        <div class="at-card-top-row">
-            <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
-            <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-        </div>
-        <div class="at-card-compact-meta">@item.AssigneeName <span aria-hidden="true">·</span> @task.DueDate.ToString("dd MMM yyyy")</div>
-        <div class="at-card-footer">
+        <div class="at-card-scan-row">
             <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
+            <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
             @if (pageModel.IsTaskOverdue(task))
             {
                 <span class="at-overdue-marker">Overdue</span>
             }
-            <span class="at-open-details-label">Open details</span>
+            else
+            {
+                <span class="at-due-marker">Due @task.DueDate.ToString("dd MMM")</span>
+            }
+        </div>
+        <h3 class="at-card-subject">AT-@task.Id · @task.Title</h3>
+        <div class="at-card-compact-meta at-card-scan-meta">
+            <span>@item.AssigneeName</span>
+            <span aria-hidden="true">·</span>
+            <span>@pageModel.GetSprintBadgeText(task)</span>
         </div>
     </a>
     @if (allowMoveToBacklog && pageModel.CanMoveTaskToBacklog(task))

--- a/Pages/ActionTasks/_PlanningViewsTab.cshtml
+++ b/Pages/ActionTasks/_PlanningViewsTab.cshtml
@@ -1,21 +1,34 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Views tab exposes exactly one selected alternate view at a time. *@
-<section class="at-planning-tab-panel at-planning-views-panel" aria-label="Sprint Board Views tab">
-    <nav class="at-panel at-planning-view-toggle" aria-label="Sprint Board alternate view selector">
-        <span class="at-section-eyebrow">Alternate views</span>
-        <div class="btn-group" role="group" aria-label="Sprint Board view options">
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="DueExceptions" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-outline-primary" : "btn-primary")">Due / exceptions</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="Kanban" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")">Kanban</a>
-        </div>
-    </nav>
+@* SECTION: Views tab cockpit is explicitly secondary analysis and does not compete with Plan, Execute, or Close. *@
+<section class="at-planning-tab-panel at-cockpit-tab at-planning-views-panel at-planning-analysis-panel" aria-label="Sprint Board Views tab">
+    @* SECTION: Views main zone presents the selected analysis surface with subdued styling. *@
+    <section class="at-cockpit-main at-analysis-main-surface">
+        <nav class="at-panel at-planning-view-toggle at-analysis-toggle" aria-label="Sprint Board alternate view selector">
+            <div>
+                <span class="at-section-eyebrow">Secondary analysis</span>
+                <h2>Views</h2>
+                <p class="at-panel-note">Use these views to inspect exceptions or historical flow after primary planning decisions.</p>
+            </div>
+            <div class="btn-group" role="group" aria-label="Sprint Board view options">
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="DueExceptions" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-outline-primary" : "btn-primary")">Due / exceptions</a>
+                <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="Kanban" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")">Kanban</a>
+            </div>
+        </nav>
 
-    @if (string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase))
-    {
-        <partial name="_TaskKanban" model="Model" />
-    }
-    else
-    {
-        <partial name="_PlanningDueExceptionsView" model="Model" />
-    }
+        @if (string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase))
+        {
+            <partial name="_TaskKanban" model="Model" />
+        }
+        else
+        {
+            <partial name="_PlanningDueExceptionsView" model="Model" />
+        }
+    </section>
+
+    @* SECTION: Views secondary zone explains this tab's support role without adding new state. *@
+    <aside class="at-cockpit-secondary at-analysis-context-panel at-panel">
+        <span class="at-section-eyebrow">Context</span>
+        <p>Analysis views are read-only navigation aids for due risk and status distribution. Use Plan, Execute, or Close for sprint decisions.</p>
+    </aside>
 </section>

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -1,24 +1,29 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Sprint Board workspace composes Phase 3A-2 partials without changing handlers or workflow rules. *@
-<section class="at-sprints-workspace at-planning-board-workspace">
-    <partial name="_PlanningCommandStrip" model="Model" />
-    <partial name="_PlanningTabs" model="Model" />
+@* SECTION: Sprint Board cockpit composition root preserves route-driven tab partials and existing handlers. *@
+<section class="at-sprints-workspace at-planning-board-workspace at-sprint-cockpit" aria-label="Sprint Board cockpit">
+    <div class="at-sprint-cockpit-topbar">
+        <partial name="_PlanningCommandStrip" model="Model" />
+        <partial name="_PlanningTabs" model="Model" />
+    </div>
 
-    @if (Model.IsPlanningPlanTab)
-    {
-        <partial name="_PlanningPlanTab" model="Model" />
-    }
-    else if (Model.IsPlanningExecuteTab)
-    {
-        <partial name="_PlanningExecuteTab" model="Model" />
-    }
-    else if (Model.IsPlanningCloseTab)
-    {
-        <partial name="_PlanningCloseTab" model="Model" />
-    }
-    else if (Model.IsPlanningViewsTab)
-    {
-        <partial name="_PlanningViewsTab" model="Model" />
-    }
+    @* SECTION: Sprint Board tab host renders one cockpit surface without changing tab route parameters. *@
+    <div class="at-sprint-cockpit-body">
+        @if (Model.IsPlanningPlanTab)
+        {
+            <partial name="_PlanningPlanTab" model="Model" />
+        }
+        else if (Model.IsPlanningExecuteTab)
+        {
+            <partial name="_PlanningExecuteTab" model="Model" />
+        }
+        else if (Model.IsPlanningCloseTab)
+        {
+            <partial name="_PlanningCloseTab" model="Model" />
+        }
+        else if (Model.IsPlanningViewsTab)
+        {
+            <partial name="_PlanningViewsTab" model="Model" />
+        }
+    </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3396,3 +3396,352 @@ html {
         flex-direction: column;
     }
 }
+
+/* SECTION: Sprint Board cockpit shell and shared three-zone tab structure. */
+.at-sprint-cockpit {
+    gap: 1rem;
+}
+
+.at-sprint-cockpit-topbar,
+.at-sprint-cockpit-body {
+    display: grid;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.at-cockpit-tab {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+    grid-template-areas:
+        "main support"
+        "main secondary";
+    align-items: start;
+    gap: 0.85rem;
+}
+
+.at-cockpit-main {
+    grid-area: main;
+    min-width: 0;
+}
+
+.at-cockpit-support {
+    grid-area: support;
+    min-width: 0;
+}
+
+.at-cockpit-secondary {
+    grid-area: secondary;
+    min-width: 0;
+}
+
+/* SECTION: Sprint Board top band identity, signals, and dominant next action. */
+.at-sprint-top-band {
+    grid-template-columns: minmax(260px, 1.35fr) minmax(360px, 1fr) minmax(220px, 0.8fr) auto;
+    align-items: stretch;
+    border-color: #bfdbfe;
+    background: linear-gradient(135deg, #ffffff 0%, #f8fbff 58%, #eff6ff 100%);
+}
+
+.at-sprint-top-band-empty {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 0.55fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.at-sprint-top-band-identity,
+.at-sprint-next-action {
+    display: grid;
+    align-content: start;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.at-sprint-top-band-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.at-sprint-top-band-title h2 {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 1.05rem;
+    font-weight: var(--at-weight-bold);
+    letter-spacing: -0.02em;
+}
+
+.at-sprint-top-band-signals {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(5.1rem, 1fr));
+    gap: 0.45rem;
+    align-content: stretch;
+}
+
+.at-sprint-signal {
+    display: grid;
+    align-content: center;
+    gap: 0.08rem;
+    border: 1px solid #dbeafe;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.78);
+    padding: 0.52rem 0.58rem;
+    min-width: 0;
+}
+
+.at-sprint-signal strong {
+    color: var(--at-text);
+    font-size: 1rem;
+    font-weight: var(--at-weight-bold);
+    line-height: 1;
+}
+
+.at-sprint-signal small {
+    color: var(--at-muted);
+    font-size: var(--at-font-xs);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.at-sprint-signal.is-risk,
+.at-sprint-signal.is-warning {
+    border-color: #fed7aa;
+    background: #fffbeb;
+}
+
+.at-sprint-signal.is-danger {
+    border-color: #fecaca;
+    background: #fef2f2;
+}
+
+.at-sprint-next-action {
+    border: 1px solid #bfdbfe;
+    border-left: 4px solid var(--at-blue);
+    border-radius: 12px;
+    background: #ffffff;
+    padding: 0.65rem 0.75rem;
+}
+
+.at-sprint-next-action strong {
+    color: var(--at-text);
+    font-size: var(--at-font-lg);
+    line-height: 1.1;
+}
+
+.at-sprint-next-action span:last-child {
+    color: var(--at-muted);
+    font-size: var(--at-font-md);
+    line-height: 1.35;
+}
+
+/* SECTION: Plan cockpit makes scope cards dominant and supporting sprint modules slimmer. */
+.at-plan-scope-board {
+    padding: 0.9rem;
+}
+
+.at-plan-scope-list {
+    display: grid;
+    gap: 0.55rem;
+    max-height: min(66vh, 52rem);
+}
+
+.at-plan-scope-card {
+    border-left: 4px solid #bfdbfe;
+    padding: 0.7rem 0.75rem;
+}
+
+.at-plan-sprint-rail,
+.at-plan-secondary-rail .at-panel {
+    box-shadow: none;
+}
+
+.at-plan-sprint-rail .at-sprint-list-item,
+.at-plan-history-lite .at-sprint-list-item {
+    padding: 0.48rem 0.58rem;
+}
+
+.at-plan-history-lite {
+    margin-top: 0.75rem;
+    padding: 0.72rem 0.85rem;
+}
+
+/* SECTION: Execute cockpit emphasizes the board and moves interventions to a right-side rail. */
+.at-planning-execute-panel {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+}
+
+.at-planning-execute-panel .at-execute-status-grid {
+    grid-template-columns: repeat(4, minmax(180px, 1fr));
+}
+
+.at-execute-intervention-rail {
+    position: sticky;
+    top: 5rem;
+    padding: 0.85rem;
+}
+
+.at-execute-rail-groups {
+    grid-template-columns: 1fr;
+}
+
+.at-execute-secondary-rail .at-execute-quick-add-inline {
+    width: 100%;
+}
+
+/* SECTION: Close cockpit promotes closure disposition while making history secondary. */
+.at-planning-close-panel {
+    grid-template-columns: minmax(0, 1fr) minmax(250px, 320px);
+}
+
+.at-close-review-surface .at-closure-review {
+    border-color: #fed7aa;
+    box-shadow: 0 12px 30px rgba(146, 64, 14, 0.08);
+}
+
+.at-close-warning-rail .at-close-carry-forward-panel {
+    border-color: #fed7aa;
+    background: #fffbeb;
+}
+
+.at-sprint-history-secondary {
+    opacity: 0.78;
+    box-shadow: none;
+}
+
+.at-sprint-history-secondary:not([open]) {
+    background: #f8fafc;
+}
+
+/* SECTION: Views cockpit is subdued as secondary analysis. */
+.at-planning-analysis-panel {
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+}
+
+.at-analysis-main-surface {
+    opacity: 0.92;
+}
+
+.at-analysis-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-style: dashed;
+    box-shadow: none;
+}
+
+.at-analysis-toggle h2 {
+    margin: 0;
+    font-size: var(--at-font-lg);
+}
+
+.at-analysis-context-panel {
+    border-style: dashed;
+    background: #f8fafc;
+    box-shadow: none;
+    color: var(--at-muted);
+    font-size: var(--at-font-md);
+}
+
+.at-analysis-context-panel p {
+    margin: 0.35rem 0 0;
+}
+
+/* SECTION: Dense Sprint Board task cards reduce chrome and keep task facts scannable. */
+.at-sprint-task-card-dense {
+    border-radius: 10px;
+    box-shadow: none;
+}
+
+.at-sprint-task-card-dense .at-task-card-link {
+    gap: 0.32rem;
+    padding: 0.55rem 0.62rem;
+}
+
+.at-card-scan-row,
+.at-card-scan-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.28rem 0.4rem;
+}
+
+.at-sprint-task-card-dense .at-card-subject {
+    display: -webkit-box;
+    margin: 0;
+    overflow: hidden;
+    color: var(--at-text);
+    font-size: var(--at-font-md);
+    font-weight: var(--at-weight-bold);
+    line-height: 1.28;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.at-card-scan-meta {
+    color: var(--at-muted);
+    font-size: var(--at-font-xs);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-due-marker {
+    border: 1px solid #dbe4f0;
+    border-radius: 999px;
+    background: #f8fafc;
+    color: var(--at-muted);
+    padding: 0.12rem 0.45rem;
+    font-size: var(--at-font-xs);
+    font-weight: var(--at-weight-bold);
+}
+
+/* SECTION: Sprint Board cockpit responsive containment. */
+@media (max-width: 1399px) {
+    .at-sprint-top-band {
+        grid-template-columns: minmax(0, 1fr) minmax(280px, 0.85fr);
+    }
+
+    .at-sprint-top-band-signals,
+    .at-planning-command-actions {
+        grid-column: 1 / -1;
+    }
+}
+
+@media (max-width: 1199px) {
+    .at-cockpit-tab,
+    .at-planning-execute-panel,
+    .at-planning-close-panel,
+    .at-planning-analysis-panel {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "main"
+            "support"
+            "secondary";
+    }
+
+    .at-execute-intervention-rail {
+        position: static;
+    }
+
+    .at-planning-execute-panel .at-execute-status-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 767px) {
+    .at-sprint-top-band,
+    .at-sprint-top-band-empty {
+        grid-template-columns: 1fr;
+    }
+
+    .at-sprint-top-band-signals,
+    .at-planning-execute-panel .at-execute-status-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-analysis-toggle {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a consistent three-zone Sprint Board presentation (top-band + cockpit main/support/secondary zones) to make Plan/Execute/Close/Views surfaces clearer and reduce visual chrome.
- Surface sprint identity, health signals, and a single dominant next-action summary in a top command band for faster decision-making.
- Make scope-shaping the primary Plan activity and promote closure review / execution interventions while keeping existing server-driven handlers and routes unchanged.
- Improve card density so task facts (status, priority, due, assignee, sprint context, title) scan quickly in busy boards.

### Description
- Added a cockpit composition shell around the existing command strip and tabs in `Pages/ActionTasks/_TaskSprints.cshtml` and preserved the route-driven tab partial rendering.
- Reworked `Pages/ActionTasks/_PlanningCommandStrip.cshtml` into a top-band (`at-sprint-top-band`) that shows selected sprint identity, status, date range, completion/open/blocked/overdue/carry-forward signals, and a dominant `Next action` summary while leaving all `asp-page-handler` forms and route parameters intact.
- Reorganized tab partials so each renders into the same cockpit structure: `main` (dominant board/review), `support` (exceptions/intervention), and `secondary` (backlog/filters/history); changes applied to `Pages/ActionTasks/_PlanningPlanTab.cshtml`, `_PlanningExecuteTab.cshtml`, `_PlanningCloseTab.cshtml`, and `_PlanningViewsTab.cshtml` with no workflow or handler semantics changed.
- Tightened card density by replacing the previous card chrome with a compact layout in `Pages/ActionTasks/_PlanningTaskCard.cshtml` and added a dense card CSS class to reduce visual weight while retaining Move/Assign handlers.
- Added scoped CSS blocks in `wwwroot/css/action-tracker.css` for the cockpit shell, top-band signals, three-zone tab layout, per-tab cockpit styles, dense task cards, and responsive containment, each preceded by `SECTION:` comments for clarity.
- Kept all routing, `asp-route-*` parameters, `asp-page-handler` form posts, and service-layer logic unchanged, and avoided introducing inline scripts or SPA-like state.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge artefacts and it returned no issues (ok).
- Scanned for inline scripts with `rg -n "<script"` across the modified Razor and CSS files and found no matches (ok).
- Verified `SECTION:` comments are present with `rg -n "SECTION:"` across modified files (ok).
- Attempted a project build with `dotnet build` which could not be executed in this environment because the `dotnet` CLI is not installed (build not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc350b7e188329b26209f6ae841cf1)