### PR TITLE
Evolve action-tracker.css into a semantic CSS module design system

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -13,6 +13,21 @@
     --at-radius-lg: 18px;
     --at-radius-md: 12px;
     --at-shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.06);
+    --at-shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
+    --at-surface-flagship: linear-gradient(135deg, #0f2748 0%, #1e3a8a 58%, #2563eb 100%);
+    --at-surface-primary: #ffffff;
+    --at-surface-support: #f8fafc;
+    --at-surface-embedded: #fbfdff;
+    --at-surface-audit: #ffffff;
+    --at-surface-status: #eef6ff;
+    --at-border-subtle: #eef2f7;
+    --at-border-strong: #94a3b8;
+    --at-row-hover: #f8fafc;
+    --at-focus-ring: rgba(37, 99, 235, 0.25);
+    --at-density-board-card-padding: 0.55rem 0.6rem;
+    --at-density-register-row-padding: 0.38rem 0.55rem;
+    --at-density-mini-list-gap: 0.45rem;
+    --at-density-timeline-padding: 0.45rem 0.6rem;
     --at-font-xs: 0.68rem;
     --at-font-sm: 0.74rem;
     --at-font-md: 0.8125rem;
@@ -22,6 +37,277 @@
     --at-weight-medium: 500;
     --at-weight-semibold: 600;
     --at-weight-bold: 700;
+}
+
+/* SECTION: Module design system primitives */
+.at-surface,
+.at-surface-primary,
+.at-surface-working {
+    background: var(--at-surface-primary);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    box-shadow: var(--at-shadow-sm);
+    padding: 0.9rem;
+}
+
+.at-surface-flagship {
+    color: #ffffff;
+    background: var(--at-surface-flagship);
+    border: 1px solid rgba(191, 219, 254, 0.45);
+    border-radius: var(--at-radius-lg);
+    box-shadow: var(--at-shadow-sm);
+}
+
+.at-surface-support {
+    background: var(--at-surface-support);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    box-shadow: var(--at-shadow-xs);
+    padding: 0.7rem;
+}
+
+.at-surface-metric,
+.at-surface-compact-metric {
+    background: linear-gradient(180deg, var(--at-surface-primary) 0%, var(--at-surface-support) 100%);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    box-shadow: var(--at-shadow-sm);
+    padding: 0.85rem;
+}
+
+.at-surface-disclosure,
+.at-surface-audit {
+    background: var(--at-surface-audit);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    box-shadow: none;
+}
+
+.at-surface-inline-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--at-surface-status);
+    border: 1px solid #bfdbfe;
+    border-radius: 999px;
+    color: #1d4ed8;
+    padding: 0.14rem 0.5rem;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-embedded-section {
+    background: var(--at-surface-embedded);
+    border: 1px solid var(--at-border-subtle);
+    border-radius: var(--at-radius-md);
+    padding: 0.65rem;
+}
+
+.at-page-title {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 1.32rem;
+    font-weight: var(--at-weight-semibold);
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+}
+
+.at-workspace-title {
+    margin: 0;
+    color: var(--at-text);
+    font-size: var(--at-font-xl);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: -0.018em;
+    line-height: 1.25;
+}
+
+.at-section-title {
+    margin: 0 0 0.55rem;
+    color: var(--at-muted);
+    font-size: var(--at-font-md);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
+}
+
+.at-panel-title {
+    margin: 0;
+    color: var(--at-text);
+    font-size: var(--at-font-lg);
+    font-weight: var(--at-weight-semibold);
+    line-height: 1.25;
+}
+
+.at-micro-label {
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.at-density-compact {
+    --at-density-board-card-padding: 0.45rem 0.5rem;
+    --at-density-register-row-padding: 0.28rem 0.45rem;
+    --at-density-mini-list-gap: 0.32rem;
+    --at-density-timeline-padding: 0.35rem 0.5rem;
+}
+
+.at-density-comfortable {
+    --at-density-board-card-padding: 0.7rem 0.75rem;
+    --at-density-register-row-padding: 0.5rem 0.65rem;
+    --at-density-mini-list-gap: 0.55rem;
+    --at-density-timeline-padding: 0.55rem 0.7rem;
+}
+
+.at-board-card-density-compact,
+.at-board-card--compact {
+    --at-density-board-card-padding: 0.45rem 0.5rem;
+}
+
+.at-board-card-density-comfortable,
+.at-board-card--comfortable {
+    --at-density-board-card-padding: 0.7rem 0.75rem;
+}
+
+.at-register-row-density-compact,
+.at-register-row--compact {
+    --at-density-register-row-padding: 0.28rem 0.45rem;
+}
+
+.at-register-row-density-comfortable,
+.at-register-row--comfortable {
+    --at-density-register-row-padding: 0.5rem 0.65rem;
+}
+
+.at-mini-list-density-compact,
+.at-mini-list--compact {
+    --at-density-mini-list-gap: 0.32rem;
+}
+
+.at-mini-list-density-comfortable,
+.at-mini-list--comfortable {
+    --at-density-mini-list-gap: 0.55rem;
+}
+
+.at-timeline-entry-density-compact,
+.at-timeline-entry--compact {
+    --at-density-timeline-padding: 0.35rem 0.5rem;
+}
+
+.at-timeline-entry-density-comfortable,
+.at-timeline-entry--comfortable {
+    --at-density-timeline-padding: 0.55rem 0.7rem;
+}
+
+.at-chip,
+.at-badge,
+.at-count-chip,
+.at-scope-badge,
+.at-compact-counter {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    max-width: 100%;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.at-chip-status,
+.at-chip-status-assigned,
+.at-badge-status-assigned {
+    color: #1f2937;
+    background: #e5e7eb;
+}
+
+.at-chip-status-progress,
+.at-badge-status-progress {
+    color: #1e3a8a;
+    background: #dbeafe;
+}
+
+.at-chip-status-blocked,
+.at-badge-status-blocked,
+.at-chip-warning,
+.at-chip-warning-critical {
+    color: #991b1b;
+    background: #fee2e2;
+    border-color: #fecaca;
+}
+
+.at-chip-status-submitted,
+.at-badge-status-submitted,
+.at-chip-warning-attention {
+    color: #92400e;
+    background: #fef3c7;
+    border-color: #fde68a;
+}
+
+.at-chip-status-closed,
+.at-badge-status-closed {
+    color: #166534;
+    background: #dcfce7;
+}
+
+.at-chip-priority-normal,
+.at-badge-priority-normal {
+    color: #334155;
+    background: #e2e8f0;
+}
+
+.at-chip-priority-high,
+.at-badge-priority-high {
+    color: #92400e;
+    background: #fef3c7;
+}
+
+.at-chip-priority-critical,
+.at-badge-priority-critical {
+    color: #991b1b;
+    background: #fee2e2;
+}
+
+.at-chip-sprint,
+.at-scope-badge-sprint {
+    color: #1e3a8a;
+    background: #dbeafe;
+    border-color: #bfdbfe;
+}
+
+.at-chip-sprint-backlog,
+.at-scope-badge-backlog {
+    color: #475569;
+    background: #f1f5f9;
+    border-color: #cbd5e1;
+}
+
+.at-chip-sprint-non,
+.at-scope-badge-non-sprint {
+    color: #64748b;
+    background: #f8fafc;
+    border-color: #e2e8f0;
+}
+
+.at-chip-sprint-closed,
+.at-scope-badge-closed {
+    color: #166534;
+    background: #dcfce7;
+    border-color: #bbf7d0;
+}
+
+.at-chip-count,
+.at-count-chip {
+    min-width: 2rem;
+    color: #1d4ed8;
+    background: #dbeafe;
+    border-color: #bfdbfe;
+    padding: 0.15rem 0.55rem;
+    font-weight: var(--at-weight-bold);
 }
 
 /* SECTION: Action Tracker shell */
@@ -175,6 +461,7 @@ html {
     font-size: 1.32rem;
     font-weight: var(--at-weight-semibold);
     letter-spacing: -0.02em;
+    line-height: 1.2;
 }
 
 .at-header p {
@@ -183,8 +470,9 @@ html {
     font-size: var(--at-font-base);
 }
 
-.at-panel {
-    background: var(--at-surface);
+.at-panel,
+.at-primary-surface {
+    background: var(--at-surface-primary);
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-lg);
     box-shadow: var(--at-shadow-sm);
@@ -263,7 +551,7 @@ html {
 }
 
 .at-task-details-panel:focus {
-    outline: 3px solid rgba(37, 99, 235, 0.25);
+    outline: 3px solid var(--at-focus-ring);
     outline-offset: 4px;
 }
 
@@ -287,8 +575,9 @@ html {
     text-align: center;
     background: #dbeafe;
     color: #1d4ed8;
+    border-color: #bfdbfe;
     padding: 0.15rem 0.55rem;
-    font-weight: 700;
+    font-weight: var(--at-weight-bold);
     font-size: var(--at-font-md);
 }
 
@@ -297,12 +586,12 @@ html {
 }
 
 .at-section-title {
-    font-size: var(--at-font-md);
-    text-transform: uppercase;
-    letter-spacing: 0.045em;
+    margin: 0 0 0.55rem;
     color: var(--at-muted);
+    font-size: var(--at-font-md);
     font-weight: var(--at-weight-bold);
-    margin-bottom: 0.55rem;
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
 }
 
 .at-kpis {
@@ -360,7 +649,7 @@ html {
     gap: 0.9rem;
     padding: 1rem;
     color: #ffffff;
-    background: linear-gradient(135deg, #0f2748 0%, #1e3a8a 58%, #2563eb 100%);
+    background: var(--at-surface-flagship);
     border-color: rgba(191, 219, 254, 0.45);
 }
 
@@ -607,7 +896,7 @@ html {
 /* SECTION: Compact mini lists */
 .at-mini-list {
     display: grid;
-    gap: 0.45rem;
+    gap: var(--at-density-mini-list-gap);
 }
 
 .at-mini-row {
@@ -615,7 +904,7 @@ html {
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
     padding: 0.6rem;
-    background: var(--at-surface-soft);
+    background: var(--at-surface-support);
     text-decoration: none;
 }
 
@@ -661,7 +950,7 @@ html {
 }
 
 .at-table tbody tr:hover {
-    background: #f8fafc;
+    background: var(--at-row-hover);
 }
 
 .at-task-title {
@@ -764,18 +1053,21 @@ html {
     font-weight: var(--at-weight-semibold);
 }
 
-.at-action-card {
+.at-action-card,
+.at-support-module {
     border: 1px solid var(--at-border);
-    border-radius: 12px;
-    background: #f8fafc;
+    border-radius: var(--at-radius-md);
+    background: var(--at-surface-support);
+    box-shadow: var(--at-shadow-xs);
     padding: 0.55rem;
 }
 .at-inspector-section {
     margin-bottom: 0.55rem;
 }
 
-.at-journal-card {
-    background: #fbfdff;
+.at-journal-card,
+.at-embedded-module {
+    background: var(--at-surface-embedded);
 }
 
 .at-action-card-compact {
@@ -797,7 +1089,7 @@ html {
     gap: .4rem .65rem;
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
-    background: var(--at-surface-soft);
+    background: var(--at-surface-support);
     padding: .55rem;
 }
 
@@ -808,11 +1100,13 @@ html {
 .at-audit-list {
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
+    background: var(--at-surface-audit);
     overflow: hidden;
 }
 
-.at-audit-item {
-    padding: .45rem .6rem;
+.at-audit-item,
+.at-timeline-entry {
+    padding: var(--at-density-timeline-padding);
     border-bottom: 1px solid #e5e7eb;
 }
 
@@ -823,8 +1117,8 @@ html {
 .at-audit-remarks {
     margin-top: .25rem;
     padding: .35rem .5rem;
-    border-left: 3px solid var(--at-border-strong, #94a3b8);
-    background: #f8fafc;
+    border-left: 3px solid var(--at-border-strong);
+    background: var(--at-surface-support);
     color: var(--at-text);
     border-radius: .35rem;
     white-space: pre-line;
@@ -979,11 +1273,11 @@ html {
 }
 
 .at-register-table td {
-    padding: 0.38rem 0.55rem;
+    padding: var(--at-density-register-row-padding);
 }
 
 .at-register-table tbody tr:hover td {
-    background: #f8fafc;
+    background: var(--at-row-hover);
 }
 
 .at-register-task-cell {
@@ -1057,51 +1351,60 @@ html {
     }
 }
 
-/* SECTION: Badge system */
-.at-badge {
+/* SECTION: Chip and badge compatibility system */
+.at-badge,
+.at-chip {
     border-radius: 999px;
     padding: 0.15rem 0.45rem;
     font-size: var(--at-font-sm);
-    font-weight: 700;
+    font-weight: var(--at-weight-bold);
     border: 1px solid transparent;
 }
 
-.at-badge-status-assigned {
+.at-badge-status-assigned,
+.at-chip-status-assigned {
     color: #1f2937;
     background: #e5e7eb;
 }
 
-.at-badge-status-progress {
+.at-badge-status-progress,
+.at-chip-status-progress {
     color: #1e3a8a;
     background: #dbeafe;
 }
 
-.at-badge-status-blocked {
+.at-badge-status-blocked,
+.at-chip-status-blocked {
     color: #991b1b;
     background: #fee2e2;
 }
 
-.at-badge-status-submitted {
+.at-badge-status-submitted,
+.at-chip-status-submitted {
     color: #92400e;
     background: #fef3c7;
 }
 
-.at-badge-status-closed {
+.at-badge-status-closed,
+.at-chip-status-closed {
     color: #166534;
     background: #dcfce7;
 }
 
-.at-badge-priority-normal {
+.at-badge-priority-normal,
+.at-chip-priority-normal {
     color: #334155;
     background: #e2e8f0;
 }
 
-.at-badge-priority-high {
+.at-badge-priority-high,
+.at-chip-priority-high {
     color: #92400e;
     background: #fef3c7;
 }
 
-.at-badge-priority-critical {
+.at-badge-priority-critical,
+.at-chip-priority-critical {
     color: #991b1b;
     background: #fee2e2;
 }
@@ -1142,23 +1445,33 @@ html {
     gap: .5rem;
 }
 
-.at-task-card {
+.at-task-card,
+.at-board-card {
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
-    background: var(--at-surface-soft);
+    background: var(--at-surface-support);
     transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.at-task-card:hover {
+.at-task-card:hover,
+.at-board-card:hover {
     border-color: #b9c8de;
     background: #f3f7fd;
 }
 
-.at-task-card-link {
+.at-task-card:focus-within,
+.at-board-card:focus-within,
+.at-mini-row:focus-visible {
+    outline: 3px solid var(--at-focus-ring);
+    outline-offset: 2px;
+}
+
+.at-task-card-link,
+.at-board-card-link {
     display: block;
     text-decoration: none;
     color: inherit;
-    padding: 0.55rem 0.6rem;
+    padding: var(--at-density-board-card-padding);
     cursor: pointer;
 }
 
@@ -1249,7 +1562,7 @@ html {
     border: 1px solid var(--at-border);
     border-radius: 10px;
     padding: 0.45rem 0.55rem;
-    background: var(--at-surface-soft);
+    background: var(--at-surface-support);
 }
 
 /* SECTION: Reports metric bars */
@@ -1562,6 +1875,7 @@ html {
 .at-scope-badge {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     max-width: 100%;
     border-radius: 999px;
     padding: 0.12rem 0.45rem;
@@ -1571,25 +1885,29 @@ html {
     border: 1px solid transparent;
 }
 
-.at-scope-badge-sprint {
+.at-scope-badge-sprint,
+.at-chip-sprint {
     color: #1e3a8a;
     background: #dbeafe;
     border-color: #bfdbfe;
 }
 
-.at-scope-badge-backlog {
+.at-scope-badge-backlog,
+.at-chip-sprint-backlog {
     color: #475569;
     background: #f1f5f9;
     border-color: #cbd5e1;
 }
 
-.at-scope-badge-non-sprint {
+.at-scope-badge-non-sprint,
+.at-chip-sprint-non {
     color: #7c2d12;
     background: #ffedd5;
     border-color: #fed7aa;
 }
 
-.at-scope-badge-closed {
+.at-scope-badge-closed,
+.at-chip-sprint-closed {
     color: #334155;
     background: #e2e8f0;
     border-color: #cbd5e1;
@@ -2263,8 +2581,9 @@ html {
 .at-audit-collapsible,
 .at-details-collapsible {
     border: 1px solid var(--at-border);
-    border-radius: 12px;
-    background: #ffffff;
+    border-radius: var(--at-radius-md);
+    background: var(--at-surface-audit);
+    box-shadow: none;
     padding: 0.65rem 0.75rem;
 }
 
@@ -3992,8 +4311,8 @@ html {
 }
 
 .at-sprint-task-card-dense .at-task-card-link {
+    --at-density-board-card-padding: 0.55rem 0.62rem;
     gap: 0.32rem;
-    padding: 0.55rem 0.62rem;
 }
 
 .at-card-scan-row,


### PR DESCRIPTION
### Motivation
- Provide a deliberate, hierarchy-focused CSS module system for the Action Tracker while preserving existing class compatibility where practical. 
- Reduce heavy reliance on the generic `.at-panel` styling and expose lighter support/embedded surfaces for reuse across UI modules. 
- Introduce semantic tokens, density modes, and consolidated chip/badge language to make styles easier to consume and vary programmatically. 

### Description
- Added semantic design tokens and variables in `:root` and introduced new tokens such as `--at-surface-flagship`, `--at-surface-primary`, `--at-surface-support`, `--at-focus-ring`, and density variables like `--at-density-board-card-padding` used by the system. 
- Introduced surface-role class families (flagship, primary working, support, compact/metric, disclosure/audit, inline status, embedded) as `at-surface-*` classes and made panels opt into `at-primary-surface` to preserve compatibility with existing `.at-panel`. 
- Standardized heading classes with new primitives: `at-page-title`, `at-workspace-title`, `at-section-title`, `at-panel-title`, and `at-micro-label` and adjusted a few existing rules to consume these tokens. 
- Added explicit density mode classes and compatibility shims for board cards, register rows, mini-lists, and timeline entries (`.at-density-compact`, `.at-density-comfortable`, `.at-board-card--compact`, `.at-register-row--compact`, `.at-mini-list--compact`, `.at-timeline-entry--compact`) and wired those into padding/spacing via variables. 
- Consolidated chip/badge language into a compatibility layer so `.at-chip`, `.at-badge`, `.at-count-chip`, and `.at-scope-badge` share consolidated status/priority/sprint/count styles while preserving original class names. 
- Introduced lighter support primitives (`.at-support-module`, `.at-embedded-module`, `.at-embedded-section`) and refactored existing rules to consume semantic surfaces and density variables without changing server-rendered content or moving behaviour into inline styles. 
- Kept hover/focus behaviour subtle and enterprise-appropriate by using `var(--at-focus-ring)` for accessible outlines, modest hover tints, and avoiding decorative animations. 

### Testing
- Ran a brace-balance sanity check with a `python3` script against `wwwroot/css/action-tracker.css` and it passed (`brace balance ok`).
- Ran the CSS validator with `npx --yes csstree-validator wwwroot/css/action-tracker.css` and it completed without fatal errors (validator run succeeded). 
- Attempted to run `dotnet build ProjectManagement.sln --no-restore` but the environment does not have `dotnet` installed so the full solution build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc655da6108329bbfb58c7ff5c4ec0)