### PR TITLE
Harden action tracker correctness before publish

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -225,13 +225,22 @@ public class IndexModel : PageModel
         "Planning" => "Plan sprint work, monitor execution and review closure.",
         "MyWork" => "Focus on the work assigned to you.",
         "Register" => "Search, filter and review every task you can access.",
-        "Reports" => "Review pending, critical, blocked and closed task trends.",
+        "Reports" => "Review workload, ageing and sprint performance.",
         _ => "Monitor overdue, blocked, submitted and critical task action."
     };
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
-    public IReadOnlyList<string> RegisterStatusOptions => _workflowPolicy.AllowedStatusOptions.Concat(new[] { ActionTaskStatuses.Submitted, ActionTaskStatuses.Closed, ActionTaskStatuses.Backlog }).ToList();
+    public IReadOnlyList<string> RegisterStatusOptions => ActionTaskStatuses.All.ToList();
+    public IReadOnlyList<string> ReportStatusOptions => new[]
+    {
+        ActionTaskStatuses.Backlog,
+        ActionTaskStatuses.Assigned,
+        ActionTaskStatuses.InProgress,
+        ActionTaskStatuses.Blocked,
+        ActionTaskStatuses.Submitted,
+        ActionTaskStatuses.Closed
+    };
     public IReadOnlyList<string> PriorityOptions => _workflowPolicy.PriorityOptions;
     public bool CanPlanSprints => _permission.CanManageSprints(CurrentRole);
     public bool CanFilterByAssignee => _permission.CanViewAll(CurrentRole);
@@ -390,6 +399,12 @@ public class IndexModel : PageModel
             ActionTaskWorkCategory.Invalid => "at-scope-badge at-scope-badge-invalid",
             _ => "at-scope-badge at-scope-badge-backlog"
         };
+
+    public bool IsInvalidTaskState(ActionTaskItem task)
+        => ActionTaskCategorization.ResolveCategory(task) == ActionTaskWorkCategory.Invalid;
+
+    public bool MustReturnInvalidTaskToBacklogDuringClosure(ActionTaskItem task)
+        => IsInvalidTaskState(task) && !ActionTaskCategorization.HasAssignedUser(task);
 
     public IReadOnlyList<TaskDisplayItem> GetSprintTasksByStatus(string status)
         => ToDisplayItems(SelectedSprintTasks.Where(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase)).ToList());
@@ -1224,6 +1239,8 @@ public class IndexModel : PageModel
     public IReadOnlyList<TaskDisplayItem> ActiveSprintBlockedTaskDisplays =>
         ToDisplayItems(SprintWorkspaceSummary.ActiveSprintBlockedTasks);
 
+    public int ActiveSprintSubmittedTaskCount => SprintWorkspaceSummary.ActiveSprintSubmittedTaskCount;
+
     public IReadOnlyList<TaskDisplayItem> ActiveSprintSubmittedTaskDisplays =>
         ToDisplayItems(SprintWorkspaceSummary.ActiveSprintSubmittedTasks);
 
@@ -1622,6 +1639,8 @@ public class IndexModel : PageModel
 
     public bool IsTaskOverdue(ActionTaskItem task) =>
         IsOpenTask(task)
+        && !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+        && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
         && task.DueDate.Date < _clock.UtcToday;
 
     // SECTION: Shared open-task predicate keeps personal and command projections aligned.

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -53,7 +53,7 @@
                 {
                     <div class="at-empty-inline">No closed sprints.</div>
                 }
-                @foreach (var sprint in Model.ClosedSprints.Take(8))
+                @foreach (var sprint in Model.ClosedSprints)
                 {
                     <a class="at-sprint-list-item is-closed @(Model.SelectedSprint?.Id == sprint.Id ? "is-selected" : string.Empty)" asp-page="/ActionTasks/Index" asp-route-viewMode="Planning" asp-route-PlanningTab="Close" asp-route-SelectedSprintId="@sprint.Id">
                         <strong>@Model.DisplaySprintName(sprint)</strong>

--- a/Pages/ActionTasks/_PlanningTaskCard.cshtml
+++ b/Pages/ActionTasks/_PlanningTaskCard.cshtml
@@ -16,6 +16,10 @@
         <div class="at-card-compact-meta">@item.AssigneeName <span aria-hidden="true">·</span> Due @task.DueDate.ToString("dd MMM yyyy")</div>
         <div class="at-card-footer">
             <span class="@pageModel.GetStatusBadgeClass(task.Status)">@task.Status</span>
+            @if (pageModel.IsInvalidTaskState(task))
+            {
+                <span class="@pageModel.GetSprintBadgeClass(task)">@pageModel.GetSprintBadgeText(task)</span>
+            }
             @if (pageModel.IsTaskOverdue(task))
             {
                 <span class="at-overdue-marker">Overdue</span>

--- a/Pages/ActionTasks/_SprintClosureReview.cshtml
+++ b/Pages/ActionTasks/_SprintClosureReview.cshtml
@@ -76,18 +76,29 @@
                     </div>
                     @foreach (var task in review.UnfinishedTasks)
                     {
+                        var mustReturnInvalidTaskToBacklog = Model.MustReturnInvalidTaskToBacklogDuringClosure(task);
                         <div class="at-closure-task-row" role="row">
                             <span>
                                 <strong>AT-@task.Id</strong> @task.Title
                                 <small>Due @task.DueDate.ToString("dd MMM yyyy")</small>
+                                @if (Model.IsInvalidTaskState(task))
+                                {
+                                    <small class="at-empty-inline">Invalid sprint assignment. Return to Backlog or correct the responsible person before closure.</small>
+                                }
                             </span>
-                            <span><span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span></span>
+                            <span>
+                                <span class="@Model.GetStatusBadgeClass(task.Status)">@task.Status</span>
+                                @if (Model.IsInvalidTaskState(task))
+                                {
+                                    <span class="@Model.GetSprintBadgeClass(task)">@Model.GetSprintBadgeText(task)</span>
+                                }
+                            </span>
                             <label class="at-closure-choice">
-                                <input type="radio" name="ClosureInput.Dispositions[@task.Id]" value="carry" data-at-closure-choice="carry" required />
+                                <input type="radio" name="ClosureInput.Dispositions[@task.Id]" value="carry" data-at-closure-choice="carry" required disabled="@mustReturnInvalidTaskToBacklog" />
                                 <span>Carry Forward</span>
                             </label>
                             <label class="at-closure-choice">
-                                <input type="radio" name="ClosureInput.Dispositions[@task.Id]" value="outside" data-at-closure-choice="outside" required />
+                                <input type="radio" name="ClosureInput.Dispositions[@task.Id]" value="outside" data-at-closure-choice="outside" required disabled="@mustReturnInvalidTaskToBacklog" />
                                 <span>Keep Outside Sprint</span>
                             </label>
                             <label class="at-closure-choice">

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -31,7 +31,7 @@
     else
     {
         <p class="at-active-sprint-summary">
-            @Model.ActiveSprintMetrics.TotalTasks tasks · @Model.ActiveSprintMetrics.InProgressTasks in progress · @Model.ActiveSprintMetrics.OverdueTasks overdue · @Model.ActiveSprintMetrics.BlockedTasks blocked · @Model.ActiveSprintSubmittedTaskDisplays.Count pending closure
+            @Model.ActiveSprintMetrics.TotalTasks tasks · @Model.ActiveSprintMetrics.InProgressTasks in progress · @Model.ActiveSprintMetrics.OverdueTasks overdue · @Model.ActiveSprintMetrics.BlockedTasks blocked · @Model.ActiveSprintSubmittedTaskCount pending closure · @Model.ActiveSprintMetrics.InvalidStateTasks invalid state
         </p>
 
         @* SECTION: Active sprint exception lists render only when they contain command-relevant tasks. *@
@@ -61,7 +61,7 @@
                     @if (Model.ActiveSprintSubmittedTaskDisplays.Any())
                     {
                         <article class="at-attention-panel">
-                            <div class="at-attention-heading"><span>Submitted Pending Closure in Active Sprint</span><strong>@Model.ActiveSprintSubmittedTaskDisplays.Count</strong></div>
+                            <div class="at-attention-heading"><span>Submitted Pending Closure in Active Sprint</span><strong>@Model.ActiveSprintSubmittedTaskCount</strong></div>
                             <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, string.Empty)' />
                         </article>
                     }

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -85,7 +85,7 @@
                 <span>Status</span>
                 <select class="form-select form-select-sm" name="ReportStatus" data-at-reports-filter-control="true">
                     <option value="">All statuses</option>
-                    @foreach (var status in Model.AllowedStatusOptions)
+                    @foreach (var status in Model.ReportStatusOptions)
                     {
                         @if (string.Equals(Model.ReportStatus, status, StringComparison.OrdinalIgnoreCase))
                         {
@@ -302,7 +302,7 @@
                             <th>Open</th>
                             <th>Closed</th>
                             <th>Carried Forward</th>
-                            <th>Overdue at Closure</th>
+                            <th>Closed Late</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -41,6 +41,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(1, model.ActiveSprintMetrics.InProgressTasks);
         Assert.Equal(1, model.ActiveSprintMetrics.BlockedTasks);
         Assert.Equal(1, model.ActiveSprintMetrics.OverdueTasks);
+        Assert.Equal(1, model.ActiveSprintMetrics.SubmittedPendingClosureTasks);
+        Assert.Equal(0, model.ActiveSprintMetrics.InvalidStateTasks);
         Assert.Equal(3, model.ActiveSprintMetrics.CarryForwardCandidateTasks);
         Assert.Equal(new[] { 5 }, model.BacklogTasks.Select(t => t.Id));
         Assert.Equal(new[] { 5 }, model.SprintReadModel.BacklogTasks.Select(t => t.Id));
@@ -228,7 +230,8 @@ public class ActionTaskQueryServiceSprintMetricsTests
         {
             NewTask(51, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(3), assignedToUserId: "assignee", title: "Monthly readiness review"),
             NewTask(52, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(1), assignedToUserId: "assignee", title: "Fleet compliance check"),
-            NewTask(53, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee", title: "Inventory audit")
+            NewTask(53, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: "assignee", title: "Inventory audit"),
+            NewTask(152, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(4), assignedToUserId: "assignee", title: "Engine room inspection")
         };
         var service = CreateQueryService();
 
@@ -241,6 +244,56 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(new[] { 51 }, titleMatch.TaskListTasks.Select(t => t.Id));
         Assert.Equal(new[] { 52 }, atNumberMatch.TaskListTasks.Select(t => t.Id));
         Assert.Equal(new[] { 52 }, numericMatch.TaskListTasks.Select(t => t.Id));
+    }
+
+
+    [Fact]
+    public void BuildReadModel_SelectedSprintIncludesInvalidSprintLinkedTasksForClosureReview()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 81, Name = "Active Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var tasks = new[]
+        {
+            NewTask(81, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(1), assignedToUserId: "assignee"),
+            NewTask(82, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(2), assignedToUserId: string.Empty)
+        };
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(new[] { 81, 82 }, model.SprintReadModel.SelectedSprintTasks.Select(t => t.Id));
+        Assert.Equal(new[] { 81, 82 }, model.SprintReadModel.ClosureReview.UnfinishedTasks.Select(t => t.Id));
+        Assert.Equal(1, model.ActiveSprintMetrics.InvalidStateTasks);
+    }
+
+    [Fact]
+    public void BuildReadModel_SprintPerformanceCountsOnlyTasksClosedAfterDueDateAsLate()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 91, Name = "Closed Sprint", Status = ActionSprintStatus.Closed, StartDate = today.AddDays(-14), EndDate = today.AddDays(-1), ClosedAtUtc = today.AddDays(5) };
+        var closedOnTime = NewTask(91, sprint.Id, ActionTaskStatuses.Closed, today.AddDays(-5));
+        closedOnTime.ClosedOn = today.AddDays(-5);
+        var closedLate = NewTask(92, sprint.Id, ActionTaskStatuses.Closed, today.AddDays(-6));
+        closedLate.ClosedOn = today.AddDays(-4);
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            new[] { closedOnTime, closedLate },
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(1, model.Reports.SprintPerformanceRows.Single().OverdueAtClosure);
     }
 
     // SECTION: Test query service helper

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -230,6 +230,15 @@ public class ActionSprintService
             throw new InvalidOperationException("Closure disposition includes tasks that are not unfinished tasks in this sprint.");
         }
 
+        var unsafeAssignedDispositionIds = unfinishedTasks
+            .Where(t => (carryIds.Contains(t.Id) || outsideIds.Contains(t.Id)) && !ActionTaskCategorization.HasAssignedUser(t))
+            .Select(t => t.Id)
+            .ToList();
+        if (unsafeAssignedDispositionIds.Count > 0)
+        {
+            throw new InvalidOperationException("Tasks with invalid sprint assignment and no responsible person must be returned to backlog or corrected before sprint closure.");
+        }
+
         var performedAt = DateTime.UtcNow;
         foreach (var task in unfinishedTasks.Where(t => carryIds.Contains(t.Id)))
         {

--- a/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
@@ -113,8 +113,10 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
 
     private bool IsTaskOverdue(ActionTaskItem task)
         => IsOpenTask(task)
+           && !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
            && ActionTaskCategorization.HasAssignedUser(task)
            && !ActionTaskCategorization.IsBacklogTask(task)
+           && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
            && task.DueDate.Date < _clock.UtcToday;
 
     private static int CountByStatus(IReadOnlyList<ActionTaskItem> tasks, string status)
@@ -122,13 +124,18 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
 
     private static int GetAttentionScore(ActionTaskItem task, DateTime today)
     {
-        var isOverdue = task.DueDate.Date < today;
+        var isSubmitted = string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+        var isOverdue = !isSubmitted
+            && ActionTaskCategorization.HasAssignedUser(task)
+            && !ActionTaskCategorization.IsBacklogTask(task)
+            && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
+            && task.DueDate.Date < today;
         var isCritical = string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
-        if (isOverdue && isCritical) return 1;
-        if (isOverdue) return 2;
+        if (!isSubmitted && isOverdue && isCritical) return 1;
+        if (!isSubmitted && isOverdue) return 2;
         if (string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && isCritical) return 3;
         if (isCritical) return 4;
-        if (string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)) return 5;
+        if (isSubmitted) return 5;
         return 6;
     }
 

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -42,7 +42,7 @@ public sealed class ActionTaskQueryService
             SprintReadModel = sprintReadModel,
             ActiveSprintMetrics = activeSprintMetrics,
             CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
-            OverdueTasks = tasks.Where(t => IsOpen(t) && t.DueDate.Date < _clock.UtcToday).OrderBy(t => t.DueDate).Take(5).ToList(),
+            OverdueTasks = tasks.Where(t => IsOperationallyOverdue(t, _clock.UtcToday)).OrderBy(t => t.DueDate).Take(5).ToList(),
             RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && t.SubmittedOn.HasValue).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
             RecentlyUpdatedTasks = tasks.Where(t => ResolveLastActivityUtc(t, activityByTaskId).HasValue).OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue).ThenByDescending(t => t.Id).Take(5).ToList(),
             DueBuckets = BuildDueBuckets(tasks),
@@ -56,6 +56,17 @@ public sealed class ActionTaskQueryService
     private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
     private static bool IsBacklog(ActionTaskItem task) => ActionTaskCategorization.IsBacklogTask(task);
     private static bool IsCriticalOpen(ActionTaskItem task) => IsOpen(task) && string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSubmitted(ActionTaskItem task)
+        => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsOperationallyOverdue(ActionTaskItem task, DateTime today)
+        => IsOpen(task)
+           && !IsSubmitted(task)
+           && ActionTaskCategorization.HasAssignedUser(task)
+           && !ActionTaskCategorization.IsBacklogTask(task)
+           && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
+           && task.DueDate.Date < today;
 
     private static DateTime? ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyDictionary<int, DateTime?> activityByTaskId)
     {
@@ -92,7 +103,7 @@ public sealed class ActionTaskQueryService
 
         var selectedTasks = selectedSprint is null
             ? new List<ActionTaskItem>()
-            : tasks.Where(t => t.SprintId == selectedSprint.Id && ActionTaskBucketClassifier.ResolveBucket(t) != ActionTaskBucket.Invalid).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
+            : tasks.Where(t => t.SprintId == selectedSprint.Id).OrderBy(t => StatusOrder(t)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
         var backlogTasks = tasks.Where(IsBacklog).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList();
 
@@ -193,8 +204,10 @@ public sealed class ActionTaskQueryService
             CompletedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
             InProgressTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)),
             BlockedTasks = activeSprintTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)),
-            OverdueTasks = activeSprintTasks.Count(t => IsOpen(t) && t.DueDate.Date < today),
-            CarryForwardCandidateTasks = activeSprintTasks.Count(t => IsOpen(t))
+            OverdueTasks = activeSprintTasks.Count(t => IsOperationallyOverdue(t, today)),
+            SubmittedPendingClosureTasks = activeSprintTasks.Count(IsSubmitted),
+            InvalidStateTasks = activeSprintTasks.Count(t => ActionTaskBucketClassifier.ResolveBucket(t) == ActionTaskBucket.Invalid),
+            CarryForwardCandidateTasks = activeSprintTasks.Count(t => IsOpen(t) && ActionTaskBucketClassifier.ResolveBucket(t) != ActionTaskBucket.Invalid)
         };
     }
 
@@ -204,10 +217,10 @@ public sealed class ActionTaskQueryService
         var endOfWeek = today.AddDays(7);
         return new ActionTaskDueBuckets
         {
-            Overdue = tasks.Where(t => IsOpen(t) && t.DueDate.Date < today).OrderBy(t => t.DueDate).ToList(),
-            Today = tasks.Where(t => IsOpen(t) && t.DueDate.Date == today).OrderBy(t => t.DueDate).ToList(),
-            ThisWeek = tasks.Where(t => IsOpen(t) && t.DueDate.Date > today && t.DueDate.Date <= endOfWeek).OrderBy(t => t.DueDate).ToList(),
-            Later = tasks.Where(t => IsOpen(t) && t.DueDate.Date > endOfWeek).OrderBy(t => t.DueDate).ToList()
+            Overdue = tasks.Where(t => IsOperationallyOverdue(t, today)).OrderBy(t => t.DueDate).ToList(),
+            Today = tasks.Where(t => IsOpen(t) && !IsSubmitted(t) && t.DueDate.Date == today).OrderBy(t => t.DueDate).ToList(),
+            ThisWeek = tasks.Where(t => IsOpen(t) && !IsSubmitted(t) && t.DueDate.Date > today && t.DueDate.Date <= endOfWeek).OrderBy(t => t.DueDate).ToList(),
+            Later = tasks.Where(t => IsOpen(t) && !IsSubmitted(t) && t.DueDate.Date > endOfWeek).OrderBy(t => t.DueDate).ToList()
         };
     }
 
@@ -247,17 +260,28 @@ public sealed class ActionTaskQueryService
     }
 
 
-    // SECTION: Register search matches task identity, title, description, and visible owner text.
+    // SECTION: Register search treats AT identifiers as exact IDs while preserving broad text search.
     private static bool MatchesRegisterSearch(ActionTaskItem task, string searchTerm, string normalizedTaskNumber, IReadOnlyDictionary<string, string> assigneeNames)
     {
+        var trimmed = searchTerm.Trim();
+        var isAtNumber = trimmed.StartsWith("AT-", StringComparison.OrdinalIgnoreCase);
+        var isBareNumber = trimmed.All(char.IsDigit);
+        var matchesExactTaskId = task.Id.ToString().Equals(normalizedTaskNumber, StringComparison.OrdinalIgnoreCase);
+
+        if (isAtNumber || isBareNumber)
+        {
+            return matchesExactTaskId
+                || task.Title.Contains(trimmed, StringComparison.OrdinalIgnoreCase)
+                || (!string.IsNullOrWhiteSpace(task.Description) && task.Description.Contains(trimmed, StringComparison.OrdinalIgnoreCase));
+        }
+
         var taskNumber = $"AT-{task.Id}";
         var assigneeName = assigneeNames.TryGetValue(task.AssignedToUserId, out var resolvedAssignee) ? resolvedAssignee : string.Empty;
 
-        return task.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
-            || taskNumber.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
-            || task.Id.ToString().Equals(normalizedTaskNumber, StringComparison.OrdinalIgnoreCase)
-            || (!string.IsNullOrWhiteSpace(task.Description) && task.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
-            || (!string.IsNullOrWhiteSpace(assigneeName) && assigneeName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase));
+        return task.Title.Contains(trimmed, StringComparison.OrdinalIgnoreCase)
+            || taskNumber.Equals(trimmed, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrWhiteSpace(task.Description) && task.Description.Contains(trimmed, StringComparison.OrdinalIgnoreCase))
+            || (!string.IsNullOrWhiteSpace(assigneeName) && assigneeName.Contains(trimmed, StringComparison.OrdinalIgnoreCase));
     }
 
     // SECTION: Register bucket filtering maps user-facing buckets to central task classification.
@@ -381,6 +405,8 @@ public sealed class ActionTaskQueryService
         public int InProgressTasks { get; init; }
         public int BlockedTasks { get; init; }
         public int OverdueTasks { get; init; }
+        public int SubmittedPendingClosureTasks { get; init; }
+        public int InvalidStateTasks { get; init; }
         public int CarryForwardCandidateTasks { get; init; }
     }
 

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -194,7 +194,7 @@ public sealed class ActionTaskReportBuilder
                     Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
                     CarriedForward = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
                     OverdueAtClosure = s.Status == ActionSprintStatus.Closed
-                        ? scopedTasks.Count(t => t.DueDate.Date < (s.ClosedAtUtc ?? s.EndDate).Date && !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+                        ? scopedTasks.Count(IsClosedLate)
                         : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday))
                 };
             })
@@ -256,6 +256,11 @@ public sealed class ActionTaskReportBuilder
 
     private static bool IsSubmitted(ActionTaskItem task)
         => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsClosedLate(ActionTaskItem task)
+        => string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+           && task.ClosedOn.HasValue
+           && task.ClosedOn.Value.Date > task.DueDate.Date;
 
     private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
 

--- a/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
@@ -29,15 +29,26 @@ public sealed class ActionTaskSprintWorkspaceSummaryBuilder
             request.UnfinishedClosureTasks.OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
             request.BacklogTasks.Count,
             request.BacklogTasks.Count(IsHighPriorityBacklogTask),
-            request.BacklogTasks.Count(IsTaskOverdue),
+            request.BacklogTasks.Count(IsBacklogPastTarget),
             activeSprintTasks.OrderBy(t => StatusOrder(t.Status)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
             activeSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
             activeSprintTasks.Where(IsBlocked).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
+            activeSprintTasks.Count(IsSubmitted),
             activeSprintTasks.Where(IsSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).Take(5).ToList());
     }
 
-    // SECTION: Sprint summary predicates preserve existing open-task and status semantics.
-    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && task.DueDate.Date < _clock.UtcToday;
+    // SECTION: Sprint summary predicates separate assigned overdue work from backlog target dates.
+    private bool IsTaskOverdue(ActionTaskItem task)
+        => IsOpenTask(task)
+           && !IsSubmitted(task)
+           && ActionTaskCategorization.HasAssignedUser(task)
+           && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
+           && task.DueDate.Date < _clock.UtcToday;
+
+    private bool IsBacklogPastTarget(ActionTaskItem task)
+        => ActionTaskCategorization.IsBacklogTask(task)
+           && task.DueDate.Date < _clock.UtcToday;
+
     private static bool IsHighPriorityBacklogTask(ActionTaskItem task) => string.Equals(task.Priority, "High", StringComparison.OrdinalIgnoreCase) || string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
     private static bool IsBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
     private static bool IsSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
@@ -79,6 +90,7 @@ public sealed record ActionTaskSprintWorkspaceSummary(
     IReadOnlyList<ActionTaskItem> ActiveSprintTasks,
     IReadOnlyList<ActionTaskItem> ActiveSprintOverdueTasks,
     IReadOnlyList<ActionTaskItem> ActiveSprintBlockedTasks,
+    int ActiveSprintSubmittedTaskCount,
     IReadOnlyList<ActionTaskItem> ActiveSprintSubmittedTasks)
 {
     public static ActionTaskSprintWorkspaceSummary Empty { get; } = new(
@@ -95,5 +107,6 @@ public sealed record ActionTaskSprintWorkspaceSummary(
         Array.Empty<ActionTaskItem>(),
         Array.Empty<ActionTaskItem>(),
         Array.Empty<ActionTaskItem>(),
+        0,
         Array.Empty<ActionTaskItem>());
 }


### PR DESCRIPTION
### Motivation

- Fix several correctness issues that could produce invisible blockers, under-reported KPIs, and misleading reports (invalid sprint tasks excluded from closure review, capped submitted counts, unsafe AT-number search, capped closed-sprint access, and incorrect overdue-at-closure logic). 
- Ensure operational overdue counts distinguish assignee-overdue vs pending-closure and surface invalid-state tasks clearly for safe sprint closure. 
- Make Reports and Register filters behave as management users expect (include `Backlog`, `Submitted`, `Closed` and exact AT-id matching). 

### Description

- Include invalid sprint-linked tasks in the selected-sprint read model and closure review by removing the `Invalid` exclusion in `ActionTaskQueryService` and render invalid-state guidance in the closure UI (`Pages/ActionTasks/_SprintClosureReview.cshtml`) while disabling unsafe closure choices for invalid tasks. 
- Harden `CloseSprintWithDispositionAsync` in `Services/ActionTasks/ActionSprintService.cs` with a server-side guard that prevents carrying/keeping-as-assigned tasks that have invalid sprint assignment and no responsible person. 
- Make AT-number register search exact for `AT-` and bare numeric queries by replacing substring matching with exact-ID handling in `MatchesRegisterSearch` within `Services/ActionTasks/ActionTaskQueryService.cs`. 
- Restore access to all closed sprints by removing the `Take(8)` cap in `Pages/ActionTasks/_PlanningPlanTab.cshtml`. 
- Correct sprint performance late-closure metric to count tasks closed after their `ClosedOn` date (use `IsClosedLate`) and rename the column to `Closed Late` in `Services/ActionTasks/ActionTaskReportBuilder.cs` and `Pages/ActionTasks/_TaskReports.cshtml`. 
- Introduce an operational overdue predicate that excludes `Submitted` and `Invalid` tasks (`IsOperationallyOverdue`) and use it across `ActionTaskQueryService`, `ActionTaskCommandCentreSummaryBuilder`, and `ActionTaskSprintWorkspaceSummaryBuilder` so overdue KPIs no longer double-count submitted items. 
- Add uncapped submitted counts to the active-sprint summary (`ActiveSprintSubmittedTaskCount`) while keeping the mini-list capped, add `InvalidStateTasks` and `SubmittedPendingClosureTasks` to active-sprint metrics, and split backlog past-target logic into `IsBacklogPastTarget` in `ActionTaskSprintWorkspaceSummaryBuilder`. 
- Update page helpers and partials (`Pages/ActionTasks/Index.cshtml.cs`, `_TaskDashboard.cshtml`, `_PlanningTaskCard.cshtml`, `_PlanningPlanTab.cshtml`, `_TaskReports.cshtml`) to surface the new metrics, invalid-state badges and report filters (`ReportStatusOptions`). 
- Add/adjust unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` to cover exact AT search, invalid sprint-linked tasks visibility in closure review, active-sprint invalid metrics and the closed-late calculation. 

### Testing

- Ran `git diff --check` which reported no whitespace or diff errors. 
- Added/updated unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` but could not execute them because the environment lacks the .NET SDK. 
- `dotnet --info` and `dotnet test` were attempted and both failed in this environment with `dotnet: command not found`, so automated test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e8a9f8e88329b5643a26d0f41030)