### PR TITLE
Compact Register filters and fix bucket auto-submit

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -228,6 +228,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<string> RegisterStatusOptions => _workflowPolicy.AllowedStatusOptions.Concat(new[] { ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed, ActionTaskStatuses.Backlog }).ToList();
     public IReadOnlyList<string> PriorityOptions => _workflowPolicy.PriorityOptions;
     public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
+    public bool CanFilterByAssignee => _permission.CanViewAll(CurrentRole);
     public IReadOnlyList<ActionSprint> AssignableSprints => Sprints.Where(s => s.Status != ActionSprintStatus.Closed).ToList();
     public IReadOnlyList<ActionSprint> ClosureTargetSprints => SprintClosureReview.TargetSprintOptions;
     public bool CanActivateSelectedSprint => CanPlanSprints && SelectedSprint?.Status == ActionSprintStatus.Planned;
@@ -260,6 +261,7 @@ public class IndexModel : PageModel
             "OutsideSprint" => "Outside Sprint",
             "Sprint" => "Sprint",
             "Closed" => "Closed",
+            "Invalid" => "Invalid State",
             _ => bucket
         };
     public bool CanMoveTaskToBacklog(ActionTaskItem task)

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -29,15 +29,53 @@
 
 @* SECTION: Register filters keep task records searchable and auditable. *@
 <section class="at-panel at-register-filter-panel mb-3">
-    <div class="at-register-filter-heading">
-        <div>
-            <h2>Register Filters</h2>
-            <p class="at-panel-note">Refine the master task register without leaving the workspace.</p>
-        </div>
-        <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
-    </div>
     <form id="taskFilterForm" method="get" class="at-register-filter-toolbar" data-at-task-filter-form="true">
         <input type="hidden" name="viewMode" value="Register" />
+        <div class="at-register-filter-field at-register-filter-field-search">
+            <label class="form-label" for="RegisterFilterSearch">Search</label>
+            <input type="text" class="form-control form-control-sm" id="RegisterFilterSearch" name="FilterSearch" value="@Model.FilterSearch" placeholder="Search task title or AT number" data-at-filter-search="true" />
+        </div>
+        @if (Model.CanFilterByAssignee)
+        {
+            <div class="at-register-filter-field at-register-filter-field-person">
+                <label class="form-label" for="FilterAssigneePicker">Responsible Person</label>
+                <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
+                @{
+                    // SECTION: Build unique, user-readable datalist labels even when display names collide.
+                    var duplicateDisplayNames = Model.AssignableUsers
+                        .Where(u => !string.IsNullOrWhiteSpace(u.DisplayName))
+                        .GroupBy(u => u.DisplayName.Trim(), StringComparer.OrdinalIgnoreCase)
+                        .Where(g => g.Count() > 1)
+                        .Select(g => g.Key)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                    var selectedAssignee = string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId)
+                        ? null
+                        : Model.AssignableUsers.FirstOrDefault(u => string.Equals(u.UserId, Model.FilterAssigneeUserId, StringComparison.Ordinal));
+                    var selectedDisplayName = (selectedAssignee?.DisplayName ?? string.Empty).Trim();
+                    var selectedUserId = (selectedAssignee?.UserId ?? string.Empty).Trim();
+                    var selectedAssigneeLabel = string.IsNullOrWhiteSpace(selectedDisplayName)
+                        ? selectedUserId
+                        : (duplicateDisplayNames.Contains(selectedDisplayName) ? $"{selectedDisplayName} ({selectedUserId})" : selectedDisplayName);
+                }
+                <input
+                    type="search"
+                    class="form-control form-control-sm"
+                    id="FilterAssigneePicker"
+                    list="FilterAssigneeOptions"
+                    autocomplete="off"
+                    placeholder="All Responsible Persons"
+                    value="@selectedAssigneeLabel"
+                    data-at-assignee-picker="true"
+                    data-at-assignee-target="FilterAssigneeUserId" />
+                <datalist id="FilterAssigneeOptions">
+                    @foreach (var assignee in Model.AssignableUsers)
+                    {
+                        <option value="@((duplicateDisplayNames.Contains((assignee.DisplayName ?? string.Empty).Trim()) ? $"{assignee.DisplayName} ({assignee.UserId})" : assignee.DisplayName) ?? assignee.UserId)" data-user-id="@assignee.UserId"></option>
+                    }
+                </datalist>
+            </div>
+        }
         <div class="at-register-filter-field at-register-filter-field-narrow">
             <label class="form-label" for="RegisterFilterStatus">Status</label>
             <select class="form-select form-select-sm" id="RegisterFilterStatus" name="FilterStatus">
@@ -59,7 +97,7 @@
             <label class="form-label" for="RegisterFilterBucket">Bucket</label>
             <select class="form-select form-select-sm" id="RegisterFilterBucket" name="FilterBucket">
                 <option value="">All</option>
-                @foreach (var bucket in new[] { (Value: "Backlog", Label: "Backlog"), (Value: "OutsideSprint", Label: "Outside Sprint"), (Value: "Sprint", Label: "Sprint"), (Value: "Closed", Label: "Closed") })
+                @foreach (var bucket in new[] { (Value: "Backlog", Label: "Backlog"), (Value: "OutsideSprint", Label: "Outside Sprint"), (Value: "Sprint", Label: "Sprint"), (Value: "Closed", Label: "Closed"), (Value: "Invalid", Label: "Invalid State") })
                 {
                     @if (string.Equals(Model.FilterBucket, bucket.Value, StringComparison.OrdinalIgnoreCase))
                     {
@@ -89,51 +127,12 @@
                 }
             </select>
         </div>
-        <div class="at-register-filter-field at-register-filter-field-person">
-            <label class="form-label" for="FilterAssigneePicker">Responsible Person</label>
-            <input type="hidden" name="FilterAssigneeUserId" id="FilterAssigneeUserId" value="@Model.FilterAssigneeUserId" />
-            @{
-                // SECTION: Build unique, user-readable datalist labels even when display names collide.
-                var duplicateDisplayNames = Model.AssignableUsers
-                    .Where(u => !string.IsNullOrWhiteSpace(u.DisplayName))
-                    .GroupBy(u => u.DisplayName.Trim(), StringComparer.OrdinalIgnoreCase)
-                    .Where(g => g.Count() > 1)
-                    .Select(g => g.Key)
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-                var selectedAssignee = string.IsNullOrWhiteSpace(Model.FilterAssigneeUserId)
-                    ? null
-                    : Model.AssignableUsers.FirstOrDefault(u => string.Equals(u.UserId, Model.FilterAssigneeUserId, StringComparison.Ordinal));
-                var selectedDisplayName = (selectedAssignee?.DisplayName ?? string.Empty).Trim();
-                var selectedUserId = (selectedAssignee?.UserId ?? string.Empty).Trim();
-                var selectedAssigneeLabel = string.IsNullOrWhiteSpace(selectedDisplayName)
-                    ? selectedUserId
-                    : (duplicateDisplayNames.Contains(selectedDisplayName) ? $"{selectedDisplayName} ({selectedUserId})" : selectedDisplayName);
-            }
-            <input
-                type="search"
-                class="form-control form-control-sm"
-                id="FilterAssigneePicker"
-                list="FilterAssigneeOptions"
-                autocomplete="off"
-                placeholder="All Responsible Persons"
-                value="@selectedAssigneeLabel"
-                data-at-assignee-picker="true"
-                data-at-assignee-target="FilterAssigneeUserId" />
-            <datalist id="FilterAssigneeOptions">
-                @foreach (var assignee in Model.AssignableUsers)
-                {
-                    <option value="@((duplicateDisplayNames.Contains((assignee.DisplayName ?? string.Empty).Trim()) ? $"{assignee.DisplayName} ({assignee.UserId})" : assignee.DisplayName) ?? assignee.UserId)" data-user-id="@assignee.UserId"></option>
-                }
-            </datalist>
-        </div>
         <div class="at-register-filter-field at-register-filter-field-date">
             <label class="form-label" for="RegisterFilterDueDate">Due / Target Date</label>
             <input type="date" class="form-control form-control-sm" id="RegisterFilterDueDate" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
         </div>
-        <div class="at-register-filter-field at-register-filter-field-search">
-            <label class="form-label" for="RegisterFilterSearch">Search by title</label>
-            <input type="text" class="form-control form-control-sm" id="RegisterFilterSearch" name="FilterSearch" value="@Model.FilterSearch" data-at-filter-search="true" />
+        <div class="at-register-filter-action">
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
         </div>
     </form>
 
@@ -158,7 +157,7 @@
             }
             @if (Model.FilterDueDate.HasValue)
             {
-                <span class="at-filter-chip">Due: @Model.FilterDueDate.Value.ToString("dd MMM yyyy")</span>
+                <span class="at-filter-chip">Date: @Model.FilterDueDate.Value.ToString("dd MMM yyyy")</span>
             }
             @if (!string.IsNullOrWhiteSpace(Model.FilterSearch))
             {
@@ -175,7 +174,11 @@
     @if (!Model.Tasks.Any())
     {
         <div class="at-empty-state">
-            <div class="fw-semibold">No tasks found for the current filters.</div>
+            <div class="fw-semibold">No tasks match the selected filters.</div>
+                @if (Model.HasActiveFilters)
+                {
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm mt-2">Clear filters</a>
+                }
         </div>
     }
     else
@@ -188,7 +191,7 @@
                         <th scope="col" aria-sort='@SortAriaSort("id")'><a class='@SortLinkClass("id")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("id")</span></a></th>
                         <th scope="col" aria-sort='@SortAriaSort("title")'><a class='@SortLinkClass("title")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("title")</span></a></th>
                         <th scope="col" aria-sort='@SortAriaSort("assignee")'><a class='@SortLinkClass("assignee")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("assignee")</span></a></th>
-                        <th scope="col" class="at-register-sprint-heading">Scope</th>
+                        <th scope="col" class="at-register-sprint-heading">Bucket</th>
                         <th scope="col" aria-sort='@SortAriaSort("due")'><a class='@SortLinkClass("due")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due / Target Date<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("due")</span></a></th>
                         <th scope="col" aria-sort='@SortAriaSort("status")'><a class='@SortLinkClass("status")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("status")</span></a></th>
                         <th scope="col" aria-sort='@SortAriaSort("priority")'><a class='@SortLinkClass("priority")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("priority")</span></a></th>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -128,7 +128,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
             NewTask(31, null, ActionTaskStatuses.Backlog, today.AddDays(2), assignedToUserId: string.Empty),
             NewTask(32, null, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee"),
             NewTask(33, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee"),
-            NewTask(34, null, ActionTaskStatuses.Closed, today.AddDays(2), assignedToUserId: "assignee")
+            NewTask(34, null, ActionTaskStatuses.Closed, today.AddDays(2), assignedToUserId: "assignee"),
+            NewTask(35, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: string.Empty)
         };
         var service = CreateQueryService();
 
@@ -137,12 +138,39 @@ public class ActionTaskQueryServiceSprintMetricsTests
         var outside = BuildWithBucket(service, tasks, sprint, "OutsideSprint");
         var sprintItems = BuildWithBucket(service, tasks, sprint, "Sprint");
         var closed = BuildWithBucket(service, tasks, sprint, "Closed");
+        var invalid = BuildWithBucket(service, tasks, sprint, "Invalid");
 
         // SECTION: Assert
         Assert.Equal(new[] { 31 }, backlog.TaskListTasks.Select(t => t.Id));
         Assert.Equal(new[] { 32 }, outside.TaskListTasks.Select(t => t.Id));
         Assert.Equal(new[] { 33 }, sprintItems.TaskListTasks.Select(t => t.Id));
         Assert.Equal(new[] { 34 }, closed.TaskListTasks.Select(t => t.Id));
+        Assert.Equal(new[] { 35 }, invalid.TaskListTasks.Select(t => t.Id));
+    }
+
+    [Fact]
+    public void BuildReadModel_RegisterSearch_MatchesTitleAndAtNumber()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 51, Name = "Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var tasks = new[]
+        {
+            NewTask(51, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(3), assignedToUserId: "assignee", title: "Monthly readiness review"),
+            NewTask(52, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(1), assignedToUserId: "assignee", title: "Fleet compliance check"),
+            NewTask(53, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee", title: "Inventory audit")
+        };
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var titleMatch = BuildWithSearch(service, tasks, sprint, "readiness");
+        var atNumberMatch = BuildWithSearch(service, tasks, sprint, "AT-52");
+        var numericMatch = BuildWithSearch(service, tasks, sprint, "52");
+
+        // SECTION: Assert
+        Assert.Equal(new[] { 51 }, titleMatch.TaskListTasks.Select(t => t.Id));
+        Assert.Equal(new[] { 52 }, atNumberMatch.TaskListTasks.Select(t => t.Id));
+        Assert.Equal(new[] { 52 }, numericMatch.TaskListTasks.Select(t => t.Id));
     }
 
     // SECTION: Test query service helper
@@ -173,12 +201,20 @@ public class ActionTaskQueryServiceSprintMetricsTests
             new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null, FilterBucket: bucket),
             new Dictionary<string, string> { ["assignee"] = "Assignee" },
             new Dictionary<int, DateTime?>());
+
+    private static ActionTaskQueryService.ActionTaskReadModel BuildWithSearch(ActionTaskQueryService service, IReadOnlyList<ActionTaskItem> tasks, ActionSprint sprint, string search)
+        => service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, null, null, null, null, search, null, null),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
     // SECTION: Test data helper
-    private static ActionTaskItem NewTask(int id, int? sprintId, string status, DateTime dueDate, string priority = "Normal", string assignedToUserId = "assignee", DateTime? assignedOn = null)
+    private static ActionTaskItem NewTask(int id, int? sprintId, string status, DateTime dueDate, string priority = "Normal", string assignedToUserId = "assignee", DateTime? assignedOn = null, string? title = null)
         => new()
         {
             Id = id,
-            Title = $"Task {id}",
+            Title = title ?? $"Task {id}",
             Description = "Task",
             CreatedByUserId = "creator",
             AssignedToUserId = assignedToUserId,

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -219,7 +219,15 @@ public sealed class ActionTaskQueryService
         if (!string.IsNullOrWhiteSpace(request.FilterPriority)) query = query.Where(t => string.Equals(t.Priority, request.FilterPriority, StringComparison.OrdinalIgnoreCase));
         if (!string.IsNullOrWhiteSpace(request.FilterAssigneeUserId)) query = query.Where(t => string.Equals(t.AssignedToUserId, request.FilterAssigneeUserId, StringComparison.Ordinal));
         if (request.FilterDueDate.HasValue) { var d = request.FilterDueDate.Value.Date; query = query.Where(t => t.DueDate.Date == d); }
-        if (!string.IsNullOrWhiteSpace(request.FilterSearch)) { var s = request.FilterSearch.Trim(); query = query.Where(t => t.Title.Contains(s, StringComparison.OrdinalIgnoreCase)); }
+        if (!string.IsNullOrWhiteSpace(request.FilterSearch))
+        {
+            var s = request.FilterSearch.Trim();
+            var normalizedTaskNumber = s.StartsWith("AT-", StringComparison.OrdinalIgnoreCase)
+                ? s[3..].Trim()
+                : s;
+
+            query = query.Where(t => MatchesRegisterSearch(t, s, normalizedTaskNumber, assigneeNames));
+        }
 
         var sortBy = (request.SortBy ?? "due").Trim().ToLowerInvariant();
         var descending = string.Equals(request.SortDir, "desc", StringComparison.OrdinalIgnoreCase);
@@ -236,6 +244,20 @@ public sealed class ActionTaskQueryService
             _ => descending ? query.OrderByDescending(t => t.DueDate) : query.OrderBy(t => t.DueDate)
         };
         return ordered.ThenBy(t => t.Id);
+    }
+
+
+    // SECTION: Register search matches task identity, title, description, and visible owner text.
+    private static bool MatchesRegisterSearch(ActionTaskItem task, string searchTerm, string normalizedTaskNumber, IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var taskNumber = $"AT-{task.Id}";
+        var assigneeName = assigneeNames.TryGetValue(task.AssignedToUserId, out var resolvedAssignee) ? resolvedAssignee : string.Empty;
+
+        return task.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
+            || taskNumber.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
+            || task.Id.ToString().Equals(normalizedTaskNumber, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrWhiteSpace(task.Description) && task.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+            || (!string.IsNullOrWhiteSpace(assigneeName) && assigneeName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
     }
 
     // SECTION: Register bucket filtering maps user-facing buckets to central task classification.

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -608,30 +608,32 @@ html {
 
 /* SECTION: Register enterprise grid polish */
 .at-register-filter-panel {
-    padding: 0.75rem 0.85rem;
-}
-
-.at-register-filter-heading {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 0.55rem;
-}
-
-.at-register-filter-heading h2 {
-    margin-bottom: 0.1rem;
-}
-
-.at-register-filter-heading .at-panel-note {
-    margin: 0;
+    padding: 0.65rem 0.75rem;
 }
 
 .at-register-filter-toolbar {
     display: grid;
-    grid-template-columns: minmax(8rem, 0.75fr) minmax(8rem, 0.75fr) minmax(13rem, 1.25fr) minmax(9rem, 0.8fr) minmax(15rem, 1.5fr);
-    gap: 0.5rem;
+    grid-template-columns: minmax(15rem, 1.45fr) minmax(14rem, 1.25fr) repeat(3, minmax(8rem, 0.75fr)) minmax(10rem, 0.9fr) auto;
+    gap: 0.45rem;
     align-items: end;
+}
+
+.at-register-filter-field-search {
+    min-width: 0;
+}
+
+.at-register-filter-field-person {
+    min-width: 0;
+}
+
+.at-register-filter-action {
+    display: flex;
+    align-items: end;
+    min-height: 2rem;
+}
+
+.at-register-filter-action .btn {
+    white-space: nowrap;
 }
 
 .at-register-filter-field .form-label {
@@ -754,6 +756,10 @@ html {
     .at-register-filter-field-person,
     .at-register-filter-field-search {
         grid-column: span 2;
+    }
+
+    .at-register-filter-action {
+        align-items: stretch;
     }
 }
 

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -66,7 +66,7 @@
             return;
         }
 
-        const immediateControls = form.querySelectorAll("select[name='FilterStatus'], select[name='FilterPriority'], select[name='FilterAssigneeUserId'], input[name='FilterDueDate']");
+        const immediateControls = form.querySelectorAll("select[name='FilterStatus'], select[name='FilterBucket'], select[name='FilterPriority'], input[name='FilterDueDate']");
         immediateControls.forEach((control) => {
             control.addEventListener("change", () => {
                 form.requestSubmit();
@@ -120,8 +120,10 @@
         }
 
         assigneeInput.addEventListener("change", () => {
-            syncAssigneeSelection();
-            form.requestSubmit();
+            const valid = syncAssigneeSelection();
+            if (valid || !assigneeInput.value.trim()) {
+                form.requestSubmit();
+            }
         });
 
         assigneeInput.addEventListener("keydown", (event) => {
@@ -129,12 +131,18 @@
                 return;
             }
             event.preventDefault();
-            syncAssigneeSelection();
-            form.requestSubmit();
+            const valid = syncAssigneeSelection();
+            if (valid || !assigneeInput.value.trim()) {
+                form.requestSubmit();
+            }
         });
 
         assigneeInput.addEventListener("blur", () => {
-            syncAssigneeSelection();
+            const valid = syncAssigneeSelection();
+            if (!valid) {
+                assigneeInput.value = "";
+                hiddenInput.value = "";
+            }
         });
     }
 


### PR DESCRIPTION
### Motivation
- Improve Register UX by making the filter bar compact, moving Search to the front, and making Responsible Person more prominent for users who can view all tasks.  
- Ensure all dropdown filters (including `FilterBucket`) auto-submit so UI state matches server filtering.  
- Make Register search more useful by matching AT number, title, description and visible assignee text.  

### Description
- UI: Reworked the register filter panel in `Pages/ActionTasks/_TaskRegister.cshtml` into a single compact filter bar with Search first, optional Responsible Person picker for users who can view all tasks, `Status`, `Bucket` (now includes `Invalid State`), `Priority`, `Due / Target Date`, and an inline Reset action.  
- Display and labels: Renamed the table header from `Scope` to `Bucket`, changed the active date chip label from `Due:` to `Date:`, updated empty-state text to `No tasks match the selected filters.` and added a clear-filters action.  
- Backend: Extended register search in `Services/ActionTasks/ActionTaskQueryService.cs` to match AT number (`AT-<id>`), numeric id, title, description and visible assignee name via a new helper `MatchesRegisterSearch`.  
- Frontend JS: Fixed auto-submit selector and assignee handling in `wwwroot/js/pages/action-tasks/index.js` so `select[name='FilterBucket']` is included in the immediate submit list and the responsible-person datalist logic clears invalid visible values and only submits when selection is valid.  
- Model & helpers: Added `CanFilterByAssignee` and `Invalid` display mapping in `Pages/ActionTasks/Index.cshtml.cs` to control assignee visibility and label the new `Invalid State` bucket.  
- Styling: Updated `wwwroot/css/action-tracker.css` to support the compact filter layout and responsive behavior.  
- Tests: Added/updated unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` to cover `Invalid` bucket filtering and AT-number/title search behavior.  

### Testing
- JavaScript syntax validation: ran `node --check wwwroot/js/pages/action-tasks/index.js` and it passed.  
- Diff check: ran `git diff --check` and there were no whitespace/patch errors.  
- Unit tests: new/updated tests were added to `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs`, but `dotnet test` could not be executed in this environment because the `dotnet` CLI is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07dd527b0c83299af1f26e4a0436b1)