### PR TITLE
Action Tracker My Work: simplify UI, compact task cards, and tighten queue logic

### DIFF
--- a/Pages/ActionTasks/_TaskMyWork.cshtml
+++ b/Pages/ActionTasks/_TaskMyWork.cshtml
@@ -6,44 +6,57 @@
     var actionRequiredTasks = Model.MyWorkActionRequiredDisplays;
     var currentWorkTasks = Model.MyWorkCurrentWorkDisplays;
     var submittedTasks = Model.MyWorkSubmittedAwaitingClosureDisplays;
-    var allMyTaskDisplays = Model.MyWorkAllMyTasksDisplays;
-    var actionRequiredCount = actionRequiredTasks.Count;
+    var otherAssignedWorkDisplays = Model.MyWorkAllMyTasksDisplays;
+    var actionRequiredCount = actionRequiredTasks.Count + otherAssignedWorkDisplays.Count(item => string.Equals(item.Task.Status, ProjectManagement.Models.ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase));
     var overdueCount = Model.MyOverdueTaskDisplays.Count;
     var inProgressCount = Model.MyInProgressTaskDisplays.Count;
     var submittedCount = Model.MySubmittedTaskDisplays.Count;
 }
 
-@* SECTION: Compact personal execution KPI strip. *@
+@* SECTION: Compact personal execution count line. *@
 <section class="at-mywork-summary-line" aria-label="My work open assignment count">
     <span>@assignedTaskCount open assigned tasks</span>
 </section>
-<section class="at-kpis at-kpis-mywork" aria-label="My work task summary">
-    <article>
-        <h3>Needs Action</h3>
-        <strong>@actionRequiredCount</strong>
-        <p>Overdue, due today, or blocked.</p>
-    </article>
-    <article>
-        <h3>Overdue</h3>
-        <strong>@overdueCount</strong>
-        <p>Past due and still open.</p>
-    </article>
-    <article>
-        <h3>In Progress</h3>
-        <strong>@inProgressCount</strong>
-        <p>Currently underway.</p>
-    </article>
-    <article>
-        <h3>Submitted</h3>
-        <strong>@submittedCount</strong>
-        <p>Awaiting closure review.</p>
-    </article>
-</section>
 
-@* SECTION: Priority-based personal work queue avoids repeated tasks and oversized empty panels. *@
-<section class="at-mywork-queue" aria-label="Priority-based personal work queue">
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, actionRequiredTasks, "Action Required", "Overdue, due today, and blocked work that needs attention before other assignments.", "No action-required tasks right now.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, currentWorkTasks, "Current Work", "In-progress tasks that are already underway after urgent exceptions are removed.", "No current work in progress.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, submittedTasks, "Submitted / Awaiting Closure", "Submitted work waiting for closure review.", "No submitted tasks are awaiting closure.")' />
-    <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, allMyTaskDisplays, "All My Tasks", "Remaining assigned tasks not already shown above.", "No remaining assigned tasks.")' />
-</section>
+@if (assignedTaskCount == 0)
+{
+    @* SECTION: Single calm empty state replaces repeated empty My Work panels. *@
+    <section class="at-panel at-mywork-empty" aria-label="No open assigned work">
+        <h3>No open tasks assigned to you.</h3>
+        <p>New assigned work will appear here.</p>
+    </section>
+}
+else
+{
+    @* SECTION: Compact personal execution KPI strip appears only when open work exists. *@
+    <section class="at-kpis at-kpis-mywork at-mywork-kpis" aria-label="My work task summary">
+        <article>
+            <h3>Needs Action</h3>
+            <strong>@actionRequiredCount</strong>
+            <p>Tasks that need your attention.</p>
+        </article>
+        <article>
+            <h3>Overdue</h3>
+            <strong>@overdueCount</strong>
+            <p>Past due and still open.</p>
+        </article>
+        <article>
+            <h3>In Progress</h3>
+            <strong>@inProgressCount</strong>
+            <p>Currently underway.</p>
+        </article>
+        <article>
+            <h3>Submitted</h3>
+            <strong>@submittedCount</strong>
+            <p>Awaiting closure review.</p>
+        </article>
+    </section>
+
+    @* SECTION: Priority-based personal work queue avoids repeated tasks and hides empty groups. *@
+    <section class="at-mywork-queue" aria-label="Priority-based personal work queue">
+        <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, actionRequiredTasks, "Action Required", "Tasks that need your attention now.")' />
+        <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, currentWorkTasks, "Current Work", "Tasks currently in progress.")' />
+        <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, submittedTasks, "Submitted / Awaiting Closure", "Work submitted for closure review.")' />
+        <partial name="_TaskMyWorkQueueSection" model='@Tuple.Create(Model, otherAssignedWorkDisplays, "Other Assigned Work", "Open assigned tasks not already shown above.")' />
+    </section>
+}

--- a/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
+++ b/Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml
@@ -4,27 +4,98 @@
     var tasks = Model.Item2;
 }
 
-@* SECTION: Compact My Work rows preserve inspector routing without large task-card bodies. *@
+@* SECTION: Compact My Work task cards keep assignee actions focused and avoid command/planning controls. *@
 <div class="at-mywork-rows">
     @foreach (var item in tasks)
     {
         var task = item.Task;
-        <a class="at-mywork-row @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)"
-           asp-page="/ActionTasks/Index"
-           asp-route-taskId="@task.Id"
-           asp-route-viewMode="@pageModel.ResolvedViewMode"
-           aria-label="Open task AT-@task.Id details">
+        var isAssigned = string.Equals(task.Status, ProjectManagement.Models.ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase);
+        var isInProgress = string.Equals(task.Status, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
+        var isBlocked = string.Equals(task.Status, ProjectManagement.Models.ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+        var isSubmitted = string.Equals(task.Status, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+        var detailsLabel = isSubmitted ? "View Details" : "Details";
+
+        <article class="at-mywork-task-card @(pageModel.IsSelectedTask(task) ? "is-selected" : string.Empty)">
             <div class="at-mywork-row-main">
                 <span class="at-mywork-task-id">AT-@task.Id</span>
+                <span aria-hidden="true">·</span>
                 <span class="at-mywork-title">@task.Title</span>
             </div>
             <div class="at-mywork-row-meta" aria-label="Task metadata">
                 <span>Due @task.DueDate.ToString("dd MMM yyyy")</span>
+                <span aria-hidden="true">·</span>
+                <span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span>
                 <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
                 <span class="@pageModel.GetPriorityBadgeClass(task.Priority)">@task.Priority</span>
-                <span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span>
-                <span class="at-mywork-open-action">Open details</span>
             </div>
-        </a>
+            <div class="at-mywork-card-actions" aria-label="Task actions">
+                @if (isAssigned && pageModel.CanUpdateTaskStatus(task))
+                {
+                    <form method="post" asp-page-handler="UpdateStatus" class="at-mywork-inline-form">
+                        <input type="hidden" name="ViewMode" value="@pageModel.ResolvedViewMode" />
+                        <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
+                        <input type="hidden" name="TaskId" value="@task.Id" />
+                        <input type="hidden" name="id" value="@task.Id" />
+                        <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(task.RowVersion)" />
+                        <input type="hidden" name="status" value="@ProjectManagement.Models.ActionTaskStatuses.InProgress" />
+                        <button type="submit" class="btn btn-primary btn-sm at-mywork-primary-action">Start Work</button>
+                    </form>
+                }
+                else if (isInProgress && pageModel.CanSubmitTask(task))
+                {
+                    <form method="post" asp-page-handler="Submit" class="at-mywork-inline-form">
+                        <input type="hidden" name="ViewMode" value="@pageModel.ResolvedViewMode" />
+                        <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
+                        <input type="hidden" name="TaskId" value="@task.Id" />
+                        <input type="hidden" name="id" value="@task.Id" />
+                        <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(task.RowVersion)" />
+                        <button type="submit" class="btn btn-warning btn-sm at-mywork-primary-action">Submit for Closure</button>
+                    </form>
+                }
+                else if (isBlocked)
+                {
+                    <a class="btn btn-primary btn-sm at-mywork-primary-action"
+                       asp-page="/ActionTasks/Index"
+                       asp-route-taskId="@task.Id"
+                       asp-route-viewMode="@pageModel.ResolvedViewMode">Add Update</a>
+                }
+                else if (isSubmitted)
+                {
+                    <a class="btn btn-primary btn-sm at-mywork-primary-action"
+                       asp-page="/ActionTasks/Index"
+                       asp-route-taskId="@task.Id"
+                       asp-route-viewMode="@pageModel.ResolvedViewMode">View Details</a>
+                }
+
+                @if (isBlocked && pageModel.CanUpdateTaskStatus(task))
+                {
+                    <form method="post" asp-page-handler="UpdateStatus" class="at-mywork-inline-form">
+                        <input type="hidden" name="ViewMode" value="@pageModel.ResolvedViewMode" />
+                        <input type="hidden" name="SelectedSprintId" value="@pageModel.SelectedSprintId" />
+                        <input type="hidden" name="TaskId" value="@task.Id" />
+                        <input type="hidden" name="id" value="@task.Id" />
+                        <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(task.RowVersion)" />
+                        <input type="hidden" name="status" value="@ProjectManagement.Models.ActionTaskStatuses.InProgress" />
+                        <button type="submit" class="btn btn-outline-primary btn-sm at-mywork-secondary-action">Mark In Progress</button>
+                    </form>
+                }
+                else if (isInProgress)
+                {
+                    <a class="btn btn-link btn-sm at-mywork-secondary-action"
+                       asp-page="/ActionTasks/Index"
+                       asp-route-taskId="@task.Id"
+                       asp-route-viewMode="@pageModel.ResolvedViewMode">Add Update</a>
+                }
+
+                @if (!isSubmitted)
+                {
+                    <a class="btn btn-link btn-sm at-mywork-secondary-action"
+                       asp-page="/ActionTasks/Index"
+                       asp-route-taskId="@task.Id"
+                       asp-route-viewMode="@pageModel.ResolvedViewMode"
+                       aria-label="Open task AT-@task.Id details">@detailsLabel</a>
+                }
+            </div>
+        </article>
     }
 </div>

--- a/Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml
+++ b/Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml
@@ -1,28 +1,23 @@
-@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>, string, string, string>
+@model Tuple<ProjectManagement.Pages.ActionTasks.IndexModel, IReadOnlyList<ProjectManagement.Pages.ActionTasks.IndexModel.TaskDisplayItem>, string, string>
 @{
     var pageModel = Model.Item1;
     var tasks = Model.Item2;
     var title = Model.Item3;
     var description = Model.Item4;
-    var emptyMessage = Model.Item5;
 }
 
-@* SECTION: Compact queue section keeps empty My Work groups from dominating the page. *@
-<article class="at-panel at-mywork-section @(tasks.Any() ? string.Empty : "is-empty")">
-    <div class="at-mywork-section-heading">
-        <div>
-            <h3>@title</h3>
-            <p class="at-panel-note">@description</p>
+@if (tasks.Any())
+{
+    @* SECTION: Compact queue section renders only when My Work has visible assigned tasks for the group. *@
+    <article class="at-panel at-mywork-section">
+        <div class="at-mywork-section-heading">
+            <div>
+                <h3>@title</h3>
+                <p class="at-panel-note">@description</p>
+            </div>
+            <span class="at-count-chip">@tasks.Count</span>
         </div>
-        <span class="at-count-chip">@tasks.Count</span>
-    </div>
 
-    @if (!tasks.Any())
-    {
-        <p class="at-empty-inline at-mywork-empty-line">@emptyMessage</p>
-    }
-    else
-    {
         <partial name="_TaskMyWorkQueueRows" model='@Tuple.Create(pageModel, tasks)' />
-    }
-</article>
+    </article>
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -117,11 +117,18 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task MyWorkPartial_RendersRedesignedPersonalQueueSections()
+    public async Task MyWorkPartial_RendersOpenPersonalQueueWithoutCommandNoise()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
         setup.Db.ActionTasks.Add(NewTask("Closed personal task", ActionTaskStatuses.Closed));
+        var otherUserTask = NewTask("Other user task", ActionTaskStatuses.Assigned);
+        otherUserTask.AssignedToUserId = "user-2";
+        setup.Db.ActionTasks.Add(otherUserTask);
+        var backlogTask = NewTask("Backlog personal task", ActionTaskStatuses.Backlog);
+        backlogTask.AssignedToUserId = string.Empty;
+        backlogTask.AssignedToRole = string.Empty;
+        setup.Db.ActionTasks.Add(backlogTask);
         await setup.Db.SaveChangesAsync();
         var page = setup.Page;
         page.ViewMode = "MyWork";
@@ -134,13 +141,22 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("Assigned to me", html, StringComparison.Ordinal);
         Assert.Contains("Needs Action", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Tasks in Active Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Action Required", html, StringComparison.Ordinal);
-        Assert.Contains("Current Work", html, StringComparison.Ordinal);
-        Assert.Contains("Submitted / Awaiting Closure", html, StringComparison.Ordinal);
-        Assert.Contains("All My Tasks", html, StringComparison.Ordinal);
-        Assert.Contains("Open details", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Action Required", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Current Work", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Submitted / Awaiting Closure", html, StringComparison.Ordinal);
+        Assert.Contains("Other Assigned Work", html, StringComparison.Ordinal);
+        Assert.Contains("Open assigned tasks not already shown above.", html, StringComparison.Ordinal);
+        Assert.Contains("Start Work", html, StringComparison.Ordinal);
+        Assert.Contains("Details", html, StringComparison.Ordinal);
         Assert.Contains("Mine", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("All My Tasks", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Closed personal task", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Backlog personal task", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Other user task", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Remove from Sprint", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Return to Backlog", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Reassign", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Close Task", html, StringComparison.Ordinal);
         Assert.Single(page.MyWorkAllMyTasksDisplays);
         Assert.DoesNotContain(page.MyWorkAllMyTasksDisplays, item => string.Equals(item.Task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
     }
@@ -171,10 +187,13 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task MyWorkPartial_EmptySectionsRenderCompactly()
+    public async Task MyWorkPartial_ZeroOpenTasksRendersSingleEmptyStateOnly()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.Status = ActionTaskStatuses.Closed;
+        await setup.Db.SaveChangesAsync();
         var page = setup.Page;
         page.ViewMode = "MyWork";
         await page.OnGetAsync();
@@ -183,10 +202,57 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("at-mywork-empty-line", html, StringComparison.Ordinal);
-        Assert.Contains("No action-required tasks right now.", html, StringComparison.Ordinal);
-        Assert.Contains("at-panel at-mywork-section is-empty", html, StringComparison.Ordinal);
-        Assert.DoesNotContain("No tasks assigned to you are due today.", html, StringComparison.Ordinal);
+        Assert.Contains("0 open assigned tasks", html, StringComparison.Ordinal);
+        Assert.Contains("No open tasks assigned to you.", html, StringComparison.Ordinal);
+        Assert.Contains("New assigned work will appear here.", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("at-mywork-kpis", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Action Required", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Current Work", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Submitted / Awaiting Closure", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Other Assigned Work", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("at-mywork-section", html, StringComparison.Ordinal);
+    }
+
+
+    [Fact]
+    public async Task MyWorkPartial_RendersStatusSpecificPrimaryActionsAndExclusiveSections()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var assigned = await setup.Db.ActionTasks.SingleAsync();
+        assigned.Title = "Assigned future";
+        assigned.Status = ActionTaskStatuses.Assigned;
+        assigned.DueDate = DateTime.UtcNow.Date.AddDays(5);
+        setup.Db.ActionTasks.Add(NewTask("Blocked task", ActionTaskStatuses.Blocked));
+        var overdueTask = NewTask("Overdue task", ActionTaskStatuses.Assigned);
+        overdueTask.DueDate = DateTime.UtcNow.Date.AddDays(-1);
+        setup.Db.ActionTasks.Add(overdueTask);
+        var dueTodayTask = NewTask("Due today task", ActionTaskStatuses.Assigned);
+        dueTodayTask.DueDate = DateTime.UtcNow.Date;
+        setup.Db.ActionTasks.Add(dueTodayTask);
+        setup.Db.ActionTasks.Add(NewTask("In progress task", ActionTaskStatuses.InProgress));
+        setup.Db.ActionTasks.Add(NewTask("Submitted task", ActionTaskStatuses.Submitted));
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskMyWork.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains(page.MyWorkActionRequiredDisplays, item => item.Task.Title == "Blocked task");
+        Assert.Contains(page.MyWorkActionRequiredDisplays, item => item.Task.Title == "Overdue task");
+        Assert.Contains(page.MyWorkActionRequiredDisplays, item => item.Task.Title == "Due today task");
+        Assert.Contains(page.MyWorkCurrentWorkDisplays, item => item.Task.Title == "In progress task");
+        Assert.Contains(page.MyWorkSubmittedAwaitingClosureDisplays, item => item.Task.Title == "Submitted task");
+        Assert.Contains(page.MyWorkAllMyTasksDisplays, item => item.Task.Title == "Assigned future");
+        Assert.Equal(6, page.MyWorkActionRequiredDisplays.Count + page.MyWorkCurrentWorkDisplays.Count + page.MyWorkSubmittedAwaitingClosureDisplays.Count + page.MyWorkAllMyTasksDisplays.Count);
+        Assert.Contains("Start Work", html, StringComparison.Ordinal);
+        Assert.Contains("Submit for Closure", html, StringComparison.Ordinal);
+        Assert.Contains("Add Update", html, StringComparison.Ordinal);
+        Assert.Contains("Mark In Progress", html, StringComparison.Ordinal);
+        Assert.Contains("View Details", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs
+++ b/Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs
@@ -93,7 +93,12 @@ public sealed class ActionTaskMyWorkQueueBuilder
     // SECTION: My Work precedence prevents repeated cards across action, execution, submitted, and remaining sections.
     private ActionTaskMyWorkQueueSection ResolveMyWorkQueueSection(ActionTaskItem task)
     {
-        if (IsTaskOverdue(task) || IsTaskDueToday(task) || IsTaskBlocked(task))
+        if (IsTaskSubmitted(task))
+        {
+            return ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure;
+        }
+
+        if (IsTaskBlocked(task) || IsTaskOverdue(task) || IsTaskDueToday(task))
         {
             return ActionTaskMyWorkQueueSection.ActionRequired;
         }
@@ -101,11 +106,6 @@ public sealed class ActionTaskMyWorkQueueBuilder
         if (IsTaskInProgress(task))
         {
             return ActionTaskMyWorkQueueSection.CurrentWork;
-        }
-
-        if (IsTaskSubmitted(task))
-        {
-            return ActionTaskMyWorkQueueSection.SubmittedAwaitingClosure;
         }
 
         return ActionTaskMyWorkQueueSection.AllMyTasks;
@@ -123,12 +123,16 @@ public sealed class ActionTaskMyWorkQueueBuilder
     }
 
     // SECTION: Shared My Work predicates keep queue grouping aligned with open-task lifecycle rules.
-    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
-    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date == _clock.UtcToday;
+    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date < _clock.UtcToday;
+    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date == _clock.UtcToday;
     private static bool IsTaskBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
     private static bool IsTaskInProgress(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
     private static bool IsTaskSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
-    private static bool IsOpenTask(ActionTaskItem task) => !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    private static bool IsOpenTask(ActionTaskItem task)
+        => !task.IsDeleted
+           && ActionTaskCategorization.HasAssignedUser(task)
+           && !string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase)
+           && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
 
     // SECTION: Reusable status ordering mirrors operational list ordering.
     private static int StatusOrder(string status) => status switch

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2182,7 +2182,7 @@ html {
 
 /* SECTION: My Work focused execution workspace */
 .at-kpis-mywork {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0.65rem;
 }
 
@@ -2207,17 +2207,33 @@ html {
     line-height: 1.25;
 }
 
+.at-mywork-empty {
+    display: grid;
+    gap: 0.25rem;
+    max-width: 36rem;
+    padding: 1.25rem;
+}
+
+.at-mywork-empty h3 {
+    margin: 0;
+    color: var(--at-text);
+    font-size: 1rem;
+    font-weight: var(--at-weight-bold);
+}
+
+.at-mywork-empty p {
+    margin: 0;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+}
+
 .at-mywork-queue {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.65rem;
 }
 
 .at-mywork-section {
-    padding: 0.85rem;
-}
-
-.at-mywork-section.is-empty {
-    padding: 0.65rem 0.85rem;
+    padding: 0.8rem;
 }
 
 .at-mywork-section-heading {
@@ -2225,11 +2241,7 @@ html {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.5rem;
     align-items: start;
-    margin-bottom: 0.65rem;
-}
-
-.at-mywork-section.is-empty .at-mywork-section-heading {
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.55rem;
 }
 
 .at-mywork-section-heading h3 {
@@ -2239,46 +2251,30 @@ html {
     font-weight: var(--at-weight-bold);
 }
 
-.at-mywork-empty-line {
-    margin: 0;
-}
-
 .at-mywork-rows {
     display: grid;
     gap: 0.45rem;
 }
 
-.at-mywork-row {
+.at-mywork-task-card {
     display: grid;
-    grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 1.4fr);
+    grid-template-columns: minmax(0, 1.25fr) minmax(17rem, 1.35fr) auto;
     gap: 0.65rem;
     align-items: center;
-    padding: 0.65rem 0.75rem;
+    padding: 0.6rem 0.7rem;
     border: 1px solid var(--at-border);
     border-radius: 12px;
     background: #fff;
-    color: inherit;
-    text-decoration: none;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
-.at-mywork-row:hover,
-.at-mywork-row:focus {
-    border-color: rgba(37, 99, 235, 0.45);
-    box-shadow: var(--at-shadow-sm);
-    color: inherit;
-    text-decoration: none;
-    transform: translateY(-1px);
-}
-
-.at-mywork-row.is-selected {
+.at-mywork-task-card.is-selected {
     border-color: var(--at-primary);
     box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.16);
 }
 
 .at-mywork-row-main {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.35rem;
     align-items: baseline;
     min-width: 0;
 }
@@ -2309,29 +2305,47 @@ html {
     font-size: var(--at-font-sm);
 }
 
-.at-mywork-open-action {
-    color: var(--at-primary);
-    font-weight: 800;
+.at-mywork-card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.at-mywork-inline-form {
+    margin: 0;
+}
+
+.at-mywork-primary-action {
+    font-weight: var(--at-weight-bold);
+    white-space: nowrap;
+}
+
+.at-mywork-secondary-action {
+    color: var(--at-muted);
+    font-weight: var(--at-weight-semibold);
     white-space: nowrap;
 }
 
 @media (max-width: 1399px) {
     .at-kpis-mywork {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-mywork-task-card {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .at-mywork-row-meta,
+    .at-mywork-card-actions {
+        justify-content: flex-start;
     }
 }
 
 @media (max-width: 767px) {
     .at-kpis-mywork {
         grid-template-columns: 1fr;
-    }
-
-    .at-mywork-row {
-        grid-template-columns: 1fr;
-    }
-
-    .at-mywork-row-meta {
-        justify-content: flex-start;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Reduce noise on the `My Work` page and make it focused on the logged-in user’s open assigned tasks only. 
- Replace multiple empty panels and zero-value KPI cards with a single calm empty state to improve clarity for assignees. 
- Ensure tasks appear in exactly one mutually-exclusive My Work section and remove backlog/closed/deleted items from the personal queue.

### Description

- UI: Replace the multi-panel empty layout with a single empty state and show the KPI row only when there is at least one open assigned task by updating `Pages/ActionTasks/_TaskMyWork.cshtml` and `wwwroot/css/action-tracker.css`.
- Sections: Rename `All My Tasks` to `Other Assigned Work`, shorten subtitles, and render only non-empty sections using `Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml`.
- Task cards: Convert My Work rows into compact, assignee-focused task cards with due/sprint/status/priority badges and single primary actions per status (`Start Work`, `Submit for Closure`, `Add Update`, `View Details`, etc.) in `Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml` and supporting CSS changes.
- Queue logic: Tighten the My Work queue builder so `IsOpenTask` excludes deleted/backlog/closed tasks, treat `Submitted` tasks first, then `Blocked`/`Overdue`/`DueToday` as `ActionRequired`, then `InProgress`, otherwise `Other` in `Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs`.
- Tests: Update My Work page tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert the new empty-state behaviour, section exclusivity, status-specific primary actions, and that backlog/closed/other-user tasks are excluded.

### Testing

- Ran `git diff --check` to ensure no whitespace/patch issues and it passed.
- Updated unit tests under `ProjectManagement.Tests/ActionTasks` to reflect the redesigned page and new behaviours; the test suite could not be executed here because `dotnet` is unavailable in the environment (`dotnet test` attempted but not run). 
- Manual code inspection and local static checks were performed on the modified files: `Pages/ActionTasks/_TaskMyWork.cshtml`, `Pages/ActionTasks/_TaskMyWorkQueueSection.cshtml`, `Pages/ActionTasks/_TaskMyWorkQueueRows.cshtml`, `Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs`, `wwwroot/css/action-tracker.css`, and updated tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d9fd0d9c8329adfdeede0b3ddf4f)