### PR TITLE
Fix My Work queue partial model type mismatch

### DIFF
--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
 @{
@@ -5,7 +6,7 @@
     var overdueTasks = Model.MyOverdueTaskDisplays;
     var todayTasks = Model.MyDueTodayTaskDisplays;
     var submittedTasks = Model.MyWorkSubmittedAwaitingClosureDisplays;
-    var nextUpTasks = Model.MyWorkCurrentWorkDisplays
+    IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem> nextUpTasks = Model.MyWorkCurrentWorkDisplays
         .Concat(Model.MyWorkAllMyTasksDisplays)
         .ToList();
     var assignedTaskCount = Model.Tasks.Count;


### PR DESCRIPTION
### Motivation
- Prevent a runtime Razor binding error when passing the combined “Next up” collection into the `_TaskMyWorkQueueSection` partial by making its type match the partial’s expected `IReadOnlyList<TaskDisplayItem>`.

### Description
- Add `@using System.Collections.Generic` to `Pages/ActionTasks/_TaskMyWork.cshtml` so the `IReadOnlyList<>` interface resolves in the view.
- Change the `nextUpTasks` local to an explicit `IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>` by calling `.Concat(...).ToList()` so the value passed into the `_TaskMyWorkQueueSection` tuple matches the partial model type.

### Testing
- Ran `git diff --check` to validate no whitespace/conflict errors and it passed.
- Attempted a project build with `dotnet build` but it could not be executed in this environment because the `dotnet` CLI is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc69aafbc483298476299622773d7e)