### PR TITLE
Polish Reports page UI and separate Active Overdue from Closed Late

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -1023,7 +1023,7 @@ public class IndexModel : PageModel
         BucketDistribution = readModel.Reports.BucketDistribution.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         ResponsiblePersonWorkloads = readModel.Reports.ResponsiblePersonWorkloads.Select(x => new ResponsibleWorkloadSummary(x.ResponsiblePerson, x.Open, x.Overdue, x.Blocked, x.InProgress, x.Submitted, x.Critical)).ToList();
         OutsideSprintWorkloadCounts = readModel.Reports.OutsideSprintWorkloadCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
-        SprintPerformanceRows = readModel.Reports.SprintPerformanceRows.Select(x => new SprintPerformanceSummary(x.Sprint, x.Status, x.Open, x.Closed, x.CarriedForward, x.ClosedLate)).ToList();
+        SprintPerformanceRows = readModel.Reports.SprintPerformanceRows.Select(x => new SprintPerformanceSummary(x.Sprint, x.Status, x.Open, x.Closed, x.OverdueNow, x.CarriedForward, x.ClosedLate)).ToList();
         InvalidStateRows = readModel.Reports.InvalidStateRows.Select(x => new InvalidTaskStateSummary(x.Task, x.Issue, x.SuggestedCorrection)).ToList();
         WorkloadSummary = new ActionTaskReportSummary(readModel.Reports.WorkloadSummary.OpenTasks, readModel.Reports.WorkloadSummary.Overdue, readModel.Reports.WorkloadSummary.Blocked, readModel.Reports.WorkloadSummary.PendingClosure, readModel.Reports.WorkloadSummary.BacklogItems);
         CarryForwardBySprint = readModel.Reports.CarryForwardBySprint.Select(x => new CountSummary(x.Name, x.Count)).ToList();
@@ -1638,7 +1638,7 @@ public class IndexModel : PageModel
     public sealed record CountSummary(string Name, int Count);
     public sealed record ActionTaskReportSummary(int OpenTasks = 0, int Overdue = 0, int Blocked = 0, int PendingClosure = 0, int BacklogItems = 0);
     public sealed record ResponsibleWorkloadSummary(string ResponsiblePerson, int Open, int Overdue, int Blocked, int InProgress, int Submitted, int Critical);
-    public sealed record SprintPerformanceSummary(string Sprint, string Status, int Open, int Closed, int CarriedForward, int ClosedLate);
+    public sealed record SprintPerformanceSummary(string Sprint, string Status, int Open, int Closed, int OverdueNow, int CarriedForward, int ClosedLate);
     public sealed record InvalidTaskStateSummary(string Task, string Issue, string SuggestedCorrection);
     public sealed class TaskDisplayItem
     {

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -68,14 +68,6 @@
                 </select>
             </label>
             <label>
-                <span>From</span>
-                <input class="form-control form-control-sm" type="date" name="ReportFromDate" value="@reportFromDateValue" data-at-reports-date-filter="true" />
-            </label>
-            <label>
-                <span>To</span>
-                <input class="form-control form-control-sm" type="date" name="ReportToDate" value="@reportToDateValue" data-at-reports-date-filter="true" />
-            </label>
-            <label>
                 <span>Status</span>
                 <select class="form-select form-select-sm" name="ReportStatus" data-at-reports-filter-control="true">
                     <option value="">All statuses</option>
@@ -91,6 +83,14 @@
                         }
                     }
                 </select>
+            </label>
+            <label>
+                <span>From</span>
+                <input class="form-control form-control-sm" type="date" name="ReportFromDate" value="@reportFromDateValue" data-at-reports-date-filter="true" />
+            </label>
+            <label>
+                <span>To</span>
+                <input class="form-control form-control-sm" type="date" name="ReportToDate" value="@reportToDateValue" data-at-reports-date-filter="true" />
             </label>
             <label>
                 <span>Priority</span>
@@ -109,13 +109,15 @@
                     }
                 </select>
             </label>
+            <div class="at-reports-filter-action-cell">
+                <a class="btn btn-sm btn-outline-secondary" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports">Reset / Clear all</a>
+            </div>
         </div>
         <div class="at-reports-filter-actions">
             <span class="at-reports-filter-loading" data-at-reports-filter-loading="true" role="status" aria-live="polite">
                 <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
                 <span>Updating reports...</span>
             </span>
-            <a class="btn btn-sm btn-outline-secondary" asp-page="/ActionTasks/Index" asp-route-viewMode="Reports">Reset / Clear all</a>
         </div>
     </form>
 </section>
@@ -143,7 +145,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Bucket Distribution</h2>
-                <p class="at-panel-note">Official bucket distribution from the central classifier.</p>
+                <p class="at-panel-note">Task distribution by work bucket.</p>
             </div>
         </div>
         <div class="at-report-bucket-row">
@@ -158,7 +160,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Responsible Person Workload</h2>
-                <p class="at-panel-note">Open assigned Outside Sprint and Sprint work only; backlog and closed records are excluded.</p>
+                <p class="at-panel-note">Open assigned work only. Backlog and closed records are excluded.</p>
             </div>
         </div>
         @if (!Model.ResponsiblePersonWorkloads.Any())
@@ -172,12 +174,12 @@
                     <thead>
                         <tr>
                             <th>Responsible Person</th>
-                            <th>Open</th>
-                            <th>Overdue</th>
-                            <th>Blocked</th>
-                            <th>In Progress</th>
-                            <th>Submitted</th>
-                            <th>Critical</th>
+                            <th class="text-center">Open</th>
+                            <th class="text-center">Overdue</th>
+                            <th class="text-center">Blocked</th>
+                            <th class="text-center">In Progress</th>
+                            <th class="text-center">Submitted</th>
+                            <th class="text-center">Critical</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -185,12 +187,12 @@
                         {
                             <tr>
                                 <td>@item.ResponsiblePerson</td>
-                                <td>@item.Open</td>
-                                <td>@item.Overdue</td>
-                                <td>@item.Blocked</td>
-                                <td>@item.InProgress</td>
-                                <td>@item.Submitted</td>
-                                <td>@item.Critical</td>
+                                <td class="at-report-number">@item.Open</td>
+                                <td class="at-report-number @(item.Overdue > 0 ? "at-risk-count" : string.Empty)">@item.Overdue</td>
+                                <td class="at-report-number">@item.Blocked</td>
+                                <td class="at-report-number">@item.InProgress</td>
+                                <td class="at-report-number">@item.Submitted</td>
+                                <td class="at-report-number @(item.Critical > 0 ? "at-risk-count" : string.Empty)">@item.Critical</td>
                             </tr>
                         }
                     </tbody>
@@ -203,74 +205,64 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Ageing and Overdue Analysis</h2>
-                <p class="at-panel-note">Backlog Ageing and Assigned Task Ageing are separated so planning inventory is not mixed with responsible-person workload.</p>
+                <p class="at-panel-note">Ageing separated by backlog and assigned work.</p>
             </div>
         </div>
+        @* SECTION: Structured ageing cards replace raw metric rows for faster scan and consistent report polish. *@
         <div class="at-ageing-grid">
-            <div>
-                <h3 class="at-small at-section-eyebrow">Backlog Ageing</h3>
-                @if (Model.BacklogAgeingBuckets.All(item => item.Count == 0))
-                {
-                    <p class="at-empty-state-note">No backlog items.</p>
-                }
-                else
-                {
-                    <div class="at-metric-bars">
+            <div class="at-ageing-card">
+                <h3>Backlog Ageing</h3>
+                <table class="at-ageing-table">
+                    <thead>
+                        <tr><th>Age Band</th><th>Count</th></tr>
+                    </thead>
+                    <tbody>
                         @foreach (var item in Model.BacklogAgeingBuckets)
                         {
-                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                            <tr><td>@item.Name.Replace(" in backlog", string.Empty)</td><td>@item.Count</td></tr>
                         }
-                    </div>
-                }
+                    </tbody>
+                </table>
             </div>
-            <div>
-                <h3 class="at-small at-section-eyebrow">Assigned Task Ageing</h3>
-                @if (Model.AssignedTaskAgeingBuckets.All(item => item.Count == 0))
-                {
-                    <p class="at-empty-state-note">No open assigned workload.</p>
-                }
-                else
-                {
-                    <div class="at-metric-bars">
+            <div class="at-ageing-card">
+                <h3>Assigned Task Ageing</h3>
+                <table class="at-ageing-table">
+                    <thead>
+                        <tr><th>Age Band</th><th>Count</th></tr>
+                    </thead>
+                    <tbody>
                         @foreach (var item in Model.AssignedTaskAgeingBuckets)
                         {
-                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                            <tr><td>@item.Name.Replace(" assigned", string.Empty)</td><td>@item.Count</td></tr>
                         }
-                    </div>
-                }
+                    </tbody>
+                </table>
             </div>
-            <div>
-                <h3 class="at-small at-section-eyebrow">Overdue Analysis</h3>
-                @if (Model.OverdueAgeingBuckets.All(item => item.Count == 0))
-                {
-                    <p class="at-empty-state-note">No overdue tasks.</p>
-                }
-                else
-                {
-                    <div class="at-metric-bars">
+            <div class="at-ageing-card at-ageing-card-risk">
+                <h3>Overdue Analysis</h3>
+                <table class="at-ageing-table">
+                    <thead>
+                        <tr><th>Age Band</th><th>Count</th></tr>
+                    </thead>
+                    <tbody>
                         @foreach (var item in Model.OverdueAgeingBuckets)
                         {
-                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
+                            <tr><td>@item.Name</td><td class="@(item.Count > 0 ? "at-risk-count" : string.Empty)">@item.Count</td></tr>
                         }
-                    </div>
-                }
+                    </tbody>
+                </table>
             </div>
-            <div>
-                <h3 class="at-small at-section-eyebrow">Pending Closure</h3>
-                @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
-                {
-                    <p class="at-empty-state-note">No submitted tasks are awaiting closure in the selected report scope.</p>
-                }
-                else
-                {
-                    <div class="at-metric-bars">
-                        @foreach (var item in Model.SubmittedPendingClosureAgeingBuckets)
-                        {
-                            <div class="at-metric-row"><span class="at-metric-label" title="@item.Name">@item.Name</span><strong>@item.Count</strong></div>
-                        }
-                    </div>
-                }
-            </div>
+        </div>
+        <div class="at-pending-closure-inline">
+            <h3>Pending Closure</h3>
+            @if (Model.SubmittedPendingClosureAgeingBuckets.All(item => item.Count == 0))
+            {
+                <p>No submitted tasks are awaiting closure in the selected report scope.</p>
+            }
+            else
+            {
+                <span>@Model.SubmittedPendingClosureAgeingBuckets.Sum(item => item.Count) submitted tasks awaiting closure.</span>
+            }
         </div>
     </article>
 
@@ -278,7 +270,7 @@
         <div class="at-panel-heading">
             <div>
                 <h2>Sprint Performance</h2>
-                <p class="at-panel-note">Compact sprint-level progress and closure trend summary.</p>
+                <p class="at-panel-note">Sprint-level progress and closure summary.</p>
             </div>
         </div>
         @if (!Model.SprintPerformanceRows.Any())
@@ -294,9 +286,10 @@
                             <th>Sprint</th>
                             <th>Status</th>
                             <th>Open</th>
-                            <th>Closed</th>
-                            <th>Carried Forward</th>
-                            <th>Closed Late</th>
+                            <th class="text-center">Closed</th>
+                            <th class="text-center">Overdue Now</th>
+                            <th class="text-center">Carried Forward</th>
+                            <th class="text-center">Closed Late</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -305,10 +298,11 @@
                             <tr>
                                 <td>@item.Sprint</td>
                                 <td>@item.Status</td>
-                                <td>@item.Open</td>
-                                <td>@item.Closed</td>
-                                <td>@item.CarriedForward</td>
-                                <td>@item.ClosedLate</td>
+                                <td class="at-report-number">@item.Open</td>
+                                <td class="at-report-number">@item.Closed</td>
+                                <td class="at-report-number @(item.OverdueNow > 0 ? "at-risk-count" : string.Empty)">@(string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase) ? "—" : item.OverdueNow.ToString())</td>
+                                <td class="at-report-number">@item.CarriedForward</td>
+                                <td class="at-report-number">@(string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase) ? item.ClosedLate.ToString() : "—")</td>
                             </tr>
                         }
                     </tbody>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -297,6 +297,29 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(1, model.Reports.SprintPerformanceRows.Single().ClosedLate);
     }
 
+    [Fact]
+    public void BuildReadModel_SprintPerformanceSeparatesActiveOverdueFromClosedLate()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 92, Name = "Active Sprint", Status = ActionSprintStatus.Active, StartDate = today.AddDays(-7), EndDate = today.AddDays(7) };
+        var overdueOpen = NewTask(93, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(-2));
+        var futureOpen = NewTask(94, sprint.Id, ActionTaskStatuses.InProgress, today.AddDays(2));
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            new[] { overdueOpen, futureOpen },
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, false, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        var row = model.Reports.SprintPerformanceRows.Single();
+        Assert.Equal(1, row.OverdueNow);
+        Assert.Equal(0, row.ClosedLate);
+    }
+
     // SECTION: Test query service helper
     [Fact]
     public void ResolveBucket_WhenSprintExistsWithoutResponsiblePerson_ReturnsInvalid()

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -459,6 +459,7 @@ public sealed class ActionTaskQueryService
         public string Status { get; init; } = string.Empty;
         public int Open { get; init; }
         public int Closed { get; init; }
+        public int OverdueNow { get; init; }
         public int CarriedForward { get; init; }
         public int ClosedLate { get; init; }
     }

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -101,7 +101,7 @@ public sealed class ActionTaskReportBuilder
             BacklogItems = backlogTasks.Count
         };
 
-    // SECTION: Official bucket distribution uses the central classifier and hides Invalid State when no records exist.
+    // SECTION: Official bucket distribution uses shared bucket rules and hides Invalid State when no records exist.
     private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBucketDistribution(IReadOnlyList<ActionTaskItem> tasks)
     {
         var bucketCounts = tasks
@@ -207,10 +207,9 @@ public sealed class ActionTaskReportBuilder
                     Status = s.Status.ToString(),
                     Open = assignedOpen.Count,
                     Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
+                    OverdueNow = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday)),
                     CarriedForward = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
-                    ClosedLate = s.Status == ActionSprintStatus.Closed
-                        ? scopedTasks.Count(IsClosedLate)
-                        : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday))
+                    ClosedLate = s.Status == ActionSprintStatus.Closed ? scopedTasks.Count(IsClosedLate) : 0
                 };
             })
             .ToList();

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -1020,8 +1020,8 @@ html {
 
 .at-ageing-grid {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 0.5rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: .75rem;
 }
 
 /* SECTION: Empty states */
@@ -3349,20 +3349,20 @@ html {
 }
 
 .at-report-filter-summary {
-    background: rgba(15, 23, 42, .05);
-    border: 1px solid rgba(15, 23, 42, .08);
-    border-radius: 999px;
-    color: #475569;
-    font-size: .78rem;
-    font-weight: 700;
-    padding: .35rem .7rem;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    color: #64748b;
+    font-size: .72rem;
+    font-weight: 650;
+    padding: .2rem 0;
     white-space: nowrap;
 }
 
 .at-reports-filter-grid {
     display: grid;
     gap: .65rem;
-    grid-template-columns: minmax(13rem, 1.35fr) minmax(13rem, 1.35fr) repeat(4, minmax(8.5rem, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .at-reports-filter-grid label {
@@ -3421,8 +3421,20 @@ html {
         grid-template-columns: 1fr;
     }
 
-    .at-reports-filter-actions {
+    .at-reports-filter-actions,
+    .at-reports-filter-action-cell {
         align-items: stretch;
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 991.98px) {
+    .at-ageing-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .at-pending-closure-inline {
+        align-items: flex-start;
         flex-direction: column;
     }
 }
@@ -3697,17 +3709,19 @@ html {
 .at-report-bucket-row {
     display: grid;
     gap: .75rem;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .at-report-bucket-card {
+    align-items: center;
     background: #f8fafc;
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
     display: flex;
-    flex-direction: column;
-    gap: .2rem;
-    padding: .85rem;
+    gap: .55rem;
+    justify-content: space-between;
+    min-height: 3.35rem;
+    padding: .65rem .8rem;
 }
 
 .at-report-bucket-card span {
@@ -3720,7 +3734,7 @@ html {
 
 .at-report-bucket-card strong {
     color: var(--at-text);
-    font-size: 1.35rem;
+    font-size: 1.2rem;
 }
 
 .at-panel-warning {
@@ -3738,4 +3752,102 @@ html {
     .at-report-bucket-row {
         grid-template-columns: 1fr;
     }
+}
+
+/* SECTION: Final Reports page polish keeps filters, ageing cards, and risk counts visually consistent. */
+.at-reports-filter-action-cell {
+    align-self: end;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.at-reports-filter-action-cell .btn {
+    width: 100%;
+}
+
+.at-report-number {
+    font-weight: 700;
+    text-align: center;
+}
+
+.at-risk-count {
+    color: #b91c1c;
+    font-weight: 800;
+}
+
+.at-ageing-card {
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    box-shadow: 0 8px 20px rgba(15, 23, 42, .04);
+    padding: .9rem;
+}
+
+.at-ageing-card-risk {
+    border-color: rgba(220, 38, 38, .18);
+}
+
+.at-ageing-card h3,
+.at-pending-closure-inline h3 {
+    color: var(--at-text);
+    font-size: .82rem;
+    font-weight: 800;
+    letter-spacing: .04em;
+    margin: 0 0 .65rem;
+    text-transform: uppercase;
+}
+
+.at-ageing-table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.at-ageing-table th {
+    border-bottom: 1px solid var(--at-border);
+    color: var(--at-muted);
+    font-size: .72rem;
+    font-weight: 800;
+    letter-spacing: .04em;
+    padding: 0 0 .45rem;
+    text-transform: uppercase;
+}
+
+.at-ageing-table th:last-child,
+.at-ageing-table td:last-child {
+    text-align: right;
+}
+
+.at-ageing-table td {
+    border-bottom: 1px solid rgba(226, 232, 240, .72);
+    color: var(--at-text);
+    font-size: .88rem;
+    font-weight: 650;
+    padding: .5rem 0;
+}
+
+.at-ageing-table tr:last-child td {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.at-pending-closure-inline {
+    align-items: center;
+    background: rgba(248, 250, 252, .8);
+    border-radius: var(--at-radius-md);
+    color: var(--at-muted);
+    display: flex;
+    gap: .75rem;
+    margin-top: .85rem;
+    padding: .55rem .7rem;
+}
+
+.at-pending-closure-inline h3,
+.at-pending-closure-inline p {
+    margin: 0;
+}
+
+.at-pending-closure-inline p,
+.at-pending-closure-inline span {
+    font-size: var(--at-font-sm);
+    font-weight: 650;
 }


### PR DESCRIPTION
### Motivation
- Improve visual consistency and hierarchy on the Reports page by replacing raw text metric lists with compact, scan-friendly components and reducing noisy developer-facing copy.
- Reduce filter height and visual weight of the report summary so filters occupy space more efficiently and the `Priority` control does not sit alone on a second row.
- Make Sprint Performance semantics unambiguous by not counting currently overdue open tasks as `Closed Late` for active/planned sprints.

### Description
- Reworked the Reports view layout and ageing presentation by updating `Pages/ActionTasks/_TaskReports.cshtml` to compact filters, move the Reset action into the filter grid, replace the ageing metric rows with three mini-tables/cards (Backlog Ageing, Assigned Task Ageing, Overdue Analysis), and convert Pending Closure to a compact inline state.
- Added an `OverdueNow` field to the sprint DTO and plumbing (`Services/ActionTasks/ActionTaskQueryService.cs`, `Services/ActionTasks/ActionTaskReportBuilder.cs`, `Pages/ActionTasks/Index.cshtml.cs`) and changed sprint row rendering to show `Overdue Now` for active/planned sprints while keeping `Closed Late` only for closed sprints.
- Toned down developer-facing helper text and improved bucket language by replacing "central classifier" with user-facing phrasing and shortening several panel notes in `Pages/ActionTasks/_TaskReports.cshtml`.
- Updated visuals/CSS for compact filters, bucket cards, ageing cards, and risk emphasis in `wwwroot/css/action-tracker.css`, and added small table/number styling and responsive adjustments to keep the page density consistent.
- Added a regression unit test `BuildReadModel_SprintPerformanceSeparatesActiveOverdueFromClosedLate` to `ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs` to assert `OverdueNow` is used for active sprints and `ClosedLate` remains for closed sprints.

### Testing
- Ran `npm test` which passed all JS unit tests (`15/15` passing). 
- Ran `git diff --check` and addressed no new whitespace or diff-check issues from these changes. 
- Ran `npm run lint:views` which reported pre-existing inline-style violations in other, unrelated views (these warnings predate this change). 
- Could not run `dotnet test` in this environment because the `dotnet` CLI is not available, so the new C# unit test was added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080cd347788329b550625bdd85db5e)