### PR TITLE
Command Centre: executive brief, banded dashboard layout, and CSS surfaces

### DIFF
--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -1,75 +1,124 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Command-attention strip for command-centre exceptions. *@
-<section class="at-kpis" aria-label="Command attention metrics">
-    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Past due and open</p></article>
-    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Needs unblock action</p></article>
-    <article><h3>Pending Closure</h3><strong>@Model.SubmittedPendingClosureCount</strong><p>Submitted for close-out</p></article>
-    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Critical priority, not closed</p></article>
-    <article><h3>Carry Forward</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong><p>Active sprint candidates</p></article>
-</section>
-<section class="at-panel at-command-focus-strip mb-3">
-    <strong>Command Attention:</strong> @Model.DashboardCommandFocusSummary
+@* SECTION: Executive command brief with integrated exception severity. *@
+<section class="at-command-brief" aria-label="Command Centre executive brief">
+    <div class="at-command-brief-lead">
+        <div>
+            <span class="at-section-eyebrow">Command Centre</span>
+            <h2>Exception command surface</h2>
+        </div>
+        <p class="at-command-sentence"><strong>Command Attention:</strong> @Model.DashboardCommandFocusSummary</p>
+    </div>
+    <div class="at-command-exception-grid" aria-label="Command exception metrics">
+        <article class="at-command-exception at-command-exception-major">
+            <span class="at-command-exception-label">Critical Open</span>
+            <strong>@Model.CriticalOpenCount</strong>
+            <p>Critical priority, not closed</p>
+        </article>
+        <article class="at-command-exception is-danger">
+            <span class="at-command-exception-label">Overdue</span>
+            <strong>@Model.OverdueCount</strong>
+            <p>Past due and open</p>
+        </article>
+        <article class="at-command-exception is-warning">
+            <span class="at-command-exception-label">Blocked</span>
+            <strong>@Model.BlockedCount</strong>
+            <p>Needs unblock action</p>
+        </article>
+        <article class="at-command-exception is-amber">
+            <span class="at-command-exception-label">Submitted Pending Closure</span>
+            <strong>@Model.SubmittedPendingClosureCount</strong>
+            <p>Submitted for close-out</p>
+        </article>
+        <article class="at-command-exception is-neutral">
+            <span class="at-command-exception-label">Carry-Forward Risk</span>
+            <strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong>
+            <p>Active sprint candidates</p>
+        </article>
+    </div>
 </section>
 
-@* SECTION: Active sprint operational health metrics. *@
-<section class="at-panel at-active-sprint-dashboard">
-    <div class="at-panel-heading">
+@* SECTION: Band A - active sprint health and current operational signal. *@
+<section class="at-command-health-band" aria-labelledby="active-sprint-health-title">
+    <div class="at-command-band-heading">
         <div>
-            <h2>Active Sprint Health</h2>
-            @if (Model.ActiveSprint is not null)
-            {
-                <p class="at-panel-note">@Model.DisplaySprintName(Model.ActiveSprint) · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
-            }
-            else
-            {
-                <p class="at-panel-note">No active sprint is currently set.</p>
-            }
+            <span class="at-section-eyebrow">Band A</span>
+            <h2 id="active-sprint-health-title">Active Sprint Health &amp; Operational Signal</h2>
+        </div>
+        @if (Model.ActiveSprint is not null)
+        {
+            <p class="at-panel-note">@Model.DisplaySprintName(Model.ActiveSprint) · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
+        }
+        else
+        {
+            <p class="at-panel-note">No active sprint is currently set.</p>
+        }
+    </div>
+    <div class="at-command-health-layout">
+        <div class="at-sprint-health-surface" aria-label="Active Sprint health metrics">
+            <article class="is-primary"><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong><span>Current execution scope</span></article>
+            <article><h3>Completed</h3><strong>@Model.ActiveSprintMetrics.CompletedTasks</strong></article>
+            <article><h3>In progress</h3><strong>@Model.ActiveSprintMetrics.InProgressTasks</strong></article>
+            <article><h3>Backlog</h3><strong>@Model.ActiveSprintMetrics.BacklogTasks</strong></article>
+            <article class="is-warning"><h3>Blocked</h3><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></article>
+            <article class="is-danger"><h3>Overdue in sprint</h3><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></article>
+            <article class="is-amber"><h3>Carry-forward candidates</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong></article>
+        </div>
+        @* SECTION: Slim active Sprint operational signals using existing mini-list partials. *@
+        <div class="at-operational-signal-stack" aria-label="Active Sprint operational signals">
+            <article class="at-attention-panel at-attention-panel-slim is-danger">
+                <div class="at-attention-heading"><span>Overdue</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, "No overdue tasks in the active sprint.")' />
+            </article>
+            <article class="at-attention-panel at-attention-panel-slim is-warning">
+                <div class="at-attention-heading"><span>Blocked</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, "No blocked tasks in the active sprint.")' />
+            </article>
+            <article class="at-attention-panel at-attention-panel-slim is-amber">
+                <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, "No submitted tasks pending closure in the active sprint.")' />
+            </article>
         </div>
     </div>
-    <div class="at-sprint-health-grid at-sprint-health-grid-readable" aria-label="Active Sprint health metrics">
-        <article class="is-primary"><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong><span>Current execution scope</span></article>
-        <article><h3>Completed</h3><strong>@Model.ActiveSprintMetrics.CompletedTasks</strong></article>
-        <article><h3>In progress</h3><strong>@Model.ActiveSprintMetrics.InProgressTasks</strong></article>
-        <article><h3>Blocked</h3><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></article>
-        <article><h3>Overdue in sprint</h3><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></article>
-        <article><h3>Backlog</h3><strong>@Model.ActiveSprintMetrics.BacklogTasks</strong></article>
-        <article><h3>Carry-forward candidates</h3><strong>@Model.ActiveSprintMetrics.CarryForwardCandidateTasks</strong></article>
-    </div>
-    @* SECTION: Command attention grouping for active Sprint exceptions. *@
-    <div class="at-dashboard-attention-grid" aria-label="Active Sprint command attention">
-        <article class="at-attention-panel">
-            <div class="at-attention-heading"><span>Overdue</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, "No overdue tasks in the active sprint.")' />
-        </article>
-        <article class="at-attention-panel">
-            <div class="at-attention-heading"><span>Blocked</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, "No blocked tasks in the active sprint.")' />
-        </article>
-        <article class="at-attention-panel">
-            <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, "No submitted tasks pending closure in the active sprint.")' />
-        </article>
-    </div>
 </section>
 
-@* SECTION: Attention-required panels with compact task rows. *@
-<section class="at-section-group">
-    <h2 class="at-section-title">Attention Required</h2>
-    <div class="at-card-grid">
-        <article class="at-panel">
+@* SECTION: Band B - attention-required queues with compact task rows. *@
+<section class="at-command-attention-band" aria-labelledby="attention-required-title">
+    <div class="at-command-band-heading">
+        <div>
+            <span class="at-section-eyebrow">Band B</span>
+            <h2 id="attention-required-title">Attention-Required Queues</h2>
+        </div>
+        <p class="at-panel-note">Command queues remain server-rendered and compact for fast triage.</p>
+    </div>
+    <div class="at-card-grid at-command-queue-grid">
+        <article class="at-panel at-attention-queue is-danger">
             <div class="at-panel-heading">
                 <h3>Critical Open Tasks</h3>
                 <span class="at-count-chip">@Model.CriticalOpenTaskDisplays.Count</span>
             </div>
             <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CriticalOpenTaskDisplays, "No critical open tasks.")' />
         </article>
-        <article class="at-panel">
+        <article class="at-panel at-attention-queue is-danger">
             <div class="at-panel-heading">
                 <h3>Overdue Tasks</h3>
                 <span class="at-count-chip">@Model.OverdueTaskDisplays.Count</span>
             </div>
             <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.OverdueTaskDisplays, "No overdue tasks.")' />
+        </article>
+        <article class="at-panel at-attention-queue is-warning">
+            <div class="at-panel-heading">
+                <h3>Blocked Tasks</h3>
+                <span class="at-count-chip">@Model.KanbanBlockedTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.KanbanBlockedTaskDisplays, "No blocked tasks.")' />
+        </article>
+        <article class="at-panel at-attention-queue is-amber">
+            <div class="at-panel-heading">
+                <h3>Submitted Pending Closure</h3>
+                <span class="at-count-chip">@Model.KanbanSubmittedTaskDisplays.Count</span>
+            </div>
+            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.KanbanSubmittedTaskDisplays, "No submitted tasks awaiting closure.")' />
         </article>
     </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -294,6 +294,256 @@ html {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+
+/* SECTION: Command Centre executive hierarchy surfaces */
+.at-command-brief,
+.at-command-health-band,
+.at-command-attention-band {
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    box-shadow: var(--at-shadow-sm);
+    margin-bottom: 1rem;
+}
+
+.at-command-brief {
+    display: grid;
+    gap: 0.9rem;
+    padding: 1rem;
+    color: #ffffff;
+    background: linear-gradient(135deg, #0f2748 0%, #1e3a8a 58%, #2563eb 100%);
+    border-color: rgba(191, 219, 254, 0.45);
+}
+
+.at-command-brief .at-section-eyebrow {
+    color: #bfdbfe;
+}
+
+.at-command-brief h2,
+.at-command-band-heading h2 {
+    margin: 0;
+    font-size: var(--at-font-lg);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: -0.015em;
+}
+
+.at-command-brief-lead {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.at-command-sentence {
+    max-width: 48rem;
+    margin: 0;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    border-radius: var(--at-radius-md);
+    padding: 0.55rem 0.7rem;
+    background: rgba(15, 23, 42, 0.28);
+    color: #eff6ff;
+    font-size: var(--at-font-md);
+    line-height: 1.45;
+}
+
+.at-command-exception-grid {
+    display: grid;
+    grid-template-columns: minmax(180px, 1.35fr) repeat(4, minmax(130px, 1fr));
+    gap: 0.65rem;
+}
+
+.at-command-exception {
+    min-width: 0;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    border-radius: var(--at-radius-md);
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.11);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.at-command-exception-major {
+    background: linear-gradient(180deg, rgba(254, 226, 226, 0.98), rgba(255, 255, 255, 0.94));
+    border-color: #fecaca;
+    color: #7f1d1d;
+}
+
+.at-command-exception-label {
+    display: block;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.045em;
+}
+
+.at-command-exception strong {
+    display: block;
+    margin-top: 0.15rem;
+    color: inherit;
+    font-size: 1.7rem;
+    line-height: 1;
+}
+
+.at-command-exception p {
+    margin: 0.3rem 0 0;
+    color: inherit;
+    font-size: var(--at-font-sm);
+    opacity: 0.82;
+}
+
+.at-command-exception.is-danger {
+    border-left: 4px solid #fecaca;
+}
+
+.at-command-exception.is-warning {
+    border-left: 4px solid #fcd34d;
+}
+
+.at-command-exception.is-amber {
+    border-left: 4px solid #fed7aa;
+}
+
+.at-command-exception.is-neutral {
+    border-left: 4px solid #bfdbfe;
+}
+
+.at-command-health-band,
+.at-command-attention-band {
+    display: grid;
+    gap: 0.8rem;
+    padding: 0.9rem;
+    background: #ffffff;
+}
+
+.at-command-health-band {
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.at-command-attention-band {
+    background: linear-gradient(180deg, #ffffff 0%, #fffaf2 100%);
+}
+
+.at-command-band-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.at-command-band-heading .at-panel-note {
+    margin: 0;
+    text-align: right;
+}
+
+.at-command-health-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.75fr);
+    gap: 0.85rem;
+    align-items: start;
+}
+
+.at-sprint-health-surface {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.65rem;
+    border: 1px solid #dbeafe;
+    border-radius: var(--at-radius-lg);
+    padding: 0.75rem;
+    background: linear-gradient(135deg, #eff6ff 0%, #ffffff 62%);
+}
+
+.at-sprint-health-surface article {
+    border: 1px solid #dbe4f0;
+    border-radius: var(--at-radius-md);
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.88);
+}
+
+.at-sprint-health-surface article.is-primary {
+    grid-row: span 2;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    border-color: #bfdbfe;
+    background: #dbeafe;
+}
+
+.at-sprint-health-surface article.is-danger {
+    border-color: #fecaca;
+    background: #fff7f7;
+}
+
+.at-sprint-health-surface article.is-warning,
+.at-sprint-health-surface article.is-amber {
+    border-color: #fde68a;
+    background: #fffbeb;
+}
+
+.at-sprint-health-surface h3 {
+    margin: 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.at-sprint-health-surface strong {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--at-text);
+    font-size: 1.35rem;
+    line-height: 1;
+}
+
+.at-sprint-health-surface span {
+    display: block;
+    margin-top: 0.25rem;
+    color: #334155;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-operational-signal-stack {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.at-attention-panel-slim {
+    padding: 0.55rem;
+    background: #ffffff;
+}
+
+.at-attention-panel-slim.is-danger {
+    border-left: 4px solid var(--at-danger);
+}
+
+.at-attention-panel-slim.is-warning {
+    border-left: 4px solid var(--at-warning);
+}
+
+.at-attention-panel-slim.is-amber {
+    border-left: 4px solid #f59e0b;
+}
+
+.at-command-queue-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.at-attention-queue {
+    box-shadow: none;
+}
+
+.at-attention-queue.is-danger {
+    border-top: 4px solid var(--at-danger);
+}
+
+.at-attention-queue.is-warning {
+    border-top: 4px solid var(--at-warning);
+}
+
+.at-attention-queue.is-amber {
+    border-top: 4px solid #f59e0b;
+}
+
 .at-card-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1088,8 +1338,14 @@ html {
 @media (max-width: 1199px) {
     .at-kpis,
     .at-kpis-reports,
-    .at-card-grid {
+    .at-card-grid,
+    .at-command-exception-grid,
+    .at-command-queue-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-command-health-layout {
+        grid-template-columns: 1fr;
     }
 
 }
@@ -1120,8 +1376,24 @@ html {
 
     .at-kpis,
     .at-kpis-reports,
-    .at-card-grid {
+    .at-card-grid,
+    .at-command-exception-grid,
+    .at-command-queue-grid,
+    .at-sprint-health-surface {
         grid-template-columns: 1fr;
+    }
+
+    .at-command-brief-lead,
+    .at-command-band-heading {
+        flex-direction: column;
+    }
+
+    .at-command-band-heading .at-panel-note {
+        text-align: left;
+    }
+
+    .at-sprint-health-surface article.is-primary {
+        grid-row: auto;
     }
 
     .at-task-details-grid {


### PR DESCRIPTION
### Motivation
- Move from an equal-weight KPI strip to a single executive command surface that emphasises severity and places the command-focus sentence as the primary command sentence. 
- Reorganise the dashboard into two clear bands so operational health and triage queues are easier to scan while preserving server-rendered mini-lists and existing summary/query logic.

### Description
- Replaced the five-card `.at-kpis` strip with a composed `at-command-brief` section that integrates the existing exception categories (`overdue`, `blocked`, `submitted pending closure`, `critical open`, `carry-forward risk`) and places `Model.DashboardCommandFocusSummary` inside the brief. (modified `Pages/ActionTasks/_TaskDashboard.cshtml`)
- Split the main content into `Band A` (`at-command-health-band`) showing a differentiated sprint health surface and slimmer operational signal modules that reuse the `_TaskMiniList` partials, and `Band B` (`at-command-attention-band`) for attention-required queues with compact task rows. (modified `Pages/ActionTasks/_TaskDashboard.cshtml`)
- Preserved all existing partial usage and server-side task projections; no changes were made to dashboard summary builders or task query logic. (no code logic changes)
- Added CSS surface roles and supporting styles for `at-command-brief`, `at-command-health-band`, and `at-command-attention-band`, including severity treatments, a sprint health surface, slim attention modules, queue styling, and responsive rules. (modified `wwwroot/css/action-tracker.css`)

### Testing
- Ran `git diff --check` which passed with no whitespace/merge issues. 
- Attempted `dotnet build ProjectManagement.sln` but it could not be executed in the environment because `dotnet` is not installed, so a full build was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc621f3e3c8329beeead5eca860910)