### PR TITLE
Implement Action Tracker Agile Backlog buckets

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -289,6 +289,11 @@ public class IndexModel : PageModel
 
     public string ResolveAssigneeName(string assignedToUserId)
     {
+        if (string.IsNullOrWhiteSpace(assignedToUserId))
+        {
+            return "Unassigned";
+        }
+
         return TaskAssigneeNames.TryGetValue(assignedToUserId, out var assigneeName)
             ? assigneeName
             : "User";
@@ -325,12 +330,12 @@ public class IndexModel : PageModel
             : name;
     }
 
-    // SECTION: Task scope badges use official Sprint / Backlog / Non-sprint categorisation.
+    // SECTION: Task scope badges use official Sprint / Backlog / Outside Sprint bucket classification.
     public string GetSprintBadgeText(ActionTaskItem task)
         => ActionTaskCategorization.ResolveCategory(task) switch
         {
             ActionTaskWorkCategory.Sprint => ResolveSprintName(task.SprintId),
-            ActionTaskWorkCategory.NonSprint => "Non-sprint",
+            ActionTaskWorkCategory.OutsideSprint or ActionTaskWorkCategory.NonSprint => "Outside Sprint",
             ActionTaskWorkCategory.Closed => "Closed",
             _ => "Backlog"
         };
@@ -339,7 +344,7 @@ public class IndexModel : PageModel
         => ActionTaskCategorization.ResolveCategory(task) switch
         {
             ActionTaskWorkCategory.Sprint => "at-scope-badge at-scope-badge-sprint",
-            ActionTaskWorkCategory.NonSprint => "at-scope-badge at-scope-badge-non-sprint",
+            ActionTaskWorkCategory.OutsideSprint or ActionTaskWorkCategory.NonSprint => "at-scope-badge at-scope-badge-non-sprint",
             ActionTaskWorkCategory.Closed => "at-scope-badge at-scope-badge-closed",
             _ => "at-scope-badge at-scope-badge-backlog"
         };
@@ -366,8 +371,11 @@ public class IndexModel : PageModel
         await LoadDataAsync();
     }
 
-    // SECTION: Create action task
-    public async Task<IActionResult> OnPostCreateAsync()
+    // SECTION: Backward-compatible direct-task handler preserves existing Create posts.
+    public Task<IActionResult> OnPostCreateAsync() => OnPostCreateDirectTaskAsync();
+
+    // SECTION: Create assigned work outside a sprint.
+    public async Task<IActionResult> OnPostCreateDirectTaskAsync()
     {
         await ResolveIdentityAsync();
 
@@ -376,60 +384,16 @@ public class IndexModel : PageModel
             return Forbid();
         }
 
-        if (!ModelState.IsValid)
+        if (!ValidateCreateTaskCore(requireAssignee: true))
         {
             ShowCreateModal = true;
             await LoadDataAsync();
             return Page();
         }
 
-        // SECTION: Business validation for due-date discipline
-        if (Input.DueDate.Date < _clock.UtcToday)
-        {
-            ModelState.AddModelError(nameof(Input.DueDate), "Due date cannot be in the past.");
-            ShowCreateModal = true;
-            await LoadDataAsync();
-            return Page();
-        }
-
-        var assignedUser = await _users.FindByIdAsync(Input.AssignedToUserId);
-        if (assignedUser is null)
-        {
-            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user was not found.");
-            ShowCreateModal = true;
-            await LoadDataAsync();
-            return Page();
-        }
-
-        if (assignedUser.IsDisabled || assignedUser.PendingDeletion)
-        {
-            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user is inactive and cannot be assigned a task.");
-            ShowCreateModal = true;
-            await LoadDataAsync();
-            return Page();
-        }
-
-        if (assignedUser.LockoutEnd.HasValue && assignedUser.LockoutEnd > new DateTimeOffset(_clock.UtcNow, TimeSpan.Zero))
-        {
-            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user is locked and cannot be assigned a task.");
-            ShowCreateModal = true;
-            await LoadDataAsync();
-            return Page();
-        }
-
-        var assignedRoles = await _users.GetRolesAsync(assignedUser);
-        var assignedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(assignedRoles);
+        var assignedRole = await ResolveAssignableRoleForInputAsync(Input.AssignedToUserId);
         if (assignedRole is null)
         {
-            ModelState.AddModelError(string.Empty, "Selected user does not have an assignable Task Tracker role.");
-            ShowCreateModal = true;
-            await LoadDataAsync();
-            return Page();
-        }
-
-        if (!_permission.CanAssign(CurrentRole, assignedRole))
-        {
-            ModelState.AddModelError(string.Empty, $"Current role is not permitted to assign tasks to {assignedRole}.");
             ShowCreateModal = true;
             await LoadDataAsync();
             return Page();
@@ -447,9 +411,98 @@ public class IndexModel : PageModel
             Priority = Input.Priority
         });
 
-        TempData["ToastMessage"] = "Task created.";
+        TempData["ToastMessage"] = "Direct task created outside sprint.";
         return RedirectToPage("/ActionTasks/Index", BuildTaskWorkspaceRouteValues(TaskId, SelectedSprintId));
     }
+
+    // SECTION: Create unassigned backlog work for future planning.
+    public async Task<IActionResult> OnPostCreateBacklogItemAsync()
+    {
+        await ResolveIdentityAsync();
+
+        if (!_permission.CanCreate(CurrentRole))
+        {
+            return Forbid();
+        }
+
+        if (!ValidateCreateTaskCore(requireAssignee: false))
+        {
+            ShowCreateModal = true;
+            await LoadDataAsync();
+            return Page();
+        }
+
+        await _service.CreateTaskAsync(new ActionTaskItem
+        {
+            Title = Input.Title.Trim(),
+            Description = Input.Description.Trim(),
+            CreatedByUserId = CurrentUserId,
+            AssignedToUserId = string.Empty,
+            CreatedByRole = CurrentRole,
+            AssignedToRole = string.Empty,
+            DueDate = Input.DueDate,
+            Priority = Input.Priority
+        });
+
+        TempData["ToastMessage"] = "Backlog item created.";
+        return RedirectToPage("/ActionTasks/Index", BuildTaskWorkspaceRouteValues(TaskId, SelectedSprintId));
+    }
+
+    // SECTION: Create-task validation helpers keep backlog and direct-task flows aligned without requiring inline scripts.
+    private bool ValidateCreateTaskCore(bool requireAssignee)
+    {
+        ModelState.Clear();
+        TryValidateModel(Input, nameof(Input));
+
+        if (requireAssignee && string.IsNullOrWhiteSpace(Input.AssignedToUserId))
+        {
+            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Select a responsible person for a direct task.");
+        }
+
+        if (Input.DueDate.Date < _clock.UtcToday)
+        {
+            ModelState.AddModelError(nameof(Input.DueDate), "Due date cannot be in the past.");
+        }
+
+        return ModelState.IsValid;
+    }
+
+    private async Task<string?> ResolveAssignableRoleForInputAsync(string assignedToUserId)
+    {
+        var assignedRole = await ResolveAssignableRoleForUserAsync(assignedToUserId);
+        if (assignedRole is null)
+        {
+            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user cannot be assigned this task.");
+        }
+
+        return assignedRole;
+    }
+
+    private async Task<string?> ResolveAssignableRoleForUserAsync(string assignedToUserId)
+    {
+        if (string.IsNullOrWhiteSpace(assignedToUserId))
+        {
+            return null;
+        }
+
+        var assignedUser = await _users.FindByIdAsync(assignedToUserId);
+        if (assignedUser is null || assignedUser.IsDisabled || assignedUser.PendingDeletion)
+        {
+            return null;
+        }
+
+        if (assignedUser.LockoutEnd.HasValue && assignedUser.LockoutEnd > new DateTimeOffset(_clock.UtcNow, TimeSpan.Zero))
+        {
+            return null;
+        }
+
+        var assignedRoles = await _users.GetRolesAsync(assignedUser);
+        var assignedRole = ActionTaskRoleResolver.ResolveAssignableRoleFromRoles(assignedRoles);
+        return assignedRole is not null && _permission.CanAssign(CurrentRole, assignedRole)
+            ? assignedRole
+            : null;
+    }
+
 
 
 
@@ -703,14 +756,21 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Assign backlog or visible task into an available sprint.
-    public async Task<IActionResult> OnPostAssignToSprintAsync(int id, int sprintId)
+    public async Task<IActionResult> OnPostAssignToSprintAsync(int id, int sprintId, string responsibleUserId)
     {
         await ResolveIdentityAsync();
 
         try
         {
-            await _sprintService.AssignTaskToSprintAsync(id, sprintId, CurrentUserId, CurrentRole);
-            TempData["ToastMessage"] = "Task assigned to sprint.";
+            var responsibleRole = await ResolveAssignableRoleForUserAsync(responsibleUserId);
+            if (responsibleRole is null)
+            {
+                TempData["ToastError"] = "Select an active responsible person before adding the backlog item to a sprint.";
+                return RedirectToTaskPage(id, SelectedSprintId);
+            }
+
+            await _sprintService.AssignTaskToSprintAsync(id, sprintId, responsibleUserId, responsibleRole, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Backlog item added to sprint with a responsible person.";
         }
         catch (InvalidOperationException ex)
         {
@@ -720,15 +780,33 @@ public class IndexModel : PageModel
         return RedirectToTaskPage(id, sprintId);
     }
 
-    // SECTION: Move a sprint task back to backlog without altering task lifecycle state.
-    public async Task<IActionResult> OnPostMoveToBacklogAsync(int id)
+    // SECTION: Remove a sprint task from sprint scope while preserving the responsible person.
+    public async Task<IActionResult> OnPostRemoveFromSprintKeepAssignedAsync(int id)
     {
         await ResolveIdentityAsync();
 
         try
         {
-            await _sprintService.MoveTaskToBacklogAsync(id, CurrentUserId, CurrentRole);
-            TempData["ToastMessage"] = "Task moved to backlog.";
+            await _sprintService.RemoveTaskFromSprintKeepAssignedAsync(id, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task removed from sprint and kept assigned.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToTaskPage(id, SelectedSprintId);
+    }
+
+    // SECTION: Move a sprint or outside-sprint task to backlog by clearing sprint and assignee.
+    public async Task<IActionResult> OnPostMoveToBacklogRemoveAssigneeAsync(int id)
+    {
+        await ResolveIdentityAsync();
+
+        try
+        {
+            await _sprintService.MoveTaskToBacklogRemoveAssigneeAsync(id, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task moved to backlog and assignee removed.";
         }
         catch (InvalidOperationException ex)
         {
@@ -749,6 +827,7 @@ public class IndexModel : PageModel
                 DecodeRowVersion(ClosureInput.RowVersion),
                 ClosureInput.CarryForwardTaskIds,
                 ClosureInput.TargetSprintId,
+                ClosureInput.OutsideSprintTaskIds,
                 ClosureInput.BacklogTaskIds,
                 ClosureInput.Remarks,
                 CurrentUserId,
@@ -1279,7 +1358,6 @@ public class IndexModel : PageModel
         [Required, StringLength(4000)]
         public string Description { get; set; } = string.Empty;
 
-        [Required]
         public string AssignedToUserId { get; set; } = string.Empty;
 
         [Display(Name = "Due Date")]
@@ -1374,6 +1452,8 @@ public class IndexModel : PageModel
         public int? TargetSprintId { get; set; }
 
         public List<int> CarryForwardTaskIds { get; set; } = new();
+
+        public List<int> OutsideSprintTaskIds { get; set; } = new();
 
         public List<int> BacklogTaskIds { get; set; } = new();
 

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -110,7 +110,7 @@
             <div>
                 <h2>Backlog Queue</h2>
                 <p class="at-panel-note">Filter true backlog tasks and assign eligible work into a Sprint.</p>
-                <p class="at-panel-note">Non-sprint means assigned work outside sprint commitment.</p>
+                <p class="at-panel-note">Assigned Tasks Outside Sprint are assigned work not included in a sprint commitment.</p>
             </div>
             <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
         </div>
@@ -206,6 +206,13 @@
                                         <input type="hidden" name="PlanningTab" value="Execute" />
                                         <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                         <input type="hidden" name="id" value="@task.Id" />
+                                        <select class="form-select form-select-sm" name="responsibleUserId" aria-label="Select responsible person for AT-@task.Id" required>
+                                            <option value="">Responsible person</option>
+                                            @foreach (var user in Model.AssignableUsers)
+                                            {
+                                                <option value="@user.UserId">@user.DisplayName</option>
+                                            }
+                                        </select>
                                         <select class="form-select form-select-sm" name="sprintId" aria-label="Select Sprint for AT-@task.Id" required>
                                             <option value="">Select Sprint</option>
                                             @foreach (var sprint in Model.AssignableSprints)
@@ -213,7 +220,7 @@
                                                 <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
                                             }
                                         </select>
-                                        <button type="submit" class="btn btn-primary btn-sm">Assign</button>
+                                        <button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button>
                                     </form>
                                 }
                                 else

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -26,12 +26,21 @@
     </a>
     @if (allowMoveToBacklog && pageModel.CanMoveTaskToBacklog(task))
     {
-        <form method="post" asp-page-handler="MoveToBacklog" class="at-card-action-form">
-            <input type="hidden" name="ViewMode" value="Planning" />
-            <input type="hidden" name="PlanningTab" value="Execute" />
-            <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
-            <input type="hidden" name="id" value="@task.Id" />
-            <button type="submit" class="btn btn-link btn-sm at-card-subtle-action">Move to Backlog</button>
-        </form>
+        <div class="at-card-action-stack">
+            <form method="post" asp-page-handler="RemoveFromSprintKeepAssigned" class="at-card-action-form">
+                <input type="hidden" name="ViewMode" value="Planning" />
+                <input type="hidden" name="PlanningTab" value="Execute" />
+                <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
+                <input type="hidden" name="id" value="@task.Id" />
+                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action">Remove from Sprint, Keep Assigned</button>
+            </form>
+            <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
+                <input type="hidden" name="ViewMode" value="Planning" />
+                <input type="hidden" name="PlanningTab" value="Execute" />
+                <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
+                <input type="hidden" name="id" value="@task.Id" />
+                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action">Move to Backlog, Remove Assignee</button>
+            </form>
+        </div>
     }
 </article>

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -71,14 +71,15 @@
                     <div class="form-text">Next sprint is required only for tasks marked to carry forward to the next sprint.</div>
                 </div>
 
-                <p class="at-panel-note">Each unfinished task must be carried forward to the next sprint or moved to backlog before this sprint can close.</p>
+                <p class="at-panel-note">Each unfinished task must be carried forward, removed from sprint while keeping its assignee, or moved to backlog with the assignee removed before this sprint can close.</p>
 
                 <div class="at-closure-task-table" role="table" aria-label="Unfinished Sprint tasks requiring disposition">
                     <div class="at-closure-task-row at-closure-task-head" role="row">
                         <span>Task</span>
                         <span>Status</span>
                         <span>Carry forward</span>
-                        <span>Move to backlog</span>
+                        <span>Remove from Sprint</span>
+                        <span>Move to Backlog</span>
                     </div>
                     @foreach (var task in review.UnfinishedTasks)
                     {
@@ -93,8 +94,12 @@
                                 <span>Next Sprint</span>
                             </label>
                             <label class="at-closure-choice">
+                                <input type="checkbox" name="ClosureInput.OutsideSprintTaskIds" value="@task.Id" data-at-closure-choice="outside" />
+                                <span>Keep Assigned</span>
+                            </label>
+                            <label class="at-closure-choice">
                                 <input type="checkbox" name="ClosureInput.BacklogTaskIds" value="@task.Id" data-at-closure-choice="backlog" />
-                                <span>Backlog</span>
+                                <span>Remove Assignee</span>
                             </label>
                         </div>
                     }

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -1,68 +1,111 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Create-task modal for focused task capture workflow. *@
+@* SECTION: Create-task modal separates Agile backlog capture from assigned outside-sprint work. *@
 <div class="modal fade" id="createTaskModal" tabindex="-1" aria-labelledby="createTaskModalLabel" aria-hidden="true" data-bs-backdrop="static" data-at-open-on-load="@(Model.ShowCreateModal ? "true" : "false")">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content">
-            <form method="post" asp-page-handler="Create">
-                <div class="modal-header">
-                    <h2 class="modal-title h5 mb-0" id="createTaskModalLabel">Create Task</h2>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    @if (!ViewData.ModelState.IsValid)
-                    {
-                        <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
-                    }
-                    @* SECTION: Preserve selected view mode during postbacks. *@
-                    <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                    <div class="row g-3">
-                        <div class="col-md-5">
-                            <label asp-for="Input.Title" class="form-label">Task Title</label>
-                            <input asp-for="Input.Title" class="form-control" />
-                            <span asp-validation-for="Input.Title" class="text-danger small"></span>
-                        </div>
-                        <div class="col-md-7">
-                            <label asp-for="Input.Description" class="form-label">Description / Instructions</label>
-                            <textarea asp-for="Input.Description"
-                                      class="form-control"
-                                      rows="4"
-                                      placeholder="Enter task instructions, background and expected output"></textarea>
-                            <span asp-validation-for="Input.Description" class="text-danger small"></span>
-                        </div>
-                        <div class="col-12">
-                            <label asp-for="Input.AssignedToUserId" class="form-label">Assign To</label>
-                            <select asp-for="Input.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person">
-                                <option value="">Select user</option>
-                                @foreach (var user in Model.AssignableUsers)
-                                {
-                                    <option value="@user.UserId">@user.DisplayName</option>
-                                }
-                            </select>
-                            <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
-                        </div>
-                        <div class="col-md-3">
-                            <label asp-for="Input.Priority" class="form-label">Priority</label>
-                            <select asp-for="Input.Priority" class="form-select">
-                                <option>Low</option>
-                                <option selected>Normal</option>
-                                <option>High</option>
-                                <option>Critical</option>
-                            </select>
-                            <span asp-validation-for="Input.Priority" class="text-danger small"></span>
-                        </div>
-                        <div class="col-md-4">
-                            <label asp-for="Input.DueDate" class="form-label">Due Date</label>
-                            <input asp-for="Input.DueDate" type="date" class="form-control" />
-                            <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
+            <div class="modal-header">
+                <h2 class="modal-title h5 mb-0" id="createTaskModalLabel">Create Action Tracker Work</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                @if (!ViewData.ModelState.IsValid)
+                {
+                    <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
+                }
+
+                @* SECTION: Direct task creation keeps assigned work outside sprint until planners add it to a sprint. *@
+                <section class="at-create-flow-panel">
+                    <div class="at-panel-heading at-panel-heading-compact">
+                        <div>
+                            <h3 class="h6 mb-1">Create Direct Task</h3>
+                            <p class="at-panel-note mb-0">Assigned to a responsible person now. It remains Outside Sprint until added to a sprint.</p>
                         </div>
                     </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Create Task</button>
-                </div>
-            </form>
+                    <form method="post" asp-page-handler="CreateDirectTask" class="at-create-flow-form">
+                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                        <div class="row g-3">
+                            <div class="col-md-5">
+                                <label asp-for="Input.Title" class="form-label">Task Title</label>
+                                <input asp-for="Input.Title" class="form-control" />
+                                <span asp-validation-for="Input.Title" class="text-danger small"></span>
+                            </div>
+                            <div class="col-md-7">
+                                <label asp-for="Input.Description" class="form-label">Description / Instructions</label>
+                                <textarea asp-for="Input.Description" class="form-control" rows="4" placeholder="Enter task instructions, background and expected output"></textarea>
+                                <span asp-validation-for="Input.Description" class="text-danger small"></span>
+                            </div>
+                            <div class="col-12">
+                                <label asp-for="Input.AssignedToUserId" class="form-label">Responsible Person</label>
+                                <select asp-for="Input.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person" required>
+                                    <option value="">Select user</option>
+                                    @foreach (var user in Model.AssignableUsers)
+                                    {
+                                        <option value="@user.UserId">@user.DisplayName</option>
+                                    }
+                                </select>
+                                <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
+                            </div>
+                            <div class="col-md-3">
+                                <label asp-for="Input.Priority" class="form-label">Priority</label>
+                                <select asp-for="Input.Priority" class="form-select">
+                                    <option>Low</option>
+                                    <option selected>Normal</option>
+                                    <option>High</option>
+                                    <option>Critical</option>
+                                </select>
+                                <span asp-validation-for="Input.Priority" class="text-danger small"></span>
+                            </div>
+                            <div class="col-md-4">
+                                <label asp-for="Input.DueDate" class="form-label">Due Date</label>
+                                <input asp-for="Input.DueDate" type="date" class="form-control" />
+                                <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
+                            </div>
+                        </div>
+                        <div class="at-create-flow-actions">
+                            <button type="submit" class="btn btn-primary">Create Direct Task</button>
+                        </div>
+                    </form>
+                </section>
+
+                @* SECTION: Backlog item creation intentionally omits assignee and sprint fields. *@
+                <details class="at-create-flow-panel at-create-backlog-panel mt-3">
+                    <summary class="btn btn-outline-primary btn-sm">Create Backlog Item</summary>
+                    <p class="at-panel-note mt-2">Capture future work without assigning a responsible person or sprint.</p>
+                    <form method="post" asp-page-handler="CreateBacklogItem" class="at-create-flow-form">
+                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                        <div class="row g-3">
+                            <div class="col-md-5">
+                                <label asp-for="Input.Title" class="form-label">Backlog Item Title</label>
+                                <input asp-for="Input.Title" class="form-control" />
+                            </div>
+                            <div class="col-md-7">
+                                <label asp-for="Input.Description" class="form-label">Description / Planning Notes</label>
+                                <textarea asp-for="Input.Description" class="form-control" rows="4" placeholder="Enter the work idea, context and planning notes"></textarea>
+                            </div>
+                            <div class="col-md-3">
+                                <label asp-for="Input.Priority" class="form-label">Priority</label>
+                                <select asp-for="Input.Priority" class="form-select">
+                                    <option>Low</option>
+                                    <option selected>Normal</option>
+                                    <option>High</option>
+                                    <option>Critical</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4">
+                                <label asp-for="Input.DueDate" class="form-label">Planning Due Date</label>
+                                <input asp-for="Input.DueDate" type="date" class="form-control" />
+                            </div>
+                        </div>
+                        <div class="at-create-flow-actions">
+                            <button type="submit" class="btn btn-outline-primary">Create Backlog Item</button>
+                        </div>
+                    </form>
+                </details>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
         </div>
     </div>
 </div>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -33,7 +33,7 @@
             <label>
                 <span>Scope</span>
                 <select class="form-select form-select-sm" name="ReportSprintId" data-at-reports-filter-control="true">
-                    <option value="">All Sprint, Backlog &amp; Non-sprint work</option>
+                    <option value="">All Sprint, Backlog &amp; Outside Sprint work</option>
                     @if (Model.ReportSprintId == 0)
                     {
                         <option value="0" selected>True backlog only</option>
@@ -270,13 +270,13 @@
     <article class="at-panel">
         <div class="at-panel-heading">
             <div>
-                <h2>Non-sprint Assigned Workload</h2>
+                <h2>Assigned Tasks Outside Sprint</h2>
                 <p class="at-panel-note">Counts open assigned work that is not part of Sprint commitment and is excluded from backlog ageing.</p>
             </div>
         </div>
         @if (!Model.NonSprintAssignedWorkloadCounts.Any())
         {
-            <p class="at-empty-state-note">No open non-sprint assigned work is visible in the selected report scope.</p>
+            <p class="at-empty-state-note">No open assigned work outside sprint is visible in the selected report scope.</p>
         }
         else
         {

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -258,7 +258,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task MoveTaskToBacklogAsync_ClearsSprintIdAndAuditsMove()
+    public async Task MoveTaskToBacklogAsync_ClearsSprintAndAssigneeAndAuditsMove()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -272,7 +272,8 @@ public class ActionSprintServiceTests
 
         // SECTION: Assert
         Assert.Null(backlogTask.SprintId);
-        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskMovedToBacklog");
+        Assert.Equal(string.Empty, backlogTask.AssignedToUserId);
+        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskMovedToBacklogRemoveAssignee");
     }
 
     [Fact]
@@ -375,7 +376,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task CloseSprintWithDispositionAsync_MovesSelectedTaskToBacklog()
+    public async Task CloseSprintWithDispositionAsync_MovesSelectedTaskToBacklogAndRemovesAssignee()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -391,7 +392,8 @@ public class ActionSprintServiceTests
         // SECTION: Assert
         var movedTask = await db.ActionTasks.SingleAsync(t => t.Id == task.Id);
         Assert.Null(movedTask.SprintId);
-        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskRemovedFromSprint");
+        Assert.Equal(string.Empty, movedTask.AssignedToUserId);
+        Assert.Contains(await db.ActionTaskAuditLogs.ToListAsync(), x => x.TaskId == task.Id && x.ActionType == "TaskMovedToBacklogRemoveAssignee");
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -407,7 +407,7 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task TaskScopeBadges_UseSprintBacklogNonSprintAndClosedLabels()
+    public async Task TaskScopeBadges_UseSprintBacklogOutsideSprintAndClosedLabels()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
@@ -427,7 +427,7 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Equal("Badge Sprint", page.GetSprintBadgeText(sprintTask));
         Assert.Equal("Backlog", page.GetSprintBadgeText(backlogTask));
-        Assert.Equal("Non-sprint", page.GetSprintBadgeText(nonSprintTask));
+        Assert.Equal("Outside Sprint", page.GetSprintBadgeText(nonSprintTask));
         Assert.Equal("Closed", page.GetSprintBadgeText(closedTask));
         Assert.Contains("at-scope-badge-sprint", page.GetSprintBadgeClass(sprintTask), StringComparison.Ordinal);
         Assert.Contains("at-scope-badge-backlog", page.GetSprintBadgeClass(backlogTask), StringComparison.Ordinal);
@@ -759,7 +759,7 @@ public class ActionTaskPageTests
         Assert.Null(page.SelectedSprint);
         Assert.Contains("No sprint has been created yet", html, StringComparison.Ordinal);
         Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Non-sprint means assigned work outside sprint commitment.", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned Tasks Outside Sprint are assigned work not included in a sprint commitment.", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Create " + "Planning " + "Window", html, StringComparison.Ordinal);
         Assert.Contains("handler=CreateSprint", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Select a sprint to view sprint command details.", html, StringComparison.Ordinal);
@@ -895,7 +895,7 @@ public class ActionTaskPageTests
         Assert.Contains("Priority Exposure", html, StringComparison.Ordinal);
         Assert.Contains("Workflow Distribution", html, StringComparison.Ordinal);
         Assert.Contains("Backlog Ageing Summary", html, StringComparison.Ordinal);
-        Assert.Contains("Non-sprint Assigned Workload", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned Tasks Outside Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Carry-forward by Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Blocked Task Ageing", html, StringComparison.Ordinal);
     }

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -153,7 +153,7 @@ public class ActionSprintService
         var unfinishedTaskCount = await CountUnfinishedSprintTasksAsync(sprint.Id, cancellationToken);
         if (unfinishedTaskCount > 0)
         {
-            throw new InvalidOperationException("Sprint contains unfinished tasks. Use the closure review to move unfinished tasks to the next sprint or backlog before closing.");
+            throw new InvalidOperationException("Sprint contains unfinished tasks. Use the closure review to carry forward, remove from sprint while keeping assignee, or move unfinished tasks to backlog before closing.");
         }
 
         var performedAt = DateTime.UtcNow;
@@ -171,7 +171,10 @@ public class ActionSprintService
         return sprint;
     }
 
-    public async Task<ActionSprint> CloseSprintWithDispositionAsync(int sprintId, byte[] rowVersion, IReadOnlyCollection<int> carryForwardTaskIds, int? targetSprintId, IReadOnlyCollection<int> backlogTaskIds, string remarks, string userId, string role, CancellationToken cancellationToken = default)
+    public Task<ActionSprint> CloseSprintWithDispositionAsync(int sprintId, byte[] rowVersion, IReadOnlyCollection<int> carryForwardTaskIds, int? targetSprintId, IReadOnlyCollection<int> backlogTaskIds, string remarks, string userId, string role, CancellationToken cancellationToken = default)
+        => CloseSprintWithDispositionAsync(sprintId, rowVersion, carryForwardTaskIds, targetSprintId, Array.Empty<int>(), backlogTaskIds, remarks, userId, role, cancellationToken);
+
+    public async Task<ActionSprint> CloseSprintWithDispositionAsync(int sprintId, byte[] rowVersion, IReadOnlyCollection<int> carryForwardTaskIds, int? targetSprintId, IReadOnlyCollection<int> outsideSprintTaskIds, IReadOnlyCollection<int> backlogTaskIds, string remarks, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanCloseSprint(role);
         EnsureSprintRowVersionSupplied(rowVersion);
@@ -181,8 +184,13 @@ public class ActionSprintService
         }
 
         var carryIds = (carryForwardTaskIds ?? Array.Empty<int>()).Distinct().ToList();
+        var outsideIds = (outsideSprintTaskIds ?? Array.Empty<int>()).Distinct().ToList();
         var backIds = (backlogTaskIds ?? Array.Empty<int>()).Distinct().ToList();
-        var duplicateDispositionIds = carryIds.Intersect(backIds).ToList();
+        var duplicateDispositionIds = carryIds.Concat(outsideIds).Concat(backIds)
+            .GroupBy(id => id)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
         if (duplicateDispositionIds.Count > 0)
         {
             throw new InvalidOperationException("Each unfinished task can have only one closure disposition.");
@@ -209,11 +217,11 @@ public class ActionSprintService
             .OrderBy(t => t.Id)
             .ToListAsync(cancellationToken);
 
-        var dispositionedIds = carryIds.Concat(backIds).Distinct().ToHashSet();
+        var dispositionedIds = carryIds.Concat(outsideIds).Concat(backIds).Distinct().ToHashSet();
         var missingDispositionIds = unfinishedTasks.Select(t => t.Id).Where(id => !dispositionedIds.Contains(id)).ToList();
         if (missingDispositionIds.Count > 0)
         {
-            throw new InvalidOperationException("All unfinished tasks must be moved to the next sprint or backlog before the sprint can close.");
+            throw new InvalidOperationException("All unfinished tasks must be carried forward, removed from sprint while assigned, or moved to backlog before the sprint can close.");
         }
 
         var invalidDispositionIds = dispositionedIds.Except(unfinishedTasks.Select(t => t.Id)).ToList();
@@ -230,11 +238,20 @@ public class ActionSprintService
             AddTaskSprintAudit(task.Id, "TaskCarriedForward", userId, role, oldValue, targetSprint.Id.ToString(), $"Carried forward from sprint {sprint.Name} to {targetSprint.Name}. Closure remarks: {remarks.Trim()}", performedAt);
         }
 
-        foreach (var task in unfinishedTasks.Where(t => backIds.Contains(t.Id)))
+        foreach (var task in unfinishedTasks.Where(t => outsideIds.Contains(t.Id)))
         {
             var oldValue = task.SprintId?.ToString();
             task.SprintId = null;
-            AddTaskSprintAudit(task.Id, "TaskRemovedFromSprint", userId, role, oldValue, null, $"Moved from sprint {sprint.Name} to backlog during closure. Closure remarks: {remarks.Trim()}", performedAt);
+            AddTaskSprintAudit(task.Id, "TaskRemovedFromSprintKeepAssigned", userId, role, oldValue, null, $"Removed from sprint {sprint.Name} and kept assigned during closure. Closure remarks: {remarks.Trim()}", performedAt);
+        }
+
+        foreach (var task in unfinishedTasks.Where(t => backIds.Contains(t.Id)))
+        {
+            var oldValue = DescribeTaskBucket(task);
+            task.SprintId = null;
+            task.AssignedToUserId = string.Empty;
+            task.AssignedToRole = string.Empty;
+            AddTaskSprintAudit(task.Id, "TaskMovedToBacklogRemoveAssignee", userId, role, oldValue, DescribeTaskBucket(task), $"Moved from sprint {sprint.Name} to backlog and removed assignee during closure. Closure remarks: {remarks.Trim()}", performedAt);
         }
 
         var oldStatus = sprint.Status.ToString();
@@ -245,7 +262,7 @@ public class ActionSprintService
         sprint.UpdatedAtUtc = performedAt;
         sprint.RowVersion = NewSprintRowVersion();
 
-        var detail = $"Closed sprint: {sprint.Name}. Carried forward: {carryIds.Count}. Moved to backlog: {backIds.Count}. Remarks: {remarks.Trim()}";
+        var detail = $"Closed sprint: {sprint.Name}. Carried forward: {carryIds.Count}. Removed from sprint, kept assigned: {outsideIds.Count}. Moved to backlog, assignee removed: {backIds.Count}. Remarks: {remarks.Trim()}";
         AddSprintAudit(sprint.Id, "SprintClosed", userId, role, performedAt, oldStatus, sprint.Status.ToString(), detail);
         await SaveSprintChangesAsync(cancellationToken);
         return sprint;
@@ -254,42 +271,84 @@ public class ActionSprintService
     // SECTION: Sprint task assignment APIs
     public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
     {
+        var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        return await AssignTaskToSprintAsync(taskId, sprintId, task.AssignedToUserId, task.AssignedToRole, userId, role, cancellationToken);
+    }
+
+    public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string responsibleUserId, string responsibleRole, string userId, string role, CancellationToken cancellationToken = default)
+    {
         EnsureCanAssignTaskToSprint(role);
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
         EnsureTaskIsNotClosed(task, "Closed tasks cannot be assigned to a sprint.");
+        if (string.IsNullOrWhiteSpace(responsibleUserId) || string.IsNullOrWhiteSpace(responsibleRole))
+        {
+            throw new InvalidOperationException("Select a responsible person before adding a backlog item to a sprint.");
+        }
 
         var sprint = await GetSprintForUpdateAsync(sprintId, cancellationToken);
         _workflow.EnsureCanAcceptTask(sprint);
 
-        var oldValue = task.SprintId?.ToString();
+        var oldValue = DescribeTaskBucket(task);
+        task.AssignedToUserId = responsibleUserId;
+        task.AssignedToRole = responsibleRole;
+        task.AssignedOn = DateTime.UtcNow;
         task.SprintId = sprint.Id;
-        AddTaskSprintAudit(task.Id, "TaskAssignedToSprint", userId, role, oldValue, sprint.Id.ToString(), $"Assigned to sprint: {sprint.Name}");
+        AddTaskSprintAudit(task.Id, "TaskAssignedToSprint", userId, role, oldValue, DescribeTaskBucket(task), $"Assigned to sprint: {sprint.Name}; responsible person selected.");
 
         await _context.SaveChangesAsync(cancellationToken);
         return task;
     }
 
-    public async Task<ActionTaskItem> MoveTaskToBacklogAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionTaskItem> RemoveTaskFromSprintKeepAssignedAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanMoveTaskToBacklog(role);
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
-        EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between a sprint and backlog.");
+        EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between sprint buckets.");
+        await EnsureCurrentSprintCanChangeAsync(task, cancellationToken);
 
+        var oldValue = DescribeTaskBucket(task);
+        task.SprintId = null;
+        AddTaskSprintAudit(task.Id, "TaskRemovedFromSprintKeepAssigned", userId, role, oldValue, DescribeTaskBucket(task), "Removed from sprint and kept assigned as Outside Sprint work.");
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return task;
+    }
+
+    public Task<ActionTaskItem> MoveTaskToBacklogAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+        => MoveTaskToBacklogRemoveAssigneeAsync(taskId, userId, role, cancellationToken);
+
+    public async Task<ActionTaskItem> MoveTaskToBacklogRemoveAssigneeAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        EnsureCanMoveTaskToBacklog(role);
+
+        var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
+        EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between sprint buckets.");
+        await EnsureCurrentSprintCanChangeAsync(task, cancellationToken);
+
+        var oldValue = DescribeTaskBucket(task);
+        task.SprintId = null;
+        task.AssignedToUserId = string.Empty;
+        task.AssignedToRole = string.Empty;
+        AddTaskSprintAudit(task.Id, "TaskMovedToBacklogRemoveAssignee", userId, role, oldValue, DescribeTaskBucket(task), "Moved to backlog and removed assignee.");
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return task;
+    }
+
+    // SECTION: Sprint bucket mutation helpers
+    private async Task EnsureCurrentSprintCanChangeAsync(ActionTaskItem task, CancellationToken cancellationToken)
+    {
         if (task.SprintId.HasValue)
         {
             var currentSprint = await GetSprintForUpdateAsync(task.SprintId.Value, cancellationToken);
             _workflow.EnsureCanUpdate(currentSprint);
         }
-
-        var oldValue = task.SprintId?.ToString();
-        task.SprintId = null;
-        AddTaskSprintAudit(task.Id, "TaskMovedToBacklog", userId, role, oldValue, null, "Removed from sprint and moved to backlog.");
-
-        await _context.SaveChangesAsync(cancellationToken);
-        return task;
     }
+
+    private static string DescribeTaskBucket(ActionTaskItem task)
+        => $"Bucket={ActionTaskBucketClassifier.ResolveBucket(task)}; SprintId={task.SprintId?.ToString() ?? "none"}; Assignee={(string.IsNullOrWhiteSpace(task.AssignedToUserId) ? "none" : task.AssignedToUserId)}";
 
     // SECTION: Authorization helpers
     private async Task<int> CountUnfinishedSprintTasksAsync(int sprintId, CancellationToken cancellationToken)

--- a/Services/ActionTasks/ActionTaskCategorization.cs
+++ b/Services/ActionTasks/ActionTaskCategorization.cs
@@ -3,32 +3,41 @@ using ProjectManagement.Models;
 
 namespace ProjectManagement.Services.ActionTasks;
 
+public enum ActionTaskBucket
+{
+    Backlog,
+    OutsideSprint,
+    Sprint,
+    Closed
+}
+
 public enum ActionTaskWorkCategory
 {
     Sprint,
     Backlog,
+    OutsideSprint,
     NonSprint,
     Closed
 }
 
-public static class ActionTaskCategorization
+public static class ActionTaskBucketClassifier
 {
-    // SECTION: Official task category source of truth for sprint, backlog, non-sprint, and closed work.
-    public static ActionTaskWorkCategory ResolveCategory(ActionTaskItem task)
+    // SECTION: Central Agile Backlog bucket source of truth for backlog, outside-sprint, sprint, and closed work.
+    public static ActionTaskBucket ResolveBucket(ActionTaskItem task)
     {
         if (IsClosedTask(task))
         {
-            return ActionTaskWorkCategory.Closed;
+            return ActionTaskBucket.Closed;
         }
 
         if (IsSprintTask(task))
         {
-            return ActionTaskWorkCategory.Sprint;
+            return ActionTaskBucket.Sprint;
         }
 
         return HasAssignedUser(task)
-            ? ActionTaskWorkCategory.NonSprint
-            : ActionTaskWorkCategory.Backlog;
+            ? ActionTaskBucket.OutsideSprint
+            : ActionTaskBucket.Backlog;
     }
 
     public static bool IsSprintTask(ActionTaskItem task)
@@ -37,8 +46,11 @@ public static class ActionTaskCategorization
     public static bool IsBacklogTask(ActionTaskItem task)
         => task.SprintId is null && !HasAssignedUser(task) && IsOpenTask(task);
 
-    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
+    public static bool IsOutsideSprintTask(ActionTaskItem task)
         => task.SprintId is null && HasAssignedUser(task) && IsOpenTask(task);
+
+    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
+        => IsOutsideSprintTask(task);
 
     public static bool IsClosedTask(ActionTaskItem task)
         => string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
@@ -48,4 +60,41 @@ public static class ActionTaskCategorization
 
     public static bool HasAssignedUser(ActionTaskItem task)
         => !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+}
+
+public static class ActionTaskCategorization
+{
+    // SECTION: Backward-compatible category facade delegates to the central Agile Backlog bucket classifier.
+    public static ActionTaskWorkCategory ResolveCategory(ActionTaskItem task)
+        => ActionTaskBucketClassifier.ResolveBucket(task) switch
+        {
+            ActionTaskBucket.Sprint => ActionTaskWorkCategory.Sprint,
+            ActionTaskBucket.OutsideSprint => ActionTaskWorkCategory.OutsideSprint,
+            ActionTaskBucket.Closed => ActionTaskWorkCategory.Closed,
+            _ => ActionTaskWorkCategory.Backlog
+        };
+
+    public static ActionTaskBucket ResolveBucket(ActionTaskItem task)
+        => ActionTaskBucketClassifier.ResolveBucket(task);
+
+    public static bool IsSprintTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsSprintTask(task);
+
+    public static bool IsBacklogTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsBacklogTask(task);
+
+    public static bool IsOutsideSprintTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsOutsideSprintTask(task);
+
+    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsAssignedNonSprintTask(task);
+
+    public static bool IsClosedTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsClosedTask(task);
+
+    public static bool IsOpenTask(ActionTaskItem task)
+        => ActionTaskBucketClassifier.IsOpenTask(task);
+
+    public static bool HasAssignedUser(ActionTaskItem task)
+        => ActionTaskBucketClassifier.HasAssignedUser(task);
 }

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -167,7 +167,7 @@ public sealed class ActionTaskQueryService
             return new[] { "Close the sprint after recording closure remarks." };
         }
 
-        var options = new List<string> { "Move unfinished tasks with continuing operational value to the next open sprint.", "Move deferred or unscheduled tasks to backlog." };
+        var options = new List<string> { "Carry unfinished tasks with continuing operational value forward to the next open sprint.", "Remove still-owned work from the sprint to keep it assigned outside sprint, or move deferred work to backlog and remove the assignee." };
         if (targetOptions.Count == 0)
         {
             options.Add("Create or reopen a planned sprint before carrying tasks forward.");

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -24,7 +24,7 @@ public sealed class ActionTaskReportBuilder
         var backlogOpenTasks = openTasks.Where(ActionTaskCategorization.IsBacklogTask).ToList();
         var nonSprintOpenTasks = openTasks.Where(ActionTaskCategorization.IsAssignedNonSprintTask).ToList();
         var blockedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
-        string Assignee(string id) => assigneeNames.TryGetValue(id, out var name) ? name : "User";
+        string Assignee(string id) => string.IsNullOrWhiteSpace(id) ? "Unassigned" : assigneeNames.TryGetValue(id, out var name) ? name : "User";
 
         return new ActionTaskQueryService.ActionTaskReportReadModel
         {
@@ -79,10 +79,10 @@ public sealed class ActionTaskReportBuilder
             .ToList();
     }
 
-    // SECTION: Non-sprint assigned workload remains separate from backlog ageing and sprint workload.
+    // SECTION: Outside Sprint assigned workload remains separate from backlog ageing and sprint workload.
     private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildNonSprintAssignedWorkloadCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
         => tasks
-            .GroupBy(t => assigneeNames.TryGetValue(t.AssignedToUserId, out var name) ? name : "User")
+            .GroupBy(t => string.IsNullOrWhiteSpace(t.AssignedToUserId) ? "Unassigned" : assigneeNames.TryGetValue(t.AssignedToUserId, out var name) ? name : "User")
             .OrderByDescending(g => g.Count())
             .ThenBy(g => g.Key)
             .Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count()))

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1222,7 +1222,7 @@ html {
     background: #f1f5f9;
 }
 
-/* SECTION: Sprint, backlog, non-sprint, and closed scope badges */
+/* SECTION: Sprint, backlog, outside-sprint, and closed scope badges */
 .at-scope-badge {
     display: inline-flex;
     align-items: center;
@@ -1469,7 +1469,7 @@ html {
 
 .at-closure-task-row {
     display: grid;
-    grid-template-columns: minmax(220px, 1fr) 150px 150px 130px;
+    grid-template-columns: minmax(220px, 1fr) 140px 130px 150px 150px;
     gap: 0.75rem;
     align-items: center;
     padding: 0.7rem 0.8rem;


### PR DESCRIPTION
### Motivation

- Introduce an explicit Agile Backlog model that clearly separates work into Backlog (unassigned), Outside Sprint (assigned but not in a sprint), and Sprint buckets to align planner and execution workflows.
- Preserve backwards compatibility while adding validation and clearer disposition options for sprint planning and closure.

### Description

- Added a central bucket classifier (`ActionTaskBucketClassifier`) and backward-compatible facade so all categorisation now routes through a single source of truth for Backlog / Outside Sprint / Sprint / Closed. (Services/ActionTasks/ActionTaskCategorization.cs)
- Split create flows: `CreateDirectTask` (assigned, Outside Sprint) and `CreateBacklogItem` (unassigned backlog) with shared validation helpers and UI changes in the create modal. (Pages/ActionTasks/Index.cshtml.cs, Pages/ActionTasks/_TaskCreatePanel.cshtml)
- Require selection of a responsible person when adding a backlog item to a sprint and updated the assign handler and service to accept the responsible user and role; `AssignTaskToSprintAsync` now records the responsible person when moving a backlog item into a sprint. (Pages/ActionTasks/_PlanningPlanTab.cshtml, Pages/ActionTasks/Index.cshtml.cs, Services/ActionTasks/ActionSprintService.cs)
- Split old “Move to Backlog” into two explicit actions: `RemoveFromSprintKeepAssigned` (keeps assignee, becomes Outside Sprint) and `MoveToBacklogRemoveAssignee` (clears assignee and moves to backlog), with corresponding service mutations and audit events. (Pages/ActionTasks/_PlanningTaskCard.cshtml, Pages/ActionTasks/Index.cshtml.cs, Services/ActionTasks/ActionSprintService.cs)
- Enhanced sprint-closure disposition to support three options per unfinished task: carry forward to next sprint, remove from sprint but keep assignee (Outside Sprint), or move to backlog and remove assignee; updated UI checkboxes, validation and audit text accordingly. (Pages/ActionTasks/_SprintClosureReview.cshtml, Services/ActionTasks/ActionSprintService.cs)
- Replaced user-facing “Non-sprint” wording with “Assigned Tasks Outside Sprint” / “Outside Sprint” in partials, reports, and badge text; report builder now groups unassigned tasks as “Unassigned”. (Pages/ActionTasks/_TaskReports.cshtml, Services/ActionTasks/ActionTaskReportBuilder.cs, Pages/ActionTasks/Index.cshtml.cs)
- Minor UI/CSS adjustments to accommodate the new closure table columns and keep layout compact and CSP-safe. (wwwroot/css/action-tracker.css)
- Tests and test fixtures updated to reflect the new labels and changed behaviour around moving tasks to backlog / assignee removal. (ProjectManagement.Tests/ActionTasks/*)

### Testing

- Ran `git diff --check` to verify no whitespace/index errors (passed).
- Attempted `dotnet build` in this environment but it could not run because the `dotnet` CLI is not installed here (build not executed).
- Updated unit tests to reflect new behaviour and labels; tests were modified but not executed in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0715ddc3f88329973e8c46cd24de47)