### PR TITLE
Fix command queue desktop grid specificity

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -889,6 +889,11 @@ html {
     gap: .75rem;
 }
 
+/* SECTION: Command queue cards retain the four-column desktop layout */
+.at-card-grid.at-command-queue-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .at-card-grid-reports {
     margin-top: 0.6rem;
 }


### PR DESCRIPTION
### Motivation
- Ensure the Command Centre Band B queue keeps its intended four-column desktop layout when it also uses the shared `.at-card-grid` class by increasing selector specificity in the stylesheet.

### Description
- Added a compound selector in `wwwroot/css/action-tracker.css`: `.at-card-grid.at-command-queue-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }` to restore the four-column desktop layout for command queues.

### Testing
- Ran `npm test` which executed the JavaScript unit tests and all tests passed (15 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc68f5b46483299307f09fc2648e9e)