### PR TITLE
Harden Action Tracker backlog bucket movements

### DIFF
--- a/Migrations/20261125200000_NormalizeActionTaskBacklogRows.cs
+++ b/Migrations/20261125200000_NormalizeActionTaskBacklogRows.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125200000_NormalizeActionTaskBacklogRows")]
+    public partial class NormalizeActionTaskBacklogRows : Migration
+    {
+        // SECTION: Normalize legacy unassigned open no-sprint rows into true backlog records
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (ActiveProvider.Contains("Npgsql", StringComparison.OrdinalIgnoreCase)
+                || ActiveProvider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    UPDATE "ActionTasks"
+                    SET "Status" = 'Backlog',
+                        "SubmittedOn" = NULL,
+                        "ClosedOn" = NULL
+                    WHERE "IsDeleted" = FALSE
+                      AND ("AssignedToUserId" IS NULL OR "AssignedToUserId" = '')
+                      AND "SprintId" IS NULL
+                      AND "Status" <> 'Closed';
+                    """);
+
+                // SECTION: Defensive check for invalid sprint rows retained for manual business correction
+                // Rows returned by this query have a SprintId but no assignee. Do not auto-fix them here because
+                // the correct responsible person needs a business decision before the sprint bucket can be trusted.
+                migrationBuilder.Sql(
+                    """
+                    SELECT *
+                    FROM "ActionTasks"
+                    WHERE "IsDeleted" = FALSE
+                      AND "SprintId" IS NOT NULL
+                      AND ("AssignedToUserId" IS NULL OR "AssignedToUserId" = '');
+                    """);
+            }
+            else if (ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                migrationBuilder.Sql(
+                    """
+                    UPDATE [ActionTasks]
+                    SET [Status] = N'Backlog',
+                        [SubmittedOn] = NULL,
+                        [ClosedOn] = NULL
+                    WHERE [IsDeleted] = CAST(0 AS bit)
+                      AND ([AssignedToUserId] IS NULL OR [AssignedToUserId] = N'')
+                      AND [SprintId] IS NULL
+                      AND [Status] <> N'Closed';
+                    """);
+
+                // SECTION: Defensive check for invalid sprint rows retained for manual business correction
+                // Rows returned by this query have a SprintId but no assignee. Do not auto-fix them here because
+                // the correct responsible person needs a business decision before the sprint bucket can be trusted.
+                migrationBuilder.Sql(
+                    """
+                    SELECT *
+                    FROM [ActionTasks]
+                    WHERE [IsDeleted] = CAST(0 AS bit)
+                      AND [SprintId] IS NOT NULL
+                      AND ([AssignedToUserId] IS NULL OR [AssignedToUserId] = N'');
+                    """);
+            }
+        }
+
+        // SECTION: Data normalization is forward-only and does not reintroduce invalid legacy states
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -241,11 +241,12 @@ public class IndexModel : PageModel
     public bool CanAssignTaskToSprint(ActionTaskItem task)
     {
         return _permission.CanAssignTaskToSprint(CurrentRole)
-               && string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase)
-               && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+               && IsBacklogTask(task)
                && AssignableSprints.Any();
     }
 
+    public bool IsBacklogTask(ActionTaskItem task)
+        => ActionTaskCategorization.IsBacklogTask(task);
 
     public bool CanAddOutsideSprintTaskToSprint(ActionTaskItem task)
     {

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -109,8 +109,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Backlog Queue</h2>
-                <p class="at-panel-note">Filter true backlog tasks and assign eligible work into a Sprint.</p>
-                <p class="at-panel-note">Assigned Tasks Outside Sprint are assigned work not included in a sprint commitment.</p>
+                <p class="at-panel-note">Unassigned future work awaiting sprint planning.</p>
             </div>
             <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
         </div>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -7,6 +7,10 @@
         ? Model.ResolvedPlanningView
         : null;
     var selectedSprintRouteValue = Model.IsPlanningView ? Model.SelectedSprintId : null;
+    var selectedTaskIsBacklog = Model.SelectedTask is not null && Model.IsBacklogTask(Model.SelectedTask);
+    var updateButtonText = selectedTaskIsBacklog ? "Add Planning Note" : "+ Update";
+    var updatePanelTitle = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
+    var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Add progress details or clarification notes";
 }
 
 @* SECTION: Right-side task inspector drawer content. *@
@@ -149,10 +153,10 @@
                             <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                             <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
                             <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
-                            <div class="at-action-title">Add Update</div>
+                            <div class="at-action-title">@updatePanelTitle</div>
                             <div class="mb-2">
                                 <label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label>
-                                <textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="Add progress details or clarification notes"></textarea>
+                                <textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="@updatePlaceholder"></textarea>
                             </div>
                             <div class="mb-2">
                                 <label class="form-label at-small" asp-for="UpdateInput.Files">Supporting files</label>
@@ -259,7 +263,7 @@
                 </div>
 
                 <div class="at-action-toolbar" aria-label="Task actions">
-                    <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">+ Update</button>
+                    <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">@updateButtonText</button>
                     @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
                     {
                         <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Change Status</button>

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -219,11 +219,11 @@ public class ActionSprintServiceTests
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
         await service.CloseSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
-        var task = await SeedTaskAsync(db);
+        var task = await SeedBacklogTaskAsync(db);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt));
+            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.Comdt));
         Assert.Contains("closed sprint", ex.Message.ToLowerInvariant());
     }
 
@@ -265,7 +265,7 @@ public class ActionSprintServiceTests
         var service = CreateService(db);
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+        await AssignBacklogTaskToSprintAsync(db, service, task, sprint.Id, "planner", RoleNames.HoD);
 
         // SECTION: Act
         var backlogTask = await service.MoveTaskToBacklogAsync(task.Id, "planner", RoleNames.HoD);
@@ -304,7 +304,7 @@ public class ActionSprintServiceTests
         var service = CreateService(db);
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+        await AssignBacklogTaskToSprintAsync(db, service, task, sprint.Id, "planner", RoleNames.HoD);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -322,7 +322,7 @@ public class ActionSprintServiceTests
         var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(sprint.Id, sprint.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, sprint.Id, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -340,7 +340,7 @@ public class ActionSprintServiceTests
         var target = await service.CreateSprintAsync(NewSprint("Next", 15, 30), "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.Comdt);
 
         // SECTION: Act
         await service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), "Continue next cycle", "planner", RoleNames.Comdt);
@@ -363,7 +363,7 @@ public class ActionSprintServiceTests
         var target = await service.CreateSprintAsync(NewSprint("Next", 15, 30), "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.Comdt);
         var remarks = new string('R', 2000);
 
         // SECTION: Act
@@ -387,7 +387,7 @@ public class ActionSprintServiceTests
         var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.HoD);
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.HoD);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Blocked);
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.HoD);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.HoD);
 
         // SECTION: Act
         await service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, Array.Empty<int>(), null, new[] { task.Id }, "Return to backlog", "planner", RoleNames.HoD);
@@ -410,8 +410,8 @@ public class ActionSprintServiceTests
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
         var carriedTask = await SeedTaskAsync(db, ActionTaskStatuses.Assigned);
         var undispositionedTask = await SeedTaskAsync(db, ActionTaskStatuses.Blocked);
-        await service.AssignTaskToSprintAsync(carriedTask.Id, source.Id, "planner", RoleNames.Comdt);
-        await service.AssignTaskToSprintAsync(undispositionedTask.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, carriedTask, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, undispositionedTask, source.Id, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -432,7 +432,7 @@ public class ActionSprintServiceTests
         var target = await service.CreateSprintAsync(NewSprint("Older or Same Target", targetStartOffsetDays, targetEndOffsetDays), "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -452,7 +452,7 @@ public class ActionSprintServiceTests
         await service.CloseSprintAsync(target.Id, target.RowVersion, "planner", RoleNames.Comdt);
         await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
         var task = await SeedTaskAsync(db);
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.Comdt);
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -473,7 +473,7 @@ public class ActionSprintServiceTests
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Submitted);
         task.SubmittedOn = DateTime.UtcNow;
         await db.SaveChangesAsync();
-        await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+        await AssignBacklogTaskToSprintAsync(db, service, task, sprint.Id, "planner", RoleNames.HoD);
         task.Status = ActionTaskStatuses.Submitted;
         task.SubmittedOn = DateTime.UtcNow;
         await db.SaveChangesAsync();
@@ -529,6 +529,123 @@ public class ActionSprintServiceTests
         Assert.Equal(ActionTaskStatuses.InProgress, sprintTask.Status);
     }
 
+
+
+    [Fact]
+    public async Task AssignExistingAssignedTaskToSprintAsync_SubmittedOutsideSprintTask_RetainsStatusAndSubmittedOn()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var submittedOn = DateTime.UtcNow.AddHours(-2);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Submitted);
+        task.SubmittedOn = submittedOn;
+        await db.SaveChangesAsync();
+
+        // SECTION: Act
+        var sprintTask = await service.AssignExistingAssignedTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        Assert.Equal(sprint.Id, sprintTask.SprintId);
+        Assert.Equal("assignee", sprintTask.AssignedToUserId);
+        Assert.Equal(RoleNames.Ta, sprintTask.AssignedToRole);
+        Assert.Equal(ActionTaskStatuses.Submitted, sprintTask.Status);
+        Assert.Equal(submittedOn, sprintTask.SubmittedOn);
+    }
+
+    [Fact]
+    public async Task AssignTaskToSprintAsync_OutsideSprintTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
+        Assert.Equal("Only backlog items can be assigned to sprint through this action.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AssignTaskToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.HoD);
+        var target = await service.CreateSprintAsync(NewSprint("Target", 15, 30), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignTaskToSprintAsync(task.Id, target.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
+        Assert.Equal("Only backlog items can be assigned to sprint through this action.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AssignExistingAssignedTaskToSprintAsync_BacklogTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.HoD);
+        var task = await SeedBacklogTaskAsync(db);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignExistingAssignedTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD));
+        Assert.Equal("Only assigned tasks outside sprint can be added to sprint through this action.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AssignExistingAssignedTaskToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.HoD);
+        var target = await service.CreateSprintAsync(NewSprint("Target", 15, 30), "planner", RoleNames.HoD);
+        var task = await SeedTaskAsync(db);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.HoD);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AssignExistingAssignedTaskToSprintAsync(task.Id, target.Id, "planner", RoleNames.HoD));
+        Assert.Equal("Only assigned tasks outside sprint can be added to sprint through this action.", ex.Message);
+    }
+
+    [Fact]
+    public async Task RemoveTaskFromSprintKeepAssignedAsync_OutsideSprintTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.RemoveTaskFromSprintKeepAssignedAsync(task.Id, "planner", RoleNames.HoD));
+        Assert.Equal("Only sprint tasks can be removed from sprint.", ex.Message);
+    }
+
+    [Fact]
+    public async Task MoveTaskToBacklogRemoveAssigneeAsync_AlreadyBacklogTask_RejectsRequest()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedBacklogTaskAsync(db);
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.MoveTaskToBacklogRemoveAssigneeAsync(task.Id, "planner", RoleNames.HoD));
+        Assert.Equal("Task is already in backlog.", ex.Message);
+    }
+
     [Fact]
     public async Task CloseSprintWithDispositionAsync_BacklogDisposition_ResetsTaskToBacklogStatus()
     {
@@ -540,7 +657,7 @@ public class ActionSprintServiceTests
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Submitted);
         task.SubmittedOn = DateTime.UtcNow;
         await db.SaveChangesAsync();
-        await service.AssignTaskToSprintAsync(task.Id, source.Id, "planner", RoleNames.Comdt);
+        await AssignBacklogTaskToSprintAsync(db, service, task, source.Id, "planner", RoleNames.Comdt);
         task.Status = ActionTaskStatuses.Submitted;
         task.SubmittedOn = DateTime.UtcNow;
         await db.SaveChangesAsync();
@@ -597,6 +714,29 @@ public class ActionSprintServiceTests
             StartDate = DateTime.UtcNow.Date.AddDays(startOffsetDays),
             EndDate = DateTime.UtcNow.Date.AddDays(endOffsetDays)
         };
+
+    private static async Task<ActionTaskItem> AssignBacklogTaskToSprintAsync(ApplicationDbContext db, ActionSprintService service, ActionTaskItem task, int sprintId, string userId, string role)
+    {
+        // SECTION: Prepare true backlog source state before exercising Backlog -> Sprint movement.
+        task.SprintId = null;
+        task.AssignedToUserId = string.Empty;
+        task.AssignedToRole = string.Empty;
+        task.Status = ActionTaskStatuses.Backlog;
+        task.SubmittedOn = null;
+        task.ClosedOn = null;
+        await db.SaveChangesAsync();
+
+        return await service.AssignTaskToSprintAsync(task.Id, sprintId, "assignee", RoleNames.Ta, userId, role);
+    }
+
+    private static async Task<ActionTaskItem> SeedBacklogTaskAsync(ApplicationDbContext db)
+    {
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Backlog);
+        task.AssignedToUserId = string.Empty;
+        task.AssignedToRole = string.Empty;
+        await db.SaveChangesAsync();
+        return task;
+    }
 
     private static async Task<ActionTaskItem> SeedTaskAsync(ApplicationDbContext db, string status = ActionTaskStatuses.Assigned)
     {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -226,6 +226,54 @@ public class ActionTaskPageTests
         Assert.Contains("PlanningView=Kanban", html, StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public async Task TaskDetailsPartial_BacklogInspector_UsesPlanningNoteLabels()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.Status = ActionTaskStatuses.Backlog;
+        task.AssignedToUserId = string.Empty;
+        task.AssignedToRole = string.Empty;
+        task.SprintId = null;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Add Planning Note", html, StringComparison.Ordinal);
+        Assert.Contains("placeholder=\"Add planning note or clarification\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(">+ Update</button>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<div class=\"at-action-title\">Add Update</div>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlanningPlanTab_BacklogQueueHeader_DoesNotMentionOutsideSprint()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Plan";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningPlanTab.cshtml");
+        var headerStart = html.IndexOf("<h2>Backlog Queue</h2>", StringComparison.Ordinal);
+        var headerEnd = html.IndexOf("<div class=\"at-planning-backlog-body\">", StringComparison.Ordinal);
+        var backlogHeader = html[headerStart..headerEnd];
+
+        // SECTION: Assert
+        Assert.Contains("Unassigned future work awaiting sprint planning.", backlogHeader, StringComparison.Ordinal);
+        Assert.DoesNotContain("Outside Sprint", backlogHeader, StringComparison.Ordinal);
+        Assert.DoesNotContain("Assigned Tasks Outside Sprint", backlogHeader, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task PlanningDueExceptionsTaskCards_PreserveViewsRouteState()
     {
@@ -385,7 +433,7 @@ public class ActionTaskPageTests
         var sprint = AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
         await setup.Db.SaveChangesAsync();
         setup.Db.ActionTasks.Add(NewTask("Sprint task", ActionTaskStatuses.Assigned, sprint.Id));
-        var trueBacklog = NewTask("True backlog", ActionTaskStatuses.Assigned);
+        var trueBacklog = NewTask("True backlog", ActionTaskStatuses.Backlog);
         trueBacklog.AssignedToUserId = string.Empty;
         setup.Db.ActionTasks.Add(trueBacklog);
         setup.Db.ActionTasks.Add(NewTask("Closed backlog", ActionTaskStatuses.Closed));
@@ -413,7 +461,7 @@ public class ActionTaskPageTests
         var setup = await CreateSetupAsync();
         var sprint = AddSprint(setup.Db, "Badge Sprint", ActionSprintStatus.Active);
         var sprintTask = NewTask("Sprint scoped", ActionTaskStatuses.Assigned, sprint.Id);
-        var backlogTask = NewTask("Backlog scoped", ActionTaskStatuses.Assigned);
+        var backlogTask = NewTask("Backlog scoped", ActionTaskStatuses.Backlog);
         backlogTask.AssignedToUserId = string.Empty;
         var nonSprintTask = NewTask("Non sprint scoped", ActionTaskStatuses.Assigned);
         var closedTask = NewTask("Closed scoped", ActionTaskStatuses.Closed);

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -21,7 +21,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(2, activeSprint.Id, ActionTaskStatuses.InProgress, today.AddDays(1)),
             NewTask(3, activeSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(-2)),
             NewTask(4, activeSprint.Id, ActionTaskStatuses.Submitted, today.AddDays(2)),
-            NewTask(5, null, ActionTaskStatuses.Assigned, today.AddDays(3), assignedToUserId: string.Empty),
+            NewTask(5, null, ActionTaskStatuses.Backlog, today.AddDays(3), assignedToUserId: string.Empty),
             NewTask(6, null, ActionTaskStatuses.Closed, today.AddDays(4)),
             NewTask(7, null, ActionTaskStatuses.Assigned, today.AddDays(5))
         };
@@ -64,7 +64,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(11, sprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "assignee", today.AddDays(-9)),
             NewTask(12, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(4), "Normal", "assignee", today.AddDays(-1)),
             NewTask(13, otherSprint.Id, ActionTaskStatuses.Blocked, today.AddDays(2), "High", "other", today.AddDays(-16)),
-            NewTask(14, null, ActionTaskStatuses.Assigned, today.AddDays(2), "High", string.Empty, today.AddDays(-5)),
+            NewTask(14, null, ActionTaskStatuses.Backlog, today.AddDays(2), "High", string.Empty, today.AddDays(-5)),
             NewTask(15, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-3))
         };
         var service = CreateQueryService();
@@ -94,7 +94,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         var sprint = new ActionSprint { Id = 31, Name = "Sprint Scope", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
         var tasks = new[]
         {
-            NewTask(21, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", string.Empty, today.AddDays(-5)),
+            NewTask(21, null, ActionTaskStatuses.Backlog, today.AddDays(2), "Normal", string.Empty, today.AddDays(-5)),
             NewTask(22, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-12)),
             NewTask(23, null, ActionTaskStatuses.Closed, today.AddDays(2), "Normal", "assignee", today.AddDays(-20)),
             NewTask(24, null, ActionTaskStatuses.Assigned, today.AddDays(2), "Normal", "assignee", today.AddDays(-20))

--- a/ProjectManagement.Tests/ApplicationDatabaseMigrationsTests.cs
+++ b/ProjectManagement.Tests/ApplicationDatabaseMigrationsTests.cs
@@ -1,13 +1,77 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Configuration;
 using ProjectManagement.Data;
+using ProjectManagement.Models;
 using Xunit;
 
 namespace ProjectManagement.Tests;
 
 public sealed class ApplicationDatabaseMigrationsTests
 {
+
+
+    [Fact]
+    public async Task NormalizeActionTaskBacklogRowsMigration_UnassignedOpenNoSprintTasksBecomeBacklog()
+    {
+        // SECTION: Arrange
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using (var context = new ApplicationDbContext(options))
+        {
+            var migrator = context.Database.GetService<IMigrator>();
+            await migrator.MigrateAsync("20261125190000_AddActionSprintAuditAndConcurrency");
+        }
+
+        await using (var context = new ApplicationDbContext(options))
+        {
+            context.ActionTasks.Add(new ActionTaskItem
+            {
+                Title = "Legacy backlog-style task",
+                Description = "Old unassigned no-sprint row",
+                CreatedByUserId = "creator",
+                AssignedToUserId = string.Empty,
+                CreatedByRole = RoleNames.HoD,
+                AssignedToRole = string.Empty,
+                AssignedOn = DateTime.UtcNow,
+                DueDate = DateTime.UtcNow.Date.AddDays(2),
+                Priority = "Normal",
+                Status = ActionTaskStatuses.Assigned,
+                SubmittedOn = DateTime.UtcNow,
+                ClosedOn = DateTime.UtcNow,
+                SprintId = null,
+                RowVersion = Array.Empty<byte>()
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // SECTION: Act
+        await using (var context = new ApplicationDbContext(options))
+        {
+            await context.Database.MigrateAsync();
+        }
+
+        // SECTION: Assert
+        await using (var context = new ApplicationDbContext(options))
+        {
+            var normalizedTask = await context.ActionTasks.SingleAsync(t => t.Title == "Legacy backlog-style task");
+            Assert.Equal(ActionTaskStatuses.Backlog, normalizedTask.Status);
+            Assert.Null(normalizedTask.SubmittedOn);
+            Assert.Null(normalizedTask.ClosedOn);
+            Assert.Null(normalizedTask.SprintId);
+            Assert.True(string.IsNullOrWhiteSpace(normalizedTask.AssignedToUserId));
+        }
+    }
+
     [Fact]
     public async Task ApplyingMigrations_LeavesNoPendingMigrations()
     {

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -287,6 +287,11 @@ public class ActionSprintService
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
         EnsureTaskIsNotClosed(task, "Closed tasks cannot be assigned to a sprint.");
+        if (!ActionTaskCategorization.IsBacklogTask(task))
+        {
+            throw new InvalidOperationException("Only backlog items can be assigned to sprint through this action.");
+        }
+
         if (string.IsNullOrWhiteSpace(responsibleUserId) || string.IsNullOrWhiteSpace(responsibleRole))
         {
             throw new InvalidOperationException("Select a responsible person before adding a backlog item to a sprint.");
@@ -317,6 +322,11 @@ public class ActionSprintService
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
         EnsureTaskIsNotClosed(task, "Closed tasks cannot be assigned to a sprint.");
+        if (!ActionTaskCategorization.IsOutsideSprintTask(task))
+        {
+            throw new InvalidOperationException("Only assigned tasks outside sprint can be added to sprint through this action.");
+        }
+
         if (string.IsNullOrWhiteSpace(task.AssignedToUserId) || string.IsNullOrWhiteSpace(task.AssignedToRole))
         {
             throw new InvalidOperationException("Outside Sprint tasks must have a responsible person before adding to a sprint.");
@@ -341,6 +351,11 @@ public class ActionSprintService
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
         EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between sprint buckets.");
+        if (!ActionTaskCategorization.IsSprintTask(task))
+        {
+            throw new InvalidOperationException("Only sprint tasks can be removed from sprint.");
+        }
+
         await EnsureCurrentSprintCanChangeAsync(task, cancellationToken);
 
         var oldValue = DescribeTaskBucket(task);
@@ -361,6 +376,11 @@ public class ActionSprintService
 
         var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
         EnsureTaskIsNotClosed(task, "Closed tasks cannot be moved between sprint buckets.");
+        if (ActionTaskCategorization.IsBacklogTask(task))
+        {
+            throw new InvalidOperationException("Task is already in backlog.");
+        }
+
         await EnsureCurrentSprintCanChangeAsync(task, cancellationToken);
 
         var oldValue = DescribeTaskBucket(task);

--- a/Services/ActionTasks/ActionTaskCategorization.cs
+++ b/Services/ActionTasks/ActionTaskCategorization.cs
@@ -41,13 +41,15 @@ public static class ActionTaskBucketClassifier
     }
 
     public static bool IsSprintTask(ActionTaskItem task)
-        => task.SprintId.HasValue && IsOpenTask(task);
+        => task.SprintId.HasValue && HasAssignedUser(task) && IsSprintStatus(task.Status);
 
     public static bool IsBacklogTask(ActionTaskItem task)
-        => task.SprintId is null && !HasAssignedUser(task) && IsOpenTask(task);
+        => task.SprintId is null
+           && !HasAssignedUser(task)
+           && string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase);
 
     public static bool IsOutsideSprintTask(ActionTaskItem task)
-        => task.SprintId is null && HasAssignedUser(task) && IsOpenTask(task);
+        => task.SprintId is null && HasAssignedUser(task) && IsAssignedWorkStatus(task.Status);
 
     public static bool IsAssignedNonSprintTask(ActionTaskItem task)
         => IsOutsideSprintTask(task);
@@ -60,6 +62,17 @@ public static class ActionTaskBucketClassifier
 
     public static bool HasAssignedUser(ActionTaskItem task)
         => !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+
+    // SECTION: Official Agile Backlog execution statuses for assigned work buckets.
+    private static bool IsSprintStatus(string status)
+        => IsAssignedWorkStatus(status)
+           || string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAssignedWorkStatus(string status)
+        => string.Equals(status, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
 }
 
 public static class ActionTaskCategorization


### PR DESCRIPTION
### Motivation
- Ensure Action Tracker service operations only move tasks when the task is in the correct source bucket to prevent silent or incorrect bucket conversions.
- Normalize legacy data that looks like backlog (unassigned, no sprint) but is stored with non-backlog timestamps so UI and reports show correct buckets.
- Remove ambiguous Backlog header copy and make the inspector update wording explicit for backlog items to improve UX clarity.

### Description
- Add strict source-bucket checks in `ActionSprintService` so `AssignTaskToSprintAsync` requires `IsBacklogTask`, `AssignExistingAssignedTaskToSprintAsync` requires `IsOutsideSprintTask`, `RemoveTaskFromSprintKeepAssignedAsync` requires `IsSprintTask`, and `MoveTaskToBacklogRemoveAssigneeAsync` rejects already-backlog tasks while preserving the existing reset behaviour. (Files: `Services/ActionTasks/ActionSprintService.cs`)
- Tighten the canonical bucket classifier so backlog/outside-sprint/sprint categories reflect the official model (require explicit backlog status for backlog tasks and require assignee + appropriate statuses for sprint/outside-sprint). (Files: `Services/ActionTasks/ActionTaskCategorization.cs`)
- Add a forward-only EF migration to normalize legacy unassigned open no-sprint rows to `Backlog` and emit a defensive SELECT to surface sprint rows that lack an assignee for manual review. (Files: `Migrations/20261125200000_NormalizeActionTaskBacklogRows.cs`)
- Expose a page helper `IsBacklogTask` and use it in the planning view to avoid status-only checks, update Backlog Queue header copy to: "Unassigned future work awaiting sprint planning.", and change backlog inspector UI strings to show "Add Planning Note" / "Add planning note or clarification" for true backlog items while keeping backend update behaviour unchanged. (Files: `Pages/ActionTasks/Index.cshtml.cs`, `Pages/ActionTasks/_PlanningPlanTab.cshtml`, `Pages/ActionTasks/_TaskDetails.cshtml`)
- Add and update unit tests to cover the hardened behaviours and migration normalization (tests added/updated under `ProjectManagement.Tests/ActionTasks/*` and `ProjectManagement.Tests/ApplicationDatabaseMigrationsTests.cs`).

### Testing
- Ran `git diff --check` to ensure no whitespace or trivial diff problems; check passed.
- Attempted to run the focused test filter `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActionTasks|FullyQualifiedName~ApplicationDatabaseMigrationsTests"` but the command could not be executed in this environment because `dotnet` is not installed, so test execution could not be completed here.
- Unit tests were added to cover the new guard conditions and migration behaviour (see `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs`, `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`, and `ProjectManagement.Tests/ApplicationDatabaseMigrationsTests.cs`) and should be executed in CI or a developer machine with the .NET SDK to validate success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07295a652c83298a02ad08174343d0)