### PR TITLE
Polish Reports UI, rename Carried Forward → Unfinished, and restore Active Sprint exceptions

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -1023,7 +1023,7 @@ public class IndexModel : PageModel
         BucketDistribution = readModel.Reports.BucketDistribution.Select(x => new CountSummary(x.Name, x.Count)).ToList();
         ResponsiblePersonWorkloads = readModel.Reports.ResponsiblePersonWorkloads.Select(x => new ResponsibleWorkloadSummary(x.ResponsiblePerson, x.Open, x.Overdue, x.Blocked, x.InProgress, x.Submitted, x.Critical)).ToList();
         OutsideSprintWorkloadCounts = readModel.Reports.OutsideSprintWorkloadCounts.Select(x => new CountSummary(x.Name, x.Count)).ToList();
-        SprintPerformanceRows = readModel.Reports.SprintPerformanceRows.Select(x => new SprintPerformanceSummary(x.Sprint, x.Status, x.Open, x.Closed, x.OverdueNow, x.CarriedForward, x.ClosedLate)).ToList();
+        SprintPerformanceRows = readModel.Reports.SprintPerformanceRows.Select(x => new SprintPerformanceSummary(x.Sprint, x.Status, x.Open, x.Closed, x.OverdueNow, x.Unfinished, x.ClosedLate)).ToList();
         InvalidStateRows = readModel.Reports.InvalidStateRows.Select(x => new InvalidTaskStateSummary(x.Task, x.Issue, x.SuggestedCorrection)).ToList();
         WorkloadSummary = new ActionTaskReportSummary(readModel.Reports.WorkloadSummary.OpenTasks, readModel.Reports.WorkloadSummary.Overdue, readModel.Reports.WorkloadSummary.Blocked, readModel.Reports.WorkloadSummary.PendingClosure, readModel.Reports.WorkloadSummary.BacklogItems);
         CarryForwardBySprint = readModel.Reports.CarryForwardBySprint.Select(x => new CountSummary(x.Name, x.Count)).ToList();
@@ -1318,6 +1318,14 @@ public class IndexModel : PageModel
         ActiveSprintOverdueTaskDisplays.Any()
         || ActiveSprintBlockedTaskDisplays.Any()
         || ActiveSprintSubmittedTaskDisplays.Any();
+
+    public int ActiveSprintExceptionCount =>
+        SprintWorkspaceSummary.ActiveSprintOverdueTasks
+            .Concat(SprintWorkspaceSummary.ActiveSprintBlockedTasks)
+            .Concat(SprintWorkspaceSummary.ActiveSprintSubmittedTasks)
+            .Select(t => t.Id)
+            .Distinct()
+            .Count();
 
     public bool HasRecentActivityItems =>
         RecentlySubmittedTaskDisplays.Any()
@@ -1638,7 +1646,7 @@ public class IndexModel : PageModel
     public sealed record CountSummary(string Name, int Count);
     public sealed record ActionTaskReportSummary(int OpenTasks = 0, int Overdue = 0, int Blocked = 0, int PendingClosure = 0, int BacklogItems = 0);
     public sealed record ResponsibleWorkloadSummary(string ResponsiblePerson, int Open, int Overdue, int Blocked, int InProgress, int Submitted, int Critical);
-    public sealed record SprintPerformanceSummary(string Sprint, string Status, int Open, int Closed, int OverdueNow, int CarriedForward, int ClosedLate);
+    public sealed record SprintPerformanceSummary(string Sprint, string Status, int Open, int Closed, int OverdueNow, int Unfinished, int ClosedLate);
     public sealed record InvalidTaskStateSummary(string Task, string Issue, string SuggestedCorrection);
     public sealed class TaskDisplayItem
     {

--- a/Pages/ActionTasks/_TaskDashboard.cshtml
+++ b/Pages/ActionTasks/_TaskDashboard.cshtml
@@ -30,7 +30,7 @@
     }
     else
     {
-        @* SECTION: Active sprint status remains a compact summary; detailed exception cards live under Attention Required to avoid duplicate task lists. *@
+        @* SECTION: Active sprint status remains compact while exception details stay active-sprint-specific and independent of capped global attention lists. *@
         <p class="at-active-sprint-summary">
             @Model.ActiveSprintMetrics.TotalTasks tasks ·
             @Model.ActiveSprintMetrics.InProgressTasks in progress ·
@@ -42,6 +42,35 @@
                 <text> · @Model.ActiveSprintMetrics.InvalidStateTasks invalid state</text>
             }
         </p>
+        @if (Model.HasActiveSprintExceptions)
+        {
+            <details class="at-active-sprint-exceptions at-details-collapsible">
+                <summary>Active Sprint Exceptions (@Model.ActiveSprintExceptionCount)</summary>
+                <div class="at-active-sprint-exception-grid at-dashboard-task-list">
+                    @if (Model.ActiveSprintOverdueTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Overdue</span><strong>@Model.ActiveSprintMetrics.OverdueTasks</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintOverdueTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                    @if (Model.ActiveSprintBlockedTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Blocked</span><strong>@Model.ActiveSprintMetrics.BlockedTasks</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintBlockedTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                    @if (Model.ActiveSprintSubmittedTaskDisplays.Any())
+                    {
+                        <article class="at-attention-panel">
+                            <div class="at-attention-heading"><span>Pending Closure</span><strong>@Model.ActiveSprintSubmittedTaskCount</strong></div>
+                            <partial name="_TaskMiniList" model='@Tuple.Create(Model, Model.ActiveSprintSubmittedTaskDisplays, string.Empty)' />
+                        </article>
+                    }
+                </div>
+            </details>
+        }
     }
 </section>
 

--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -10,9 +10,6 @@
     <form method="get" class="at-panel at-reports-filter-panel" aria-label="Reports filters" data-at-reports-filter-form="true">
         <input type="hidden" name="ViewMode" value="Reports" />
         <div class="at-reports-filter-heading">
-            <div>
-                <h2>Report Filters</h2>
-            </div>
             <span class="at-report-filter-summary">@Model.ReportFilterSummary</span>
         </div>
         <div class="at-reports-filter-grid">
@@ -127,7 +124,6 @@
     <div class="at-panel-heading">
         <div>
             <h2>Workload Summary</h2>
-            <p class="at-panel-note">@Model.ReportFilterSummary</p>
         </div>
     </div>
     <div class="at-kpis">
@@ -159,8 +155,8 @@
     <article class="at-panel">
         <div class="at-panel-heading">
             <div>
-                <h2>Responsible Person Workload</h2>
-                <p class="at-panel-note">Open assigned work only. Backlog and closed records are excluded.</p>
+                <h2>Workload by Assignee</h2>
+                <p class="at-panel-note">Open assigned work only.</p>
             </div>
         </div>
         @if (!Model.ResponsiblePersonWorkloads.Any())
@@ -173,13 +169,12 @@
                 <table class="table table-sm at-table align-middle">
                     <thead>
                         <tr>
-                            <th>Responsible Person</th>
+                            <th>Assignee</th>
                             <th class="text-center">Open</th>
                             <th class="text-center">Overdue</th>
                             <th class="text-center">Blocked</th>
                             <th class="text-center">In Progress</th>
                             <th class="text-center">Submitted</th>
-                            <th class="text-center">Critical</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -192,7 +187,6 @@
                                 <td class="at-report-number">@item.Blocked</td>
                                 <td class="at-report-number">@item.InProgress</td>
                                 <td class="at-report-number">@item.Submitted</td>
-                                <td class="at-report-number @(item.Critical > 0 ? "at-risk-count" : string.Empty)">@item.Critical</td>
                             </tr>
                         }
                     </tbody>
@@ -288,7 +282,7 @@
                             <th>Open</th>
                             <th class="text-center">Closed</th>
                             <th class="text-center">Overdue Now</th>
-                            <th class="text-center">Carried Forward</th>
+                            <th class="text-center">Unfinished</th>
                             <th class="text-center">Closed Late</th>
                         </tr>
                     </thead>
@@ -301,7 +295,7 @@
                                 <td class="at-report-number">@item.Open</td>
                                 <td class="at-report-number">@item.Closed</td>
                                 <td class="at-report-number @(item.OverdueNow > 0 ? "at-risk-count" : string.Empty)">@(string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase) ? "—" : item.OverdueNow.ToString())</td>
-                                <td class="at-report-number">@item.CarriedForward</td>
+                                <td class="at-report-number">@(string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase) ? "—" : item.Unfinished.ToString())</td>
                                 <td class="at-report-number">@(string.Equals(item.Status, "Closed", StringComparison.OrdinalIgnoreCase) ? item.ClosedLate.ToString() : "—")</td>
                             </tr>
                         }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1232,6 +1232,44 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("No submitted tasks pending closure in the active sprint.", activeSprint, StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public async Task DashboardPartial_ActiveSprintExceptions_RenderActiveDetailsOutsideGlobalAttentionCap()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Exception Sprint", ActionSprintStatus.Active);
+        for (var i = 0; i < 6; i++)
+        {
+            var globalOverdue = NewTask($"Global overdue {i + 1}", ActionTaskStatuses.Assigned);
+            globalOverdue.DueDate = DateTime.UtcNow.Date.AddDays(-10 - i);
+            setup.Db.ActionTasks.Add(globalOverdue);
+        }
+
+        var activeOverdue = NewTask("Active sprint overdue visible", ActionTaskStatuses.Assigned, sprint.Id);
+        activeOverdue.DueDate = DateTime.UtcNow.Date.AddDays(-1);
+        var activeBlocked = NewTask("Active sprint blocked visible", ActionTaskStatuses.Blocked, sprint.Id);
+        activeBlocked.DueDate = DateTime.UtcNow.Date.AddDays(1);
+        setup.Db.ActionTasks.AddRange(activeOverdue, activeBlocked);
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "CommandCentre";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDashboard.cshtml");
+        var sprintStart = html.IndexOf("at-active-sprint-snapshot", StringComparison.Ordinal);
+        var attentionStart = html.IndexOf("Attention Required", StringComparison.Ordinal);
+        var activeSprint = html[sprintStart..attentionStart];
+
+        // SECTION: Assert
+        Assert.Contains("Active Sprint Exceptions (2)", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Active sprint overdue visible", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Active sprint blocked visible", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Overdue", activeSprint, StringComparison.Ordinal);
+        Assert.Contains("Blocked", activeSprint, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task DashboardPartial_AttentionRequired_RendersOnlyNonEmptyDeduplicatedLists()
     {
@@ -1306,7 +1344,7 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskReports.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("Report Filters", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<h2>Report Filters</h2>", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ReportBucket""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
         Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
@@ -1359,6 +1397,7 @@ public class ActionTaskPageTests
         Assert.Equal(1, page.PriorityCounts.Single(x => x.Name == "High").Count);
         Assert.Equal(1, page.BlockedAgeingBuckets.Single(x => x.Name == "8-14 days assigned").Count);
         Assert.Contains("Showing 1 of 2 tasks", html, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(html, "Showing 1 of 2 tasks"));
         Assert.DoesNotContain("Showing showing", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(@"method=""get""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ViewMode"" value=""Reports""", html, StringComparison.Ordinal);
@@ -1372,7 +1411,11 @@ public class ActionTaskPageTests
         Assert.Contains(@"value=""user-1"" selected", html, StringComparison.Ordinal);
         Assert.Contains("Ageing and Overdue Analysis", html, StringComparison.Ordinal);
         Assert.Contains("Pending Closure", html, StringComparison.Ordinal);
-        Assert.Contains("Responsible Person Workload", html, StringComparison.Ordinal);
+        Assert.Contains("Workload by Assignee", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Responsible Person Workload", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"<th class=""text-center"">Critical</th>", html, StringComparison.Ordinal);
+        Assert.Contains(@"<th class=""text-center"">Unfinished</th>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"<th class=""text-center"">Carried Forward</th>", html, StringComparison.Ordinal);
         Assert.Contains("Bucket Distribution", html, StringComparison.Ordinal);
         Assert.Contains("Backlog Ageing", html, StringComparison.Ordinal);
         Assert.Contains("Assigned Task Ageing", html, StringComparison.Ordinal);

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -294,7 +294,9 @@ public class ActionTaskQueryServiceSprintMetricsTests
             new Dictionary<int, DateTime?>());
 
         // SECTION: Assert
-        Assert.Equal(1, model.Reports.SprintPerformanceRows.Single().ClosedLate);
+        var row = model.Reports.SprintPerformanceRows.Single();
+        Assert.Equal(1, row.ClosedLate);
+        Assert.Equal(0, row.Unfinished);
     }
 
     [Fact]
@@ -317,6 +319,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
         // SECTION: Assert
         var row = model.Reports.SprintPerformanceRows.Single();
         Assert.Equal(1, row.OverdueNow);
+        Assert.Equal(2, row.Unfinished);
         Assert.Equal(0, row.ClosedLate);
     }
 

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -460,7 +460,7 @@ public sealed class ActionTaskQueryService
         public int Open { get; init; }
         public int Closed { get; init; }
         public int OverdueNow { get; init; }
-        public int CarriedForward { get; init; }
+        public int Unfinished { get; init; }
         public int ClosedLate { get; init; }
     }
 

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -208,7 +208,7 @@ public sealed class ActionTaskReportBuilder
                     Open = assignedOpen.Count,
                     Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
                     OverdueNow = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday)),
-                    CarriedForward = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
+                    Unfinished = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
                     ClosedLate = s.Status == ActionSprintStatus.Closed ? scopedTasks.Count(IsClosedLate) : 0
                 };
             })
@@ -240,7 +240,7 @@ public sealed class ActionTaskReportBuilder
     private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildOutsideSprintWorkloadCounts(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyDictionary<string, string> assigneeNames)
         => BuildAssigneePendingCounts(tasks, assigneeNames);
 
-    // SECTION: Safely-derived carry-forward candidates from unfinished tasks still associated with non-closed sprints.
+    // SECTION: Safely-derived unfinished work candidates from tasks still associated with non-closed sprints.
     private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildCarryForwardBySprint(IReadOnlyList<ActionTaskItem> openTasks, IReadOnlyList<ActionSprint> sprints)
     {
         var sprintLookup = sprints.ToDictionary(s => s.Id);

--- a/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
@@ -31,10 +31,10 @@ public sealed class ActionTaskSprintWorkspaceSummaryBuilder
             request.BacklogTasks.Count(IsHighPriorityBacklogTask),
             request.BacklogTasks.Count(IsBacklogPastTarget),
             activeSprintTasks.OrderBy(t => StatusOrder(t.Status)).ThenBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
-            activeSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
-            activeSprintTasks.Where(IsBlocked).OrderBy(t => t.DueDate).ThenBy(t => t.Id).Take(5).ToList(),
+            activeSprintTasks.Where(IsTaskOverdue).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
+            activeSprintTasks.Where(IsBlocked).OrderBy(t => t.DueDate).ThenBy(t => t.Id).ToList(),
             activeSprintTasks.Count(IsSubmitted),
-            activeSprintTasks.Where(IsSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).Take(5).ToList());
+            activeSprintTasks.Where(IsSubmitted).OrderBy(t => t.SubmittedOn ?? t.DueDate).ThenBy(t => t.Id).ToList());
     }
 
     // SECTION: Sprint summary predicates separate assigned overdue work from backlog target dates.

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3338,14 +3338,16 @@ html {
 .at-reports-filter-panel {
     display: flex;
     flex-direction: column;
-    gap: .85rem;
+    gap: .55rem;
+    padding-block: .85rem;
 }
 
 .at-reports-filter-heading {
-    align-items: flex-start;
+    align-items: center;
     display: flex;
-    gap: 1rem;
-    justify-content: space-between;
+    gap: .75rem;
+    justify-content: flex-end;
+    min-height: 0;
 }
 
 .at-report-filter-summary {
@@ -3361,7 +3363,7 @@ html {
 
 .at-reports-filter-grid {
     display: grid;
-    gap: .65rem;
+    gap: .5rem;
     grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
@@ -3369,9 +3371,9 @@ html {
     color: #475569;
     display: flex;
     flex-direction: column;
-    font-size: .74rem;
+    font-size: .72rem;
     font-weight: 800;
-    gap: .25rem;
+    gap: .18rem;
     letter-spacing: .02em;
     text-transform: uppercase;
 }
@@ -3554,9 +3556,15 @@ html {
 }
 
 .at-active-sprint-exceptions {
-    display: grid;
-    gap: 0.55rem;
+    display: block;
     margin-top: 0.7rem;
+}
+
+.at-active-sprint-exception-grid {
+    display: grid;
+    gap: 0.7rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 0.75rem;
 }
 
 .at-active-sprint-exceptions h3 {
@@ -3850,4 +3858,10 @@ html {
 .at-pending-closure-inline span {
     font-size: var(--at-font-sm);
     font-weight: 650;
+}
+
+@media (max-width: 991.98px) {
+    .at-active-sprint-exception-grid {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
### Motivation
- Make the Reports filter area visually compact and remove redundant heading so reports start above the fold and feel like a toolbar rather than a large card. 
- Replace awkward label `Responsible Person Workload` and remove the noisy `Critical` column to improve clarity for workload review. 
- Fix the semantic error where active-sprint open tasks were shown as “Carried Forward” and only show a carry-forward term when true disposition exists. 
- Restore active-sprint-specific exception visibility so users can view overdue/blocked/submitted items for the active sprint even when global attention lists are capped.

### Description
- UI: removed the visible `Report Filters` heading and the duplicate workload scope summary from `Pages/ActionTasks/_TaskReports.cshtml`, and reduced vertical padding/gaps in the reports filter panel; CSS adjustments in `wwwroot/css/action-tracker.css` to make the filter area compact. 
- Workload table: renamed `Responsible Person Workload` → `Workload by Assignee`, changed the first column label to `Assignee`, shortened helper text, and removed the `Critical` column from the reports table in `Pages/ActionTasks/_TaskReports.cshtml`. 
- Sprint performance: replaced `CarriedForward` with `Unfinished` in the reports model and page rendering, updated `ActionTaskReportBuilder` to populate `Unfinished`, and adjusted `ActionTaskQueryService` and `Index` view-model types to surface `Unfinished` in `Pages/ActionTasks/Index.cshtml.cs` and `Services/ActionTasks/ActionTaskReportBuilder.cs`. Closed-sprint `Unfinished` values render as `—` in the table. 
- Active sprint exceptions: restored a compact, collapsed Active Sprint Exceptions block under the Command Centre snapshot in `Pages/ActionTasks/_TaskDashboard.cshtml`, backed by active-sprint-specific lists (`SprintWorkspaceSummary.ActiveSprintOverdueTasks`, `ActiveSprintBlockedTasks`, `ActiveSprintSubmittedTasks`) instead of the globally capped attention lists; added `ActiveSprintExceptionCount` that counts distinct task IDs. 
- Attention lists: `ActionTaskSprintWorkspaceSummaryBuilder` no longer truncates active-sprint exception lists with `Take(5)` so active-sprint-specific displays are not lost by global caps. 
- Tests: updated relevant unit tests to expect the new labels/columns/terms and to assert that active-sprint exceptions are shown even when global attention lists would be capped (`ProjectManagement.Tests/ActionTasks/*`). 

### Testing
- Ran static checks: `git diff --check` (no whitespace/format issues) — passed. 
- Attempted to run the test suite with `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore`, but `dotnet` is not installed in this environment so automated unit tests were not executed. 
- Updated unit test files to cover the UI and report model changes (tests modified under `ProjectManagement.Tests/ActionTasks`), but their execution remains pending in an environment with .NET tooling available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0811a90ec48329bf3a3288968299b3)