### PR TITLE
Polish Action Tracker release UI

### DIFF
--- a/Pages/ActionTasks/_PlanningCommandStrip.cshtml
+++ b/Pages/ActionTasks/_PlanningCommandStrip.cshtml
@@ -34,7 +34,7 @@
                 @Model.SprintSummary.OpenCount open · @Model.SelectedSprintOverdueCount overdue · @Model.SprintSummary.BlockedCount blocked · @Model.SprintAttentionSubmittedTaskDisplays.Count pending closure
             </p>
             <div class="at-command-focus-strip at-sprint-command-focus at-planning-command-focus">
-                <strong>Command focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
+                <strong>Focus:</strong> @(string.IsNullOrWhiteSpace(Model.SelectedSprint.Goal) ? "No command focus recorded." : Model.SelectedSprint.Goal)
             </div>
         </div>
 

--- a/Pages/ActionTasks/_PlanningPlanTab.cshtml
+++ b/Pages/ActionTasks/_PlanningPlanTab.cshtml
@@ -211,11 +211,11 @@
     </section>
 
     @* SECTION: Outside Sprint list makes assigned work outside sprint explicit and separate from backlog items. *@
-    <details class="at-panel at-planning-outside-sprint at-planning-plan-card">
-        <summary class="at-panel-heading">
+    <details class="at-planning-outside-sprint at-planning-plan-card">
+        <summary class="at-planning-outside-summary">
             <div>
                 <h2>Assigned Tasks Outside Sprint</h2>
-                <p class="at-panel-note">Assigned work not included in any sprint.</p>
+                <p class="at-panel-note">@Model.OutsideSprintTaskDisplays.Count assigned tasks outside sprint</p>
             </div>
             <span class="at-count-chip">@Model.OutsideSprintTaskDisplays.Count</span>
         </summary>

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -30,44 +30,18 @@
     }
     else
     {
+        @* SECTION: Active sprint status remains a compact summary; detailed exception cards live under Attention Required to avoid duplicate task lists. *@
         <p class="at-active-sprint-summary">
-            @Model.ActiveSprintMetrics.TotalTasks tasks · @Model.ActiveSprintMetrics.InProgressTasks in progress · @Model.ActiveSprintMetrics.OverdueTasks overdue · @Model.ActiveSprintMetrics.BlockedTasks blocked · @Model.ActiveSprintSubmittedTaskCount pending closure@if (Model.ActiveSprintMetrics.InvalidStateTasks > 0) { <text> · @Model.ActiveSprintMetrics.InvalidStateTasks invalid state</text> }
+            @Model.ActiveSprintMetrics.TotalTasks tasks ·
+            @Model.ActiveSprintMetrics.InProgressTasks in progress ·
+            @Model.ActiveSprintMetrics.OverdueTasks overdue ·
+            @Model.ActiveSprintMetrics.BlockedTasks blocked ·
+            @Model.ActiveSprintSubmittedTaskCount pending closure
+            @if (Model.ActiveSprintMetrics.InvalidStateTasks > 0)
+            {
+                <text> · @Model.ActiveSprintMetrics.InvalidStateTasks invalid state</text>
+            }
         </p>
-
-        @* SECTION: Active sprint exception lists render only when they contain command-relevant tasks. *@
-        <div class="at-active-sprint-exceptions" aria-label="Active Sprint Exceptions">
-            <h3>Active Sprint Exceptions</h3>
-            @if (!Model.HasActiveSprintExceptions)
-            {
-                <div class="at-dashboard-empty-line">No active sprint exceptions.</div>
-            }
-            else
-            {
-                <div class="at-attention-grid">
-                    @if (Model.ActiveSprintOverdueTaskDisplays.Any())
-                    {
-                        <article class="at-attention-panel">
-                            <div class="at-attention-heading"><span>Overdue in Active Sprint</span><strong>@Model.ActiveSprintOverdueTaskDisplays.Count</strong></div>
-                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, string.Empty)' />
-                        </article>
-                    }
-                    @if (Model.ActiveSprintBlockedTaskDisplays.Any())
-                    {
-                        <article class="at-attention-panel">
-                            <div class="at-attention-heading"><span>Blocked in Active Sprint</span><strong>@Model.ActiveSprintBlockedTaskDisplays.Count</strong></div>
-                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, string.Empty)' />
-                        </article>
-                    }
-                    @if (Model.ActiveSprintSubmittedTaskDisplays.Any())
-                    {
-                        <article class="at-attention-panel">
-                            <div class="at-attention-heading"><span>Submitted Pending Closure in Active Sprint</span><strong>@Model.ActiveSprintSubmittedTaskCount</strong></div>
-                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, string.Empty)' />
-                        </article>
-                    }
-                </div>
-            }
-        </div>
     }
 </section>
 

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -3,21 +3,7 @@
     // SECTION: Date filter display values are preformatted for CSP-safe server rendering.
     var reportFromDateValue = Model.ReportFromDate?.ToString("yyyy-MM-dd");
     var reportToDateValue = Model.ReportToDate?.ToString("yyyy-MM-dd");
-    var reportFilterSummary = Model.ReportFilterSummary.ToLowerInvariant();
 }
-
-@* SECTION: Reports introduction and scope. *@
-<section class="at-section-group">
-    <article class="at-panel">
-        <div class="at-panel-heading">
-            <div>
-                <h2>Reports</h2>
-                <p class="at-panel-note">Review workload, ageing and sprint performance.</p>
-            </div>
-        </div>
-        <p class="at-empty-state-note">This management view summarises workload, risk, ageing and closure trends without duplicating Command Centre, Sprint Board or Register actions.</p>
-    </article>
-</section>
 
 @* SECTION: Compact reports filter bar for management analysis. *@
 <section class="at-section-group">
@@ -26,7 +12,6 @@
         <div class="at-reports-filter-heading">
             <div>
                 <h2>Report Filters</h2>
-                <p class="at-panel-note">Keep reports focused with date range, responsible person, bucket, sprint, status and priority.</p>
             </div>
             <span class="at-report-filter-summary">@Model.ReportFilterSummary</span>
         </div>
@@ -140,7 +125,7 @@
     <div class="at-panel-heading">
         <div>
             <h2>Workload Summary</h2>
-            <p class="at-panel-note">Showing @reportFilterSummary.</p>
+            <p class="at-panel-note">@Model.ReportFilterSummary</p>
         </div>
     </div>
     <div class="at-kpis">

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -647,6 +647,31 @@ public class ActionSprintServiceTests
     }
 
     [Fact]
+    public async Task CloseSprintWithDispositionAsync_InvalidSprintTaskMustReturnToBacklogOrBeCorrected()
+    {
+        // SECTION: Arrange invalid sprint assignment
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var source = await service.CreateSprintAsync(NewSprint("Source"), "planner", RoleNames.Comdt);
+        await service.ActivateSprintAsync(source.Id, source.RowVersion, "planner", RoleNames.Comdt);
+        var target = await service.CreateSprintAsync(NewSprint("Target", 15, 29), "planner", RoleNames.Comdt);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned);
+        task.SprintId = source.Id;
+        task.AssignedToUserId = "assignee";
+        task.AssignedToRole = string.Empty;
+        await db.SaveChangesAsync();
+
+        // SECTION: Act + Assert carry-forward and keep-outside dispositions are rejected for invalid sprint tasks.
+        var carryEx = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, new[] { task.Id }, target.Id, Array.Empty<int>(), Array.Empty<int>(), "Carry invalid", "planner", RoleNames.Comdt));
+        var outsideEx = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseSprintWithDispositionAsync(source.Id, source.RowVersion, Array.Empty<int>(), null, new[] { task.Id }, Array.Empty<int>(), "Keep invalid outside", "planner", RoleNames.Comdt));
+
+        Assert.Equal("Tasks with invalid sprint assignment must be returned to backlog or corrected before sprint closure.", carryEx.Message);
+        Assert.Equal("Tasks with invalid sprint assignment must be returned to backlog or corrected before sprint closure.", outsideEx.Message);
+    }
+
+    [Fact]
     public async Task CloseSprintWithDispositionAsync_BacklogDisposition_ResetsTaskToBacklogStatus()
     {
         // SECTION: Arrange

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1002,7 +1002,8 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("Quick open", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Open Sprint", html, StringComparison.Ordinal);
         Assert.Contains("<details class=\"at-planning-backlog-filter-shell\">", html, StringComparison.Ordinal);
-        Assert.Contains("<details class=\"at-panel at-planning-outside-sprint at-planning-plan-card\">", html, StringComparison.Ordinal);
+        Assert.Contains("<details class=\"at-planning-outside-sprint at-planning-plan-card\">", html, StringComparison.Ordinal);
+        Assert.Contains("assigned tasks outside sprint", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1221,7 +1222,9 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Contains("<h2>Active Sprint</h2>", activeSprint, StringComparison.Ordinal);
         Assert.Contains("Health Sprint", activeSprint, StringComparison.Ordinal);
-        Assert.Contains("No active sprint exceptions.", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("1 tasks", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("Active Sprint Exceptions", activeSprint, StringComparison.Ordinal);
+        Assert.DoesNotContain("No active sprint exceptions.", activeSprint, StringComparison.Ordinal);
         Assert.DoesNotContain("Active Sprint Health", activeSprint, StringComparison.Ordinal);
         Assert.DoesNotContain("<h3>Backlog</h3>", activeSprint, StringComparison.Ordinal);
         Assert.DoesNotContain("No overdue tasks in the active sprint.", activeSprint, StringComparison.Ordinal);
@@ -1308,6 +1311,8 @@ public class ActionTaskPageTests
         Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
         Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Reset / Clear all", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("This management view summarises", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Keep reports focused", html, StringComparison.Ordinal);
         Assert.DoesNotContain("<span>Bucket / Sprint</span>", html, StringComparison.Ordinal);
         Assert.Contains("<span>Bucket</span>", html, StringComparison.Ordinal);
         Assert.Contains("<span>Sprint</span>", html, StringComparison.Ordinal);
@@ -1354,6 +1359,7 @@ public class ActionTaskPageTests
         Assert.Equal(1, page.PriorityCounts.Single(x => x.Name == "High").Count);
         Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8-14 days assigned").Count);
         Assert.Contains("Showing 1 of 2 tasks", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Showing showing", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(@"method=""get""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ViewMode"" value=""Reports""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ReportBucket""", html, StringComparison.Ordinal);

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3618,12 +3618,28 @@ html {
     margin-top: 0.5rem;
 }
 
+/* SECTION: Outside sprint disclosure stays visually secondary to the backlog planning queue. */
 .at-planning-outside-sprint {
-    border-style: dashed;
+    border: 1px dashed var(--at-border);
+    border-radius: var(--at-radius-lg);
+    background: #f8fafc;
+    padding: 0.75rem 0.85rem;
 }
 
 .at-planning-outside-sprint > summary {
     cursor: pointer;
+}
+
+.at-planning-outside-summary {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.at-planning-outside-summary h2 {
+    margin: 0;
+    font-size: 1rem;
 }
 
 .at-execute-status-board,


### PR DESCRIPTION
### Motivation

- Fix a Razor rendering bug in the Command Centre that caused raw Razor markup to appear in the UI and remove duplicate task lists that created visual noise.
- Simplify Reports page header and summary to avoid duplicated copy and the “Showing showing…” issue and make the Sprint Board outside-sprint area more visually secondary.

### Description

- Fix inline Razor rendering in `Pages/ActionTasks/_TaskDashboard.cshtml` by moving the `@if` conditional into a proper Razor block and keeping active-sprint details as a compact summary so exception cards are only shown under `Attention Required`.
- Simplify Reports by removing the repeated intro panel and helper copy and render the report summary directly in `Pages/ActionTasks/_TaskReports.cshtml` to prevent duplicate “Showing”.
- Shorten the selected-sprint label from `Command focus:` to `Focus:` in `Pages/ActionTasks/_PlanningCommandStrip.cshtml` and make the Assigned Tasks Outside Sprint disclosure more compact by altering markup in `Pages/ActionTasks/_PlanningPlanTab.cshtml` and styling in `wwwroot/css/action-tracker.css`.
- Add/adjust tests to match the UI polish and regression expectations in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` and add a unit test to assert invalid sprint-assignment dispositions are rejected in `ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs` (service already guards this in `Services/ActionTasks/ActionSprintService.cs`).

### Testing

- Ran automated textual checks: `git diff --check` (no whitespace errors) and repository search checks with `rg` for the problematic strings (no remaining matches found).
- Updated unit tests to assert the UI changes and invalid-sprint closure guard; these tests were added/adjusted but could not be executed here because the .NET SDK is not installed in this environment, so `dotnet test` could not be run.
- Note: runtime build and test execution should be run in CI or a local environment with the .NET SDK to validate the new/updated tests and ensure no regressions at build/runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08005a8f688329aa57d6b13cfb2fd3)