### PR TITLE
Group action tracker shell rail

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -15,26 +15,40 @@
 <div class="at-shell @(Model.TaskId.HasValue ? "has-selection" : string.Empty) @(Model.IsPlanningView ? "is-planning-board" : string.Empty)">
     @* SECTION: Compact left rail navigation. *@
     <aside class="at-rail" aria-label="Task tracker navigation">
-        <nav class="at-nav">
-            @* SECTION: Icon-led rail links for compact enterprise navigation. *@
-            <a title="Command Centre" asp-page="/ActionTasks/Index" asp-route-viewMode="CommandCentre" class="@(Model.IsCommandCentreView ? "active" : string.Empty)"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Command Centre</span></a>
-            <a title="Sprint Board" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" class="@(Model.IsPlanningView ? "active" : string.Empty)"><i class="bi bi-calendar-range" aria-hidden="true"></i><span>Sprint Board</span></a>
-            <a title="My Work" asp-page="/ActionTasks/Index" asp-route-viewMode="MyWork" class="@(Model.IsMyWorkView ? "active" : string.Empty)"><i class="bi bi-check2-circle" aria-hidden="true"></i><span>My Work</span></a>
-            <a title="Register" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="@(Model.IsRegisterView ? "active" : string.Empty)"><i class="bi bi-list-task" aria-hidden="true"></i><span>Register</span></a>
-            <a title="Reports" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="@(Model.IsReportsView ? "active" : string.Empty)"><i class="bi bi-bar-chart" aria-hidden="true"></i><span>Reports</span></a>
+        <nav class="at-nav" aria-label="Task tracker operating layers">
+            @* SECTION: Grouped rail - Monitor layer. *@
+            <section class="at-nav-group" aria-labelledby="at-nav-monitor-label">
+                <h2 id="at-nav-monitor-label" class="at-nav-group-label">Monitor</h2>
+                <a title="Command Centre" asp-page="/ActionTasks/Index" asp-route-viewMode="CommandCentre" class="at-nav-link @(Model.IsCommandCentreView ? "active" : string.Empty)"><i class="bi bi-speedometer2" aria-hidden="true"></i><span>Command Centre</span></a>
+                <a title="Reports" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports" class="at-nav-link @(Model.IsReportsView ? "active" : string.Empty)"><i class="bi bi-bar-chart" aria-hidden="true"></i><span>Reports</span></a>
+            </section>
+
+            @* SECTION: Grouped rail - Execute layer. *@
+            <section class="at-nav-group" aria-labelledby="at-nav-execute-label">
+                <h2 id="at-nav-execute-label" class="at-nav-group-label">Execute</h2>
+                <a title="My Work" asp-page="/ActionTasks/Index" asp-route-viewMode="MyWork" class="at-nav-link @(Model.IsMyWorkView ? "active" : string.Empty)"><i class="bi bi-check2-circle" aria-hidden="true"></i><span>My Work</span></a>
+            </section>
+
+            @* SECTION: Grouped rail - Plan layer. *@
+            <section class="at-nav-group" aria-labelledby="at-nav-plan-label">
+                <h2 id="at-nav-plan-label" class="at-nav-group-label">Plan</h2>
+                <a title="Sprint Board" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" class="at-nav-link at-nav-link-flagship @(Model.IsPlanningView ? "active" : string.Empty)"><i class="bi bi-calendar-range" aria-hidden="true"></i><span>Sprint Board</span></a>
+                <a title="Register" asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-nav-link @(Model.IsRegisterView ? "active" : string.Empty)"><i class="bi bi-list-task" aria-hidden="true"></i><span>Register</span></a>
+            </section>
         </nav>
     </aside>
 
     @* SECTION: Main workspace column. *@
     <section class="at-workspace">
+        @* SECTION: Shell header and global actions. *@
         <header class="at-header">
-            <div>
+            <div class="at-header-copy">
                 <h1>@Model.PageHeading</h1>
                 <p>@Model.PageSubtitle</p>
             </div>
             @if (Model.CanCreate)
             {
-                <button class="btn btn-primary at-create-trigger" type="button" data-bs-toggle="modal" data-bs-target="#createTaskModal"><i class="bi bi-plus-lg" aria-hidden="true"></i><span>Create Task</span></button>
+                <button class="btn btn-outline-primary at-create-trigger" type="button" data-bs-toggle="modal" data-bs-target="#createTaskModal"><i class="bi bi-plus-lg" aria-hidden="true"></i><span>Create Task</span></button>
             }
         </header>
 

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -32,16 +32,17 @@ html {
 .at-shell {
     display: grid;
     font-size: var(--at-font-base);
-    grid-template-columns: 88px minmax(0, 1fr);
+    grid-template-columns: 104px minmax(0, 1fr);
     gap: 1rem;
     min-height: 70vh;
     width: 100%;
 }
 
 .at-shell.has-selection {
-    grid-template-columns: 88px minmax(0, 1fr) minmax(320px, 30vw);
+    grid-template-columns: 104px minmax(0, 1fr) minmax(320px, 30vw);
 }
 
+/* SECTION: Grouped rail navigation */
 .at-rail {
     position: sticky;
     top: 5rem;
@@ -49,51 +50,95 @@ html {
     background: #ffffff;
     border: 1px solid var(--at-border);
     border-radius: 1rem;
-    padding: 0.65rem 0.5rem;
+    padding: 0.55rem 0.45rem;
     box-shadow: var(--at-shadow-sm);
 }
 
 .at-nav {
     display: grid;
-    gap: 0.45rem;
+    gap: 0.55rem;
 }
 
-.at-nav a {
+.at-nav-group {
+    display: grid;
+    gap: 0.28rem;
+    margin: 0;
+    padding: 0 0 0.55rem;
+    border-bottom: 1px solid #eef2f7;
+}
+
+.at-nav-group:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+.at-nav-group-label {
+    margin: 0;
+    padding: 0 0.2rem;
+    color: #64748b;
+    font-size: 0.62rem;
+    font-weight: var(--at-weight-bold);
+    letter-spacing: 0.08em;
+    line-height: 1.1;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.at-nav-link {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: 0.25rem;
+    min-height: 3.8rem;
     text-align: center;
     color: #334155;
     text-decoration: none;
     border-radius: 10px;
-    padding: 0.55rem 0.35rem;
+    padding: 0.52rem 0.35rem;
     font-size: var(--at-font-sm);
     font-weight: 700;
     line-height: 1.2;
     border: 1px solid transparent;
-    transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
 }
 
-.at-nav a i {
+.at-nav-link i {
     font-size: var(--at-font-base);
 }
 
-.at-nav a span {
+.at-nav-link span {
     font-size: var(--at-font-sm);
     font-weight: 700;
 }
 
-.at-nav a:hover,
-.at-nav a.active {
+.at-nav-link:hover,
+.at-nav-link.active {
     color: #1d4ed8;
     background: #f8fbff;
     border-color: #cfe0fb;
 }
 
-.at-nav a:hover {
+.at-nav-link:hover {
     transform: translateY(-1px);
+}
+
+.at-nav-link-flagship {
+    color: #1e3a8a;
+    background: linear-gradient(180deg, #eff6ff 0%, #ffffff 100%);
+    border-color: #bfdbfe;
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
+}
+
+.at-nav-link-flagship i {
+    font-size: 1.08rem;
+}
+
+.at-nav-link-flagship.active {
+    color: #ffffff;
+    background: linear-gradient(135deg, #1d4ed8 0%, #2563eb 100%);
+    border-color: #1d4ed8;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
 }
 
 .at-drawer-host {
@@ -111,12 +156,17 @@ html {
     padding-bottom: 1.5rem;
 }
 
+/* SECTION: Shell header and global actions */
 .at-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 1rem;
     margin-bottom: 1rem;
+}
+
+.at-header-copy {
+    min-width: 0;
 }
 
 .at-header h1 {
@@ -1298,15 +1348,29 @@ html {
     line-height: 1.35;
 }
 
+/* SECTION: Global create task action */
 .at-create-trigger {
     display: inline-flex;
     gap: 0.35rem;
     align-items: center;
+    flex: 0 0 auto;
+    border-color: #cbd5e1;
+    color: #1d4ed8;
+    background: #ffffff;
+    box-shadow: none;
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-create-trigger:hover,
+.at-create-trigger:focus {
+    border-color: #bfdbfe;
+    color: #1d4ed8;
+    background: #eff6ff;
 }
 
 @media (max-width: 1399px) {
     .at-shell {
-        grid-template-columns: 88px minmax(0, 1fr);
+        grid-template-columns: 104px minmax(0, 1fr);
     }
 
     .at-drawer-host {
@@ -2919,7 +2983,7 @@ html {
 
 /* SECTION: Phase 3A-2 Sprint Board compact command strip and overlay-safe workspace. */
 .at-shell.is-planning-board.has-selection {
-    grid-template-columns: 88px minmax(0, 1fr);
+    grid-template-columns: 104px minmax(0, 1fr);
 }
 
 .at-shell.is-planning-board.has-selection .at-drawer-host {
@@ -3211,7 +3275,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-kanban-view {
-    max-width: calc(100vw - 88px - 2rem);
+    max-width: calc(100vw - 104px - 2rem);
 }
 
 .at-shell.is-planning-board.has-selection .at-kanban-scroll {
@@ -3384,7 +3448,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-kanban-view {
-    max-width: min(100%, calc(100vw - 88px - 31rem));
+    max-width: min(100%, calc(100vw - 104px - 31rem));
 }
 
 .at-shell.is-planning-board.has-selection .at-kanban-scroll {


### PR DESCRIPTION
### Motivation
- Improve left-rail usability by visually grouping navigation into operating layers while keeping existing server-side routing values unchanged. 
- Surface the Sprint Board as a flagship planning mode without hiding other modes and keep `Create Task` as a global but visually restrained header action. 
- Preserve existing Razor Page partial selection logic and avoid any client-side routing or inline scripts to respect CSP and offline deployment constraints. 

### Description
- Reorganized the left rail in `Pages/ActionTasks/Index.cshtml` into three accessible groups: Monitor (Command Centre, Reports), Execute (My Work), and Plan (Sprint Board, Register) while keeping the existing `asp-route-viewMode` values (`CommandCentre`, `Planning`, `MyWork`, `Register`, `Reports`).
- Added accessible group headings using `aria-labelledby` and section comments for the grouped rail and the shell header area, and kept the partial-selection rendering logic unchanged. 
- Updated `wwwroot/css/action-tracker.css` to support the grouped rail and header: increased rail width (grid column from `88px` to `104px`), added `.at-nav-group`, `.at-nav-group-label`, `.at-nav-link`, and `.at-nav-link-flagship` styles to give the Sprint Board flagship emphasis, and added a restrained global `Create Task` style. 
- No inline JavaScript or client-side routing was added and existing Razor partials and route semantics were preserved. 

### Testing
- Ran `git diff --check` to ensure no whitespace or simple diff issues and it completed successfully. 
- Attempted `dotnet build ProjectManagement.sln` to validate a build, but it could not be executed in this environment because the `dotnet` SDK is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc63675d148329aa8be1b20fb99fc6)