### PR TITLE
Apply Action Tracker design refresh to My Work, Register, and Reports surfaces

### DIFF
--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -1,57 +1,58 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
 @{
-    // SECTION: My Work read-model aliases keep personal task presentation consistent and CSP-safe.
-    var assignedTaskCount = Model.Tasks.Count;
-    var actionRequiredTasks = Model.MyWorkActionRequiredDisplays;
-    var currentWorkTasks = Model.MyWorkCurrentWorkDisplays;
+    // SECTION: My Work read-model aliases keep assignee queues focused on immediate execution.
+    var overdueTasks = Model.MyOverdueTaskDisplays;
+    var todayTasks = Model.MyDueTodayTaskDisplays;
     var submittedTasks = Model.MyWorkSubmittedAwaitingClosureDisplays;
-    var allMyTaskDisplays = Model.MyWorkAllMyTasksDisplays;
-    var actionRequiredCount = actionRequiredTasks.Count;
-    var overdueCount = Model.MyOverdueTaskDisplays.Count;
-    var inProgressCount = Model.MyInProgressTaskDisplays.Count;
-    var submittedCount = Model.MySubmittedTaskDisplays.Count;
+    var nextUpTasks = Model.MyWorkCurrentWorkDisplays
+        .Concat(Model.MyWorkAllMyTasksDisplays)
+        .ToList();
+    var assignedTaskCount = Model.Tasks.Count;
     var activeSprintTaskCount = Model.MyActiveSprintTaskDisplays.Count;
 }
 
-@* SECTION: Compact personal execution KPI strip. *@
-<section class="at-kpis at-kpis-mywork" aria-label="My work task summary">
-    <article>
-        <h3>Assigned to me</h3>
-        <strong>@assignedTaskCount</strong>
-        <p>Total tasks in your personal queue.</p>
-    </article>
-    <article>
-        <h3>Needs action now</h3>
-        <strong>@actionRequiredCount</strong>
-        <p>Overdue, due today, or blocked.</p>
-    </article>
-    <article>
+@* SECTION: Assignee-first work header prioritises the four queues that drive daily execution. *@
+<section class="at-mywork-command at-surface-flagship" aria-label="My work execution summary">
+    <div class="at-mywork-command-copy">
+        <span class="at-section-eyebrow">Personal command queue</span>
+        <h2>Start with what needs you now.</h2>
+        <p>Today, overdue, submitted, and next-up work are separated so the assignee can act without scanning operational noise.</p>
+    </div>
+    <div class="at-mywork-command-meta" aria-label="Personal scope context">
+        <span>@assignedTaskCount total assigned</span>
+        <span>@activeSprintTaskCount in @(Model.ActiveSprint is null ? "active sprint" : Model.DisplaySprintName(Model.ActiveSprint))</span>
+    </div>
+</section>
+
+@* SECTION: Compact personal execution KPI strip mirrors the My Work queue order. *@
+<section class="at-kpis at-kpis-mywork at-mywork-focus-kpis" aria-label="My work task summary">
+    <article class="is-critical">
         <h3>Overdue</h3>
-        <strong>@overdueCount</strong>
+        <strong>@overdueTasks.Count</strong>
         <p>Past due and still open.</p>
     </article>
-    <article>
-        <h3>In progress</h3>
-        <strong>@inProgressCount</strong>
-        <p>Currently underway.</p>
+    <article class="is-today">
+        <h3>Due today</h3>
+        <strong>@todayTasks.Count</strong>
+        <p>Finish or update before close of day.</p>
     </article>
-    <article>
+    <article class="is-submitted">
         <h3>Submitted</h3>
-        <strong>@submittedCount</strong>
-        <p>Awaiting closure review.</p>
+        <strong>@submittedTasks.Count</strong>
+        <p>Waiting for close-out review.</p>
     </article>
-    <article>
-        <h3>Tasks in Active Sprint</h3>
-        <strong>@activeSprintTaskCount</strong>
-        <p>@(Model.ActiveSprint is null ? "No active sprint set." : Model.DisplaySprintName(Model.ActiveSprint))</p>
+    <article class="is-next">
+        <h3>Next up</h3>
+        <strong>@nextUpTasks.Count</strong>
+        <p>Current work and remaining assignments.</p>
     </article>
 </section>
 
-@* SECTION: Priority-based personal work queue avoids repeated tasks and oversized empty panels. *@
-<section class="at-mywork-queue" aria-label="Priority-based personal work queue">
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, actionRequiredTasks, "Action Required", "Overdue, due today, and blocked work that needs attention before other assignments.", "No action-required tasks right now.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, currentWorkTasks, "Current Work", "In-progress tasks that are already underway after urgent exceptions are removed.", "No current work in progress.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, submittedTasks, "Submitted / Awaiting Closure", "Submitted work waiting for closure review.", "No submitted tasks are awaiting closure.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, allMyTaskDisplays, "All My Tasks", "Remaining assigned tasks not already shown above.", "No remaining assigned tasks.")' />
+@* SECTION: Assignee queue order emphasises today, overdue, submitted, then next-up work. *@
+<section class="at-mywork-queue at-mywork-focus-queue" aria-label="Assignee execution queues">
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, todayTasks, "Today", "Tasks due today are the first same-day commitments to finish, update, or unblock.", "No tasks are due today. Keep the queue clear by pulling from Next up.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, overdueTasks, "Overdue", "Past-due open tasks that need a status update, revised plan, or immediate completion.", "No overdue tasks. Your personal queue is current.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, submittedTasks, "Submitted", "Work you have submitted and can follow up until closure is confirmed.", "No submitted tasks are awaiting closure.")' />
+    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, nextUpTasks, "Next up", "In-progress work and remaining assignments after today, overdue, and submitted items are removed.", "No next-up assignments are available right now.")' />
 </section>

--- a/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
+++ b/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
@@ -4,12 +4,13 @@
     var tasks = Model.Item2;
 }
 
-@* SECTION: Compact My Work rows preserve inspector routing without large task-card bodies. *@
+@* SECTION: Compact My Work rows preserve inspector routing with high-signal task metadata. *@
 <div class="at-mywork-rows">
     @foreach (var item in tasks)
     {
         var task = item.Task;
-        <a class="at-mywork-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)"
+        var dueClass = pageModel.IsTaskOverdue(task) ? "is-overdue" : string.Empty;
+        <a class="at-mywork-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty) @dueClass"
            asp-page="/ActionTasks/Index"
            asp-route-taskId="@task.Id"
            asp-route-viewMode="@pageModel.ResolvedViewMode"
@@ -19,7 +20,7 @@
                 <span class="at-mywork-title">@task.Title</span>
             </div>
             <div class="at-mywork-row-meta" aria-label="Task metadata">
-                <span>Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                <span class="at-mywork-due-chip @dueClass">Due @task.DueDate.ToString("dd MMM yyyy")</span>
                 <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
                 <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                 <span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span>

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -27,14 +27,18 @@
     }
 }
 
-@* SECTION: Register filters keep task records searchable and auditable. *@
-<section class="at-panel at-register-filter-panel mb-3">
+@* SECTION: Register filters are promoted to the primary control surface for master-list review. *@
+<section class="at-panel at-register-filter-panel at-register-command-surface mb-3">
     <div class="at-register-filter-heading">
         <div>
+            <span class="at-section-eyebrow">Control surface</span>
             <h2>Register Filters</h2>
-            <p class="at-panel-note">Refine the master task register without leaving the workspace.</p>
+            <p class="at-panel-note">Refine the master task register with auto-applied controls that preserve server-rendered routes.</p>
         </div>
-        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
+        <div class="at-register-filter-actions">
+            <span class="at-register-result-pill">@Model.Tasks.Count visible</span>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
+        </div>
     </div>
     <form id="taskFilterForm" method="get" class="at-register-filter-toolbar" data-at-task-filter-form="true">
         <input type="hidden" name="viewMode" value="Register" />
@@ -120,9 +124,10 @@
         </div>
     </form>
 
+    <div class="at-active-filters at-register-active-filters @(Model.HasActiveFilters ? "" : "is-empty")" aria-label="Active filters">
+        <span class="at-active-filter-label">Active filters</span>
     @if (Model.HasActiveFilters)
     {
-        <div class="at-active-filters at-register-active-filters" aria-label="Active filters">
             @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
             {
                 <span class="at-filter-chip">Status: @Model.FilterStatus</span>
@@ -144,17 +149,28 @@
                 <span class="at-filter-chip">Search: @Model.FilterSearch</span>
             }
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-filter-clear">Clear all</a>
-        </div>
     }
+    else
+    {
+        <span class="at-filter-chip at-filter-chip-muted">None — showing the full register.</span>
+    }
+    </div>
 </section>
 
-@* SECTION: Auditable task register table. *@
-<section class="at-panel">
-    <h2>Register</h2>
+@* SECTION: Auditable task register table focuses on dense row scanability. *@
+<section class="at-panel at-register-results-panel">
+    <div class="at-register-results-heading">
+        <div>
+            <h2>Register</h2>
+            <p class="at-panel-note">Scan ID, owner, scope, due date, status, and priority without opening the inspector.</p>
+        </div>
+        <span class="at-register-result-pill">@Model.Tasks.Count rows</span>
+    </div>
     @if (!Model.Tasks.Any())
     {
-        <div class="at-empty-state">
-            <div class="fw-semibold">No tasks found for the current filters.</div>
+        <div class="at-empty-state at-register-no-results">
+            <strong>No register rows match the current controls.</strong>
+            <span>Clear filters or broaden the search term to return tasks to this operational register.</span>
         </div>
     }
     else
@@ -176,10 +192,12 @@
                 <tbody>
                     @foreach (var task in Model.Tasks)
                     {
-                        <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
+                        <tr class="at-register-data-row @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
                             <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">AT-@task.Id</a></td>
                             <td class="at-register-task-cell">
-                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">@task.Title</a>
+                                <div class="at-register-task-line">
+                                    <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">@task.Title</a>
+                                </div>
                                 <div class="at-task-desc-preview">@task.Description</div>
                             </td>
                             <td class="at-register-person-cell">@Model.ResolveAssigneeName(task.AssignedToUserId)</td>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -1,33 +1,56 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 @{
-    // SECTION: Date filter display values are preformatted for CSP-safe server rendering.
+    // SECTION: Report date filter display values are preformatted for CSP-safe server rendering.
     var reportFromDateValue = Model.ReportFromDate?.ToString("yyyy-MM-dd");
     var reportToDateValue = Model.ReportToDate?.ToString("yyyy-MM-dd");
+    var reportDateRangeContext = (Model.ReportFromDate, Model.ReportToDate) switch
+    {
+        (not null, not null) => $"Due from {Model.ReportFromDate.Value:dd MMM yyyy} to {Model.ReportToDate.Value:dd MMM yyyy}",
+        (not null, null) => $"Due on or after {Model.ReportFromDate.Value:dd MMM yyyy}",
+        (null, not null) => $"Due on or before {Model.ReportToDate.Value:dd MMM yyyy}",
+        _ => "All due dates"
+    };
 }
 
-@* SECTION: Reports introduction and scope. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Task Analysis Reports</h2>
-                <p class="at-panel-note">Analytical views computed from current task and Sprint data, with historical trend reporting deferred until Sprint metric snapshots exist.</p>
-            </div>
-        </div>
-        <p class="at-empty-state-note">This page intentionally excludes the Command Centre KPI strip so reports remain focused on analysis rather than operational command cards.</p>
-    </article>
+@* SECTION: Strong reports header gives analytical context before filters and grouped report cards. *@
+<section class="at-reports-hero at-surface-flagship" aria-label="Reports summary">
+    <div class="at-reports-hero-copy">
+        <span class="at-section-eyebrow">Analytical surface</span>
+        <h2>Task Analysis Reports</h2>
+        <p>@Model.ReportFilterSummary</p>
+        <span class="at-reports-date-context">@reportDateRangeContext</span>
+    </div>
+    <div class="at-reports-summary-grid" aria-label="Report summary metrics">
+        <article>
+            <span>Active</span>
+            <strong>@Model.ActiveCount</strong>
+        </article>
+        <article>
+            <span>Overdue</span>
+            <strong>@Model.OverdueCount</strong>
+        </article>
+        <article>
+            <span>Blocked</span>
+            <strong>@Model.BlockedCount</strong>
+        </article>
+        <article>
+            <span>Submitted</span>
+            <strong>@Model.SubmittedPendingClosureCount</strong>
+        </article>
+    </div>
 </section>
 
-@* SECTION: Compact reports filter bar for management analysis. *@
+@* SECTION: Compact reports filter bar keeps existing auto-apply behaviour route-compatible. *@
 <section class="at-section-group">
     <form method="get" class="at-panel at-reports-filter-panel" aria-label="Reports filters" data-at-reports-filter-form="true">
         <input type="hidden" name="ViewMode" value="Reports" />
         <div class="at-reports-filter-heading">
             <div>
-                <h2>Report Filters</h2>
+                <span class="at-section-eyebrow">Report controls</span>
+                <h2>Filters</h2>
                 <p class="at-panel-note">Narrow every report section by scope, responsible person, due-date range, workflow status and priority.</p>
             </div>
-            <span class="at-report-filter-summary">@Model.ReportFilterSummary</span>
+            <span class="at-report-filter-summary">@reportDateRangeContext</span>
         </div>
         <div class="at-reports-filter-grid">
             <label>
@@ -125,227 +148,252 @@
     </form>
 </section>
 
-@* SECTION: Current-state analytical reports with proportional bars. *@
-<section class="at-card-grid at-card-grid-reports" aria-label="Task analytical reports">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Ageing Analysis</h2>
-                <p class="at-panel-note">Identifies open work by age and highlights overdue exposure by elapsed overdue period.</p>
-            </div>
-        </div>
-        <div class="at-ageing-grid">
-            <div>
-                <h3 class="at-small at-section-eyebrow">Open tasks ageing</h3>
-                <div class="at-metric-bars">
-                    @foreach (var item in Model.OpenAgeingBuckets)
-                    {
-                        <div class="at-metric-row">
-                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                            <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.OpenAgeingBucketsMax)%"></div></div>
-                            <strong>@item.Count</strong>
-                        </div>
-                    }
+@* SECTION: Delivery risk groups blocked, overdue, and submitted wait states together. *@
+<section class="at-report-group" aria-labelledby="deliveryRiskHeading">
+    <div class="at-report-group-heading">
+        <span class="at-section-eyebrow">Delivery risk</span>
+        <h2 id="deliveryRiskHeading">Blocked, overdue, and closure exposure</h2>
+        <p>Use these sections to identify work that needs intervention before it becomes hidden operational debt.</p>
+    </div>
+    <div class="at-card-grid at-card-grid-reports">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Overdue &amp; Open Ageing</h2>
+                    <p class="at-panel-note">Identifies open work by age and highlights overdue exposure by elapsed overdue period.</p>
                 </div>
             </div>
-            <div>
-                <h3 class="at-small at-section-eyebrow">Overdue ageing</h3>
-                <div class="at-metric-bars">
-                    @foreach (var item in Model.OverdueAgeingBuckets)
-                    {
-                        <div class="at-metric-row">
-                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.OverdueAgeingBucketsMax)%"></div></div>
-                            <strong>@item.Count</strong>
-                        </div>
-                    }
+            <div class="at-ageing-grid">
+                <div>
+                    <h3 class="at-small at-section-eyebrow">Open tasks ageing</h3>
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.OpenAgeingBuckets)
+                        {
+                            <div class="at-metric-row">
+                                <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                                <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.OpenAgeingBucketsMax)%"></div></div>
+                                <strong>@item.Count</strong>
+                            </div>
+                        }
+                    </div>
+                </div>
+                <div>
+                    <h3 class="at-small at-section-eyebrow">Overdue ageing</h3>
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.OverdueAgeingBuckets)
+                        {
+                            <div class="at-metric-row">
+                                <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                                <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.OverdueAgeingBucketsMax)%"></div></div>
+                                <strong>@item.Count</strong>
+                            </div>
+                        }
+                    </div>
                 </div>
             </div>
-        </div>
-    </article>
+        </article>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Pending Closure Ageing</h2>
-                <p class="at-panel-note">Shows how long submitted tasks have been waiting for close-out review.</p>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Blocked Task Ageing</h2>
+                    <p class="at-panel-note">Ages blocked tasks by time since assignment to support unblock decisions without changing backend workflow.</p>
+                </div>
             </div>
-        </div>
-        @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
-        {
-            <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
-        }
-        else
-        {
             <div class="at-metric-bars">
-                @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+                @foreach (var item in Model.BlockedAgeingBuckets)
                 {
                     <div class="at-metric-row">
                         <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedPendingClosureAgeingBuckets.Max(x => x.Count))%"></div></div>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.BlockedAgeingBucketsMax)%"></div></div>
                         <strong>@item.Count</strong>
                     </div>
                 }
             </div>
-        }
-    </article>
+        </article>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Assignee Workload</h2>
-                <p class="at-panel-note">Compares pending task volume across assignees to surface capacity imbalance.</p>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Pending Closure Ageing</h2>
+                    <p class="at-panel-note">Shows how long submitted tasks have been waiting for close-out review.</p>
+                </div>
             </div>
-        </div>
-        <div class="at-metric-bars at-metric-bars-tight">
-            @foreach (var item in Model.AssigneePendingCounts)
+            @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
             {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.AssigneePendingCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+                <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
+            }
+            else
+            {
+                <div class="at-metric-bars">
+                    @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+                    {
+                        <div class="at-metric-row">
+                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedPendingClosureAgeingBuckets.Max(x => x.Count))%"></div></div>
+                            <strong>@item.Count</strong>
+                        </div>
+                    }
                 </div>
             }
-        </div>
-    </article>
+        </article>
+    </div>
+</section>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Priority Exposure</h2>
-                <p class="at-panel-note">Breaks down open task volume by urgency to support prioritisation decisions.</p>
+@* SECTION: Backlog and Sprint continuity reports are intentionally grouped for planning decisions. *@
+<section class="at-report-group" aria-labelledby="backlogContinuityHeading">
+    <div class="at-report-group-heading">
+        <span class="at-section-eyebrow">Backlog &amp; continuity</span>
+        <h2 id="backlogContinuityHeading">Backlog, carry-forward, and non-sprint work</h2>
+        <p>Review work that has not landed cleanly in current sprint execution or assigned ownership.</p>
+    </div>
+    <div class="at-card-grid at-card-grid-reports">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Backlog Ageing Summary</h2>
+                    <p class="at-panel-note">Highlights true backlog only: open, not in a Sprint, and not assigned to a user.</p>
+                </div>
             </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.PriorityCounts)
+            <div class="at-metric-bars">
+                @foreach (var item in Model.BacklogAgeingBuckets)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.BacklogAgeingBucketsMax)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        </article>
+
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Carry-forward by Sprint</h2>
+                    <p class="at-panel-note">Safely derived from unfinished tasks that remain assigned to non-closed Sprints.</p>
+                </div>
+            </div>
+            @if (Model.CarryForwardBySprint.All(item => item.Count == 0))
             {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.PriorityCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+                <p class="at-empty-state-note">No carry-forward candidates are visible in the selected report scope.</p>
+            }
+            else
+            {
+                <div class="at-metric-bars">
+                    @foreach (var item in Model.CarryForwardBySprint)
+                    {
+                        <div class="at-metric-row">
+                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.CarryForwardBySprintMax)%"></div></div>
+                            <strong>@item.Count</strong>
+                        </div>
+                    }
                 </div>
             }
-        </div>
-    </article>
+        </article>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Workflow Distribution</h2>
-                <p class="at-panel-note">Summarises task spread by workflow stage for process-level analysis.</p>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Non-sprint Assigned Workload</h2>
+                    <p class="at-panel-note">Counts open assigned work that is not part of Sprint commitment and is excluded from backlog ageing.</p>
+                </div>
             </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.StatusCounts)
+            @if (!Model.NonSprintAssignedWorkloadCounts.Any())
             {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+                <p class="at-empty-state-note">No open non-sprint assigned work is visible in the selected report scope.</p>
+            }
+            else
+            {
+                <div class="at-metric-bars at-metric-bars-tight">
+                    @foreach (var item in Model.NonSprintAssignedWorkloadCounts)
+                    {
+                        <div class="at-metric-row">
+                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.NonSprintAssignedWorkloadCountsMax)%"></div></div>
+                            <strong>@item.Count</strong>
+                        </div>
+                    }
                 </div>
             }
-        </div>
-    </article>
+        </article>
+    </div>
+</section>
 
-    @* SECTION: Decision-support summaries derived from the existing task and Sprint read model. *@
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Backlog Ageing Summary</h2>
-                <p class="at-panel-note">Highlights true backlog only: open, not in a Sprint, and not assigned to a user.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.BacklogAgeingBuckets)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.BacklogAgeingBucketsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+@* SECTION: Workload and exposure reports support balancing without external chart dependencies. *@
+<section class="at-report-group" aria-labelledby="workloadExposureHeading">
+    <div class="at-report-group-heading">
+        <span class="at-section-eyebrow">Workload &amp; exposure</span>
+        <h2 id="workloadExposureHeading">Assignee, priority, and workflow distribution</h2>
+        <p>Compare ownership, urgency, and workflow spread using offline-friendly proportional bars.</p>
+    </div>
+    <div class="at-card-grid at-card-grid-reports">
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Assignee Workload</h2>
+                    <p class="at-panel-note">Compares pending task volume across assignees to surface capacity imbalance.</p>
                 </div>
-            }
-        </div>
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Non-sprint Assigned Workload</h2>
-                <p class="at-panel-note">Counts open assigned work that is not part of Sprint commitment and is excluded from backlog ageing.</p>
             </div>
-        </div>
-        @if (!Model.NonSprintAssignedWorkloadCounts.Any())
-        {
-            <p class="at-empty-state-note">No open non-sprint assigned work is visible in the selected report scope.</p>
-        }
-        else
-        {
             <div class="at-metric-bars at-metric-bars-tight">
-                @foreach (var item in Model.NonSprintAssignedWorkloadCounts)
+                @foreach (var item in Model.AssigneePendingCounts)
                 {
                     <div class="at-metric-row">
                         <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.NonSprintAssignedWorkloadCountsMax)%"></div></div>
+                        <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.AssigneePendingCountsMax)%"></div></div>
                         <strong>@item.Count</strong>
                     </div>
                 }
             </div>
-        }
-    </article>
+        </article>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Carry-forward by Sprint</h2>
-                <p class="at-panel-note">Safely derived from unfinished tasks that remain assigned to non-closed Sprints.</p>
-            </div>
-        </div>
-        @if (Model.CarryForwardBySprint.All(item => item.Count == 0))
-        {
-            <p class="at-empty-state-note">No carry-forward candidates are visible in the selected report scope.</p>
-        }
-        else
-        {
-            <div class="at-metric-bars">
-                @foreach (var item in Model.CarryForwardBySprint)
-                {
-                    <div class="at-metric-row">
-                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.CarryForwardBySprintMax)%"></div></div>
-                        <strong>@item.Count</strong>
-                    </div>
-                }
-            </div>
-        }
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Blocked Task Ageing</h2>
-                <p class="at-panel-note">Ages blocked tasks by time since assignment to support unblock decisions without changing backend workflow.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.BlockedAgeingBuckets)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.BlockedAgeingBucketsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Priority Exposure</h2>
+                    <p class="at-panel-note">Breaks down open task volume by urgency to support prioritisation decisions.</p>
                 </div>
-            }
-        </div>
-    </article>
-
-    @* SECTION: Deferred trend report state because the current read model has no historical snapshots. *@
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Historical Trend Reports</h2>
-                <p class="at-panel-note">Trend charts require dated snapshot data before they can show reliable movement over time.</p>
             </div>
-        </div>
-        <p class="at-empty-state-note">Trend reporting will be enabled after historical Sprint metrics are available.</p>
-    </article>
+            <div class="at-metric-bars">
+                @foreach (var item in Model.PriorityCounts)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.PriorityCountsMax)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        </article>
+
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Workflow Distribution</h2>
+                    <p class="at-panel-note">Summarises task spread by workflow stage for process-level analysis.</p>
+                </div>
+            </div>
+            <div class="at-metric-bars">
+                @foreach (var item in Model.StatusCounts)
+                {
+                    <div class="at-metric-row">
+                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
+                        <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
+                        <strong>@item.Count</strong>
+                    </div>
+                }
+            </div>
+        </article>
+
+        <article class="at-panel">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Historical Trend Reports</h2>
+                    <p class="at-panel-note">Trend charts require dated snapshot data before they can show reliable movement over time.</p>
+                </div>
+            </div>
+            <p class="at-empty-state-note">Trend reporting will be enabled after historical Sprint metrics are available.</p>
+        </article>
+    </div>
 </section>

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -4620,3 +4620,263 @@ html {
         grid-template-columns: 1fr;
     }
 }
+
+/* SECTION: Action Tracker operational and analytical surface refresh. */
+.at-mywork-command,
+.at-reports-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(18rem, .9fr);
+    gap: 1rem;
+    margin-bottom: .85rem;
+    padding: 1rem;
+}
+
+.at-mywork-command h2,
+.at-reports-hero h2 {
+    margin: .15rem 0 .35rem;
+    color: #fff;
+    font-size: 1.35rem;
+    font-weight: 800;
+    letter-spacing: -.02em;
+}
+
+.at-mywork-command p,
+.at-reports-hero p {
+    margin: 0;
+    color: rgba(255, 255, 255, .82);
+    max-width: 54rem;
+}
+
+.at-mywork-command .at-section-eyebrow,
+.at-reports-hero .at-section-eyebrow {
+    color: rgba(219, 234, 254, .95);
+}
+
+.at-mywork-command-meta,
+.at-reports-summary-grid {
+    display: grid;
+    gap: .5rem;
+    align-content: center;
+}
+
+.at-mywork-command-meta span,
+.at-reports-date-context,
+.at-reports-summary-grid article {
+    border: 1px solid rgba(191, 219, 254, .34);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, .11);
+    color: #fff;
+    padding: .55rem .7rem;
+    font-weight: 800;
+}
+
+.at-reports-date-context {
+    display: inline-flex;
+    margin-top: .7rem;
+}
+
+.at-reports-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.at-reports-summary-grid article span {
+    display: block;
+    color: rgba(255, 255, 255, .72);
+    font-size: var(--at-font-sm);
+    font-weight: 800;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+}
+
+.at-reports-summary-grid article strong {
+    display: block;
+    margin-top: .15rem;
+    font-size: 1.45rem;
+    line-height: 1;
+}
+
+.at-mywork-focus-kpis {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.at-mywork-focus-kpis article {
+    border-top: 4px solid #2563eb;
+}
+
+.at-mywork-focus-kpis article.is-critical {
+    border-top-color: var(--at-danger);
+}
+
+.at-mywork-focus-kpis article.is-today,
+.at-mywork-focus-kpis article.is-submitted {
+    border-top-color: var(--at-warning);
+}
+
+.at-mywork-focus-kpis article.is-next {
+    border-top-color: var(--at-success);
+}
+
+.at-mywork-focus-queue .at-mywork-section:first-child,
+.at-mywork-focus-queue .at-mywork-section:nth-child(2) {
+    border-left: 4px solid var(--at-warning);
+}
+
+.at-mywork-focus-queue .at-mywork-section:nth-child(2) {
+    border-left-color: var(--at-danger);
+}
+
+.at-mywork-row.is-overdue {
+    border-left: 4px solid var(--at-danger);
+}
+
+.at-mywork-due-chip {
+    border: 1px solid var(--at-border);
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #334155;
+    padding: .12rem .45rem;
+    font-weight: 800;
+}
+
+.at-mywork-due-chip.is-overdue {
+    border-color: #fecaca;
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.at-register-command-surface {
+    border-top: 4px solid var(--at-blue);
+}
+
+.at-register-filter-actions,
+.at-register-results-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .65rem;
+}
+
+.at-register-filter-actions {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+
+.at-register-result-pill,
+.at-active-filter-label {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #bfdbfe;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    padding: .22rem .6rem;
+    font-size: var(--at-font-sm);
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.at-register-active-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.at-register-active-filters.is-empty {
+    opacity: .86;
+}
+
+.at-filter-chip-muted {
+    border-color: var(--at-border);
+    background: #f8fafc;
+    color: var(--at-muted);
+}
+
+.at-register-results-panel {
+    padding-top: .8rem;
+}
+
+.at-register-results-heading {
+    margin-bottom: .65rem;
+}
+
+.at-register-results-heading h2 {
+    margin-bottom: .1rem;
+}
+
+.at-register-data-row td:first-child {
+    border-left: 4px solid transparent;
+}
+
+.at-register-data-row:hover td:first-child,
+.at-register-data-row.is-selected td:first-child {
+    border-left-color: var(--at-blue);
+}
+
+.at-register-task-line {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: .35rem;
+}
+
+.at-register-no-results {
+    display: grid;
+    gap: .2rem;
+}
+
+.at-register-no-results strong {
+    color: var(--at-text);
+}
+
+.at-report-group {
+    margin-top: .9rem;
+}
+
+.at-report-group-heading {
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+    box-shadow: var(--at-shadow-xs);
+    padding: .85rem .95rem;
+}
+
+.at-report-group-heading h2 {
+    margin: .15rem 0 .2rem;
+    color: var(--at-text);
+    font-size: 1.05rem;
+    font-weight: 800;
+}
+
+.at-report-group-heading p {
+    margin: 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-md);
+}
+
+.at-report-group .at-card-grid-reports {
+    margin-top: .65rem;
+}
+
+@media (max-width: 991.98px) {
+    .at-mywork-command,
+    .at-reports-hero {
+        grid-template-columns: 1fr;
+    }
+
+    .at-mywork-focus-kpis {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 575.98px) {
+    .at-mywork-focus-kpis,
+    .at-reports-summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-register-filter-actions,
+    .at-register-results-heading {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
### Motivation
- Apply the new Action Tracker design system to operational (My Work, Register) and analytical (Reports) surfaces to match the stabilized Sprint Board / Inspector patterns. 
- Emphasise assignee-focused execution flows (today, overdue, submitted, next-up), elevate filter controls for register reviewers, and provide stronger analytical context and grouping in reports. 
- Preserve server-rendered forms, existing auto-apply filter and searchable-select behavior, CSP/offline compatibility, and avoid new external charting/script dependencies. 

### Description
- My Work: reoriented the partial to an assignee-first layout and KPI strip, prioritising Today, Overdue, Submitted and Next-up queues and demoting unrelated totals; updated queue ordering to use the existing read-model projections. (`Pages/ActionTasks/_TaskMyWork.cshtml`) 
- My Work rows: added overdue emphasis and a compact due-date chip to improve row scanability while preserving inspector routing and selection state. (`Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml`) 
- Register: promoted the filter bar into a first-class control surface with a result pill, active-filter feedback (including an explicit empty/none state), clearer reset affordance, denser row styles and selectable row hooks for improved scanability while keeping server-side routing/sort links unchanged. (`Pages/ActionTasks/_TaskRegister.cshtml`) 
- Reports: added a flagship reports hero with filter-summary and date-range context, reorganised report cards into grouped sections (delivery risk, backlog/continuity, workload/exposure) and kept proportional bar visualisations that require no external chart dependencies. (`Pages/ActionTasks/_TaskReports.cshtml`) 
- Design tokens and CSS: extended `wwwroot/css/action-tracker.css` with new component classes and responsive rules supporting the refreshed My Work, Register, and Reports surfaces (hero, command surfaces, result pills, overdue chip, grouped report headings). (`wwwroot/css/action-tracker.css`) 
- Client behavior: left `wwwroot/js/pages/action-tasks/index.js` intact and compatible with the updated markup; auto-apply filters, searchable-select and report filter-loading behaviors remain unchanged. (`wwwroot/js/pages/action-tasks/index.js`) 
- Implementation notes: all forms remain server-rendered and route-compatible; no external charting or runtime dependencies were introduced; code includes section comments to aid future edits and maintain CSP/offline constraints. 

### Testing
- Ran `git diff --check` to detect whitespace/merge problems and no issues were reported. (success) 
- Attempted to run a full build with `dotnet build` but the `dotnet` SDK is not available in the environment so a CI build was not executed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc670678f4832983e99b678094a075)