### PR TITLE
Fix command queue responsive grid overrides

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1718,11 +1718,13 @@ html {
 }
 
 @media (max-width: 1199px) {
+    /* SECTION: Responsive grid collapse rules */
     .at-kpis,
     .at-kpis-reports,
     .at-card-grid,
     .at-command-exception-grid,
-    .at-command-queue-grid {
+    .at-command-queue-grid,
+    .at-card-grid.at-command-queue-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
@@ -1756,11 +1758,13 @@ html {
         border: none;
     }
 
+    /* SECTION: Mobile single-column grid collapse rules */
     .at-kpis,
     .at-kpis-reports,
     .at-card-grid,
     .at-command-exception-grid,
     .at-command-queue-grid,
+    .at-card-grid.at-command-queue-grid,
     .at-sprint-health-surface {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
### Motivation
- Ensure the command-queue card grid collapses correctly at tablet and mobile breakpoints by adding equal-specificity rules so the desktop four-column layout does not persist at smaller widths.

### Description
- Add `.at-card-grid.at-command-queue-grid` to the `@media (max-width: 1199px)` and `@media (max-width: 767px)` blocks in `wwwroot/css/action-tracker.css` so the command-queue grid follows the two-column and single-column collapse rules respectively, and add brief section comments to clarify intent.

### Testing
- Ran `npm test` and all JS tests passed (15 tests, 0 failures).
- `dotnet test` was not executed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6bb91b18832997777a94d4048845)