### PR TITLE
Clean up Sprint Board: Plan/Execute/Close UI, compact cards, responsive Execute grid

### DIFF
--- a/Pages/ActionTasks/_PlanningCloseTab.cshtml
+++ b/Pages/ActionTasks/_PlanningCloseTab.cshtml
@@ -10,15 +10,18 @@
     {
         <partial name="_SprintClosureReview" model="Model" />
 
-        <details class="at-panel at-sprint-attention-lane at-close-carry-forward-panel">
-            <summary>
-                <span>Carry-forward candidates</span>
-                <span class="at-count-chip">@Model.SprintCarryForwardCandidateDisplays.Count</span>
-            </summary>
-            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
-        </details>
+        @if (Model.SprintCarryForwardCandidateDisplays.Any())
+        {
+            <details class="at-panel at-sprint-attention-lane at-close-carry-forward-panel">
+                <summary>
+                    <span>Carry-forward candidates</span>
+                    <span class="at-count-chip">@Model.SprintCarryForwardCandidateDisplays.Count</span>
+                </summary>
+                <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintCarryForwardCandidateDisplays, "No carry-forward candidates.")' />
+            </details>
+        }
 
-        @if (Model.SelectedSprint is not null)
+        @if (Model.SelectedSprint is not null && Model.SprintAuditHistory.Any())
         {
             <details class="at-panel at-sprint-history-panel">
                 <summary>Sprint History <span class="at-count-chip">@Model.SprintAuditHistory.Count</span></summary>

--- a/Pages/ActionTasks/_PlanningCommandStrip.cshtml
+++ b/Pages/ActionTasks/_PlanningCommandStrip.cshtml
@@ -30,19 +30,15 @@
                 <span class="at-sprint-status-pill">@Model.SelectedSprint.Status</span>
                 <span class="at-sprint-date-range">@Model.SelectedSprint.StartDate.ToString("dd MMM yyyy") – @Model.SelectedSprint.EndDate.ToString("dd MMM yyyy")</span>
             </div>
-            <div class="at-planning-command-pills" aria-label="Sprint summary">
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.OpenCount</strong> Open</span>
-                <span class="at-compact-counter"><strong>@Model.SelectedSprintOverdueCount</strong> Overdue</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.BlockedCount</strong> Blocked</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.ClosedCount</strong> Closed</span>
-                <span class="at-compact-counter"><strong>@Model.SprintSummary.TaskCount</strong> Total</span>
-            </div>
+            <p class="at-planning-command-summary" aria-label="Sprint summary">
+                @Model.SprintSummary.OpenCount open · @Model.SelectedSprintOverdueCount overdue · @Model.SprintSummary.BlockedCount blocked · @Model.SprintAttentionSubmittedTaskDisplays.Count pending closure
+            </p>
             <div class="at-command-focus-strip at-sprint-command-focus at-planning-command-focus">
                 <strong>Command focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
             </div>
         </div>
 
-        @if (Model.CanEditSelectedSprint || Model.CanActivateSelectedSprint || Model.CanCloseSelectedSprintDirectly || (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any()))
+        @if (Model.CanEditSelectedSprint || Model.CanActivateSelectedSprint || (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any()))
         {
             @* SECTION: Lifecycle and edit actions continue to post to existing handlers. *@
             <div class="at-sprint-action-row at-sprint-action-row-strip at-planning-command-actions">
@@ -77,16 +73,7 @@
                         <button type="submit" class="btn btn-success btn-sm">Activate</button>
                     </form>
                 }
-                @if (Model.CanCloseSelectedSprintDirectly)
-                {
-                    <form method="post" asp-page-handler="CloseSprint">
-                        <input type="hidden" name="PlanningTab" value="Close" />
-                        <input type="hidden" name="sprintId" value="@Model.SelectedSprint.Id" />
-                        <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedSprint.RowVersion)" />
-                        <button type="submit" class="btn btn-danger btn-sm">Close</button>
-                    </form>
-                }
-                else if (Model.CanReviewSprintClosure && Model.SprintClosureReview.UnfinishedTasks.Any())
+                @if (Model.CanReviewSprintClosure && Model.SelectedSprint.Status == ProjectManagement.Models.ActionSprintStatus.Active)
                 {
                     <a class="btn btn-outline-danger btn-sm" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@Model.SelectedSprintId">Review Closure</a>
                 }

--- a/Pages/ActionTasks/_PlanningExecuteTab.cshtml
+++ b/Pages/ActionTasks/_PlanningExecuteTab.cshtml
@@ -11,6 +11,7 @@
     };
     var closedTasks = Model.GetSprintTasksByStatus(ActionTaskStatuses.Closed);
     var attentionCount = Model.SprintAttentionOverdueTaskDisplays.Count + Model.SprintAttentionBlockedTaskDisplays.Count + Model.SprintAttentionSubmittedTaskDisplays.Count;
+    var hasExecutionAttention = attentionCount > 0;
 }
 
 @* SECTION: Execute tab opens directly into the selected sprint status board. *@
@@ -73,39 +74,43 @@
             </details>
         }
 
-        @* SECTION: Attention and due-exception lists are secondary to the visible status board. *@
-        <details class="at-panel at-sprint-attention-lane at-execute-attention">
-            <summary>
-                <span>Execution attention</span>
-                <span class="at-execute-attention-summary" aria-label="Execution attention counts">
-                    <span>Overdue <strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></span>
-                    <span>Blocked <strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></span>
-                    <span>Submitted pending closure <strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></span>
-                </span>
-                <span class="at-count-chip">@attentionCount</span>
-            </summary>
-            <div class="at-attention-grid">
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
+        @* SECTION: Attention renders only when there is something to review beyond the status grid counts. *@
+        @if (hasExecutionAttention)
+        {
+            <details class="at-panel at-sprint-attention-lane at-execute-attention">
+                <summary>
+                    <span>Execution Attention</span>
+                    <span class="at-execute-attention-summary" aria-label="Execution attention counts">
+                        <span>Overdue <strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></span>
+                        <span>Blocked <strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></span>
+                        <span>Pending Closure <strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></span>
+                    </span>
+                    <span class="at-count-chip">@attentionCount</span>
+                </summary>
+                <div class="at-attention-grid">
+                    @if (Model.SprintAttentionOverdueTaskDisplays.Any())
+                    {
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Overdue</span><strong>@Model.SprintAttentionOverdueTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionOverdueTaskDisplays, "No overdue planning tasks.")' />
+                        </div>
+                    }
+                    @if (Model.SprintAttentionBlockedTaskDisplays.Any())
+                    {
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
+                        </div>
+                    }
+                    @if (Model.SprintAttentionSubmittedTaskDisplays.Any())
+                    {
+                        <div class="at-attention-group">
+                            <div class="at-attention-heading"><span>Pending Closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
+                        </div>
+                    }
                 </div>
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Blocked</span><strong>@Model.SprintAttentionBlockedTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionBlockedTaskDisplays, "No blocked planning tasks.")' />
-                </div>
-                <div class="at-attention-group">
-                    <div class="at-attention-heading"><span>Submitted pending closure</span><strong>@Model.SprintAttentionSubmittedTaskDisplays.Count</strong></div>
-                    <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.SprintAttentionSubmittedTaskDisplays, "No submitted planning tasks.")' />
-                </div>
-            </div>
-        </details>
-
-        @* SECTION: Due / Exceptions is collapsed and contains only the exception view. *@
-        <details class="at-panel at-execute-secondary-views">
-            <summary>Due / Exceptions</summary>
-            <div class="at-execute-secondary-view-stack mt-3">
-                <partial name="_PlanningDueExceptionsView" model="Model" />
-            </div>
-        </details>
+            </details>
+        }
     }
 </section>

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -17,26 +17,6 @@
         }
         else
         {
-            <form method="get" class="at-sprint-selector-form at-sprint-selector-compact" data-at-sprint-selector="true">
-                <input type="hidden" name="viewMode" value="Planning" />
-                <input type="hidden" name="PlanningTab" value="Execute" />
-                <label class="form-label at-small" for="SelectedSprintId">Quick open</label>
-                <select class="form-select form-select-sm" id="SelectedSprintId" name="SelectedSprintId">
-                    @foreach (var sprint in Model.Sprints)
-                    {
-                        if (Model.SelectedSprint?.Id == sprint.Id)
-                        {
-                            <option value="@sprint.Id" selected>@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
-                        }
-                        else
-                        {
-                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
-                        }
-                    }
-                </select>
-                <button type="submit" class="btn btn-outline-primary btn-sm">Open Sprint</button>
-            </form>
-
             <div class="at-sprint-list-group">
                 <div class="at-sprint-list-heading">Active</div>
                 @if (Model.ActiveSprint is null)
@@ -114,11 +94,19 @@
             <span class="at-count-chip">@Model.BacklogTaskDisplays.Count</span>
         </div>
         <div class="at-planning-backlog-body">
-            <div class="at-backlog-summary-grid" aria-label="Backlog summary">
-                <article><strong>@Model.BacklogTotalCount</strong><span>Backlog items</span></article>
-                <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
-                <article><strong>@Model.BacklogOverdueCount</strong><span>Past Target</span></article>
-            </div>
+            @* SECTION: Low-volume backlogs use one compact summary line; larger or urgent queues keep cards. *@
+            @if (Model.BacklogTotalCount <= 5 && Model.BacklogHighPriorityCount == 0 && Model.BacklogOverdueCount == 0)
+            {
+                <p class="at-backlog-summary-line">@Model.BacklogTotalCount @(Model.BacklogTotalCount == 1 ? "backlog item" : "backlog items") · @Model.BacklogHighPriorityCount high priority · @Model.BacklogOverdueCount past target</p>
+            }
+            else
+            {
+                <div class="at-backlog-summary-grid" aria-label="Backlog summary">
+                    <article><strong>@Model.BacklogTotalCount</strong><span>Backlog items</span></article>
+                    <article><strong>@Model.BacklogHighPriorityCount</strong><span>High priority</span></article>
+                    <article><strong>@Model.BacklogOverdueCount</strong><span>Past Target</span></article>
+                </div>
+            }
 
             @* SECTION: Backlog filters remain GET-based, CSP-safe, and collapsed so low counts keep the queue prominent. *@
             <details class="at-planning-backlog-filter-shell" open="@hasBacklogFilters">
@@ -185,7 +173,7 @@
                             {
                                 @if (Model.CanAssignTaskToSprint(task))
                                 {
-                                    <details class="at-backlog-add-disclosure">
+                                    <details class="at-backlog-add-disclosure at-inline-action">
                                         <summary class="btn btn-outline-primary btn-sm">Add to Sprint</summary>
                                         <form method="post" asp-page-handler="AssignToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
                                             <input type="hidden" name="ViewMode" value="Planning" />
@@ -227,7 +215,7 @@
         <summary class="at-panel-heading">
             <div>
                 <h2>Assigned Tasks Outside Sprint</h2>
-                <p class="at-panel-note">Tasks already assigned to a responsible person but not included in any sprint.</p>
+                <p class="at-panel-note">Assigned work not included in any sprint.</p>
             </div>
             <span class="at-count-chip">@Model.OutsideSprintTaskDisplays.Count</span>
         </summary>
@@ -245,7 +233,6 @@
                     <article class="at-planning-backlog-card @(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
                         <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Planning" asp-route-PlanningTab="Plan" asp-route-SelectedSprintId="@Model.SelectedSprintId">AT-@task.Id · @task.Title</a>
                         <div class="at-backlog-task-meta">
-                            <span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span>
                             <span class="at-cell-primary">@item.AssigneeName</span>
                             <span class="@Model.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
                             @if (Model.IsTaskOverdue(task))
@@ -259,20 +246,23 @@
                         </div>
                         @if (Model.CanPlanSprints && Model.CanAddOutsideSprintTaskToSprint(task))
                         {
-                            <form method="post" asp-page-handler="AddOutsideSprintTaskToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
-                                <input type="hidden" name="ViewMode" value="Planning" />
-                                <input type="hidden" name="PlanningTab" value="Execute" />
-                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                <input type="hidden" name="id" value="@task.Id" />
-                                <select class="form-select form-select-sm" name="sprintId" aria-label="Select Sprint for AT-@task.Id" required>
-                                    <option value="">Select Sprint</option>
-                                    @foreach (var sprint in Model.AssignableSprints)
-                                    {
-                                        <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
-                                    }
-                                </select>
-                                <button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button>
-                            </form>
+                            <details class="at-backlog-add-disclosure at-inline-action">
+                                <summary class="btn btn-outline-primary btn-sm">Add to Sprint</summary>
+                                <form method="post" asp-page-handler="AddOutsideSprintTaskToSprint" class="at-inline-sprint-form at-planning-backlog-assign-form">
+                                    <input type="hidden" name="ViewMode" value="Planning" />
+                                    <input type="hidden" name="PlanningTab" value="Execute" />
+                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                    <input type="hidden" name="id" value="@task.Id" />
+                                    <select class="form-select form-select-sm" name="sprintId" aria-label="Select Sprint for AT-@task.Id" required>
+                                        <option value="">Select Sprint</option>
+                                        @foreach (var sprint in Model.AssignableSprints)
+                                        {
+                                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
+                                        }
+                                    </select>
+                                    <button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button>
+                                </form>
+                            </details>
                         }
                     </article>
                 }

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -20,7 +20,7 @@
             {
                 <span class="at-overdue-marker">Overdue</span>
             }
-            <span class="at-open-details-label">Open details</span>
+            <span class="at-open-details-label">Details</span>
         </div>
     </a>
 </article>

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -8,7 +8,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Sprint Closure Review</h2>
-                <p class="at-panel-note">Review unfinished work before closing the Sprint.</p>
+                <p class="at-panel-note">Review unfinished work before closing the sprint.</p>
             </div>
             <span class="at-count-chip">@review.UnfinishedTasks.Count unfinished</span>
         </div>
@@ -21,13 +21,8 @@
         </div>
 
         <div class="at-closure-recommendations">
-            <strong>Recommended disposition:</strong>
-            <ul>
-                @foreach (var option in review.RecommendedDispositionOptions)
-                {
-                    <li>@option</li>
-                }
-            </ul>
+            <strong>Closure guidance:</strong>
+            <span>Choose one disposition for each unfinished task. Return to Backlog removes the responsible person.</span>
         </div>
 
         @if (review.UnfinishedTasks.Any() && Model.ShouldShowCreateNextSprint)
@@ -68,10 +63,8 @@
                             <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status) · @sprint.StartDate.ToString("dd MMM") – @sprint.EndDate.ToString("dd MMM yyyy")</option>
                         }
                     </select>
-                    <div class="form-text">Return to Backlog removes the responsible person. Carry Forward requires a next sprint.</div>
                 </div>
 
-                <p class="at-panel-note">Return to Backlog removes the responsible person. Carry Forward requires a next sprint.</p>
 
                 <div class="at-closure-task-table" role="table" aria-label="Unfinished Sprint tasks requiring disposition">
                     <div class="at-closure-task-row at-closure-task-head" role="row">
@@ -111,7 +104,7 @@
             }
 
             <label class="form-label" asp-for="ClosureInput.Remarks">Closure remarks</label>
-            <textarea class="form-control" asp-for="ClosureInput.Remarks" rows="3" maxlength="2000" required placeholder="Summarize command decision and disposition rationale."></textarea>
+            <textarea class="form-control" asp-for="ClosureInput.Remarks" rows="3" maxlength="2000" required placeholder="Summarise command decision and disposition rationale."></textarea>
 
             <div class="at-closure-actions">
                 <button type="submit" class="btn btn-danger">Close Sprint with Review</button>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -214,6 +214,34 @@
                         </details>
                     }
 
+                    @if (!selectedTaskIsBacklog && Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="add-outside-to-sprint">
+                            <summary class="visually-hidden">Open add to sprint panel</summary>
+                            <form method="post" asp-page-handler="AddOutsideSprintTaskToSprint" class="at-action-card at-action-card-compact">
+                                <input type="hidden" name="ViewMode" value="Planning" />
+                                <input type="hidden" name="PlanningTab" value="Execute" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <div class="at-action-title">Add to Sprint</div>
+                                <div class="mb-2">
+                                    <label class="form-label at-small">Sprint</label>
+                                    <select class="form-select form-select-sm" name="sprintId" required>
+                                        <option value="">Select Sprint</option>
+                                        @foreach (var sprint in Model.AssignableSprints)
+                                        {
+                                            <option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="at-action-buttons">
+                                    <button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-outside-to-sprint">Cancel</button>
+                                </div>
+                            </form>
+                        </details>
+                    }
+
                     @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
                     {
                         <details class="at-action-drawer" data-at-action-panel="status">
@@ -315,6 +343,11 @@
                         {
                             <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="add-to-sprint">Add to Sprint</button>
                         }
+                    }
+                    else if (Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
+                    {
+                        <button type="button" class="btn btn-primary btn-sm" data-at-open-action="add-outside-to-sprint">Add to Sprint</button>
+                        <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="update">Add Update</button>
                     }
                     else if (string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
                     {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -274,7 +274,7 @@ public class ActionTaskPageTests
 
         // SECTION: Assert
         Assert.Contains("Unassigned future work awaiting sprint planning.", backlogHeader, StringComparison.Ordinal);
-        Assert.Contains("Past Target", backlogHeader, StringComparison.Ordinal);
+        Assert.Contains("past target", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("<span>Overdue</span>", backlogHeader, StringComparison.Ordinal);
         Assert.DoesNotContain("Outside Sprint", backlogHeader, StringComparison.Ordinal);
         Assert.DoesNotContain("Assigned Tasks Outside Sprint", backlogHeader, StringComparison.Ordinal);
@@ -824,7 +824,8 @@ public class ActionTaskPageTests
         Assert.Null(page.SelectedSprint);
         Assert.Contains("No sprint has been created yet", html, StringComparison.Ordinal);
         Assert.Contains("Create Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Assigned Tasks Outside Sprint are assigned work not included in a sprint commitment.", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned Tasks Outside Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned work not included in any sprint.", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Create " + "Planning " + "Window", html, StringComparison.Ordinal);
         Assert.Contains("handler=CreateSprint", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Select a sprint to view sprint command details.", html, StringComparison.Ordinal);
@@ -881,11 +882,195 @@ public class ActionTaskPageTests
         Assert.Contains($"<h2>{ActionTaskStatuses.Blocked}</h2>", html, StringComparison.Ordinal);
         Assert.Contains($"<h2>{ActionTaskStatuses.Submitted}</h2>", html, StringComparison.Ordinal);
         Assert.DoesNotContain($"<h2>{ActionTaskStatuses.Closed}</h2>", html, StringComparison.Ordinal);
-        Assert.True(html.IndexOf("Selected Sprint Board task board", StringComparison.Ordinal) < html.IndexOf("Execution attention", StringComparison.Ordinal));
+        Assert.DoesNotContain("Execution Attention", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Due / Exceptions and Kanban", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Add from Backlog", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Add Backlog Task", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Backlog Queue", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Due / Exceptions", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Remove from Sprint", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Return to Backlog", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SprintBoardTabs_RenderOnlyPlanExecuteClose()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningTabs.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains(">Plan</span>", html, StringComparison.Ordinal);
+        Assert.Contains(">Execute</span>", html, StringComparison.Ordinal);
+        Assert.Contains(">Close</span>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(">Views</span>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Kanban", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlanningPlanTab_RemovesQuickOpenAndKeepsCollapsedPlanningControls()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        AddSprint(setup.Db, "Active Sprint", ActionSprintStatus.Active);
+        AddSprint(setup.Db, "Planned Sprint", ActionSprintStatus.Planned, 10);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Plan";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningPlanTab.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("<h2>Sprints</h2>", html, StringComparison.Ordinal);
+        Assert.Contains("at-sprint-list-heading\">Active", html, StringComparison.Ordinal);
+        Assert.Contains("at-sprint-list-heading\">Planned", html, StringComparison.Ordinal);
+        Assert.Contains("<h2>Backlog Items</h2>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Quick open", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Open Sprint", html, StringComparison.Ordinal);
+        Assert.Contains("<details class=\"at-planning-backlog-filter-shell\">", html, StringComparison.Ordinal);
+        Assert.Contains("<details class=\"at-panel at-planning-outside-sprint at-planning-plan-card\">", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlanningPlanTab_BacklogSummaryCardsRenderOnlyWhenUseful()
+    {
+        // SECTION: Arrange compact backlog
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var compactPage = setup.Page;
+        compactPage.ViewMode = "Planning";
+        compactPage.PlanningTab = "Plan";
+        await compactPage.OnGetAsync();
+
+        // SECTION: Act compact backlog
+        var compactHtml = await RenderPartialAsync(compactPage, "/Pages/ActionTasks/_PlanningPlanTab.cshtml");
+
+        // SECTION: Assert compact backlog
+        Assert.Contains("backlog items · 0 high priority · 0 past target", compactHtml, StringComparison.Ordinal);
+        Assert.DoesNotContain("at-backlog-summary-grid", compactHtml, StringComparison.Ordinal);
+
+        // SECTION: Arrange urgent backlog
+        var urgent = NewTask("Urgent backlog", ActionTaskStatuses.Backlog);
+        urgent.AssignedToUserId = string.Empty;
+        urgent.AssignedToRole = string.Empty;
+        urgent.Priority = "High";
+        urgent.DueDate = DateTime.UtcNow.Date.AddDays(3);
+        setup.Db.ActionTasks.Add(urgent);
+        await setup.Db.SaveChangesAsync();
+        await compactPage.OnGetAsync();
+
+        // SECTION: Act urgent backlog
+        var urgentHtml = await RenderPartialAsync(compactPage, "/Pages/ActionTasks/_PlanningPlanTab.cshtml");
+
+        // SECTION: Assert urgent backlog
+        Assert.Contains("at-backlog-summary-grid", urgentHtml, StringComparison.Ordinal);
+        Assert.Contains("<span>High priority</span>", urgentHtml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlanningPlanTab_BacklogAddToSprintFormIsHiddenDisclosure()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        AddSprint(setup.Db, "Planning Sprint", ActionSprintStatus.Planned);
+        var backlogTask = NewTask("Plan me", ActionTaskStatuses.Backlog);
+        backlogTask.AssignedToUserId = string.Empty;
+        backlogTask.AssignedToRole = string.Empty;
+        backlogTask.SprintId = null;
+        setup.Db.ActionTasks.Add(backlogTask);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Plan";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_PlanningPlanTab.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("<details class=\"at-backlog-add-disclosure at-inline-action\">", html, StringComparison.Ordinal);
+        Assert.Contains(">Add to Sprint</summary>", html, StringComparison.Ordinal);
+        Assert.Contains("Responsible person", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Pull from Backlog", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SprintBoardCss_UsesResponsiveExecuteGridWithoutHorizontalScrollRequirement()
+    {
+        // SECTION: Arrange
+        var css = File.ReadAllText(Path.Combine(GetContentRoot(), "wwwroot", "css", "action-tracker.css"));
+        var cleanupStart = css.IndexOf("/* SECTION: Sprint Board cleanup", StringComparison.Ordinal);
+        var cleanupCss = css[cleanupStart..];
+
+        // SECTION: Assert
+        Assert.Contains("grid-template-columns: repeat(4, minmax(0, 1fr));", cleanupCss, StringComparison.Ordinal);
+        Assert.Contains("grid-template-columns: repeat(2, minmax(0, 1fr));", cleanupCss, StringComparison.Ordinal);
+        Assert.Contains("grid-template-columns: 1fr;", cleanupCss, StringComparison.Ordinal);
+        Assert.Contains("overflow-x: visible;", cleanupCss, StringComparison.Ordinal);
+        Assert.DoesNotContain("min-width: max-content", cleanupCss, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SprintClosureReview_UsesConciseDispositionTextWithoutDuplicateHelper()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.Comdt);
+        var sprint = AddSprint(setup.Db, "Close Sprint", ActionSprintStatus.Active);
+        setup.Db.ActionTasks.Add(NewTask("Unfinished task", ActionTaskStatuses.Assigned, sprint.Id));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Close";
+        page.SelectedSprintId = sprint.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_SprintClosureReview.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Choose one disposition for each unfinished task. Return to Backlog removes the responsible person.", html, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(html, "Return to Backlog removes the responsible person"));
+        Assert.Contains("<span>Carry Forward</span>", html, StringComparison.Ordinal);
+        Assert.Contains("<span>Keep Outside Sprint</span>", html, StringComparison.Ordinal);
+        Assert.Contains("<span>Return to Backlog</span>", html, StringComparison.Ordinal);
+        Assert.Contains("Closure remarks", html, StringComparison.Ordinal);
+        Assert.Contains("Summarise command decision and disposition rationale.", html, StringComparison.Ordinal);
+        Assert.Contains("Close Sprint with Review", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Move to Backlog, Remove Assignee", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Keep Assigned Outside Sprint", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TaskDetails_KeepsMovementActionsAndBacklogConfirmationInInspector()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var sprint = AddSprint(setup.Db, "Inspector Sprint", ActionSprintStatus.Active);
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.SprintId = sprint.Id;
+        task.Status = ActionTaskStatuses.Assigned;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Execute";
+        page.SelectedSprintId = sprint.Id;
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Remove from Sprint, Keep Assigned", html, StringComparison.Ordinal);
+        Assert.Contains("Move to Backlog, Remove Assignee", html, StringComparison.Ordinal);
+        Assert.Contains("This will remove the responsible person and return the work to Backlog. Continue?", html, StringComparison.Ordinal);
     }
 
 

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -822,7 +822,7 @@ html {
     grid-auto-flow: column;
     grid-auto-columns: minmax(250px, 1fr);
     gap: 1rem;
-    min-width: max-content;
+    min-width: 0;
 }
 
 .at-board-grid.at-board-grid-sprint {
@@ -2783,7 +2783,7 @@ html {
     box-shadow: none;
 }
 
-/* SECTION: Execute Kanban board uses five visible status columns on wide screens, then stacks responsively. */
+/* SECTION: Execute status board uses four active workflow columns, then stacks responsively. */
 .at-planning-execute-panel {
     gap: 0.7rem;
 }
@@ -2791,13 +2791,13 @@ html {
 .at-execute-status-board {
     gap: 0.7rem;
     max-width: 100%;
-    overflow-x: auto;
+    overflow-x: visible;
     padding-bottom: 0.2rem;
 }
 
 .at-execute-status-grid {
     display: grid;
-    grid-template-columns: repeat(5, minmax(210px, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0.75rem;
     align-items: start;
     min-width: max-content;
@@ -2849,7 +2849,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-execute-status-grid {
-    grid-template-columns: repeat(5, minmax(180px, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-view-toggle {
@@ -3574,4 +3574,90 @@ html {
 
 .at-recent-activity .at-details-collapsible {
     padding: 0.55rem 0.7rem;
+}
+
+
+/* SECTION: Sprint Board cleanup compacts planning cards, disclosures, and command summary. */
+.at-planning-command-summary,
+.at-backlog-summary-line {
+    margin: 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+}
+
+.at-planning-command-summary {
+    margin-top: 0.25rem;
+}
+
+.at-planning-backlog-card {
+    gap: 0.35rem;
+    padding: 0.75rem 0.85rem;
+}
+
+.at-inline-action > summary {
+    cursor: pointer;
+}
+
+.at-inline-action .at-planning-backlog-assign-form {
+    margin-top: 0.5rem;
+}
+
+.at-planning-outside-sprint {
+    border-style: dashed;
+}
+
+.at-planning-outside-sprint > summary {
+    cursor: pointer;
+}
+
+.at-execute-status-board,
+.at-execute-status-grid {
+    max-width: 100%;
+    overflow-x: visible;
+}
+
+.at-execute-status-grid,
+.at-shell.is-planning-board.has-selection .at-execute-status-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    min-width: 0;
+}
+
+.at-sprint-task-card .at-card-top-row,
+.at-sprint-task-card .at-card-footer {
+    gap: 0.4rem;
+}
+
+.at-sprint-task-card .at-card-subject {
+    font-size: var(--at-font-sm);
+}
+
+.at-sprint-task-card .at-card-compact-meta {
+    font-size: var(--at-font-xs);
+}
+
+.at-closure-recommendations {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.at-closure-recommendations span {
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+}
+
+@media (max-width: 1200px) {
+    .at-execute-status-grid,
+    .at-shell.is-planning-board.has-selection .at-execute-status-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 767px) {
+    .at-execute-status-grid,
+    .at-shell.is-planning-board.has-selection .at-execute-status-grid {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
### Motivation
- Simplify the Sprint Board to a three-stage workflow (Plan | Execute | Close) so it behaves as a focused work area rather than a dashboard. 
- Reduce visual noise by collapsing secondary panels, removing duplicate sprint selectors, and making cards/action controls action-light.

### Description
- UI: Plan tab removed the Quick Open form and kept the grouped sprint list, made backlog summary conditional, kept backlog/add-to-sprint forms hidden in disclosures, and made `Assigned Tasks Outside Sprint` secondary and collapsed by default (`Pages/ActionTasks/_PlanningPlanTab.cshtml`).
- UI: Selected sprint strip replaced multiple pills with a single compact summary and limited lifecycle actions to relevant cases (`Pages/ActionTasks/_PlanningCommandStrip.cshtml`).
- UI: Execute tab now renders only the four active columns (`Assigned`, `In Progress`, `Blocked`, `Submitted`), keeps `Closed` collapsed, and shows the Execution Attention panel only when non-empty (`Pages/ActionTasks/_PlanningExecuteTab.cshtml`, `Pages/ActionTasks/_PlanningTaskCard.cshtml`).
- UI: Close workflow simplified by shortening guidance, removing duplicated helper text, and using concise disposition labels while preserving closure remarks and carry-forward flows (`Pages/ActionTasks/_SprintClosureReview.cshtml`, `Pages/ActionTasks/_PlanningCloseTab.cshtml`).
- Inspector: Movement/structural actions removed from cards remain available in the task inspector, including adding outside-sprint tasks into a sprint and the Return-to-Backlog confirmation text (`Pages/ActionTasks/_TaskDetails.cshtml`).
- CSS: `wwwroot/css/action-tracker.css` updated to remove horizontal-scroll dependency for the main board, provide a responsive grid `4 / 2 / 1` columns, and compact card/disclosure styles.
- Tests: Updated and extended page tests to assert the new tab set, plan cleanup, conditional backlog summary, hidden add-to-sprint disclosures, execute layout/CSS expectations, concise close text, and inspector movement actions (`ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`).
- Files modified (principal): `Pages/ActionTasks/_PlanningPlanTab.cshtml`, `_PlanningExecuteTab.cshtml`, `_PlanningCloseTab.cshtml`, `_PlanningCommandStrip.cshtml`, `_PlanningTaskCard.cshtml`, `_SprintClosureReview.cshtml`, `_TaskDetails.cshtml`, `wwwroot/css/action-tracker.css`, and test file `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`.

### Testing
- Updated unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to cover the new Plan/Execute/Close behaviour and CSS expectations; these test files were modified and are ready for CI execution.
- Ran `git diff --check` to validate whitespace/format issues and prepared the changes for review. 
- Attempted to run `dotnet test` and `dotnet build` in the container but the `dotnet` CLI is not available in this environment, so automated test execution and build were not performed here; please run `dotnet test` and `dotnet build` in CI or a dev machine to verify all tests and the build pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d292ced88329a85afc1d26f3866e)