### PR TITLE
Action Tracker: simplify UI, separate create flows, and harden backlog/sprint invariants

### DIFF
--- a/Migrations/20261125200000_NormalizeActionTaskBacklogRows.cs
+++ b/Migrations/20261125200000_NormalizeActionTaskBacklogRows.cs
@@ -11,7 +11,7 @@ namespace ProjectManagement.Migrations
     [Migration("20261125200000_NormalizeActionTaskBacklogRows")]
     public partial class NormalizeActionTaskBacklogRows : Migration
     {
-        // SECTION: Normalize legacy unassigned open no-sprint rows into true backlog records
+        // SECTION: Normalize legacy unassigned open no-sprint rows into backlog item records
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             if (ActiveProvider.Contains("Npgsql", StringComparison.OrdinalIgnoreCase)
@@ -21,6 +21,7 @@ namespace ProjectManagement.Migrations
                     """
                     UPDATE "ActionTasks"
                     SET "Status" = 'Backlog',
+                        "AssignedToRole" = '',
                         "SubmittedOn" = NULL,
                         "ClosedOn" = NULL
                     WHERE "IsDeleted" = FALSE
@@ -29,16 +30,19 @@ namespace ProjectManagement.Migrations
                       AND "Status" <> 'Closed';
                     """);
 
-                // SECTION: Defensive check for invalid sprint rows retained for manual business correction
-                // Rows returned by this query have a SprintId but no assignee. Do not auto-fix them here because
-                // the correct responsible person needs a business decision before the sprint bucket can be trusted.
+                // SECTION: Invalid sprint rows with no assignee cannot remain normal sprint work; return them to Backlog explicitly.
                 migrationBuilder.Sql(
                     """
-                    SELECT *
-                    FROM "ActionTasks"
+                    UPDATE "ActionTasks"
+                    SET "Status" = 'Backlog',
+                        "SprintId" = NULL,
+                        "AssignedToRole" = '',
+                        "SubmittedOn" = NULL,
+                        "ClosedOn" = NULL
                     WHERE "IsDeleted" = FALSE
                       AND "SprintId" IS NOT NULL
-                      AND ("AssignedToUserId" IS NULL OR "AssignedToUserId" = '');
+                      AND ("AssignedToUserId" IS NULL OR "AssignedToUserId" = '')
+                      AND "Status" <> 'Closed';
                     """);
             }
             else if (ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
@@ -47,6 +51,7 @@ namespace ProjectManagement.Migrations
                     """
                     UPDATE [ActionTasks]
                     SET [Status] = N'Backlog',
+                        [AssignedToRole] = N'',
                         [SubmittedOn] = NULL,
                         [ClosedOn] = NULL
                     WHERE [IsDeleted] = CAST(0 AS bit)
@@ -55,16 +60,19 @@ namespace ProjectManagement.Migrations
                       AND [Status] <> N'Closed';
                     """);
 
-                // SECTION: Defensive check for invalid sprint rows retained for manual business correction
-                // Rows returned by this query have a SprintId but no assignee. Do not auto-fix them here because
-                // the correct responsible person needs a business decision before the sprint bucket can be trusted.
+                // SECTION: Invalid sprint rows with no assignee cannot remain normal sprint work; return them to Backlog explicitly.
                 migrationBuilder.Sql(
                     """
-                    SELECT *
-                    FROM [ActionTasks]
+                    UPDATE [ActionTasks]
+                    SET [Status] = N'Backlog',
+                        [SprintId] = NULL,
+                        [AssignedToRole] = N'',
+                        [SubmittedOn] = NULL,
+                        [ClosedOn] = NULL
                     WHERE [IsDeleted] = CAST(0 AS bit)
                       AND [SprintId] IS NOT NULL
-                      AND ([AssignedToUserId] IS NULL OR [AssignedToUserId] = N'');
+                      AND ([AssignedToUserId] IS NULL OR [AssignedToUserId] = N'')
+                      AND [Status] <> N'Closed';
                     """);
             }
         }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -52,7 +52,8 @@ public class IndexModel : PageModel
         _userLookup = userLookup;
         _clock = clock;
         _users = users;
-        Input.DueDate = _clock.UtcToday.AddDays(7);
+        DirectTaskInput.DueDate = _clock.UtcToday.AddDays(7);
+        BacklogItemInput.TargetDate = _clock.UtcToday.AddDays(7);
         SprintInput = CreateSprintInput.FromSprint(_clock.UtcToday);
     }
 
@@ -168,7 +169,10 @@ public class IndexModel : PageModel
     public ActionTaskItem? SelectedTask { get; private set; }
 
     [BindProperty]
-    public CreateTaskInput Input { get; set; } = new();
+    public CreateDirectTaskInput DirectTaskInput { get; set; } = new();
+
+    [BindProperty]
+    public CreateBacklogItemInput BacklogItemInput { get; set; } = new();
     [BindProperty]
     public AddTaskUpdateInput UpdateInput { get; set; } = new();
 
@@ -418,14 +422,14 @@ public class IndexModel : PageModel
             return Forbid();
         }
 
-        if (!ValidateCreateTaskCore(requireAssignee: true))
+        if (!ValidateCreateDirectTaskInput())
         {
             ShowCreateModal = true;
             await LoadDataAsync();
             return Page();
         }
 
-        var assignedRole = await ResolveAssignableRoleForInputAsync(Input.AssignedToUserId);
+        var assignedRole = await ResolveAssignableRoleForInputAsync(DirectTaskInput.AssignedToUserId);
         if (assignedRole is null)
         {
             ShowCreateModal = true;
@@ -435,14 +439,14 @@ public class IndexModel : PageModel
 
         await _service.CreateTaskAsync(new ActionTaskItem
         {
-            Title = Input.Title.Trim(),
-            Description = Input.Description.Trim(),
+            Title = DirectTaskInput.Title.Trim(),
+            Description = DirectTaskInput.Description.Trim(),
             CreatedByUserId = CurrentUserId,
-            AssignedToUserId = Input.AssignedToUserId,
+            AssignedToUserId = DirectTaskInput.AssignedToUserId,
             CreatedByRole = CurrentRole,
             AssignedToRole = assignedRole,
-            DueDate = Input.DueDate,
-            Priority = Input.Priority
+            DueDate = DirectTaskInput.DueDate,
+            Priority = DirectTaskInput.Priority
         });
 
         TempData["ToastMessage"] = "Direct task created outside sprint.";
@@ -459,7 +463,7 @@ public class IndexModel : PageModel
             return Forbid();
         }
 
-        if (!ValidateCreateTaskCore(requireAssignee: false))
+        if (!ValidateCreateBacklogItemInput())
         {
             ShowCreateModal = true;
             await LoadDataAsync();
@@ -468,34 +472,47 @@ public class IndexModel : PageModel
 
         await _service.CreateBacklogItemAsync(new ActionTaskItem
         {
-            Title = Input.Title.Trim(),
-            Description = Input.Description.Trim(),
+            Title = BacklogItemInput.Title.Trim(),
+            Description = BacklogItemInput.Description.Trim(),
             CreatedByUserId = CurrentUserId,
             AssignedToUserId = string.Empty,
             CreatedByRole = CurrentRole,
             AssignedToRole = string.Empty,
-            DueDate = Input.DueDate,
-            Priority = Input.Priority
+            DueDate = BacklogItemInput.TargetDate,
+            Priority = BacklogItemInput.Priority
         });
 
         TempData["ToastMessage"] = "Backlog item created.";
         return RedirectToPage("/ActionTasks/Index", BuildTaskWorkspaceRouteValues(TaskId, SelectedSprintId));
     }
 
-    // SECTION: Create-task validation helpers keep backlog and direct-task flows aligned without requiring inline scripts.
-    private bool ValidateCreateTaskCore(bool requireAssignee)
+    // SECTION: Create-task validation helpers keep backlog and direct-task flows isolated without duplicate form fields.
+    private bool ValidateCreateDirectTaskInput()
     {
         ModelState.Clear();
-        TryValidateModel(Input, nameof(Input));
+        TryValidateModel(DirectTaskInput, nameof(DirectTaskInput));
 
-        if (requireAssignee && string.IsNullOrWhiteSpace(Input.AssignedToUserId))
+        if (string.IsNullOrWhiteSpace(DirectTaskInput.AssignedToUserId))
         {
-            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Select a responsible person for a direct task.");
+            ModelState.AddModelError(nameof(DirectTaskInput.AssignedToUserId), "Select a responsible person for a direct task.");
         }
 
-        if (Input.DueDate.Date < _clock.UtcToday)
+        if (DirectTaskInput.DueDate.Date < _clock.UtcToday)
         {
-            ModelState.AddModelError(nameof(Input.DueDate), "Due date cannot be in the past.");
+            ModelState.AddModelError(nameof(DirectTaskInput.DueDate), "Due date cannot be in the past.");
+        }
+
+        return ModelState.IsValid;
+    }
+
+    private bool ValidateCreateBacklogItemInput()
+    {
+        ModelState.Clear();
+        TryValidateModel(BacklogItemInput, nameof(BacklogItemInput));
+
+        if (BacklogItemInput.TargetDate.Date < _clock.UtcToday)
+        {
+            ModelState.AddModelError(nameof(BacklogItemInput.TargetDate), "Target date cannot be in the past.");
         }
 
         return ModelState.IsValid;
@@ -506,7 +523,7 @@ public class IndexModel : PageModel
         var assignedRole = await ResolveAssignableRoleForUserAsync(assignedToUserId);
         if (assignedRole is null)
         {
-            ModelState.AddModelError(nameof(Input.AssignedToUserId), "Selected user cannot be assigned this task.");
+            ModelState.AddModelError(nameof(DirectTaskInput.AssignedToUserId), "Selected user cannot be assigned this task.");
         }
 
         return assignedRole;
@@ -710,7 +727,7 @@ public class IndexModel : PageModel
         try
         {
             await _service.SubmitTaskAsync(id, DecodeRowVersion(rowVersion), CurrentUserId, CurrentRole, remarks);
-            TempData["ToastMessage"] = "Task submitted.";
+            TempData["ToastMessage"] = "Task submitted for closure.";
         }
         catch (ActionTaskConcurrencyException ex)
         {
@@ -803,7 +820,7 @@ public class IndexModel : PageModel
                 return RedirectToTaskPage(id, SelectedSprintId);
             }
 
-            await _sprintService.AssignTaskToSprintAsync(id, sprintId, responsibleUserId, responsibleRole, CurrentUserId, CurrentRole);
+            await _sprintService.AssignBacklogItemToSprintAsync(id, sprintId, responsibleUserId, responsibleRole, CurrentUserId, CurrentRole);
             TempData["ToastMessage"] = "Backlog item added to sprint with a responsible person.";
         }
         catch (InvalidOperationException ex)
@@ -821,7 +838,7 @@ public class IndexModel : PageModel
 
         try
         {
-            await _sprintService.AssignExistingAssignedTaskToSprintAsync(id, sprintId, CurrentUserId, CurrentRole);
+            await _sprintService.AssignOutsideSprintTaskToSprintAsync(id, sprintId, CurrentUserId, CurrentRole);
             TempData["ToastMessage"] = "Outside Sprint task added to sprint.";
         }
         catch (InvalidOperationException ex)
@@ -1426,7 +1443,7 @@ public class IndexModel : PageModel
         Array.Empty<ActionTaskItem>(),
         Array.Empty<ActionTaskItem>());
 
-    public sealed class CreateTaskInput
+    public sealed class CreateDirectTaskInput
     {
         [Display(Name = "Task Title")]
         [Required, StringLength(200)]
@@ -1436,11 +1453,30 @@ public class IndexModel : PageModel
         [Required, StringLength(4000)]
         public string Description { get; set; } = string.Empty;
 
+        [Display(Name = "Responsible Person")]
         public string AssignedToUserId { get; set; } = string.Empty;
 
         [Display(Name = "Due Date")]
         [Required]
         public DateTime DueDate { get; set; }
+
+        [Required, StringLength(24)]
+        public string Priority { get; set; } = "Normal";
+    }
+
+    public sealed class CreateBacklogItemInput
+    {
+        [Display(Name = "Backlog Item Title")]
+        [Required, StringLength(200)]
+        public string Title { get; set; } = string.Empty;
+
+        [Display(Name = "Description / Planning Notes")]
+        [Required, StringLength(4000)]
+        public string Description { get; set; } = string.Empty;
+
+        [Display(Name = "Target Date")]
+        [Required]
+        public DateTime TargetDate { get; set; }
 
         [Required, StringLength(24)]
         public string Priority { get; set; } = "Normal";

--- a/Pages/ActionTasks/_PlanningCommandStrip.cshtml
+++ b/Pages/ActionTasks/_PlanningCommandStrip.cshtml
@@ -4,7 +4,7 @@
 <section class="at-panel at-sprint-command-strip at-planning-command-strip">
     @if (Model.SelectedSprint is null)
     {
-        @* SECTION: First-sprint empty command line preserves the existing create action. *@
+        @* SECTION: Empty command line points users back to the Plan tab where sprint creation lives. *@
         <div class="at-sprint-empty-command at-planning-empty-command">
             <div class="at-empty-state at-empty-state-compact">
                 @if (!Model.Sprints.Any())
@@ -18,28 +18,6 @@
                     <span>Select an existing sprint from Plan to open Execute.</span>
                 }
             </div>
-            @if (Model.CanPlanSprints)
-            {
-                <div class="at-sprint-action-row at-sprint-action-row-strip">
-                    <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
-                        <summary class="btn btn-primary btn-sm">Create Sprint</summary>
-                        <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
-                            <input type="hidden" name="ViewMode" value="Planning" />
-                            <input type="hidden" name="PlanningTab" value="Plan" />
-                            <div asp-validation-summary="All" class="text-danger small"></div>
-                            <label class="form-label" asp-for="SprintInput.Name"></label>
-                            <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
-                            <label class="form-label" asp-for="SprintInput.StartDate"></label>
-                            <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
-                            <label class="form-label" asp-for="SprintInput.EndDate"></label>
-                            <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
-                            <label class="form-label" asp-for="SprintInput.Goal"></label>
-                            <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this sprint"></textarea>
-                            <button type="submit" class="btn btn-primary btn-sm">Create Sprint</button>
-                        </form>
-                    </details>
-                </div>
-            }
         </div>
     }
     else
@@ -64,30 +42,10 @@
             </div>
         </div>
 
-        @if (Model.CanPlanSprints || Model.CanEditSelectedSprint)
+        @if (Model.CanEditSelectedSprint || Model.CanActivateSelectedSprint || Model.CanCloseSelectedSprintDirectly || (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any()))
         {
             @* SECTION: Lifecycle and edit actions continue to post to existing handlers. *@
             <div class="at-sprint-action-row at-sprint-action-row-strip at-planning-command-actions">
-                @if (Model.CanPlanSprints)
-                {
-                    <details class="at-sprint-form-disclosure" open="@Model.ShowCreateSprintPanel">
-                        <summary class="btn btn-primary btn-sm">Create Sprint</summary>
-                        <form method="post" asp-page-handler="CreateSprint" class="at-sprint-command-form">
-                            <input type="hidden" name="ViewMode" value="Planning" />
-                            <input type="hidden" name="PlanningTab" value="Plan" />
-                            <div asp-validation-summary="All" class="text-danger small"></div>
-                            <label class="form-label" asp-for="SprintInput.Name"></label>
-                            <input class="form-control" asp-for="SprintInput.Name" maxlength="160" />
-                            <label class="form-label" asp-for="SprintInput.StartDate"></label>
-                            <input class="form-control" asp-for="SprintInput.StartDate" type="date" />
-                            <label class="form-label" asp-for="SprintInput.EndDate"></label>
-                            <input class="form-control" asp-for="SprintInput.EndDate" type="date" />
-                            <label class="form-label" asp-for="SprintInput.Goal"></label>
-                            <textarea class="form-control" asp-for="SprintInput.Goal" rows="3" maxlength="2000" placeholder="Command focus for this sprint"></textarea>
-                            <button type="submit" class="btn btn-primary btn-sm">Create Sprint</button>
-                        </form>
-                    </details>
-                }
                 @if (Model.CanEditSelectedSprint)
                 {
                     <details class="at-sprint-form-disclosure" open="@Model.ShowEditSprintPanel">

--- a/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml
+++ b/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml
@@ -1,7 +1,7 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
 @{
-    // SECTION: Full Views tab due/exception view renders directly without the nested Sprint Board disclosure.
+    // SECTION: Execute secondary due/exception view renders directly without the nested Sprint Board disclosure.
     var dueExceptionCount = Model.DueTodayTaskDisplays.Count
         + Model.DueThisWeekTaskDisplays.Count
         + Model.DueLaterTaskDisplays.Count

--- a/Pages/ActionTasks/_PlanningExecuteTab.cshtml
+++ b/Pages/ActionTasks/_PlanningExecuteTab.cshtml
@@ -84,6 +84,20 @@
             </div>
         </details>
 
+
+
+        @* SECTION: Due / Exceptions and Kanban are secondary Execute views, collapsed to keep the main board primary. *@
+        <details class="at-panel at-execute-secondary-views">
+            <summary>Due / Exceptions and Kanban</summary>
+            <div class="at-execute-secondary-view-stack mt-3">
+                <partial name="_PlanningDueExceptionsView" model="Model" />
+                <details class="at-execute-kanban-view mt-3">
+                    <summary>Kanban</summary>
+                    <partial name="_TaskKanban" model="Model" />
+                </details>
+            </div>
+        </details>
+
         <section class="at-sprint-board-stack at-execute-status-board" aria-label="Selected Sprint Board task board">
             <div class="at-execute-status-grid">
                 @foreach (var status in activeStatuses)

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -115,7 +115,7 @@
         </div>
         <div class="at-planning-backlog-body">
             <div class="at-backlog-summary-grid" aria-label="Backlog summary">
-                <article><strong>@Model.BacklogTotalCount</strong><span>True backlog</span></article>
+                <article><strong>@Model.BacklogTotalCount</strong><span>Backlog items</span></article>
                 <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
                 <article><strong>@Model.BacklogOverdueCount</strong><span>Overdue</span></article>
             </div>
@@ -124,28 +124,12 @@
             <details class="at-planning-backlog-filter-shell" open="@hasBacklogFilters">
                 <summary>
                     <span>Filter Backlog</span>
-                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All true backlog")</span>
+                    <span class="at-filter-state">@(hasBacklogFilters ? "Custom backlog view" : "All backlog items")</span>
                 </summary>
                 <form method="get" class="at-planning-backlog-filter">
                     <input type="hidden" name="viewMode" value="Planning" />
                     <input type="hidden" name="PlanningTab" value="Plan" />
                     <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                    <label class="form-label at-small" for="PlanningFilterStatus">Status</label>
-                    <select class="form-select form-select-sm" id="PlanningFilterStatus" name="FilterStatus">
-                        <option value="">All open statuses</option>
-                        @foreach (var status in Model.AllowedStatusOptions)
-                        {
-                            if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
-                            {
-                                <option value="@status" selected>@status</option>
-                            }
-                            else
-                            {
-                                <option value="@status">@status</option>
-                            }
-                        }
-                    </select>
-
                     <label class="form-label at-small" for="PlanningFilterPriority">Priority</label>
                     <select class="form-select form-select-sm" id="PlanningFilterPriority" name="FilterPriority">
                         <option value="">All priorities</option>
@@ -161,6 +145,9 @@
                             }
                         }
                     </select>
+
+                    <label class="form-label at-small" for="PlanningFilterDueDate">Target Date</label>
+                    <input type="date" class="form-control form-control-sm" id="PlanningFilterDueDate" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
 
                     <label class="form-label at-small" for="PlanningFilterSearch">Search by title</label>
                     <input type="text" class="form-control form-control-sm" id="PlanningFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
@@ -185,7 +172,6 @@
                         <article class="at-planning-backlog-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
                             <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
                             <div class="at-backlog-task-meta">
-                                <span class="at-cell-primary">@item.AssigneeName</span>
                                 <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                                 @if (Model.IsTaskOverdue(task))
                                 {
@@ -193,8 +179,7 @@
                                 }
                             </div>
                             <div class="at-backlog-task-meta">
-                                <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
-                                <span class="at-cell-primary">Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                                <span class="at-cell-primary">Target @task.DueDate.ToString("dd MMM yyyy")</span>
                             </div>
                             @if (Model.CanPlanSprints)
                             {
@@ -234,7 +219,7 @@
         </div>
     </section>
 
-    @* SECTION: Outside Sprint list makes assigned non-sprint work explicit and separate from true backlog. *@
+    @* SECTION: Outside Sprint list makes assigned work outside sprint explicit and separate from backlog items. *@
     <details class="at-panel at-planning-outside-sprint at-planning-plan-card">
         <summary class="at-panel-heading">
             <div>
@@ -294,7 +279,7 @@
                                 <input type="hidden" name="PlanningTab" value="Plan" />
                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                 <input type="hidden" name="id" value="@task.Id" />
-                                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action">Move to Backlog, Remove Assignee</button>
+                                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action" data-at-confirm="This will remove the responsible person and return the work to Backlog. Continue?">Move to Backlog, Remove Assignee</button>
                             </form>
                         }
                     </article>

--- a/Pages/ActionTasks/_PlanningTabs.cshtml
+++ b/Pages/ActionTasks/_PlanningTabs.cshtml
@@ -1,13 +1,8 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
-@{
-    // SECTION: Views tab route preserves the selected alternate view while keeping Default routed to Due / exceptions.
-    var viewsPlanningView = string.Equals(Model.ResolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase) ? "DueExceptions" : Model.ResolvedPlanningView;
-}
 
-@* SECTION: Compact internal tabs reduce Sprint Board vertical height. *@
+@* SECTION: Compact internal tabs expose the simplified Sprint Board workflow. *@
 <nav class="at-panel at-planning-tabs at-planning-tabs-compact" aria-label="Sprint Board tabs">
     <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(Model.IsPlanningPlanTab ? "active" : string.Empty)" aria-current="@(Model.IsPlanningPlanTab ? "page" : null)"><span>Plan</span><small>Sprints & backlog</small></a>
     <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Execute" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(Model.IsPlanningExecuteTab ? "active" : string.Empty)" aria-current="@(Model.IsPlanningExecuteTab ? "page" : null)"><span>Execute</span><small>Status board</small></a>
     <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(Model.IsPlanningCloseTab ? "active" : string.Empty)" aria-current="@(Model.IsPlanningCloseTab ? "page" : null)"><span>Close</span><small>Review & history</small></a>
-    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="@viewsPlanningView" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="@(Model.IsPlanningViewsTab ? "active" : string.Empty)" aria-current="@(Model.IsPlanningViewsTab ? "page" : null)"><span>Views</span><small>Due & Kanban</small></a>
 </nav>

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -39,7 +39,7 @@
                 <input type="hidden" name="PlanningTab" value="Execute" />
                 <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
                 <input type="hidden" name="id" value="@task.Id" />
-                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action">Move to Backlog, Remove Assignee</button>
+                <button type="submit" class="btn btn-link btn-sm at-card-subtle-action" data-at-confirm="This will remove the responsible person and return the work to Backlog. Continue?">Move to Backlog, Remove Assignee</button>
             </form>
         </div>
     }

--- a/Pages/ActionTasks/_PlanningViewsTab.cshtml
+++ b/Pages/ActionTasks/_PlanningViewsTab.cshtml
@@ -1,21 +1,10 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Views tab exposes exactly one selected alternate view at a time. *@
-<section class="at-planning-tab-panel at-planning-views-panel" aria-label="Sprint Board Views tab">
-    <nav class="at-panel at-planning-view-toggle" aria-label="Sprint Board alternate view selector">
-        <span class="at-section-eyebrow">Alternate views</span>
-        <div class="btn-group" role="group" aria-label="Sprint Board view options">
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="DueExceptions" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-outline-primary" : "btn-primary")">Due / exceptions</a>
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Views" asp-route-PlanningView="Kanban" asp-route-SelectedSprintId="@Model.SelectedSprintId" asp-route-taskId="@Model.TaskId" class="btn btn-sm @(string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")">Kanban</a>
-        </div>
-    </nav>
-
-    @if (string.Equals(Model.ResolvedPlanningView, "Kanban", StringComparison.OrdinalIgnoreCase))
-    {
+@* SECTION: Legacy partial kept for compatibility; secondary views now belong under Execute. *@
+<section class="at-planning-tab-panel at-planning-views-panel" aria-label="Sprint Board Execute secondary views">
+    <partial name="_PlanningDueExceptionsView" model="Model" />
+    <details class="at-execute-kanban-view mt-3">
+        <summary>Kanban</summary>
         <partial name="_TaskKanban" model="Model" />
-    }
-    else
-    {
-        <partial name="_PlanningDueExceptionsView" model="Model" />
-    }
+    </details>
 </section>

--- a/Pages/ActionTasks/_TaskBacklog.cshtml
+++ b/Pages/ActionTasks/_TaskBacklog.cshtml
@@ -17,23 +17,6 @@
     <form method="get" class="row g-2" data-at-task-filter-form="true">
         <input type="hidden" name="viewMode" value="Planning" />
         <div class="col-md-2">
-            <label class="form-label">Status</label>
-            <select class="form-select" name="FilterStatus">
-                <option value="">All open statuses</option>
-                @foreach (var status in Model.AllowedStatusOptions)
-                {
-                    if (string.Equals(Model.FilterStatus, status, StringComparison.OrdinalIgnoreCase))
-                    {
-                        <option value="@status" selected>@status</option>
-                    }
-                    else
-                    {
-                        <option value="@status">@status</option>
-                    }
-                }
-            </select>
-        </div>
-        <div class="col-md-2">
             <label class="form-label">Priority</label>
             <select class="form-select" name="FilterPriority">
                 <option value="">All</option>
@@ -51,24 +34,7 @@
             </select>
         </div>
         <div class="col-md-2">
-            <label class="form-label">Responsible Person</label>
-            <select class="form-select" name="FilterAssigneeUserId">
-                <option value="">All</option>
-                @foreach (var assignee in Model.TaskAssigneeNames.OrderBy(x => x.Value))
-                {
-                    if (string.Equals(Model.FilterAssigneeUserId, assignee.Key, StringComparison.Ordinal))
-                    {
-                        <option value="@assignee.Key" selected>@assignee.Value</option>
-                    }
-                    else
-                    {
-                        <option value="@assignee.Key">@assignee.Value</option>
-                    }
-                }
-            </select>
-        </div>
-        <div class="col-md-2">
-            <label class="form-label">Due Date</label>
+            <label class="form-label">Target Date</label>
             <input type="date" class="form-control" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
         </div>
         <div class="col-md-2">
@@ -87,7 +53,7 @@
         <h2>Sprint Board Backlog Queue</h2>
         @if (Model.CanPlanSprints)
         {
-            <span class="at-panel-note">Comdt and HoD can assign true backlog tasks into open Sprints.</span>
+            <span class="at-panel-note">Comdt and HoD can assign backlog items into open Sprints.</span>
         }
     </div>
 
@@ -102,10 +68,8 @@
                 <thead>
                     <tr>
                         <th>Task</th>
-                        <th>Responsible Person</th>
                         <th>Priority</th>
-                        <th>Status</th>
-                        <th>Due Date</th>
+                        <th>Target Date</th>
                         @if (Model.CanPlanSprints)
                         {
                             <th>Assign to Sprint</th>
@@ -127,9 +91,7 @@
                                     }
                                 </div>
                             </td>
-                            <td><span class="at-cell-primary">@item.AssigneeName</span></td>
                             <td><span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span></td>
-                            <td><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></td>
                             <td><span class="at-cell-primary">@task.DueDate.ToString("dd MMM yyyy")</span></td>
                             @if (Model.CanPlanSprints)
                             {

--- a/Pages/ActionTasks/_TaskCards.cshtml
+++ b/Pages/ActionTasks/_TaskCards.cshtml
@@ -36,7 +36,7 @@ else
                         <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                     </div>
                     <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
-                    <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                    <div class="at-card-due">@(pageModel.IsBacklogTask(task) ? "Target" : "Due") @task.DueDate.ToString("dd MMM yyyy")</div>
                     <div class="mt-1"><span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span></div>
                     @if (!hideStatusBadge)
                     {

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -1,6 +1,6 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Create-task modal separates Agile backlog capture from assigned outside-sprint work. *@
+@* SECTION: Create-task modal starts with a two-choice flow, then reveals only the selected form without inline scripts. *@
 <div class="modal fade" id="createTaskModal" tabindex="-1" aria-labelledby="createTaskModalLabel" aria-hidden="true" data-bs-backdrop="static" data-at-open-on-load="@(Model.ShowCreateModal ? "true" : "false")">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content">
@@ -14,94 +14,99 @@
                     <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
                 }
 
-                @* SECTION: Direct task creation keeps assigned work outside sprint until planners add it to a sprint. *@
-                <section class="at-create-flow-panel">
-                    <div class="at-panel-heading at-panel-heading-compact">
-                        <div>
-                            <h3 class="h6 mb-1">Create Direct Task</h3>
-                            <p class="at-panel-note mb-0">Assigned to a responsible person now. It remains Outside Sprint until added to a sprint.</p>
-                        </div>
-                    </div>
-                    <form method="post" asp-page-handler="CreateDirectTask" class="at-create-flow-form">
-                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                        <div class="row g-3">
-                            <div class="col-md-5">
-                                <label asp-for="Input.Title" class="form-label">Task Title</label>
-                                <input asp-for="Input.Title" class="form-control" />
-                                <span asp-validation-for="Input.Title" class="text-danger small"></span>
-                            </div>
-                            <div class="col-md-7">
-                                <label asp-for="Input.Description" class="form-label">Description / Instructions</label>
-                                <textarea asp-for="Input.Description" class="form-control" rows="4" placeholder="Enter task instructions, background and expected output"></textarea>
-                                <span asp-validation-for="Input.Description" class="text-danger small"></span>
-                            </div>
-                            <div class="col-12">
-                                <label asp-for="Input.AssignedToUserId" class="form-label">Responsible Person</label>
-                                <select asp-for="Input.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person" required>
-                                    <option value="">Select user</option>
-                                    @foreach (var user in Model.AssignableUsers)
-                                    {
-                                        <option value="@user.UserId">@user.DisplayName</option>
-                                    }
-                                </select>
-                                <span asp-validation-for="Input.AssignedToUserId" class="text-danger small"></span>
-                            </div>
-                            <div class="col-md-3">
-                                <label asp-for="Input.Priority" class="form-label">Priority</label>
-                                <select asp-for="Input.Priority" class="form-select">
-                                    <option>Low</option>
-                                    <option selected>Normal</option>
-                                    <option>High</option>
-                                    <option>Critical</option>
-                                </select>
-                                <span asp-validation-for="Input.Priority" class="text-danger small"></span>
-                            </div>
-                            <div class="col-md-4">
-                                <label asp-for="Input.DueDate" class="form-label">Due Date</label>
-                                <input asp-for="Input.DueDate" type="date" class="form-control" />
-                                <span asp-validation-for="Input.DueDate" class="text-danger small"></span>
-                            </div>
-                        </div>
-                        <div class="at-create-flow-actions">
-                            <button type="submit" class="btn btn-primary">Create Direct Task</button>
-                        </div>
-                    </form>
-                </section>
+                @* SECTION: Choice screen keeps backlog capture separate from direct assigned work. *@
+                <div class="at-create-choice-grid" data-at-create-choice-group="true" aria-label="Choose work type">
+                    <details class="at-create-flow-panel at-create-choice-panel" data-at-create-choice="true">
+                        <summary class="btn btn-outline-primary w-100">Create Backlog Item</summary>
+                        <p class="at-panel-note mt-2">Capture future work without assigning a responsible person or sprint.</p>
 
-                @* SECTION: Backlog item creation intentionally omits assignee and sprint fields. *@
-                <details class="at-create-flow-panel at-create-backlog-panel mt-3">
-                    <summary class="btn btn-outline-primary btn-sm">Create Backlog Item</summary>
-                    <p class="at-panel-note mt-2">Capture future work without assigning a responsible person or sprint.</p>
-                    <form method="post" asp-page-handler="CreateBacklogItem" class="at-create-flow-form">
-                        <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                        <div class="row g-3">
-                            <div class="col-md-5">
-                                <label asp-for="Input.Title" class="form-label">Backlog Item Title</label>
-                                <input asp-for="Input.Title" class="form-control" />
+                        @* SECTION: Backlog item form intentionally has unique model-bound IDs and no assignee fields. *@
+                        <form method="post" asp-page-handler="CreateBacklogItem" class="at-create-flow-form">
+                            <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <div class="row g-3">
+                                <div class="col-md-5">
+                                    <label asp-for="BacklogItemInput.Title" class="form-label"></label>
+                                    <input asp-for="BacklogItemInput.Title" class="form-control" />
+                                    <span asp-validation-for="BacklogItemInput.Title" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-7">
+                                    <label asp-for="BacklogItemInput.Description" class="form-label"></label>
+                                    <textarea asp-for="BacklogItemInput.Description" class="form-control" rows="4" placeholder="Enter the work idea, context and planning notes"></textarea>
+                                    <span asp-validation-for="BacklogItemInput.Description" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-3">
+                                    <label asp-for="BacklogItemInput.Priority" class="form-label">Priority</label>
+                                    <select asp-for="BacklogItemInput.Priority" class="form-select">
+                                        <option>Low</option>
+                                        <option selected>Normal</option>
+                                        <option>High</option>
+                                        <option>Critical</option>
+                                    </select>
+                                    <span asp-validation-for="BacklogItemInput.Priority" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-4">
+                                    <label asp-for="BacklogItemInput.TargetDate" class="form-label"></label>
+                                    <input asp-for="BacklogItemInput.TargetDate" type="date" class="form-control" />
+                                    <span asp-validation-for="BacklogItemInput.TargetDate" class="text-danger small"></span>
+                                </div>
                             </div>
-                            <div class="col-md-7">
-                                <label asp-for="Input.Description" class="form-label">Description / Planning Notes</label>
-                                <textarea asp-for="Input.Description" class="form-control" rows="4" placeholder="Enter the work idea, context and planning notes"></textarea>
+                            <div class="at-create-flow-actions">
+                                <button type="submit" class="btn btn-primary">Create Backlog Item</button>
                             </div>
-                            <div class="col-md-3">
-                                <label asp-for="Input.Priority" class="form-label">Priority</label>
-                                <select asp-for="Input.Priority" class="form-select">
-                                    <option>Low</option>
-                                    <option selected>Normal</option>
-                                    <option>High</option>
-                                    <option>Critical</option>
-                                </select>
+                        </form>
+                    </details>
+
+                    <details class="at-create-flow-panel at-create-choice-panel" data-at-create-choice="true">
+                        <summary class="btn btn-outline-primary w-100">Create Direct Task</summary>
+                        <p class="at-panel-note mt-2">Assign to a responsible person now. It remains Outside Sprint until added to a sprint.</p>
+
+                        @* SECTION: Direct task form uses its own input model so generated HTML IDs are unique. *@
+                        <form method="post" asp-page-handler="CreateDirectTask" class="at-create-flow-form">
+                            <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <div class="row g-3">
+                                <div class="col-md-5">
+                                    <label asp-for="DirectTaskInput.Title" class="form-label"></label>
+                                    <input asp-for="DirectTaskInput.Title" class="form-control" />
+                                    <span asp-validation-for="DirectTaskInput.Title" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-7">
+                                    <label asp-for="DirectTaskInput.Description" class="form-label"></label>
+                                    <textarea asp-for="DirectTaskInput.Description" class="form-control" rows="4" placeholder="Enter task instructions, background and expected output"></textarea>
+                                    <span asp-validation-for="DirectTaskInput.Description" class="text-danger small"></span>
+                                </div>
+                                <div class="col-12">
+                                    <label asp-for="DirectTaskInput.AssignedToUserId" class="form-label"></label>
+                                    <select asp-for="DirectTaskInput.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person" required>
+                                        <option value="">Select user</option>
+                                        @foreach (var user in Model.AssignableUsers)
+                                        {
+                                            <option value="@user.UserId">@user.DisplayName</option>
+                                        }
+                                    </select>
+                                    <span asp-validation-for="DirectTaskInput.AssignedToUserId" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-3">
+                                    <label asp-for="DirectTaskInput.Priority" class="form-label">Priority</label>
+                                    <select asp-for="DirectTaskInput.Priority" class="form-select">
+                                        <option>Low</option>
+                                        <option selected>Normal</option>
+                                        <option>High</option>
+                                        <option>Critical</option>
+                                    </select>
+                                    <span asp-validation-for="DirectTaskInput.Priority" class="text-danger small"></span>
+                                </div>
+                                <div class="col-md-4">
+                                    <label asp-for="DirectTaskInput.DueDate" class="form-label"></label>
+                                    <input asp-for="DirectTaskInput.DueDate" type="date" class="form-control" />
+                                    <span asp-validation-for="DirectTaskInput.DueDate" class="text-danger small"></span>
+                                </div>
                             </div>
-                            <div class="col-md-4">
-                                <label asp-for="Input.DueDate" class="form-label">Planning Due Date</label>
-                                <input asp-for="Input.DueDate" type="date" class="form-control" />
+                            <div class="at-create-flow-actions">
+                                <button type="submit" class="btn btn-primary">Create Direct Task</button>
                             </div>
-                        </div>
-                        <div class="at-create-flow-actions">
-                            <button type="submit" class="btn btn-outline-primary">Create Backlog Item</button>
-                        </div>
-                    </form>
-                </details>
+                        </form>
+                    </details>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -8,7 +8,9 @@
         : null;
     var selectedSprintRouteValue = Model.IsPlanningView ? Model.SelectedSprintId : null;
     var selectedTaskIsBacklog = Model.SelectedTask is not null && Model.IsBacklogTask(Model.SelectedTask);
-    var updateButtonText = selectedTaskIsBacklog ? "Add Planning Note" : "+ Update";
+    var selectedTaskStatus = Model.SelectedTask?.Status ?? string.Empty;
+    var selectedTaskDateLabel = selectedTaskIsBacklog ? "Target" : "Due";
+    var updateButtonText = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePanelTitle = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Add progress details or clarification notes";
 }
@@ -23,11 +25,14 @@
                 <h2 class="at-panel-title mb-0">AT-@(Model.SelectedTask?.Id.ToString() ?? Model.TaskId?.ToString() ?? "—") · @(Model.SelectedTask?.Title ?? "Task")</h2>
                 @if (Model.SelectedTask is not null)
                 {
-                    <div class="at-detail-assignee">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div>
+                    @if (!selectedTaskIsBacklog)
+                    {
+                        <div class="at-detail-assignee">@Model.ResolveAssigneeName(Model.SelectedTask.AssignedToUserId)</div>
+                    }
                     <div class="d-flex gap-2 flex-wrap at-detail-meta">
                         <span class="@Model.GetStatusBadgeClass(Model.SelectedTask.Status)">@Model.SelectedTask.Status</span>
                         <span class="@Model.GetPriorityBadgeClass(Model.SelectedTask.Priority)">@Model.SelectedTask.Priority</span>
-                        <span class="at-detail-due">Due @Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</span>
+                        <span class="at-detail-due">@selectedTaskDateLabel @Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</span>
                         <span class="@Model.GetSprintBadgeClass(Model.SelectedTask)">@Model.GetSprintBadgeText(Model.SelectedTask)</span>
                     </div>
                     <div class="at-inspector-snapshot">
@@ -170,6 +175,45 @@
                         </form>
                     </details>
 
+
+                    @if (selectedTaskIsBacklog && Model.CanAssignTaskToSprint(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="add-to-sprint">
+                            <summary class="visually-hidden">Open add to sprint panel</summary>
+                            <form method="post" asp-page-handler="AssignToSprint" class="at-action-card at-action-card-compact">
+                                <input type="hidden" name="ViewMode" value="Planning" />
+                                <input type="hidden" name="PlanningTab" value="Execute" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <div class="at-action-title">Add to Sprint</div>
+                                <div class="mb-2">
+                                    <label class="form-label at-small">Responsible Person</label>
+                                    <select class="form-select form-select-sm" name="responsibleUserId" required>
+                                        <option value="">Select responsible person</option>
+                                        @foreach (var user in Model.AssignableUsers)
+                                        {
+                                            <option value="@user.UserId">@user.DisplayName</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label at-small">Sprint</label>
+                                    <select class="form-select form-select-sm" name="sprintId" required>
+                                        <option value="">Select Sprint</option>
+                                        @foreach (var sprint in Model.AssignableSprints)
+                                        {
+                                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="at-action-buttons">
+                                    <button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-to-sprint">Cancel</button>
+                                </div>
+                            </form>
+                        </details>
+                    }
+
                     @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
                     {
                         <details class="at-action-drawer" data-at-action-panel="status">
@@ -223,13 +267,13 @@
                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
-                                <div class="at-action-title">Submit Task</div>
+                                <div class="at-action-title">Submit for Closure</div>
                                 <div class="mb-2">
                                     <label class="form-label at-small">Submission Remarks</label>
                                     <textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add submission notes"></textarea>
                                 </div>
                                 <div class="at-action-buttons">
-                                    <button type="submit" class="btn btn-warning btn-sm">Submit Task</button>
+                                    <button type="submit" class="btn btn-warning btn-sm">Submit for Closure</button>
                                     <button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="submit">Cancel</button>
                                 </div>
                             </form>
@@ -262,19 +306,64 @@
                     }
                 </div>
 
+                @* SECTION: Primary action rail exposes the next useful action for the task state and tucks other actions away. *@
                 <div class="at-action-toolbar" aria-label="Task actions">
-                    <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">@updateButtonText</button>
-                    @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
+                    @if (selectedTaskIsBacklog)
                     {
-                        <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Change Status</button>
+                        <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Add Planning Note</button>
+                        @if (Model.CanAssignTaskToSprint(Model.SelectedTask))
+                        {
+                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="add-to-sprint">Add to Sprint</button>
+                        }
                     }
-                    @if (Model.CanSubmitTask(Model.SelectedTask))
+                    else if (string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
                     {
-                        <button type="button" class="btn btn-outline-warning btn-sm" data-at-open-action="submit">Submit</button>
+                        @if (Model.CanCloseTask(Model.SelectedTask))
+                        {
+                            <button type="button" class="btn btn-success btn-sm" data-at-open-action="close">Close Task</button>
+                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Return for Rework</button>
+                        }
+                        else
+                        {
+                            <span class="text-muted small">Submitted for closure</span>
+                        }
                     }
-                    @if (Model.CanCloseTask(Model.SelectedTask))
+                    else if (string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
                     {
-                        <button type="button" class="btn btn-outline-success btn-sm" data-at-open-action="close">Close</button>
+                        <span class="text-muted small">View only</span>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Add Update</button>
+                        @if (Model.CanUpdateTaskStatus(Model.SelectedTask) && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Mark In Progress</button>
+                        }
+                        @if (Model.CanSubmitTask(Model.SelectedTask) && string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
+                        {
+                            <button type="button" class="btn btn-warning btn-sm" data-at-open-action="submit">Submit for Closure</button>
+                        }
+                    }
+
+                    @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+                    {
+                        <details class="at-action-more-menu">
+                            <summary class="btn btn-outline-secondary btn-sm">More</summary>
+                            <div class="at-action-more-list">
+                            @if (!selectedTaskIsBacklog && Model.CanUpdateTaskStatus(Model.SelectedTask))
+                            {
+                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="status">Change Status</button>
+                            }
+                            @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase) && Model.CanSubmitTask(Model.SelectedTask))
+                            {
+                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="submit">Submit for Closure</button>
+                            }
+                            @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask))
+                            {
+                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="close">Close Task</button>
+                            }
+                            </div>
+                        </details>
                     }
                 </div>
             </footer>

--- a/Pages/ActionTasks/_TaskKanban.cshtml
+++ b/Pages/ActionTasks/_TaskKanban.cshtml
@@ -49,7 +49,7 @@
                                    asp-page="/ActionTasks/Index"
                                    asp-route-taskId="@task.Id"
                                    asp-route-viewMode="Planning"
-                                   asp-route-PlanningTab="Views"
+                                   asp-route-PlanningTab="Execute"
                                    asp-route-PlanningView="Kanban"
                                    asp-route-SelectedSprintId="@Model.SelectedSprintId"
                                    aria-label="Open task AT-@task.Id details">
@@ -58,7 +58,7 @@
                                         <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                                     </div>
                                     <div class="at-card-meta">AT-@task.Id · @item.AssigneeName</div>
-                                    <div class="at-card-due">Due @task.DueDate.ToString("dd MMM yyyy")</div>
+                                    <div class="at-card-due">@(Model.IsBacklogTask(task) ? "Target" : "Due") @task.DueDate.ToString("dd MMM yyyy")</div>
                                     <div class="mt-1"><span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span></div>
                                 </a>
                             </article>

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -36,11 +36,11 @@
                     <option value="">All Sprint, Backlog &amp; Outside Sprint work</option>
                     @if (Model.ReportSprintId == 0)
                     {
-                        <option value="0" selected>True backlog only</option>
+                        <option value="0" selected>Backlog items only</option>
                     }
                     else
                     {
-                        <option value="0">True backlog only</option>
+                        <option value="0">Backlog items only</option>
                     }
                     @foreach (var sprint in Model.Sprints)
                     {
@@ -252,7 +252,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Backlog Ageing Summary</h2>
-                <p class="at-panel-note">Highlights true backlog only: open, not in a Sprint, and not assigned to a user.</p>
+                <p class="at-panel-note">Highlights backlog items only: open, not in a Sprint, and not assigned to a user.</p>
             </div>
         </div>
         <div class="at-metric-bars">

--- a/Pages/ActionTasks/_TaskSprints.cshtml
+++ b/Pages/ActionTasks/_TaskSprints.cshtml
@@ -17,8 +17,4 @@
     {
         <partial name="_PlanningCloseTab" model="Model" />
     }
-    else if (Model.IsPlanningViewsTab)
-    {
-        <partial name="_PlanningViewsTab" model="Model" />
-    }
 </section>

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -211,7 +211,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_WhenSprintClosed_RejectsRequest()
+    public async Task AssignBacklogItemToSprintAsync_WhenSprintClosed_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -223,12 +223,12 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.Comdt));
+            service.AssignBacklogItemToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.Comdt));
         Assert.Contains("closed sprint", ex.Message.ToLowerInvariant());
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_WhenTaskClosed_RejectsRequest()
+    public async Task AssignBacklogItemToSprintAsync_WhenTaskClosed_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -238,12 +238,12 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.Comdt));
+            service.AssignBacklogItemToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.Comdt));
         Assert.Contains("closed tasks cannot be assigned", ex.Message.ToLowerInvariant());
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_WithNonAuthority_RejectsRequest()
+    public async Task AssignBacklogItemToSprintAsync_WithNonAuthority_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -253,7 +253,7 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "actor", RoleNames.ProjectOfficer));
+            service.AssignBacklogItemToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "actor", RoleNames.ProjectOfficer));
         Assert.Contains("not authorized", ex.Message.ToLowerInvariant());
     }
 
@@ -489,7 +489,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_BacklogItem_SetsAssigneeAndAssignedStatus()
+    public async Task AssignBacklogItemToSprintAsync_BacklogItem_SetsAssigneeAndAssignedStatus()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -501,7 +501,7 @@ public class ActionSprintServiceTests
         await db.SaveChangesAsync();
 
         // SECTION: Act
-        var sprintTask = await service.AssignTaskToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD);
+        var sprintTask = await service.AssignBacklogItemToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         Assert.Equal(sprint.Id, sprintTask.SprintId);
@@ -512,7 +512,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task AssignExistingAssignedTaskToSprintAsync_OutsideSprintTask_RetainsAssignee()
+    public async Task AssignOutsideSprintTaskToSprintAsync_OutsideSprintTask_RetainsAssignee()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -521,7 +521,7 @@ public class ActionSprintServiceTests
         var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress);
 
         // SECTION: Act
-        var sprintTask = await service.AssignExistingAssignedTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+        var sprintTask = await service.AssignOutsideSprintTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         Assert.Equal(sprint.Id, sprintTask.SprintId);
@@ -532,7 +532,7 @@ public class ActionSprintServiceTests
 
 
     [Fact]
-    public async Task AssignExistingAssignedTaskToSprintAsync_SubmittedOutsideSprintTask_RetainsStatusAndSubmittedOn()
+    public async Task AssignOutsideSprintTaskToSprintAsync_SubmittedOutsideSprintTask_RetainsStatusAndSubmittedOn()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -544,7 +544,7 @@ public class ActionSprintServiceTests
         await db.SaveChangesAsync();
 
         // SECTION: Act
-        var sprintTask = await service.AssignExistingAssignedTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
+        var sprintTask = await service.AssignOutsideSprintTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         Assert.Equal(sprint.Id, sprintTask.SprintId);
@@ -555,7 +555,7 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_OutsideSprintTask_RejectsRequest()
+    public async Task AssignBacklogItemToSprintAsync_OutsideSprintTask_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -565,12 +565,12 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
+            service.AssignBacklogItemToSprintAsync(task.Id, sprint.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
         Assert.Equal("Only backlog items can be assigned to sprint through this action.", ex.Message);
     }
 
     [Fact]
-    public async Task AssignTaskToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
+    public async Task AssignBacklogItemToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -582,12 +582,12 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignTaskToSprintAsync(task.Id, target.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
+            service.AssignBacklogItemToSprintAsync(task.Id, target.Id, "assignee", RoleNames.Ta, "planner", RoleNames.HoD));
         Assert.Equal("Only backlog items can be assigned to sprint through this action.", ex.Message);
     }
 
     [Fact]
-    public async Task AssignExistingAssignedTaskToSprintAsync_BacklogTask_RejectsRequest()
+    public async Task AssignOutsideSprintTaskToSprintAsync_BacklogTask_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -597,12 +597,12 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignExistingAssignedTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD));
+            service.AssignOutsideSprintTaskToSprintAsync(task.Id, sprint.Id, "planner", RoleNames.HoD));
         Assert.Equal("Only assigned tasks outside sprint can be added to sprint through this action.", ex.Message);
     }
 
     [Fact]
-    public async Task AssignExistingAssignedTaskToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
+    public async Task AssignOutsideSprintTaskToSprintAsync_AlreadySprintAssignedTask_RejectsRequest()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -614,7 +614,7 @@ public class ActionSprintServiceTests
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.AssignExistingAssignedTaskToSprintAsync(task.Id, target.Id, "planner", RoleNames.HoD));
+            service.AssignOutsideSprintTaskToSprintAsync(task.Id, target.Id, "planner", RoleNames.HoD));
         Assert.Equal("Only assigned tasks outside sprint can be added to sprint through this action.", ex.Message);
     }
 
@@ -717,7 +717,7 @@ public class ActionSprintServiceTests
 
     private static async Task<ActionTaskItem> AssignBacklogTaskToSprintAsync(ApplicationDbContext db, ActionSprintService service, ActionTaskItem task, int sprintId, string userId, string role)
     {
-        // SECTION: Prepare true backlog source state before exercising Backlog -> Sprint movement.
+        // SECTION: Prepare backlog item source state before exercising Backlog -> Sprint movement.
         task.SprintId = null;
         task.AssignedToUserId = string.Empty;
         task.AssignedToRole = string.Empty;
@@ -726,7 +726,7 @@ public class ActionSprintServiceTests
         task.ClosedOn = null;
         await db.SaveChangesAsync();
 
-        return await service.AssignTaskToSprintAsync(task.Id, sprintId, "assignee", RoleNames.Ta, userId, role);
+        return await service.AssignBacklogItemToSprintAsync(task.Id, sprintId, "assignee", RoleNames.Ta, userId, role);
     }
 
     private static async Task<ActionTaskItem> SeedBacklogTaskAsync(ApplicationDbContext db)

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
@@ -81,12 +81,12 @@ public class ActionTaskCompositionBuilderTests
 
         // SECTION: Assert
         Assert.Equal("Planning", state.ViewMode);
-        Assert.Equal("Views", state.PlanningTab);
+        Assert.Equal("Execute", state.PlanningTab);
         Assert.Equal("Kanban", state.PlanningView);
         Assert.Equal("Execute", state.DefaultPlanningTab);
         Assert.False(state.ShouldPreserveTaskFilters);
         Assert.Equal("Planning", routeValues[nameof(ActionTaskRouteState.ViewMode)]);
-        Assert.Equal("Views", routeValues[nameof(ActionTaskRouteState.PlanningTab)]);
+        Assert.False(routeValues.ContainsKey(nameof(ActionTaskRouteState.PlanningTab)));
         Assert.Equal("Kanban", routeValues[nameof(ActionTaskRouteState.PlanningView)]);
         Assert.False(routeValues.ContainsKey(nameof(ActionTaskRouteState.FilterStatus)));
     }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -220,9 +220,9 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("name=\"PlanningTab\" value=\"Views\"", html, StringComparison.Ordinal);
+        Assert.Contains("name=\"PlanningTab\" value=\"Execute\"", html, StringComparison.Ordinal);
         Assert.Contains("name=\"PlanningView\" value=\"Kanban\"", html, StringComparison.Ordinal);
-        Assert.Contains("PlanningTab=Views", html, StringComparison.Ordinal);
+        Assert.Contains("PlanningTab=Execute", html, StringComparison.Ordinal);
         Assert.Contains("PlanningView=Kanban", html, StringComparison.Ordinal);
     }
 
@@ -275,7 +275,7 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task PlanningDueExceptionsTaskCards_PreserveViewsRouteState()
+    public async Task PlanningDueExceptionsTaskCards_PreserveExecuteRouteState()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
@@ -286,7 +286,7 @@ public class ActionTaskPageTests
         await setup.Db.SaveChangesAsync();
         var page = setup.Page;
         page.ViewMode = "Planning";
-        page.PlanningTab = "Views";
+        page.PlanningTab = "Execute";
         page.PlanningView = "DueExceptions";
         page.SelectedSprintId = sprint.Id;
         await page.OnGetAsync();
@@ -295,7 +295,7 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningDueExceptionsView.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("PlanningTab=Views", html, StringComparison.Ordinal);
+        Assert.Contains("PlanningTab=Execute", html, StringComparison.Ordinal);
         Assert.Contains("PlanningView=DueExceptions", html, StringComparison.Ordinal);
         Assert.Contains($"SelectedSprintId={sprint.Id}", html, StringComparison.Ordinal);
     }
@@ -386,8 +386,8 @@ public class ActionTaskPageTests
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
         var page = setup.Page;
-        page.Input = new IndexModel.CreateTaskInput();
-        page.ModelState.AddModelError("Input.Title", "required");
+        page.DirectTaskInput = new IndexModel.CreateDirectTaskInput();
+        page.ModelState.AddModelError("DirectTaskInput.Title", "required");
 
         // SECTION: Act
         var result = await page.OnPostCreateAsync();
@@ -404,7 +404,7 @@ public class ActionTaskPageTests
         var setup = await CreateSetupAsync();
         var page = setup.Page;
         var existingTaskCount = await setup.Db.ActionTasks.CountAsync();
-        page.Input = new IndexModel.CreateTaskInput
+        page.DirectTaskInput = new IndexModel.CreateDirectTaskInput
         {
             Title = "Late task",
             Description = "Should be rejected",
@@ -421,7 +421,7 @@ public class ActionTaskPageTests
         Assert.True(page.ShowCreateModal);
         Assert.False(page.ModelState.IsValid);
         Assert.Equal(existingTaskCount, await setup.Db.ActionTasks.CountAsync());
-        Assert.Contains(page.ModelState[nameof(IndexModel.CreateTaskInput.DueDate)]!.Errors, e => e.ErrorMessage == "Due date cannot be in the past.");
+        Assert.Contains(page.ModelState[nameof(IndexModel.CreateDirectTaskInput.DueDate)]!.Errors, e => e.ErrorMessage == "Due date cannot be in the past.");
     }
 
 
@@ -433,8 +433,9 @@ public class ActionTaskPageTests
         var sprint = AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
         await setup.Db.SaveChangesAsync();
         setup.Db.ActionTasks.Add(NewTask("Sprint task", ActionTaskStatuses.Assigned, sprint.Id));
-        var trueBacklog = NewTask("True backlog", ActionTaskStatuses.Backlog);
+        var trueBacklog = NewTask("Backlog item", ActionTaskStatuses.Backlog);
         trueBacklog.AssignedToUserId = string.Empty;
+        trueBacklog.AssignedToRole = string.Empty;
         setup.Db.ActionTasks.Add(trueBacklog);
         setup.Db.ActionTasks.Add(NewTask("Closed backlog", ActionTaskStatuses.Closed));
         await setup.Db.SaveChangesAsync();
@@ -448,7 +449,7 @@ public class ActionTaskPageTests
         Assert.NotEmpty(page.BacklogTasks);
         Assert.All(page.BacklogTasks, task => Assert.Null(task.SprintId));
         Assert.All(page.BacklogTasks, task => Assert.True(string.IsNullOrWhiteSpace(task.AssignedToUserId)));
-        Assert.Contains(page.BacklogTasks, task => task.Title == "True backlog");
+        Assert.Contains(page.BacklogTasks, task => task.Title == "Backlog item");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Mine");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Closed backlog");
         Assert.DoesNotContain(page.BacklogTasks, task => task.Title == "Sprint task");
@@ -463,6 +464,7 @@ public class ActionTaskPageTests
         var sprintTask = NewTask("Sprint scoped", ActionTaskStatuses.Assigned, sprint.Id);
         var backlogTask = NewTask("Backlog scoped", ActionTaskStatuses.Backlog);
         backlogTask.AssignedToUserId = string.Empty;
+        backlogTask.AssignedToRole = string.Empty;
         var nonSprintTask = NewTask("Non sprint scoped", ActionTaskStatuses.Assigned);
         var closedTask = NewTask("Closed scoped", ActionTaskStatuses.Closed);
         setup.Db.ActionTasks.AddRange(sprintTask, backlogTask, nonSprintTask, closedTask);

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -275,13 +275,7 @@ public class ActionSprintService
     }
 
     // SECTION: Sprint task assignment APIs
-    public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
-    {
-        var task = await GetTaskForUpdateAsync(taskId, cancellationToken);
-        return await AssignTaskToSprintAsync(taskId, sprintId, task.AssignedToUserId, task.AssignedToRole, userId, role, cancellationToken);
-    }
-
-    public async Task<ActionTaskItem> AssignTaskToSprintAsync(int taskId, int sprintId, string responsibleUserId, string responsibleRole, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionTaskItem> AssignBacklogItemToSprintAsync(int taskId, int sprintId, string responsibleUserId, string responsibleRole, string userId, string role, CancellationToken cancellationToken = default)
     {
         EnsureCanAssignTaskToSprint(role);
 
@@ -315,7 +309,7 @@ public class ActionSprintService
         return task;
     }
 
-    public async Task<ActionTaskItem> AssignExistingAssignedTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
+    public async Task<ActionTaskItem> AssignOutsideSprintTaskToSprintAsync(int taskId, int sprintId, string userId, string role, CancellationToken cancellationToken = default)
     {
         // SECTION: Outside Sprint movement reuses the existing responsible person and only selects a target sprint.
         EnsureCanAssignTaskToSprint(role);

--- a/Services/ActionTasks/ActionTaskBucketInvariantValidator.cs
+++ b/Services/ActionTasks/ActionTaskBucketInvariantValidator.cs
@@ -8,27 +8,29 @@ public static class ActionTaskBucketInvariantValidator
     // SECTION: Central workflow bucket invariant validation for backlog, outside-sprint, sprint, and closed tasks.
     public static void ValidateTaskBucketInvariant(ActionTaskItem task)
     {
-        var hasAssignee = !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+        var hasAssignedUser = !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+        var hasAssignedRole = !string.IsNullOrWhiteSpace(task.AssignedToRole);
         var hasSprint = task.SprintId.HasValue;
+        var isBacklog = string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase);
 
-        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && hasAssignee)
+        if (isBacklog && (hasAssignedUser || hasAssignedRole))
         {
-            throw new InvalidOperationException("Backlog tasks cannot have a responsible person.");
+            throw new InvalidOperationException("Backlog tasks cannot have a responsible person or role.");
         }
 
-        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && hasSprint)
+        if (isBacklog && hasSprint)
         {
             throw new InvalidOperationException("Backlog tasks cannot be assigned to a sprint.");
         }
 
-        if (hasSprint && !hasAssignee)
+        if (hasSprint && (!hasAssignedUser || !hasAssignedRole))
         {
-            throw new InvalidOperationException("Sprint tasks must have a responsible person.");
+            throw new InvalidOperationException("Sprint tasks must have a responsible person and role.");
         }
 
-        if (IsAssignedExecutionStatus(task.Status) && !hasAssignee)
+        if (IsAssignedExecutionStatus(task.Status) && (!hasAssignedUser || !hasAssignedRole))
         {
-            throw new InvalidOperationException("Assigned, in-progress, blocked, and submitted tasks must have a responsible person.");
+            throw new InvalidOperationException("Assigned, in-progress, blocked, and submitted tasks must have a responsible person and role.");
         }
 
         if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) && task.ClosedOn is null)
@@ -37,7 +39,7 @@ public static class ActionTaskBucketInvariantValidator
         }
     }
 
-    // SECTION: Execution statuses are valid only for assigned work, not true backlog items.
+    // SECTION: Execution statuses are valid only for assigned work, not backlog items.
     private static bool IsAssignedExecutionStatus(string status)
         => string.Equals(status, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)
             || string.Equals(status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)

--- a/Services/ActionTasks/ActionTaskCategorization.cs
+++ b/Services/ActionTasks/ActionTaskCategorization.cs
@@ -30,26 +30,27 @@ public static class ActionTaskBucketClassifier
             return ActionTaskBucket.Closed;
         }
 
-        if (IsSprintTask(task))
+        if (IsSprintTask(task) || task.SprintId.HasValue)
         {
             return ActionTaskBucket.Sprint;
         }
 
-        return HasAssignedUser(task)
+        return HasAssignedUser(task) && HasAssignedRole(task)
             ? ActionTaskBucket.OutsideSprint
             : ActionTaskBucket.Backlog;
     }
 
     public static bool IsSprintTask(ActionTaskItem task)
-        => task.SprintId.HasValue && HasAssignedUser(task) && IsSprintStatus(task.Status);
+        => task.SprintId.HasValue && HasAssignedUser(task) && HasAssignedRole(task) && IsSprintStatus(task.Status);
 
     public static bool IsBacklogTask(ActionTaskItem task)
         => task.SprintId is null
            && !HasAssignedUser(task)
+           && !HasAssignedRole(task)
            && string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase);
 
     public static bool IsOutsideSprintTask(ActionTaskItem task)
-        => task.SprintId is null && HasAssignedUser(task) && IsAssignedWorkStatus(task.Status);
+        => task.SprintId is null && HasAssignedUser(task) && HasAssignedRole(task) && IsAssignedWorkStatus(task.Status);
 
     public static bool IsAssignedNonSprintTask(ActionTaskItem task)
         => IsOutsideSprintTask(task);
@@ -62,6 +63,9 @@ public static class ActionTaskBucketClassifier
 
     public static bool HasAssignedUser(ActionTaskItem task)
         => !string.IsNullOrWhiteSpace(task.AssignedToUserId);
+
+    public static bool HasAssignedRole(ActionTaskItem task)
+        => !string.IsNullOrWhiteSpace(task.AssignedToRole);
 
     // SECTION: Official Agile Backlog execution statuses for assigned work buckets.
     private static bool IsSprintStatus(string status)
@@ -110,4 +114,7 @@ public static class ActionTaskCategorization
 
     public static bool HasAssignedUser(ActionTaskItem task)
         => ActionTaskBucketClassifier.HasAssignedUser(task);
+
+    public static bool HasAssignedRole(ActionTaskItem task)
+        => ActionTaskBucketClassifier.HasAssignedRole(task);
 }

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -77,7 +77,7 @@ public sealed class ActionTaskQueryService
             : backlogTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
     }
 
-    // SECTION: Outside Sprint projection keeps assigned non-sprint work separate from true backlog.
+    // SECTION: Outside Sprint projection keeps assigned outside sprint work separate from backlog items.
     private static IReadOnlyList<ActionTaskItem> BuildOutsideSprintTasks(IReadOnlyList<ActionTaskItem> tasks)
         => tasks.Where(ActionTaskCategorization.IsOutsideSprintTask).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 

--- a/Services/ActionTasks/ActionTaskRouteStateHelper.cs
+++ b/Services/ActionTasks/ActionTaskRouteStateHelper.cs
@@ -79,15 +79,15 @@ public sealed class ActionTaskRouteStateHelper
                 _ when IsAlias(normalized, "Execution") => "Execute",
                 _ when IsAlias(normalized, "Close") => "Close",
                 _ when IsAlias(normalized, "Closure") => "Close",
-                _ when IsAlias(normalized, "Views") => "Views",
-                _ when IsAlias(normalized, "View") => "Views",
+                _ when IsAlias(normalized, "Views") => "Execute",
+                _ when IsAlias(normalized, "View") => "Execute",
                 _ => defaultPlanningTab
             };
         }
 
         return string.Equals(resolvedPlanningView, "Default", StringComparison.OrdinalIgnoreCase)
             ? defaultPlanningTab
-            : "Views";
+            : "Execute";
     }
 
 

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -144,7 +144,7 @@ public class ActionTaskService : IActionTaskService
 
     public async Task<ActionTaskItem> CreateBacklogItemAsync(ActionTaskItem task, CancellationToken cancellationToken = default)
     {
-        // SECTION: Backlog creation enforces true backlog state rather than generic assigned-task defaults.
+        // SECTION: Backlog creation enforces backlog items state rather than generic assigned-task defaults.
         task.AssignedOn = DateTime.UtcNow;
         task.Status = ActionTaskStatuses.Backlog;
         task.SprintId = null;

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -238,6 +238,49 @@
         });
     }
 
+    // SECTION: Create modal choice flow keeps only one selected form open at a time.
+    function initCreateTaskChoiceFlow() {
+        const group = document.querySelector("[data-at-create-choice-group='true']");
+        if (!group) {
+            return;
+        }
+
+        const choices = Array.from(group.querySelectorAll("details[data-at-create-choice='true']"));
+        choices.forEach((choice) => {
+            choice.addEventListener("toggle", () => {
+                if (!choice.open) {
+                    return;
+                }
+
+                choices.forEach((candidate) => {
+                    if (candidate !== choice) {
+                        candidate.removeAttribute("open");
+                    }
+                });
+            });
+        });
+    }
+
+    // SECTION: Confirmation prompts for destructive bucket moves remain CSP-safe through data attributes.
+    function initActionConfirmations() {
+        const triggers = document.querySelectorAll("[data-at-confirm]");
+        triggers.forEach((trigger) => {
+            const form = trigger.closest("form");
+            if (!form || form.dataset.atConfirmReady === "true") {
+                return;
+            }
+
+            form.addEventListener("submit", (event) => {
+                const submitter = event.submitter || trigger;
+                const message = submitter.getAttribute("data-at-confirm") || trigger.getAttribute("data-at-confirm");
+                if (message && !window.confirm(message)) {
+                    event.preventDefault();
+                }
+            });
+            form.dataset.atConfirmReady = "true";
+        });
+    }
+
 
     // SECTION: Sticky inspector action panel orchestration and keyboard behavior.
     function initInspectorActionPanels() {
@@ -297,11 +340,13 @@
     document.addEventListener("DOMContentLoaded", function () {
         openCreateTaskModalOnLoad();
         initSearchableSelects();
+        initCreateTaskChoiceFlow();
         initStatusUpdateGuard();
         initTaskRegisterFilters();
         initReportsFilters();
         initSprintSelector();
         initSprintClosureReview();
+        initActionConfirmations();
         initInspectorActionPanels();
     });
 })();


### PR DESCRIPTION
### Motivation
- Reduce user confusion in the Action Tracker by simplifying backlog UI and inspector actions while keeping the Agile backlog/Outside-Sprint/Sprint/Closed model intact. 
- MakeCreate/Assign flows explicit (Backlog vs Direct/Assigned tasks) to avoid duplicate fields and HTML id collisions. 
- Prevent invalid legacy data and runtime invariants by strengthening bucket validation and migration behavior. 
- Remove duplicated controls and secondary Views tab to focus Plan/Execute/Close workflows and consistent user-facing wording.

### Description
- UI: removed the Status filter from the Backlog Queue and limited backlog filters to Priority/Target-date/Search; backlog cards no longer show an assignee and use "Target" for backlog dates while assigned/sprint cards keep "Due"; updated many partials (`_PlanningPlanTab.cshtml`, `_TaskBacklog.cshtml`, `_TaskCards.cshtml`, `_TaskKanban.cshtml`, `_PlanningPlanTab.cshtml`) and text ("True backlog" → "Backlog items", "Non-sprint" → "Outside Sprint").
- Create flow: replaced the mixed two-form modal with a two-choice flow and separate models `CreateDirectTaskInput` and `CreateBacklogItemInput` in `Index.cshtml.cs`, rewrote the create modal (`_TaskCreatePanel.cshtml`) to expose only the selected form and avoid duplicate `asp-for` IDs and validation collisions.
- Inspector/actions: made inspector primary action state-driven in `_TaskDetails.cshtml`, added an "Add to Sprint" drawer for backlog items, and renamed submit UI to "Submit for Closure" (panel titles, buttons, and toasts updated).
- Sprint workspace: removed the separate Views tab from `_PlanningTabs.cshtml` and routed/embedded DueExceptions and Kanban as a collapsed secondary section inside Execute; command strip (`_PlanningCommandStrip.cshtml`) now keeps Create Sprint only in Plan and shows the selected-sprint summary/actions (Create Sprint disclosure removed from the strip).
- Confirmation and client behavior: added `data-at-confirm` on destructive Move-to-Backlog actions and implemented `initActionConfirmations()` in `wwwroot/js/pages/action-tasks/index.js` to trigger a standard `window.confirm` prompt (CSP-safe data-attribute based approach).  
- Services & domain: hardened `ActionTaskBucketInvariantValidator` to require both `AssignedToUserId` and `AssignedToRole` for assigned/sprint tasks and to forbid any assignee/role on Backlog items; updated `ActionTaskCategorization` to require both user and role where appropriate.
- Migrations: extended `NormalizeActionTaskBacklogRows` to clear `AssignedToRole` for legacy backlog rows and to explicitly move invalid rows (SprintId set but no assignee) back to Backlog (clearing SprintId/AssignedToRole/SubmittedOn/ClosedOn) instead of silently ignoring them.
- API/service surface: removed the ambiguous public overload by renaming assignment APIs to explicit methods (`AssignBacklogItemToSprintAsync`, `AssignOutsideSprintTaskToSprintAsync`) and updated callers and tests accordingly.

### Testing
- Performed repository-wide code inspection and automated text/code updates across the Action Tasks area and updated unit tests (file edits reflected in `ProjectManagement.Tests/ActionTasks`).
- Executed scripting checks and grep/ripgrep scans to validate changed references and propagate route-state and wording changes; local JS was updated and basic DOM-initializers were wired to new attributes. 
- Attempted to run `dotnet test` for the ActionTasks tests, but the CI/runtime `dotnet` SDK is not available in this environment so automated unit tests could not be executed (command failed with `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073ee8e78883299db0f73011cd6170)