### PR TITLE
Action Tracker: Clean up Command Centre dashboard and de-duplicate attention lists

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -1220,7 +1220,7 @@ public class IndexModel : PageModel
     public int SubmittedCount => CommandCentreSummary.SubmittedCount;
     public int BlockedCount => CommandCentreSummary.BlockedCount;
     public int ClosedCount => CommandCentreSummary.ClosedCount;
-    public int CriticalOpenCount => CriticalOpenTasks.Count;
+    public int CriticalOpenCount => CommandCentreSummary.ActiveCriticalCount;
     public int OpenTaskCount => Tasks.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
     public int StatusCountsMax => StatusCounts.Count == 0 ? 0 : StatusCounts.Max(x => x.Count);
     public int PriorityCountsMax => PriorityCounts.Count == 0 ? 0 : PriorityCounts.Max(x => x.Count);
@@ -1258,6 +1258,34 @@ public class IndexModel : PageModel
     public string DashboardCommandFocusSummary => CommandCentreSummary.DashboardCommandFocusSummary;
     public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<TaskDisplayItem> TopAttentionTaskDisplays => ToDisplayItems(CommandCentreSummary.TopAttentionTasks);
+
+    // SECTION: Command Centre attention projections are prioritized and de-duplicated for exception-led rendering.
+    public IReadOnlyList<TaskDisplayItem> CommandPendingClosureTaskDisplays =>
+        ToDisplayItems(CommandCentreSummary.PendingClosureTasks);
+
+    public IReadOnlyList<TaskDisplayItem> CommandBlockedTaskDisplays =>
+        ToDisplayItems(CommandCentreSummary.BlockedTasks);
+
+    public IReadOnlyList<TaskDisplayItem> CommandOverdueTaskDisplays =>
+        ToDisplayItems(CommandCentreSummary.OverdueTasks);
+
+    public IReadOnlyList<TaskDisplayItem> CommandCriticalOpenTaskDisplays =>
+        ToDisplayItems(CommandCentreSummary.CriticalOpenTasks);
+
+    public bool HasCommandAttentionItems =>
+        CommandPendingClosureTaskDisplays.Any()
+        || CommandBlockedTaskDisplays.Any()
+        || CommandOverdueTaskDisplays.Any()
+        || CommandCriticalOpenTaskDisplays.Any();
+
+    public bool HasActiveSprintExceptions =>
+        ActiveSprintOverdueTaskDisplays.Any()
+        || ActiveSprintBlockedTaskDisplays.Any()
+        || ActiveSprintSubmittedTaskDisplays.Any();
+
+    public bool HasRecentActivityItems =>
+        RecentlySubmittedTaskDisplays.Any()
+        || RecentlyUpdatedTaskDisplays.Any();
 
     public string CommandSummary => CommandCentreSummary.CommandSummary;
 

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -1,19 +1,19 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-@* SECTION: Command-attention strip for command-centre exceptions. *@
-<section class="at-kpis" aria-label="Command attention metrics">
-    <article><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Past due and open</p></article>
-    <article><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Needs unblock action</p></article>
-    <article><h3>Pending Closure</h3><strong>@Model.SubmittedPendingClosureCount</strong><p>Submitted for close-out</p></article>
-    <article><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Critical priority, not closed</p></article>
-    <article><h3>Open Tasks</h3><strong>@Model.OpenTaskCount</strong><p>Total not closed</p></article>
+@* SECTION: Command KPI row keeps the Command Centre focused on exception-level counters only. *@
+<section class="at-command-kpis at-kpis" aria-label="Command KPI row">
+    <article class="at-dashboard-compact-card"><h3>Overdue</h3><strong>@Model.OverdueCount</strong><p>Past due and open</p></article>
+    <article class="at-dashboard-compact-card"><h3>Blocked</h3><strong>@Model.BlockedCount</strong><p>Needs unblock action</p></article>
+    <article class="at-dashboard-compact-card"><h3>Pending Closure</h3><strong>@Model.SubmittedPendingClosureCount</strong><p>Submitted for close-out</p></article>
+    <article class="at-dashboard-compact-card"><h3>Critical Open</h3><strong>@Model.CriticalOpenCount</strong><p>Critical priority, not closed</p></article>
+    <article class="at-dashboard-compact-card"><h3>Open Tasks</h3><strong>@Model.OpenTaskCount</strong><p>Total not closed</p></article>
 </section>
 
-@* SECTION: Active sprint operational health metrics or empty state. *@
-<section class="at-panel at-active-sprint-dashboard">
+@* SECTION: Active sprint snapshot is compact and suppresses zero-card grids when no active sprint exists. *@
+<section class="at-panel at-active-sprint-snapshot" aria-label="Active Sprint Snapshot">
     <div class="at-panel-heading">
         <div>
-            <h2>Active Sprint Health</h2>
+            <h2>Active Sprint</h2>
             @if (Model.ActiveSprint is not null)
             {
                 <p class="at-panel-note">@Model.DisplaySprintName(Model.ActiveSprint) · @Model.ActiveSprintMetrics.ActiveSprintDateRange</p>
@@ -22,79 +22,125 @@
     </div>
     @if (Model.ActiveSprint is null)
     {
-        <div class="at-empty-state at-empty-state-compact">
-            <div>No active sprint is currently set.</div>
-            <div class="at-panel-note">Activate a planned sprint from Sprint Board to start execution tracking.</div>
+        <div class="at-dashboard-empty-state at-empty-state at-empty-state-compact">
+            <strong>No active sprint is currently set.</strong>
+            <span>Activate a planned sprint from Sprint Board to start execution tracking.</span>
             <a asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" class="btn btn-outline-primary btn-sm mt-2">Go to Sprint Board</a>
         </div>
     }
     else
     {
-        <div class="at-sprint-health-grid at-sprint-health-grid-readable" aria-label="Active Sprint health metrics">
-            <article class="is-primary"><h3>Total in active sprint</h3><strong>@Model.ActiveSprintMetrics.TotalTasks</strong><span>Current execution scope</span></article>
-            <article><h3>Completed</h3><strong>@Model.ActiveSprintMetrics.CompletedTasks</strong></article>
-            <article><h3>In progress</h3><strong>@Model.ActiveSprintMetrics.InProgressTasks</strong></article>
-            <article><h3>Blocked</h3><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></article>
-            <article><h3>Overdue in sprint</h3><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></article>
-        </div>
-        @* SECTION: Command attention grouping for active Sprint exceptions. *@
-        <div class="at-dashboard-attention-grid" aria-label="Active Sprint command attention">
-            <article class="at-attention-panel">
-                <div class="at-attention-heading"><span>Overdue</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, "No overdue tasks in the active sprint.")' />
-            </article>
-            <article class="at-attention-panel">
-                <div class="at-attention-heading"><span>Blocked</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, "No blocked tasks in the active sprint.")' />
-            </article>
-            <article class="at-attention-panel">
-                <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, "No submitted tasks pending closure in the active sprint.")' />
-            </article>
+        <p class="at-active-sprint-summary">
+            @Model.ActiveSprintMetrics.TotalTasks tasks · @Model.ActiveSprintMetrics.InProgressTasks in progress · @Model.ActiveSprintMetrics.OverdueTasks overdue · @Model.ActiveSprintMetrics.BlockedTasks blocked · @Model.ActiveSprintSubmittedTaskDisplays.Count pending closure
+        </p>
+
+        @* SECTION: Active sprint exception lists render only when they contain command-relevant tasks. *@
+        <div class="at-active-sprint-exceptions" aria-label="Active Sprint Exceptions">
+            <h3>Active Sprint Exceptions</h3>
+            @if (!Model.HasActiveSprintExceptions)
+            {
+                <div class="at-dashboard-empty-line">No active sprint exceptions.</div>
+            }
+            else
+            {
+                <div class="at-attention-grid">
+                    @if (Model.ActiveSprintOverdueTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Overdue in Active Sprint</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                    @if (Model.ActiveSprintBlockedTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Blocked in Active Sprint</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                    @if (Model.ActiveSprintSubmittedTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Submitted Pending Closure in Active Sprint</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                </div>
+            }
         </div>
     }
 </section>
 
-@* SECTION: Attention-required panels with compact task rows. *@
-<section class="at-section-group">
+@* SECTION: Attention Required renders only non-empty command exception lists in de-duplicated priority order. *@
+<section class="at-attention-required at-section-group" aria-label="Attention Required">
     <h2 class="at-section-title">Attention Required</h2>
-    <div class="at-card-grid">
-        <article class="at-panel">
-            <div class="at-panel-heading">
-                <h3>Critical Open Tasks</h3>
-                <span class="at-count-chip">@Model.CriticalOpenTaskDisplays.Count</span>
-            </div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CriticalOpenTaskDisplays, "No critical open tasks.")' />
-        </article>
-        <article class="at-panel">
-            <div class="at-panel-heading">
-                <h3>Overdue Tasks</h3>
-                <span class="at-count-chip">@Model.OverdueTaskDisplays.Count</span>
-            </div>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.OverdueTaskDisplays, "No overdue tasks.")' />
-        </article>
-    </div>
+    @if (!Model.HasCommandAttentionItems)
+    {
+        <div class="at-dashboard-empty-line">No command attention items.</div>
+    }
+    else
+    {
+        <div class="at-attention-grid at-dashboard-task-list">
+            @if (Model.CommandPendingClosureTaskDisplays.Any())
+            {
+                <article class="at-attention-panel">
+                    <div class="at-attention-heading"><span>Pending Closure Tasks</span><strong>@Model.CommandPendingClosureTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CommandPendingClosureTaskDisplays, string.Empty)' />
+                </article>
+            }
+            @if (Model.CommandBlockedTaskDisplays.Any())
+            {
+                <article class="at-attention-panel">
+                    <div class="at-attention-heading"><span>Blocked Tasks</span><strong>@Model.CommandBlockedTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CommandBlockedTaskDisplays, string.Empty)' />
+                </article>
+            }
+            @if (Model.CommandOverdueTaskDisplays.Any())
+            {
+                <article class="at-attention-panel">
+                    <div class="at-attention-heading"><span>Overdue Tasks</span><strong>@Model.CommandOverdueTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CommandOverdueTaskDisplays, string.Empty)' />
+                </article>
+            }
+            @if (Model.CommandCriticalOpenTaskDisplays.Any())
+            {
+                <article class="at-attention-panel">
+                    <div class="at-attention-heading"><span>Critical Open Tasks</span><strong>@Model.CommandCriticalOpenTaskDisplays.Count</strong></div>
+                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.CommandCriticalOpenTaskDisplays, string.Empty)' />
+                </article>
+            }
+        </div>
+    }
 </section>
 
-@* SECTION: Recent activity is secondary to command-critical work and collapsed by default. *@
-<section class="at-section-group">
-    <details class="at-panel at-details-collapsible">
-        <summary>Recent Activity</summary>
-        <div class="at-card-grid mt-3">
-            <article class="at-panel">
-                <div class="at-panel-heading">
-                    <h3>Recently Submitted</h3>
-                    <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
-                </div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, "No submitted tasks awaiting closure.")' />
-            </article>
-            <article class="at-panel">
-                <div class="at-panel-heading">
-                    <h3>Recently Updated</h3>
-                    <span class="at-count-chip">@Model.RecentlyUpdatedTaskDisplays.Count</span>
-                </div>
-                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlyUpdatedTaskDisplays, "No recently updated tasks.")' />
-            </article>
-        </div>
-    </details>
-</section>
+@* SECTION: Recent activity remains secondary and is hidden completely when it has no useful content. *@
+@if (Model.HasRecentActivityItems)
+{
+    <section class="at-recent-activity at-section-group" aria-label="Recent Activity">
+        <details class="at-panel at-details-collapsible">
+            <summary>Recent Activity</summary>
+            <div class="at-card-grid mt-3">
+                @if (Model.RecentlySubmittedTaskDisplays.Any())
+                {
+                    <article class="at-panel">
+                        <div class="at-panel-heading">
+                            <h3>Recently Submitted</h3>
+                            <span class="at-count-chip">@Model.RecentlySubmittedTaskDisplays.Count</span>
+                        </div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlySubmittedTaskDisplays, string.Empty)' />
+                    </article>
+                }
+                @if (Model.RecentlyUpdatedTaskDisplays.Any())
+                {
+                    <article class="at-panel">
+                        <div class="at-panel-heading">
+                            <h3>Recently Updated</h3>
+                            <span class="at-count-chip">@Model.RecentlyUpdatedTaskDisplays.Count</span>
+                        </div>
+                        <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.RecentlyUpdatedTaskDisplays, string.Empty)' />
+                    </article>
+                }
+            </div>
+        </details>
+    </section>
+}

--- a/Pages/ActionTasks/_TaskMiniList.cshtml
+++ b/Pages/ActionTasks/_TaskMiniList.cshtml
@@ -18,7 +18,7 @@ else
         {
             var task = item.Task;
             @* SECTION: Preserve contextual sprint and Sprint Board tab selection when compact task links open the inspector. *@
-            <a class="at-mini-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-route-PlanningTab="@planningTabRouteValue" asp-route-SelectedSprintId="@pageModel.SelectedSprintId">
+            <a class="at-mini-row at-dashboard-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="@pageModel.ResolvedViewMode" asp-route-PlanningTab="@planningTabRouteValue" asp-route-SelectedSprintId="@pageModel.SelectedSprintId">
                 <div class="at-mini-title">AT-@task.Id · @task.Title</div>
                 <div class="at-mini-meta">
                     <span>@item.AssigneeName</span>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -899,7 +899,58 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task DashboardPartial_ActiveSprintHealth_DoesNotShowBacklogMetric()
+    public async Task DashboardPartial_TopKpis_ShowOnlyCommandExceptionCards()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "CommandCentre";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
+        var kpiStart = html.IndexOf("at-command-kpis", StringComparison.Ordinal);
+        var kpiEnd = html.IndexOf("at-active-sprint-snapshot", StringComparison.Ordinal);
+        var kpis = html[kpiStart..kpiEnd];
+
+        // SECTION: Assert
+        Assert.Contains("Overdue", kpis, StringComparison.Ordinal);
+        Assert.Contains("Blocked", kpis, StringComparison.Ordinal);
+        Assert.Contains("Pending Closure", kpis, StringComparison.Ordinal);
+        Assert.Contains("Critical Open", kpis, StringComparison.Ordinal);
+        Assert.Contains("Open Tasks", kpis, StringComparison.Ordinal);
+        Assert.DoesNotContain("Carry Forward", kpis, StringComparison.Ordinal);
+        Assert.DoesNotContain("Backlog", kpis, StringComparison.Ordinal);
+        Assert.DoesNotContain("Sprint Tasks", kpis, StringComparison.Ordinal);
+        Assert.DoesNotContain("Completed", kpis, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DashboardPartial_NoActiveSprint_RendersCleanEmptyStateOnly()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "CommandCentre";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
+        var sprintStart = html.IndexOf("at-active-sprint-snapshot", StringComparison.Ordinal);
+        var attentionStart = html.IndexOf("Attention Required", StringComparison.Ordinal);
+        var activeSprint = html[sprintStart..attentionStart];
+
+        // SECTION: Assert
+        Assert.Contains("No active sprint is currently set.", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Activate a planned sprint from Sprint Board", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("Total in active sprint", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("Completed", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("In progress", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("Overdue in sprint", activeSprint, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DashboardPartial_ActiveSprintSnapshot_DoesNotShowBacklogOrEmptyExceptionPanels()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
@@ -912,13 +963,76 @@ public class ActionTaskPageTests
 
         // SECTION: Act
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
-        var healthStart = html.IndexOf("<h2>Active Sprint Health</h2>", StringComparison.Ordinal);
-        var attentionStart = html.IndexOf("Active Sprint command attention", StringComparison.Ordinal);
-        var activeSprintHealth = html[healthStart..attentionStart];
+        var sprintStart = html.IndexOf("at-active-sprint-snapshot", StringComparison.Ordinal);
+        var attentionStart = html.IndexOf("Attention Required", StringComparison.Ordinal);
+        var activeSprint = html[sprintStart..attentionStart];
 
         // SECTION: Assert
-        Assert.Contains("Total in active sprint", activeSprintHealth, StringComparison.Ordinal);
-        Assert.DoesNotContain("<h3>Backlog</h3>", activeSprintHealth, StringComparison.Ordinal);
+        Assert.Contains("<h2>Active Sprint</h2>", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Health Sprint", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("No active sprint exceptions.", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("Active Sprint Health", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("<h3>Backlog</h3>", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("No overdue tasks in the active sprint.", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("No blocked tasks in the active sprint.", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("No submitted tasks pending closure in the active sprint.", activeSprint, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DashboardPartial_AttentionRequired_RendersOnlyNonEmptyDeduplicatedLists()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var pendingClosure = NewTask("Pending closure item", ActionTaskStatuses.Submitted);
+        var blocked = NewTask("Blocked critical overdue item", ActionTaskStatuses.Blocked);
+        blocked.Priority = "Critical";
+        blocked.DueDate = DateTime.UtcNow.Date.AddDays(-2);
+        var overdue = NewTask("Overdue item", ActionTaskStatuses.Assigned);
+        overdue.DueDate = DateTime.UtcNow.Date.AddDays(-1);
+        var critical = NewTask("Critical open item", ActionTaskStatuses.Assigned);
+        critical.Priority = "Critical";
+        setup.Db.ActionTasks.AddRange(pendingClosure, blocked, overdue, critical);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "CommandCentre";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
+        var attentionStart = html.IndexOf("Attention Required", StringComparison.Ordinal);
+        var attentionEnd = html.IndexOf("Recent Activity", StringComparison.Ordinal);
+        var attention = attentionEnd >= 0 ? html[attentionStart..attentionEnd] : html[attentionStart..];
+
+        // SECTION: Assert
+        Assert.Contains("Pending Closure Tasks", attention, StringComparison.Ordinal);
+        Assert.Contains("Blocked Tasks", attention, StringComparison.Ordinal);
+        Assert.Contains("Overdue Tasks", attention, StringComparison.Ordinal);
+        Assert.Contains("Critical Open Tasks", attention, StringComparison.Ordinal);
+        Assert.DoesNotContain("No command attention items.", attention, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(attention, "Blocked critical overdue item"));
+        Assert.DoesNotContain("Remove from Sprint", attention, StringComparison.Ordinal);
+        Assert.DoesNotContain("Return to Backlog", attention, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DashboardPartial_EmptyAttentionAndRecentActivity_DoNotRenderEmptyPanels()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var page = setup.Page;
+        page.ViewMode = "CommandCentre";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("No command attention items.", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Critical Open Tasks", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Overdue Tasks", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Blocked Tasks", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Pending Closure Tasks", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recent Activity", html, StringComparison.Ordinal);
     }
 
 

--- a/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
@@ -22,6 +22,7 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
         var activeCriticalCount = tasks.Count(t => IsOpenTask(t) && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase));
         var blockedCount = CountByStatus(tasks, ActionTaskStatuses.Blocked);
         var submittedPendingClosureCount = CountByStatus(tasks, ActionTaskStatuses.Submitted);
+        var attentionLists = BuildCommandAttentionLists(tasks);
 
         return new ActionTaskCommandCentreSummary(
             activeCount,
@@ -31,10 +32,41 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
             blockedCount,
             CountByStatus(tasks, ActionTaskStatuses.Closed),
             activeCriticalCount,
-            BuildCommandFocusSummary(overdueCount, blockedCount, submittedPendingClosureCount, criticalOpenCount, carryForwardCandidateTasks),
+            BuildCommandFocusSummary(overdueCount, blockedCount, submittedPendingClosureCount, activeCriticalCount, carryForwardCandidateTasks),
             BuildCommandSummary(activeCount, activeCriticalCount, overdueCount, submittedPendingClosureCount),
-            BuildTopAttentionItems(tasks));
+            BuildTopAttentionItems(tasks),
+            attentionLists.PendingClosureTasks,
+            attentionLists.BlockedTasks,
+            attentionLists.OverdueTasks,
+            attentionLists.CriticalOpenTasks);
     }
+
+    // SECTION: Command attention lists de-duplicate task cards by command priority for a cleaner dashboard.
+    private CommandAttentionLists BuildCommandAttentionLists(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var usedTaskIds = new HashSet<int>();
+        var pendingClosure = TakeUnique(tasks
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id), usedTaskIds);
+        var blocked = TakeUnique(tasks
+            .Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id), usedTaskIds);
+        var overdue = TakeUnique(tasks
+            .Where(IsTaskOverdue)
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id), usedTaskIds);
+        var criticalOpen = TakeUnique(tasks
+            .Where(t => IsOpenTask(t) && string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(t => t.DueDate)
+            .ThenBy(t => t.Id), usedTaskIds);
+
+        return new CommandAttentionLists(pendingClosure, blocked, overdue, criticalOpen);
+    }
+
+    private static IReadOnlyList<ActionTaskItem> TakeUnique(IEnumerable<ActionTaskItem> tasks, HashSet<int> usedTaskIds)
+        => tasks.Where(t => usedTaskIds.Add(t.Id)).Take(5).ToList();
 
     // SECTION: Report top-attention prioritization keeps urgent overdue and critical work first.
     private IReadOnlyList<ActionTaskItem> BuildTopAttentionItems(IReadOnlyList<ActionTaskItem> tasks)
@@ -79,7 +111,11 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
         return $"{activeTasksText}{criticalText} {overdueText} {submittedPendingText}";
     }
 
-    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
+    private bool IsTaskOverdue(ActionTaskItem task)
+        => IsOpenTask(task)
+           && ActionTaskCategorization.HasAssignedUser(task)
+           && !ActionTaskCategorization.IsBacklogTask(task)
+           && task.DueDate.Date < _clock.UtcToday;
 
     private static int CountByStatus(IReadOnlyList<ActionTaskItem> tasks, string status)
         => tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));
@@ -110,7 +146,17 @@ public sealed record ActionTaskCommandCentreSummary(
     int ActiveCriticalCount,
     string DashboardCommandFocusSummary,
     string CommandSummary,
-    IReadOnlyList<ActionTaskItem> TopAttentionTasks)
+    IReadOnlyList<ActionTaskItem> TopAttentionTasks,
+    IReadOnlyList<ActionTaskItem> PendingClosureTasks,
+    IReadOnlyList<ActionTaskItem> BlockedTasks,
+    IReadOnlyList<ActionTaskItem> OverdueTasks,
+    IReadOnlyList<ActionTaskItem> CriticalOpenTasks)
 {
-    public static ActionTaskCommandCentreSummary Empty { get; } = new(0, 0, 0, 0, 0, 0, 0, "0 overdue. 0 blocked. 0 submitted pending closure. 0 critical open. 0 carry-forward candidates.", "There are 0 active tasks, including 0 critical tasks. No tasks are overdue. No submitted task is pending closure.", Array.Empty<ActionTaskItem>());
+    public static ActionTaskCommandCentreSummary Empty { get; } = new(0, 0, 0, 0, 0, 0, 0, "0 overdue. 0 blocked. 0 submitted pending closure. 0 critical open. 0 carry-forward candidates.", "There are 0 active tasks, including 0 critical tasks. No tasks are overdue. No submitted task is pending closure.", Array.Empty<ActionTaskItem>(), Array.Empty<ActionTaskItem>(), Array.Empty<ActionTaskItem>(), Array.Empty<ActionTaskItem>(), Array.Empty<ActionTaskItem>());
 }
+
+internal sealed record CommandAttentionLists(
+    IReadOnlyList<ActionTaskItem> PendingClosureTasks,
+    IReadOnlyList<ActionTaskItem> BlockedTasks,
+    IReadOnlyList<ActionTaskItem> OverdueTasks,
+    IReadOnlyList<ActionTaskItem> CriticalOpenTasks);

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -43,8 +43,8 @@ public sealed class ActionTaskQueryService
             ActiveSprintMetrics = activeSprintMetrics,
             CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
             OverdueTasks = tasks.Where(t => IsOpen(t) && t.DueDate.Date < _clock.UtcToday).OrderBy(t => t.DueDate).Take(5).ToList(),
-            RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
-            RecentlyUpdatedTasks = tasks.OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue).ThenByDescending(t => t.Id).Take(5).ToList(),
+            RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && t.SubmittedOn.HasValue).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
+            RecentlyUpdatedTasks = tasks.Where(t => ResolveLastActivityUtc(t, activityByTaskId).HasValue).OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue).ThenByDescending(t => t.Id).Take(5).ToList(),
             DueBuckets = BuildDueBuckets(tasks),
             Reports = _reportBuilder.BuildReportModel(tasks, request, assigneeNames)
         };
@@ -60,7 +60,7 @@ public sealed class ActionTaskQueryService
     private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
     {
         activityByTaskId.TryGetValue(task.Id, out var activityTimestampUtc);
-        return activityTimestampUtc ?? task.SubmittedOn ?? task.AssignedOn;
+        return activityTimestampUtc;
     }
 
     // SECTION: Backlog read-model projection uses the official open, unsprinted, unassigned backlog contract.

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3492,3 +3492,86 @@ html {
         grid-template-columns: 1fr;
     }
 }
+
+/* SECTION: Command Centre exception dashboard cleanup */
+.at-command-kpis .at-dashboard-compact-card {
+    min-height: 100%;
+}
+
+.at-active-sprint-snapshot {
+    margin-bottom: 0.9rem;
+}
+
+.at-active-sprint-snapshot .at-panel-heading {
+    margin-bottom: 0.45rem;
+}
+
+.at-dashboard-empty-state {
+    display: grid;
+    gap: 0.2rem;
+    align-items: start;
+}
+
+.at-dashboard-empty-state strong {
+    color: var(--at-text);
+}
+
+.at-active-sprint-summary {
+    margin: 0;
+    border: 1px solid var(--at-border);
+    border-radius: 12px;
+    background: #f8fafc;
+    color: var(--at-text);
+    padding: 0.6rem 0.75rem;
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-active-sprint-exceptions {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 0.7rem;
+}
+
+.at-active-sprint-exceptions h3 {
+    margin: 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.at-dashboard-empty-line {
+    border: 1px dashed var(--at-border);
+    border-radius: 10px;
+    background: #f8fafc;
+    color: var(--at-muted);
+    padding: 0.55rem 0.65rem;
+    font-size: var(--at-font-md);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-dashboard-task-list {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.at-dashboard-task-card {
+    padding: 0.55rem 0.6rem;
+}
+
+.at-dashboard-task-card .at-mini-title {
+    font-size: var(--at-font-md);
+    line-height: 1.25;
+}
+
+.at-dashboard-task-card .at-mini-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    line-height: 1.35;
+}
+
+.at-recent-activity .at-details-collapsible {
+    padding: 0.55rem 0.7rem;
+}


### PR DESCRIPTION
### Motivation
- Make the Command Centre a concise, exception-focused page that answers “What needs command attention now?” and avoid repeated metrics and large empty panels.
- Remove heavy Active Sprint Health grids and empty Recent Activity noise so the first screen is compact and scannable on normal laptop screens.
- Ensure attention lists are command-relevant and avoid duplicate task cards across multiple panels where practical.

### Description
- Restructured the dashboard view into three focused sections in `_TaskDashboard.cshtml`: a five-card Command KPI row, a compact Active Sprint snapshot with conditional exception panels, and an Attention Required area that renders only non-empty lists. (Pages/ActionTasks/_TaskDashboard.cshtml)
- Added prioritized, de-duplicated command attention lists and projection helpers, and exposed small display helpers on the page model so the view only renders non-empty panels (`Index.cshtml.cs` additions). (Pages/ActionTasks/Index.cshtml.cs)
- Extended `ActionTaskCommandCentreSummaryBuilder` to produce Command attention lists (Pending Closure, Blocked, Overdue, Critical Open) with de-duplication and adjusted `IsTaskOverdue` to exclude backlog/unassigned items from overdue counts. (Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs)
- Tightened Recent Activity selection in the read-model so only items with real activity/submitted timestamps are shown, updated compact task row partial for dashboard styling, and added focused CSS rules for compact KPI/empty-state/attention layouts. (Services/ActionTasks/ActionTaskQueryService.cs, Pages/ActionTasks/_TaskMiniList.cshtml, wwwroot/css/action-tracker.css)
- Updated dashboard-focused unit tests to assert the trimmed layout and rendering rules for KPIs, active sprint empty states, attention lists, and Recent Activity visibility. (ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs)

### Testing
- Static checks: `git diff --check` completed without local whitespace/format errors in this environment.
- Unit tests: new/updated tests were added for dashboard behaviour including `DashboardPartial_TopKpis_ShowOnlyCommandExceptionCards`, `DashboardPartial_NoActiveSprint_RendersCleanEmptyStateOnly`, `DashboardPartial_ActiveSprintSnapshot_DoesNotShowBacklogOrEmptyExceptionPanels`, `DashboardPartial_AttentionRequired_RendersOnlyNonEmptyDeduplicatedLists`, and `DashboardPartial_EmptyAttentionAndRecentActivity_DoNotRenderEmptyPanels` (tests were prepared but not executed here).
- Test execution status: attempted to run `dotnet test` for the ActionTasks page tests but the runtime is not available in this environment, so please run the full test suite in CI or locally to validate all assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07cb8ed4648329b491ef362b6d80d2)