### PR TITLE
Clean up Action Tracker reports

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -90,7 +90,13 @@ public class IndexModel : PageModel
     public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
-    public IReadOnlyList<CountSummary> NonSprintAssignedWorkloadCounts { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> AssignedTaskAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<CountSummary> BucketDistribution { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<ResponsibleWorkloadSummary> ResponsiblePersonWorkloads { get; private set; } = Array.Empty<ResponsibleWorkloadSummary>();
+    public IReadOnlyList<CountSummary> OutsideSprintWorkloadCounts { get; private set; } = Array.Empty<CountSummary>();
+    public IReadOnlyList<SprintPerformanceSummary> SprintPerformanceRows { get; private set; } = Array.Empty<SprintPerformanceSummary>();
+    public IReadOnlyList<InvalidTaskStateSummary> InvalidStateRows { get; private set; } = Array.Empty<InvalidTaskStateSummary>();
+    public ActionTaskReportSummary WorkloadSummary { get; private set; } = new();
     public IReadOnlyList<CountSummary> CarryForwardBySprint { get; private set; } = Array.Empty<CountSummary>();
     public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; private set; } = Array.Empty<CountSummary>();
     public int ReportFilteredTaskCount { get; private set; }
@@ -369,7 +375,7 @@ public class IndexModel : PageModel
         => ActionTaskCategorization.ResolveCategory(task) switch
         {
             ActionTaskWorkCategory.Sprint => ResolveSprintName(task.SprintId),
-            ActionTaskWorkCategory.OutsideSprint or ActionTaskWorkCategory.NonSprint => "Outside Sprint",
+            ActionTaskWorkCategory.OutsideSprint => "Outside Sprint",
             ActionTaskWorkCategory.Closed => "Closed",
             ActionTaskWorkCategory.Invalid => "Invalid State",
             _ => "Backlog"
@@ -379,7 +385,7 @@ public class IndexModel : PageModel
         => ActionTaskCategorization.ResolveCategory(task) switch
         {
             ActionTaskWorkCategory.Sprint => "at-scope-badge at-scope-badge-sprint",
-            ActionTaskWorkCategory.OutsideSprint or ActionTaskWorkCategory.NonSprint => "at-scope-badge at-scope-badge-outside-sprint",
+            ActionTaskWorkCategory.OutsideSprint => "at-scope-badge at-scope-badge-outside-sprint",
             ActionTaskWorkCategory.Closed => "at-scope-badge at-scope-badge-closed",
             ActionTaskWorkCategory.Invalid => "at-scope-badge at-scope-badge-invalid",
             _ => "at-scope-badge at-scope-badge-backlog"
@@ -995,7 +1001,13 @@ public class IndexModel : PageModel
         OverdueAgeingBuckets = readModel.Reports.OverdueAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         SubmittedPendingClosureAgeingBuckets = readModel.Reports.SubmittedPendingClosureAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         BacklogAgeingBuckets = readModel.Reports.BacklogAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
-        NonSprintAssignedWorkloadCounts = readModel.Reports.NonSprintAssignedWorkloadCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        AssignedTaskAgeingBuckets = readModel.Reports.AssignedTaskAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        BucketDistribution = readModel.Reports.BucketDistribution.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        ResponsiblePersonWorkloads = readModel.Reports.ResponsiblePersonWorkloads.Select(x => new ResponsibleWorkloadSummary(x.ResponsiblePerson, x.Open, x.Overdue, x.Blocked, x.InProgress, x.Submitted, x.Critical)).ToList();
+        OutsideSprintWorkloadCounts = readModel.Reports.OutsideSprintWorkloadCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
+        SprintPerformanceRows = readModel.Reports.SprintPerformanceRows.Select(x => new SprintPerformanceSummary(x.Sprint, x.Status, x.Open, x.Closed, x.CarriedForward, x.OverdueAtClosure)).ToList();
+        InvalidStateRows = readModel.Reports.InvalidStateRows.Select(x => new InvalidTaskStateSummary(x.Task, x.Issue, x.SuggestedCorrection)).ToList();
+        WorkloadSummary = new ActionTaskReportSummary(readModel.Reports.WorkloadSummary.OpenTasks, readModel.Reports.WorkloadSummary.Overdue, readModel.Reports.WorkloadSummary.Blocked, readModel.Reports.WorkloadSummary.PendingClosure, readModel.Reports.WorkloadSummary.BacklogItems);
         CarryForwardBySprint = readModel.Reports.CarryForwardBySprint.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         BlockedAgeingBuckets = readModel.Reports.BlockedAgeingBuckets.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         ReportFilteredTaskCount = readModel.Reports.FilteredTaskCount;
@@ -1230,7 +1242,8 @@ public class IndexModel : PageModel
     public int OpenAgeingBucketsMax => OpenAgeingBuckets.Count == 0 ? 0 : OpenAgeingBuckets.Max(x => x.Count);
     public int OverdueAgeingBucketsMax => OverdueAgeingBuckets.Count == 0 ? 0 : OverdueAgeingBuckets.Max(x => x.Count);
     public int BacklogAgeingBucketsMax => BacklogAgeingBuckets.Count == 0 ? 0 : BacklogAgeingBuckets.Max(x => x.Count);
-    public int NonSprintAssignedWorkloadCountsMax => NonSprintAssignedWorkloadCounts.Count == 0 ? 0 : NonSprintAssignedWorkloadCounts.Max(x => x.Count);
+    public int AssignedTaskAgeingBucketsMax => AssignedTaskAgeingBuckets.Count == 0 ? 0 : AssignedTaskAgeingBuckets.Max(x => x.Count);
+    public int OutsideSprintWorkloadCountsMax => OutsideSprintWorkloadCounts.Count == 0 ? 0 : OutsideSprintWorkloadCounts.Max(x => x.Count);
     public int CarryForwardBySprintMax => CarryForwardBySprint.Count == 0 ? 0 : CarryForwardBySprint.Max(x => x.Count);
     public int BlockedAgeingBucketsMax => BlockedAgeingBuckets.Count == 0 ? 0 : BlockedAgeingBuckets.Max(x => x.Count);
     public int ActiveCriticalCount => CommandCentreSummary.ActiveCriticalCount;
@@ -1597,6 +1610,10 @@ public class IndexModel : PageModel
     }
 
     public sealed record CountSummary(string Name, int Count);
+    public sealed record ActionTaskReportSummary(int OpenTasks = 0, int Overdue = 0, int Blocked = 0, int PendingClosure = 0, int BacklogItems = 0);
+    public sealed record ResponsibleWorkloadSummary(string ResponsiblePerson, int Open, int Overdue, int Blocked, int InProgress, int Submitted, int Critical);
+    public sealed record SprintPerformanceSummary(string Sprint, string Status, int Open, int Closed, int CarriedForward, int OverdueAtClosure);
+    public sealed record InvalidTaskStateSummary(string Task, string Issue, string SuggestedCorrection);
     public sealed class TaskDisplayItem
     {
         public ActionTaskItem Task { get; init; } = default!;

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -3,6 +3,7 @@
     // SECTION: Date filter display values are preformatted for CSP-safe server rendering.
     var reportFromDateValue = Model.ReportFromDate?.ToString("yyyy-MM-dd");
     var reportToDateValue = Model.ReportToDate?.ToString("yyyy-MM-dd");
+    var reportFilterSummary = Model.ReportFilterSummary.ToLowerInvariant();
 }
 
 @* SECTION: Reports introduction and scope. *@
@@ -10,11 +11,11 @@
     <article class="at-panel">
         <div class="at-panel-heading">
             <div>
-                <h2>Task Analysis Reports</h2>
-                <p class="at-panel-note">Analytical views computed from current task and Sprint data, with historical trend reporting deferred until Sprint metric snapshots exist.</p>
+                <h2>Reports</h2>
+                <p class="at-panel-note">Review workload, ageing and sprint performance.</p>
             </div>
         </div>
-        <p class="at-empty-state-note">This page intentionally excludes the Command Centre KPI strip so reports remain focused on analysis rather than operational command cards.</p>
+        <p class="at-empty-state-note">This management view summarises workload, risk, ageing and closure trends without duplicating Command Centre, Sprint Board or Register actions.</p>
     </article>
 </section>
 
@@ -25,15 +26,15 @@
         <div class="at-reports-filter-heading">
             <div>
                 <h2>Report Filters</h2>
-                <p class="at-panel-note">Narrow every report section by scope, responsible person, due-date range, workflow status and priority.</p>
+                <p class="at-panel-note">Keep reports focused with date range, responsible person, bucket or sprint scope, status and priority.</p>
             </div>
             <span class="at-report-filter-summary">@Model.ReportFilterSummary</span>
         </div>
         <div class="at-reports-filter-grid">
             <label>
-                <span>Scope</span>
+                <span>Bucket / Sprint</span>
                 <select class="form-select form-select-sm" name="ReportSprintId" data-at-reports-filter-control="true">
-                    <option value="">All Sprint, Backlog &amp; Outside Sprint work</option>
+                    <option value="">All Backlog, Outside Sprint and Sprint work</option>
                     @if (Model.ReportSprintId == 0)
                     {
                         <option value="0" selected>Backlog items only</option>
@@ -125,227 +126,233 @@
     </form>
 </section>
 
-@* SECTION: Current-state analytical reports with proportional bars. *@
-<section class="at-card-grid at-card-grid-reports" aria-label="Task analytical reports">
+@* SECTION: Workload Summary uses exactly five management KPIs. *@
+<section class="at-section-group" aria-label="Workload Summary">
+    <div class="at-panel-heading">
+        <div>
+            <h2>Workload Summary</h2>
+            <p class="at-panel-note">Showing @reportFilterSummary.</p>
+        </div>
+    </div>
+    <div class="at-kpis">
+        <article><h3>Open Tasks</h3><strong>@Model.WorkloadSummary.OpenTasks</strong><p>All non-closed tasks, including backlog.</p></article>
+        <article><h3>Overdue</h3><strong>@Model.WorkloadSummary.Overdue</strong><p>Assigned work past due, excluding submitted.</p></article>
+        <article><h3>Blocked</h3><strong>@Model.WorkloadSummary.Blocked</strong><p>Assigned tasks currently blocked.</p></article>
+        <article><h3>Pending Closure</h3><strong>@Model.WorkloadSummary.PendingClosure</strong><p>Submitted tasks awaiting close-out.</p></article>
+        <article><h3>Backlog Items</h3><strong>@Model.WorkloadSummary.BacklogItems</strong><p>Planning inventory not assigned.</p></article>
+    </div>
+</section>
+
+@* SECTION: Analytical report sections are stacked to avoid visual clutter. *@
+<section class="at-section-group" aria-label="Task analytical reports">
     <article class="at-panel">
         <div class="at-panel-heading">
             <div>
-                <h2>Ageing Analysis</h2>
-                <p class="at-panel-note">Identifies open work by age and highlights overdue exposure by elapsed overdue period.</p>
+                <h2>Bucket Distribution</h2>
+                <p class="at-panel-note">Official bucket distribution from the central classifier.</p>
+            </div>
+        </div>
+        <div class="at-report-bucket-row">
+            @foreach (var item in Model.BucketDistribution)
+            {
+                <div class="at-report-bucket-card"><span>@item.Name</span><strong>@item.Count</strong></div>
+            }
+        </div>
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Responsible Person Workload</h2>
+                <p class="at-panel-note">Open assigned Outside Sprint and Sprint work only; backlog and closed records are excluded.</p>
+            </div>
+        </div>
+        @if (!Model.ResponsiblePersonWorkloads.Any())
+        {
+            <p class="at-empty-state-note">No open assigned workload.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm at-table align-middle">
+                    <thead>
+                        <tr>
+                            <th>Responsible Person</th>
+                            <th>Open</th>
+                            <th>Overdue</th>
+                            <th>Blocked</th>
+                            <th>In Progress</th>
+                            <th>Submitted</th>
+                            <th>Critical</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.ResponsiblePersonWorkloads)
+                        {
+                            <tr>
+                                <td>@item.ResponsiblePerson</td>
+                                <td>@item.Open</td>
+                                <td>@item.Overdue</td>
+                                <td>@item.Blocked</td>
+                                <td>@item.InProgress</td>
+                                <td>@item.Submitted</td>
+                                <td>@item.Critical</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Ageing and Overdue Analysis</h2>
+                <p class="at-panel-note">Backlog Ageing and Assigned Task Ageing are separated so planning inventory is not mixed with responsible-person workload.</p>
             </div>
         </div>
         <div class="at-ageing-grid">
             <div>
-                <h3 class="at-small at-section-eyebrow">Open tasks ageing</h3>
-                <div class="at-metric-bars">
-                    @foreach (var item in Model.OpenAgeingBuckets)
-                    {
-                        <div class="at-metric-row">
-                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                            <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.OpenAgeingBucketsMax)%"></div></div>
-                            <strong>@item.Count</strong>
-                        </div>
-                    }
-                </div>
-            </div>
-            <div>
-                <h3 class="at-small at-section-eyebrow">Overdue ageing</h3>
-                <div class="at-metric-bars">
-                    @foreach (var item in Model.OverdueAgeingBuckets)
-                    {
-                        <div class="at-metric-row">
-                            <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                            <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.OverdueAgeingBucketsMax)%"></div></div>
-                            <strong>@item.Count</strong>
-                        </div>
-                    }
-                </div>
-            </div>
-        </div>
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Pending Closure Ageing</h2>
-                <p class="at-panel-note">Shows how long submitted tasks have been waiting for close-out review.</p>
-            </div>
-        </div>
-        @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
-        {
-            <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
-        }
-        else
-        {
-            <div class="at-metric-bars">
-                @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+                <h3 class="at-small at-section-eyebrow">Backlog Ageing</h3>
+                @if (Model.BacklogAgeingBuckets.All(item => item.Count == 0))
                 {
-                    <div class="at-metric-row">
-                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.SubmittedPendingClosureAgeingBuckets.Max(x => x.Count))%"></div></div>
-                        <strong>@item.Count</strong>
+                    <p class="at-empty-state-note">No backlog items.</p>
+                }
+                else
+                {
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.BacklogAgeingBuckets)
+                        {
+                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                        }
                     </div>
                 }
             </div>
-        }
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
             <div>
-                <h2>Assignee Workload</h2>
-                <p class="at-panel-note">Compares pending task volume across assignees to surface capacity imbalance.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars at-metric-bars-tight">
-            @foreach (var item in Model.AssigneePendingCounts)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.AssigneePendingCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
-                </div>
-            }
-        </div>
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Priority Exposure</h2>
-                <p class="at-panel-note">Breaks down open task volume by urgency to support prioritisation decisions.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.PriorityCounts)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.PriorityCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
-                </div>
-            }
-        </div>
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Workflow Distribution</h2>
-                <p class="at-panel-note">Summarises task spread by workflow stage for process-level analysis.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.StatusCounts)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.StatusCountsMax)%"></div></div>
-                    <strong>@item.Count</strong>
-                </div>
-            }
-        </div>
-    </article>
-
-    @* SECTION: Decision-support summaries derived from the existing task and Sprint read model. *@
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Backlog Ageing Summary</h2>
-                <p class="at-panel-note">Highlights backlog items only: open, not in a Sprint, and not assigned to a user.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.BacklogAgeingBuckets)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill" style="width:@Model.ToPercent(item.Count, Model.BacklogAgeingBucketsMax)%"></div></div>
-                    <strong>@item.Count</strong>
-                </div>
-            }
-        </div>
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Assigned Tasks Outside Sprint</h2>
-                <p class="at-panel-note">Counts open assigned work that is not part of Sprint commitment and is excluded from backlog ageing.</p>
-            </div>
-        </div>
-        @if (!Model.NonSprintAssignedWorkloadCounts.Any())
-        {
-            <p class="at-empty-state-note">No open assigned work outside sprint is visible in the selected report scope.</p>
-        }
-        else
-        {
-            <div class="at-metric-bars at-metric-bars-tight">
-                @foreach (var item in Model.NonSprintAssignedWorkloadCounts)
+                <h3 class="at-small at-section-eyebrow">Assigned Task Ageing</h3>
+                @if (Model.AssignedTaskAgeingBuckets.All(item => item.Count == 0))
                 {
-                    <div class="at-metric-row">
-                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.NonSprintAssignedWorkloadCountsMax)%"></div></div>
-                        <strong>@item.Count</strong>
+                    <p class="at-empty-state-note">No open assigned workload.</p>
+                }
+                else
+                {
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.AssignedTaskAgeingBuckets)
+                        {
+                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                        }
                     </div>
                 }
             </div>
-        }
-    </article>
-
-    <article class="at-panel">
-        <div class="at-panel-heading">
             <div>
-                <h2>Carry-forward by Sprint</h2>
-                <p class="at-panel-note">Safely derived from unfinished tasks that remain assigned to non-closed Sprints.</p>
-            </div>
-        </div>
-        @if (Model.CarryForwardBySprint.All(item => item.Count == 0))
-        {
-            <p class="at-empty-state-note">No carry-forward candidates are visible in the selected report scope.</p>
-        }
-        else
-        {
-            <div class="at-metric-bars">
-                @foreach (var item in Model.CarryForwardBySprint)
+                <h3 class="at-small at-section-eyebrow">Overdue Analysis</h3>
+                @if (Model.OverdueAgeingBuckets.All(item => item.Count == 0))
                 {
-                    <div class="at-metric-row">
-                        <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                        <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-amber" style="width:@Model.ToPercent(item.Count, Model.CarryForwardBySprintMax)%"></div></div>
-                        <strong>@item.Count</strong>
+                    <p class="at-empty-state-note">No overdue tasks.</p>
+                }
+                else
+                {
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.OverdueAgeingBuckets)
+                        {
+                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                        }
                     </div>
                 }
             </div>
+            <div>
+                <h3 class="at-small at-section-eyebrow">Pending Closure</h3>
+                @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
+                {
+                    <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
+                }
+                else
+                {
+                    <div class="at-metric-bars">
+                        @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
+                        {
+                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </article>
+
+    <article class="at-panel">
+        <div class="at-panel-heading">
+            <div>
+                <h2>Sprint Performance</h2>
+                <p class="at-panel-note">Compact sprint-level progress and closure trend summary.</p>
+            </div>
+        </div>
+        @if (!Model.SprintPerformanceRows.Any())
+        {
+            <p class="at-empty-state-note">No sprint activity available.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm at-table align-middle">
+                    <thead>
+                        <tr>
+                            <th>Sprint</th>
+                            <th>Status</th>
+                            <th>Open</th>
+                            <th>Closed</th>
+                            <th>Carried Forward</th>
+                            <th>Overdue at Closure</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.SprintPerformanceRows)
+                        {
+                            <tr>
+                                <td>@item.Sprint</td>
+                                <td>@item.Status</td>
+                                <td>@item.Open</td>
+                                <td>@item.Closed</td>
+                                <td>@item.CarriedForward</td>
+                                <td>@item.OverdueAtClosure</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
         }
     </article>
 
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Blocked Task Ageing</h2>
-                <p class="at-panel-note">Ages blocked tasks by time since assignment to support unblock decisions without changing backend workflow.</p>
-            </div>
-        </div>
-        <div class="at-metric-bars">
-            @foreach (var item in Model.BlockedAgeingBuckets)
-            {
-                <div class="at-metric-row">
-                    <span class="at-metric-label" title="@item.Name">@item.Name</span>
-                    <div class="at-metric-track"><div class="at-metric-fill at-metric-fill-danger" style="width:@Model.ToPercent(item.Count, Model.BlockedAgeingBucketsMax)%"></div></div>
-                    <strong>@item.Count</strong>
+    @if (Model.InvalidStateRows.Any())
+    {
+        <article class="at-panel at-panel-warning">
+            <div class="at-panel-heading">
+                <div>
+                    <h2>Data Quality</h2>
+                    <p class="at-panel-note">Data quality warning: some task records have inconsistent assignment or sprint data.</p>
                 </div>
-            }
-        </div>
-    </article>
-
-    @* SECTION: Deferred trend report state because the current read model has no historical snapshots. *@
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Historical Trend Reports</h2>
-                <p class="at-panel-note">Trend charts require dated snapshot data before they can show reliable movement over time.</p>
             </div>
-        </div>
-        <p class="at-empty-state-note">Trend reporting will be enabled after historical Sprint metrics are available.</p>
-    </article>
+            <div class="table-responsive">
+                <table class="table table-sm at-table align-middle">
+                    <thead>
+                        <tr>
+                            <th>Task</th>
+                            <th>Issue</th>
+                            <th>Suggested Correction</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.InvalidStateRows)
+                        {
+                            <tr>
+                                <td>@item.Task</td>
+                                <td>@item.Issue</td>
+                                <td>@item.SuggestedCorrection</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </article>
+    }
 </section>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1307,7 +1307,7 @@ public class ActionTaskPageTests
         Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
         Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Reset / Clear all", html, StringComparison.Ordinal);
-        Assert.Contains("<span>Scope</span>", html, StringComparison.Ordinal);
+        Assert.Contains("<span>Bucket / Sprint</span>", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-filter-form=""true""", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-filter-control=""true""", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-date-filter=""true""", html, StringComparison.Ordinal);
@@ -1348,7 +1348,7 @@ public class ActionTaskPageTests
         Assert.Equal(1, page.ReportFilteredTaskCount);
         Assert.Equal(1, page.StatusCounts.Single(x => x.Name == ActionTaskStatuses.Blocked).Count);
         Assert.Equal(1, page.PriorityCounts.Single(x => x.Name == "High").Count);
-        Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8 to 14 days").Count);
+        Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8-14 days assigned").Count);
         Assert.Contains("Showing 1 of 2 tasks", html, StringComparison.Ordinal);
         Assert.Contains(@"method=""get""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ViewMode"" value=""Reports""", html, StringComparison.Ordinal);
@@ -1359,15 +1359,14 @@ public class ActionTaskPageTests
         Assert.Contains(@"name=""ReportStatus""", html, StringComparison.Ordinal);
         Assert.Contains(@"value=""High"" selected", html, StringComparison.Ordinal);
         Assert.Contains(@"value=""user-1"" selected", html, StringComparison.Ordinal);
-        Assert.Contains("Ageing Analysis", html, StringComparison.Ordinal);
-        Assert.Contains("Pending Closure Ageing", html, StringComparison.Ordinal);
-        Assert.Contains("Assignee Workload", html, StringComparison.Ordinal);
-        Assert.Contains("Priority Exposure", html, StringComparison.Ordinal);
-        Assert.Contains("Workflow Distribution", html, StringComparison.Ordinal);
-        Assert.Contains("Backlog Ageing Summary", html, StringComparison.Ordinal);
-        Assert.Contains("Assigned Tasks Outside Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Carry-forward by Sprint", html, StringComparison.Ordinal);
-        Assert.Contains("Blocked Task Ageing", html, StringComparison.Ordinal);
+        Assert.Contains("Ageing and Overdue Analysis", html, StringComparison.Ordinal);
+        Assert.Contains("Pending Closure", html, StringComparison.Ordinal);
+        Assert.Contains("Responsible Person Workload", html, StringComparison.Ordinal);
+        Assert.Contains("Bucket Distribution", html, StringComparison.Ordinal);
+        Assert.Contains("Backlog Ageing", html, StringComparison.Ordinal);
+        Assert.Contains("Assigned Task Ageing", html, StringComparison.Ordinal);
+        Assert.Contains("Sprint Performance", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Non-sprint", html, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -44,7 +44,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(3, model.ActiveSprintMetrics.CarryForwardCandidateTasks);
         Assert.Equal(new[] { 5 }, model.BacklogTasks.Select(t => t.Id));
         Assert.Equal(new[] { 5 }, model.SprintReadModel.BacklogTasks.Select(t => t.Id));
-        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Assignee", 1) }, model.Reports.NonSprintAssignedWorkloadCounts);
+        Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Assignee", 1) }, model.Reports.OutsideSprintWorkloadCounts);
         Assert.Equal(1, model.SprintReadModel.ClosureReview.CompletedTasks.Count);
         Assert.Equal(3, model.SprintReadModel.ClosureReview.UnfinishedTasks.Count);
         Assert.Equal(nextSprint.Id, model.SprintReadModel.ClosureReview.TargetSprintOptions.Single().Id);
@@ -81,7 +81,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Responsible One", 1) }, model.Reports.AssigneePendingCounts);
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("High", 1) }, model.Reports.PriorityCounts);
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary(ActionTaskStatuses.Blocked, 1) }, model.Reports.StatusCounts);
-        Assert.Equal(1, model.Reports.BlockedAgeingBuckets.Single(x => x.Name == "8 to 14 days").Count);
+        Assert.Equal(1, model.Reports.BlockedAgeingBuckets.Single(x => x.Name == "8-14 days assigned").Count);
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Filtered Sprint", 1) }, model.Reports.CarryForwardBySprint);
     }
 
@@ -110,10 +110,80 @@ public class ActionTaskQueryServiceSprintMetricsTests
         // SECTION: Assert
         Assert.Equal(1, model.Reports.FilteredTaskCount);
         Assert.DoesNotContain(model.Reports.StatusCounts, item => string.Equals(item.Name, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
-        Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "4 to 7 days").Count);
-        Assert.Equal(0, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "15+ days").Count);
-        Assert.Empty(model.Reports.NonSprintAssignedWorkloadCounts);
+        Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "4-7 days in backlog").Count);
+        Assert.Equal(0, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "15+ days in backlog").Count);
+        Assert.Empty(model.Reports.OutsideSprintWorkloadCounts);
         Assert.All(model.Reports.CarryForwardBySprint, item => Assert.Equal(0, item.Count));
+    }
+
+
+    [Fact]
+    public void BuildReadModel_ReportsResponsibleWorkload_UsesAssignedBucketsAndSortsByRisk()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 61, Name = "Execution Sprint", Status = ActionSprintStatus.Active, StartDate = today.AddDays(-2), EndDate = today.AddDays(5) };
+        var tasks = new[]
+        {
+            NewTask(61, null, ActionTaskStatuses.Backlog, today.AddDays(3), assignedToUserId: string.Empty, assignedOn: today.AddDays(-1)),
+            NewTask(62, null, ActionTaskStatuses.Assigned, today.AddDays(-1), assignedToUserId: "one"),
+            NewTask(63, null, ActionTaskStatuses.InProgress, today.AddDays(2), assignedToUserId: "one"),
+            NewTask(64, sprint.Id, ActionTaskStatuses.Blocked, today.AddDays(-2), assignedToUserId: "two"),
+            NewTask(65, sprint.Id, ActionTaskStatuses.Submitted, today.AddDays(-3), assignedToUserId: "two"),
+            NewTask(66, null, ActionTaskStatuses.Closed, today.AddDays(-4), assignedToUserId: "one")
+        };
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null),
+            new Dictionary<string, string> { ["one"] = "One", ["two"] = "Two" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(new[] { "Backlog", "Outside Sprint", "Sprint", "Closed" }, model.Reports.BucketDistribution.Select(x => x.Name).ToArray());
+        Assert.Equal(5, model.Reports.WorkloadSummary.OpenTasks);
+        Assert.Equal(2, model.Reports.WorkloadSummary.Overdue);
+        Assert.Equal(1, model.Reports.WorkloadSummary.PendingClosure);
+        Assert.Equal(1, model.Reports.WorkloadSummary.BacklogItems);
+        Assert.Equal(new[] { "One", "Two" }, model.Reports.ResponsiblePersonWorkloads.Select(x => x.ResponsiblePerson).ToArray());
+        Assert.All(model.Reports.ResponsiblePersonWorkloads, item => Assert.Equal(2, item.Open));
+        Assert.DoesNotContain(model.Reports.ResponsiblePersonWorkloads, item => item.ResponsiblePerson == "Unassigned");
+        Assert.Equal(1, model.Reports.AssignedTaskAgeingBuckets.Single(x => x.Name == "0-3 days assigned").Count);
+        Assert.Equal(1, model.Reports.BacklogAgeingBuckets.Single(x => x.Name == "0-3 days in backlog").Count);
+        Assert.Equal(0, model.Reports.OverdueAgeingBuckets.Single(x => x.Name == "8+ days overdue").Count);
+    }
+
+    [Fact]
+    public void BuildReadModel_ReportsInvalidStates_RenderOnlyWhenPresent()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 71, Name = "Invalid Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var validTasks = new[]
+        {
+            NewTask(71, null, ActionTaskStatuses.Backlog, today.AddDays(2), assignedToUserId: string.Empty),
+            NewTask(72, null, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee")
+        };
+        var invalidTasks = validTasks.Concat(new[]
+        {
+            NewTask(73, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: string.Empty)
+        }).ToArray();
+        var service = CreateQueryService();
+        var request = new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null);
+
+        // SECTION: Act
+        var validModel = service.BuildReadModel(validTasks, request, new Dictionary<string, string> { ["assignee"] = "Assignee" }, new Dictionary<int, DateTime?>());
+        var invalidModel = service.BuildReadModel(invalidTasks, request, new Dictionary<string, string> { ["assignee"] = "Assignee" }, new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.DoesNotContain(validModel.Reports.BucketDistribution, item => item.Name == "Invalid State");
+        Assert.Empty(validModel.Reports.InvalidStateRows);
+        Assert.Contains(invalidModel.Reports.BucketDistribution, item => item.Name == "Invalid State" && item.Count == 1);
+        var invalidRow = Assert.Single(invalidModel.Reports.InvalidStateRows);
+        Assert.Contains("SprintId exists", invalidRow.Issue, StringComparison.Ordinal);
+        Assert.Contains("Assign responsible person", invalidRow.SuggestedCorrection, StringComparison.Ordinal);
     }
 
 

--- a/Services/ActionTasks/ActionTaskCategorization.cs
+++ b/Services/ActionTasks/ActionTaskCategorization.cs
@@ -17,7 +17,6 @@ public enum ActionTaskWorkCategory
     Sprint,
     Backlog,
     OutsideSprint,
-    NonSprint,
     Closed,
     Invalid
 }
@@ -34,7 +33,7 @@ public static class ActionTaskBucketClassifier
 
         if (task.SprintId.HasValue)
         {
-            return HasAssignedUser(task) && HasAssignedRole(task)
+            return IsSprintTask(task)
                 ? ActionTaskBucket.Sprint
                 : ActionTaskBucket.Invalid;
         }
@@ -44,7 +43,7 @@ public static class ActionTaskBucketClassifier
             return ActionTaskBucket.Backlog;
         }
 
-        return HasAssignedUser(task) && HasAssignedRole(task)
+        return IsOutsideSprintTask(task)
             ? ActionTaskBucket.OutsideSprint
             : ActionTaskBucket.Invalid;
     }
@@ -60,9 +59,6 @@ public static class ActionTaskBucketClassifier
 
     public static bool IsOutsideSprintTask(ActionTaskItem task)
         => task.SprintId is null && HasAssignedUser(task) && HasAssignedRole(task) && IsAssignedWorkStatus(task.Status);
-
-    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
-        => IsOutsideSprintTask(task);
 
     public static bool IsClosedTask(ActionTaskItem task)
         => string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
@@ -112,9 +108,6 @@ public static class ActionTaskCategorization
 
     public static bool IsOutsideSprintTask(ActionTaskItem task)
         => ActionTaskBucketClassifier.IsOutsideSprintTask(task);
-
-    public static bool IsAssignedNonSprintTask(ActionTaskItem task)
-        => ActionTaskBucketClassifier.IsAssignedNonSprintTask(task);
 
     public static bool IsClosedTask(ActionTaskItem task)
         => ActionTaskBucketClassifier.IsClosedTask(task);

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -386,18 +386,64 @@ public sealed class ActionTaskQueryService
 
     public sealed class ActionTaskReportReadModel
     {
+        public ActionTaskReportSummary WorkloadSummary { get; init; } = new();
+        public IReadOnlyList<CountSummary> BucketDistribution { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<ResponsiblePersonWorkloadSummary> ResponsiblePersonWorkloads { get; init; } = Array.Empty<ResponsiblePersonWorkloadSummary>();
+        public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> AssignedTaskAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
+        public IReadOnlyList<SprintPerformanceSummary> SprintPerformanceRows { get; init; } = Array.Empty<SprintPerformanceSummary>();
+        public IReadOnlyList<InvalidTaskStateSummary> InvalidStateRows { get; init; } = Array.Empty<InvalidTaskStateSummary>();
+        public IReadOnlyList<CountSummary> OutsideSprintWorkloadCounts { get; init; } = Array.Empty<CountSummary>();
+
+        // SECTION: Legacy report summaries are retained for existing page helpers and tests during Reports cleanup.
         public IReadOnlyList<CountSummary> AssigneePendingCounts { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> PriorityCounts { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> StatusCounts { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> OpenAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
-        public IReadOnlyList<CountSummary> OverdueAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
-        public IReadOnlyList<CountSummary> SubmittedPendingClosureAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
-        public IReadOnlyList<CountSummary> BacklogAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
-        public IReadOnlyList<CountSummary> NonSprintAssignedWorkloadCounts { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> CarryForwardBySprint { get; init; } = Array.Empty<CountSummary>();
         public IReadOnlyList<CountSummary> BlockedAgeingBuckets { get; init; } = Array.Empty<CountSummary>();
         public int TotalTaskCount { get; init; }
         public int FilteredTaskCount { get; init; }
     }
+
+    public sealed class ActionTaskReportSummary
+    {
+        public int OpenTasks { get; init; }
+        public int Overdue { get; init; }
+        public int Blocked { get; init; }
+        public int PendingClosure { get; init; }
+        public int BacklogItems { get; init; }
+    }
+
+    public sealed class ResponsiblePersonWorkloadSummary
+    {
+        public string ResponsiblePerson { get; init; } = string.Empty;
+        public int Open { get; init; }
+        public int Overdue { get; init; }
+        public int Blocked { get; init; }
+        public int InProgress { get; init; }
+        public int Submitted { get; init; }
+        public int Critical { get; init; }
+    }
+
+    public sealed class SprintPerformanceSummary
+    {
+        public string Sprint { get; init; } = string.Empty;
+        public string Status { get; init; } = string.Empty;
+        public int Open { get; init; }
+        public int Closed { get; init; }
+        public int CarriedForward { get; init; }
+        public int OverdueAtClosure { get; init; }
+    }
+
+    public sealed class InvalidTaskStateSummary
+    {
+        public string Task { get; init; } = string.Empty;
+        public string Issue { get; init; } = string.Empty;
+        public string SuggestedCorrection { get; init; } = string.Empty;
+    }
+
     public sealed record CountSummary(string Name, int Count);
 }

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -20,25 +20,33 @@ public sealed class ActionTaskReportBuilder
         var utcToday = _clock.UtcToday;
         var reportTasks = ApplyReportFilters(tasks, request).ToList();
         var openTasks = reportTasks.Where(IsOpen).ToList();
-        var submittedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)).ToList();
-        var backlogOpenTasks = openTasks.Where(ActionTaskCategorization.IsBacklogTask).ToList();
-        var nonSprintOpenTasks = openTasks.Where(ActionTaskCategorization.IsAssignedNonSprintTask).ToList();
-        var blockedTasks = reportTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
-        string Assignee(string id) => string.IsNullOrWhiteSpace(id) ? "Unassigned" : assigneeNames.TryGetValue(id, out var name) ? name : "User";
+        var assignedOpenTasks = openTasks.Where(IsAssignedReportWork).ToList();
+        var overdueAssignedTasks = assignedOpenTasks.Where(t => IsAssignedTaskOverdue(t, utcToday)).ToList();
+        var submittedTasks = assignedOpenTasks.Where(IsSubmitted).ToList();
+        var backlogTasks = reportTasks.Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.Backlog).ToList();
+        var blockedTasks = assignedOpenTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
 
         return new ActionTaskQueryService.ActionTaskReportReadModel
         {
             TotalTaskCount = tasks.Count,
             FilteredTaskCount = reportTasks.Count,
-            AssigneePendingCounts = openTasks.GroupBy(t => Assignee(t.AssignedToUserId)).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count())).ToList(),
+            WorkloadSummary = BuildWorkloadSummary(openTasks, overdueAssignedTasks, blockedTasks, submittedTasks, backlogTasks),
+            BucketDistribution = BuildBucketDistribution(reportTasks),
+            ResponsiblePersonWorkloads = BuildResponsiblePersonWorkloads(assignedOpenTasks, overdueAssignedTasks, assigneeNames),
+            BacklogAgeingBuckets = BuildBacklogAgeingBuckets(backlogTasks.Where(IsOpen).ToList(), utcToday),
+            AssignedTaskAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, utcToday),
+            OverdueAgeingBuckets = BuildOverdueAgeingBuckets(overdueAssignedTasks, utcToday),
+            SubmittedPendingClosureAgeingBuckets = BuildSubmittedPendingClosureAgeingBuckets(submittedTasks, utcToday),
+            SprintPerformanceRows = BuildSprintPerformanceRows(reportTasks, request.Sprints, utcToday),
+            InvalidStateRows = BuildInvalidStateRows(reportTasks),
+
+            // SECTION: Legacy report summaries remain populated for existing consumers while the Reports UI uses the management model above.
+            AssigneePendingCounts = BuildAssigneePendingCounts(assignedOpenTasks, assigneeNames),
             PriorityCounts = openTasks.GroupBy(t => t.Priority).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count())).ToList(),
             StatusCounts = reportTasks.GroupBy(t => t.Status).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count())).ToList(),
-            OpenAgeingBuckets = BuildAssignedAgeingBuckets(openTasks, utcToday),
-            OverdueAgeingBuckets = new[] { new ActionTaskQueryService.CountSummary("1 to 3 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 1 and <= 3)), new ActionTaskQueryService.CountSummary("4 to 7 days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays is >= 4 and <= 7)), new ActionTaskQueryService.CountSummary("8+ days overdue", openTasks.Count(t => (utcToday - t.DueDate.Date).TotalDays >= 8)) },
-            SubmittedPendingClosureAgeingBuckets = new[] { new ActionTaskQueryService.CountSummary("0 to 1 day", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 0 and <= 1)), new ActionTaskQueryService.CountSummary("2 to 3 days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays is >= 2 and <= 3)), new ActionTaskQueryService.CountSummary("4+ days", submittedTasks.Count(t => (utcToday - (t.SubmittedOn ?? t.AssignedOn).Date).TotalDays >= 4)) },
-            BacklogAgeingBuckets = BuildAssignedAgeingBuckets(backlogOpenTasks, utcToday),
-            NonSprintAssignedWorkloadCounts = BuildNonSprintAssignedWorkloadCounts(nonSprintOpenTasks, assigneeNames),
-            BlockedAgeingBuckets = BuildAssignedAgeingBuckets(blockedTasks, utcToday),
+            OpenAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, utcToday),
+            OutsideSprintWorkloadCounts = BuildOutsideSprintWorkloadCounts(assignedOpenTasks.Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.OutsideSprint).ToList(), assigneeNames),
+            BlockedAgeingBuckets = BuildAssignedTaskAgeingBuckets(blockedTasks, utcToday),
             CarryForwardBySprint = BuildCarryForwardBySprint(openTasks, request.Sprints)
         };
     }
@@ -50,7 +58,7 @@ public sealed class ActionTaskReportBuilder
         if (request.ReportSprintId.HasValue)
         {
             query = request.ReportSprintId.Value == 0
-                ? query.Where(ActionTaskCategorization.IsBacklogTask)
+                ? query.Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.Backlog)
                 : query.Where(t => t.SprintId == request.ReportSprintId.Value);
         }
 
@@ -62,9 +70,161 @@ public sealed class ActionTaskReportBuilder
         return query;
     }
 
-    // SECTION: Shared assigned-age buckets used by open, backlog and blocked ageing reports.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedAgeingBuckets(IReadOnlyList<ActionTaskItem> tasks, DateTime utcToday)
-        => new[] { new ActionTaskQueryService.CountSummary("0 to 3 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 0 and <= 3)), new ActionTaskQueryService.CountSummary("4 to 7 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 4 and <= 7)), new ActionTaskQueryService.CountSummary("8 to 14 days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays is >= 8 and <= 14)), new ActionTaskQueryService.CountSummary("15+ days", tasks.Count(t => (utcToday - t.AssignedOn.Date).TotalDays >= 15)) };
+    // SECTION: Workload summary cards keep Reports at management level rather than duplicating operational boards.
+    private static ActionTaskQueryService.ActionTaskReportSummary BuildWorkloadSummary(
+        IReadOnlyList<ActionTaskItem> openTasks,
+        IReadOnlyList<ActionTaskItem> overdueAssignedTasks,
+        IReadOnlyList<ActionTaskItem> blockedTasks,
+        IReadOnlyList<ActionTaskItem> submittedTasks,
+        IReadOnlyList<ActionTaskItem> backlogTasks)
+        => new()
+        {
+            OpenTasks = openTasks.Count,
+            Overdue = overdueAssignedTasks.Count,
+            Blocked = blockedTasks.Count,
+            PendingClosure = submittedTasks.Count,
+            BacklogItems = backlogTasks.Count
+        };
+
+    // SECTION: Official bucket distribution uses the central classifier and hides Invalid State when no records exist.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBucketDistribution(IReadOnlyList<ActionTaskItem> tasks)
+    {
+        var bucketCounts = tasks
+            .GroupBy(ActionTaskCategorization.ResolveBucket)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var buckets = new List<ActionTaskQueryService.CountSummary>
+        {
+            new("Backlog", bucketCounts.GetValueOrDefault(ActionTaskBucket.Backlog)),
+            new("Outside Sprint", bucketCounts.GetValueOrDefault(ActionTaskBucket.OutsideSprint)),
+            new("Sprint", bucketCounts.GetValueOrDefault(ActionTaskBucket.Sprint)),
+            new("Closed", bucketCounts.GetValueOrDefault(ActionTaskBucket.Closed))
+        };
+
+        var invalidCount = bucketCounts.GetValueOrDefault(ActionTaskBucket.Invalid);
+        if (invalidCount > 0)
+        {
+            buckets.Add(new ActionTaskQueryService.CountSummary("Invalid State", invalidCount));
+        }
+
+        return buckets;
+    }
+
+    // SECTION: Responsible workload excludes backlog and closed records, then sorts overload risk to the top.
+    private static IReadOnlyList<ActionTaskQueryService.ResponsiblePersonWorkloadSummary> BuildResponsiblePersonWorkloads(
+        IReadOnlyList<ActionTaskItem> assignedOpenTasks,
+        IReadOnlyList<ActionTaskItem> overdueAssignedTasks,
+        IReadOnlyDictionary<string, string> assigneeNames)
+    {
+        var overdueIds = overdueAssignedTasks.Select(t => t.Id).ToHashSet();
+        return assignedOpenTasks
+            .GroupBy(t => Assignee(t.AssignedToUserId, assigneeNames))
+            .Select(g => new ActionTaskQueryService.ResponsiblePersonWorkloadSummary
+            {
+                ResponsiblePerson = g.Key,
+                Open = g.Count(),
+                Overdue = g.Count(t => overdueIds.Contains(t.Id)),
+                Blocked = g.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)),
+                InProgress = g.Count(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)),
+                Submitted = g.Count(IsSubmitted),
+                Critical = g.Count(t => string.Equals(t.Priority, "Critical", StringComparison.OrdinalIgnoreCase))
+            })
+            .OrderByDescending(x => x.Open)
+            .ThenByDescending(x => x.Overdue)
+            .ThenBy(x => x.ResponsiblePerson)
+            .ToList();
+    }
+
+    // SECTION: Backlog ageing is planning-inventory ageing; AssignedOn is a temporary backlog-entry proxy until a CreatedOnUtc or EnteredBacklogOnUtc field exists.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBacklogAgeingBuckets(IReadOnlyList<ActionTaskItem> backlogTasks, DateTime utcToday)
+        => new[]
+        {
+            new ActionTaskQueryService.CountSummary("0-3 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 0 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8-14 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 8 and <= 14)),
+            new ActionTaskQueryService.CountSummary("15+ days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) >= 15))
+        };
+
+    // SECTION: Assigned task ageing applies only to Outside Sprint and Sprint work, never backlog or closed tasks.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedTaskAgeingBuckets(IReadOnlyList<ActionTaskItem> assignedTasks, DateTime utcToday)
+        => new[]
+        {
+            new ActionTaskQueryService.CountSummary("0-3 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 0 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8-14 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 8 and <= 14)),
+            new ActionTaskQueryService.CountSummary("15+ days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) >= 15))
+        };
+
+    // SECTION: Overdue analysis applies only to assigned work and excludes submitted pending-closure tasks.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildOverdueAgeingBuckets(IReadOnlyList<ActionTaskItem> overdueTasks, DateTime utcToday)
+        => new[]
+        {
+            new ActionTaskQueryService.CountSummary("1-3 days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) is >= 1 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8+ days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) >= 8))
+        };
+
+    // SECTION: Pending closure ageing is separated from assignee overdue exposure.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildSubmittedPendingClosureAgeingBuckets(IReadOnlyList<ActionTaskItem> submittedTasks, DateTime utcToday)
+        => new[]
+        {
+            new ActionTaskQueryService.CountSummary("0-1 day pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) is >= 0 and <= 1)),
+            new ActionTaskQueryService.CountSummary("2-3 days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) is >= 2 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4+ days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) >= 4))
+        };
+
+    // SECTION: Sprint performance is compact trend-style summary, not a Sprint Board duplicate.
+    private static IReadOnlyList<ActionTaskQueryService.SprintPerformanceSummary> BuildSprintPerformanceRows(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, DateTime utcToday)
+    {
+        var sprintTasks = tasks.Where(t => t.SprintId.HasValue).ToLookup(t => t.SprintId!.Value);
+        return sprints
+            .Where(s => sprintTasks.Contains(s.Id))
+            .OrderByDescending(s => s.Status == ActionSprintStatus.Active)
+            .ThenByDescending(s => s.StartDate)
+            .ThenBy(s => s.Id)
+            .Select(s =>
+            {
+                var scopedTasks = sprintTasks[s.Id].ToList();
+                var assignedOpen = scopedTasks.Where(t => IsOpen(t) && IsAssignedReportWork(t)).ToList();
+                return new ActionTaskQueryService.SprintPerformanceSummary
+                {
+                    Sprint = s.Name,
+                    Status = s.Status.ToString(),
+                    Open = assignedOpen.Count,
+                    Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
+                    CarriedForward = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
+                    OverdueAtClosure = s.Status == ActionSprintStatus.Closed
+                        ? scopedTasks.Count(t => t.DueDate.Date < (s.ClosedAtUtc ?? s.EndDate).Date && !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+                        : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday))
+                };
+            })
+            .ToList();
+    }
+
+    // SECTION: Invalid state rows give compact data-quality correction guidance only when inconsistencies exist.
+    private static IReadOnlyList<ActionTaskQueryService.InvalidTaskStateSummary> BuildInvalidStateRows(IReadOnlyList<ActionTaskItem> tasks)
+        => tasks
+            .Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.Invalid)
+            .OrderBy(t => t.Id)
+            .Select(t => new ActionTaskQueryService.InvalidTaskStateSummary
+            {
+                Task = $"AT-{t.Id}: {t.Title}",
+                Issue = BuildInvalidIssue(t),
+                SuggestedCorrection = BuildInvalidCorrection(t)
+            })
+            .ToList();
+
+    // SECTION: Legacy count helpers retain stable data for callers not yet moved to the table model.
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssigneePendingCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
+        => tasks
+            .GroupBy(t => Assignee(t.AssignedToUserId, assigneeNames))
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key)
+            .Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count()))
+            .ToList();
+
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildOutsideSprintWorkloadCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
+        => BuildAssigneePendingCounts(tasks, assigneeNames);
 
     // SECTION: Safely-derived carry-forward candidates from unfinished tasks still associated with non-closed sprints.
     private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildCarryForwardBySprint(IReadOnlyList<ActionTaskItem> openTasks, IReadOnlyList<ActionSprint> sprints)
@@ -79,14 +239,43 @@ public sealed class ActionTaskReportBuilder
             .ToList();
     }
 
-    // SECTION: Outside Sprint assigned workload remains separate from backlog ageing and sprint workload.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildNonSprintAssignedWorkloadCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
-        => tasks
-            .GroupBy(t => string.IsNullOrWhiteSpace(t.AssignedToUserId) ? "Unassigned" : assigneeNames.TryGetValue(t.AssignedToUserId, out var name) ? name : "User")
-            .OrderByDescending(g => g.Count())
-            .ThenBy(g => g.Key)
-            .Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count()))
-            .ToList();
+    private static string Assignee(string id, IReadOnlyDictionary<string, string> assigneeNames)
+        => string.IsNullOrWhiteSpace(id) ? "Unassigned" : assigneeNames.TryGetValue(id, out var name) ? name : "User";
+
+    private static bool IsAssignedReportWork(ActionTaskItem task)
+    {
+        var bucket = ActionTaskCategorization.ResolveBucket(task);
+        return bucket is (ActionTaskBucket.OutsideSprint or ActionTaskBucket.Sprint) && IsOpen(task);
+    }
+
+    private static bool IsAssignedTaskOverdue(ActionTaskItem task, DateTime utcToday)
+        => IsAssignedReportWork(task)
+           && !IsSubmitted(task)
+           && task.DueDate.Date < utcToday
+           && ActionTaskCategorization.HasAssignedUser(task);
+
+    private static bool IsSubmitted(ActionTaskItem task)
+        => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
+
+    private static int DaysSince(DateTime date, DateTime utcToday) => (int)(utcToday - date.Date).TotalDays;
+
+    private static int DaysOverdue(ActionTaskItem task, DateTime utcToday) => (int)(utcToday - task.DueDate.Date).TotalDays;
+
+    private static string BuildInvalidIssue(ActionTaskItem task)
+    {
+        if (task.SprintId.HasValue && !ActionTaskCategorization.HasAssignedUser(task)) return "SprintId exists but responsible person is missing";
+        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && ActionTaskCategorization.HasAssignedUser(task)) return "Backlog status has assignee";
+        if (!string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && !ActionTaskCategorization.HasAssignedUser(task)) return "Assigned status has no responsible person";
+        return "Task has inconsistent assignment or sprint data";
+    }
+
+    private static string BuildInvalidCorrection(ActionTaskItem task)
+    {
+        if (task.SprintId.HasValue && !ActionTaskCategorization.HasAssignedUser(task)) return "Assign responsible person or return to backlog.";
+        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && ActionTaskCategorization.HasAssignedUser(task)) return "Remove assignee or convert to assigned task.";
+        if (!string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && !ActionTaskCategorization.HasAssignedUser(task)) return "Assign responsible person or return to backlog.";
+        return "Review assignment, status and sprint fields.";
+    }
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1258,7 +1258,7 @@ html {
     border-color: #cbd5e1;
 }
 
-.at-scope-badge-non-sprint {
+.at-scope-badge-outside-sprint {
     color: #7c2d12;
     background: #ffedd5;
     border-color: #fed7aa;
@@ -3487,11 +3487,6 @@ html {
     letter-spacing: 0.04em;
 }
 
-.at-scope-badge-outside-sprint {
-    border-color: #fed7aa;
-    background: #fff7ed;
-    color: #9a3412;
-}
 
 .at-scope-badge-invalid {
     border-color: #fecaca;
@@ -3678,6 +3673,53 @@ html {
 @media (max-width: 767px) {
     .at-execute-status-grid,
     .at-shell.is-planning-board.has-selection .at-execute-status-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* SECTION: Management-level Action Tracker Reports distribution and warning panels. */
+.at-report-bucket-row {
+    display: grid;
+    gap: .75rem;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.at-report-bucket-card {
+    background: #f8fafc;
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: .2rem;
+    padding: .85rem;
+}
+
+.at-report-bucket-card span {
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    letter-spacing: .03em;
+    text-transform: uppercase;
+}
+
+.at-report-bucket-card strong {
+    color: var(--at-text);
+    font-size: 1.35rem;
+}
+
+.at-panel-warning {
+    border-color: rgba(245, 158, 11, .45);
+    box-shadow: 0 0 0 1px rgba(245, 158, 11, .08);
+}
+
+@media (max-width: 991.98px) {
+    .at-report-bucket-row {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 575.98px) {
+    .at-report-bucket-row {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Reports page a management-focused analytical view (workload, bucket distribution, responsible-person workload, ageing, overdue analysis, sprint performance and optional data-quality) and remove legacy "Non-sprint"/operational behaviour from the reports surface.
- Ensure the Reports logic uses the central bucket classifier and separates backlog ageing from assigned-task ageing so backlog is not counted as assigned workload or mixed with assignee ageing.
- Provide clear, compact UI sections and avoid duplicating Command Centre/Register behaviour while retaining backwards-compatible read-model outputs for consumers/tests during the refactor.

### Description
- Reworked report builder to a management read-model: added `WorkloadSummary`, `BucketDistribution`, `ResponsiblePersonWorkloads`, `AssignedTaskAgeingBuckets`, `SprintPerformanceRows`, and `InvalidStateRows`, and separated backlog/assigned ageing buckets in `Services/ActionTasks/ActionTaskReportBuilder.cs`.
- Updated central bucket logic and categorization to treat invalid sprint/assignment combinations as `Invalid` and removed legacy `NonSprint` enum usage in `Services/ActionTasks/ActionTaskCategorization.cs` and `ActionTaskBucketClassifier`.
- Mapped the new report read-model into the page model and replaced legacy/report-facing properties (e.g., removed `NonSprintAssignedWorkloadCounts` in favour of `OutsideSprintWorkloadCounts`, `ResponsiblePersonWorkloads`, `BucketDistribution`, `WorkloadSummary`) in `Pages/ActionTasks/Index.cshtml.cs` and added small helper records for the new summaries.
- Reworked the Razor partial `Pages/ActionTasks/_TaskReports.cshtml` into stacked analytical sections (Workload Summary, Bucket Distribution, Responsible Person Workload, Ageing and Overdue Analysis, Sprint Performance and conditional Data Quality) and added responsive CSS for bucket cards and warning panels in `wwwroot/css/action-tracker.css`.
- Updated and added unit test expectations for the new terminology and model shape in `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` and `ActionTaskPageTests.cs` to reflect bucket names, ageing labels and invalid-state behaviour.

### Testing
- Ran repository checks and static validations: `git diff --check` passed and repository grep assertions for removed legacy terminology (`Non-sprint`) returned no remaining user-facing occurrences in the modified pages and CSS; these checks succeeded.
- Updated unit tests to assert the new report model and UI text (tests modified: `ActionTaskQueryServiceSprintMetricsTests`, `ActionTaskPageTests`); changes committed but the test suite was not executed in this environment because the `dotnet` CLI is not available here.
- Attempted to run `dotnet build` / `dotnet test` but they were not run due to missing `dotnet` in the container (manual CI or local dev machine runs are required to validate build and all tests pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e33c85888329a2586ea6b325d69b)