### PR TITLE
Fix sprint Unfinished counting, rename Reports assignee label, compact Reports filter UI, and add test

### DIFF
--- a/Pages/ActionTasks/_TaskReports.cshtml
+++ b/Pages/ActionTasks/_TaskReports.cshtml
@@ -48,7 +48,7 @@
                 </select>
             </label>
             <label>
-                <span>Responsible Person</span>
+                <span>Assignee</span>
                 <select class="form-select form-select-sm" name="ReportAssigneeUserId" data-at-reports-filter-control="true">
                     <option value="">All people</option>
                     @foreach (var user in Model.AssignableUsers)

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1354,6 +1354,8 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("<span>Bucket / Sprint</span>", html, StringComparison.Ordinal);
         Assert.Contains("<span>Bucket</span>", html, StringComparison.Ordinal);
         Assert.Contains("<span>Sprint</span>", html, StringComparison.Ordinal);
+        Assert.Contains("<span>Assignee</span>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<span>Responsible Person</span>", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-filter-form=""true""", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-filter-control=""true""", html, StringComparison.Ordinal);
         Assert.Contains(@"data-at-reports-date-filter=""true""", html, StringComparison.Ordinal);
@@ -1421,6 +1423,33 @@ public class ActionTaskPageTests
         Assert.Contains("Assigned Task Ageing", html, StringComparison.Ordinal);
         Assert.Contains("Sprint Performance", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Non-sprint", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReportsSprintPerformance_ActiveSubmittedTaskCountsAsOpenAndUnfinished()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync();
+        var sprint = AddSprint(setup.Db, "Submitted Sprint", ActionSprintStatus.Active);
+        var submittedTask = await setup.Db.ActionTasks.SingleAsync();
+        submittedTask.Title = "Submitted sprint task";
+        submittedTask.Status = ActionTaskStatuses.Submitted;
+        submittedTask.SprintId = sprint.Id;
+        submittedTask.AssignedToUserId = "user-1";
+        submittedTask.SubmittedOn = DateTime.UtcNow.Date;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Reports";
+
+        // SECTION: Act
+        await page.OnGetAsync();
+        var performance = Assert.Single(page.SprintPerformanceRows);
+
+        // SECTION: Assert
+        Assert.Equal("Submitted Sprint", performance.Sprint);
+        Assert.Equal(1, performance.Open);
+        Assert.Equal(1, performance.Unfinished);
+        Assert.Equal(0, performance.ClosedLate);
     }
 
     [Fact]

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -208,7 +208,7 @@ public sealed class ActionTaskReportBuilder
                     Open = assignedOpen.Count,
                     Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
                     OverdueNow = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday)),
-                    Unfinished = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => !string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)),
+                    Unfinished = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count,
                     ClosedLate = s.Status == ActionSprintStatus.Closed ? scopedTasks.Count(IsClosedLate) : 0
                 };
             })

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3338,8 +3338,8 @@ html {
 .at-reports-filter-panel {
     display: flex;
     flex-direction: column;
-    gap: .55rem;
-    padding-block: .85rem;
+    gap: .35rem;
+    padding-block: .45rem;
 }
 
 .at-reports-filter-heading {
@@ -3363,7 +3363,7 @@ html {
 
 .at-reports-filter-grid {
     display: grid;
-    gap: .5rem;
+    gap: .35rem;
     grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
@@ -3373,7 +3373,7 @@ html {
     flex-direction: column;
     font-size: .72rem;
     font-weight: 800;
-    gap: .18rem;
+    gap: .12rem;
     letter-spacing: .02em;
     text-transform: uppercase;
 }


### PR DESCRIPTION
### Motivation

- Sprint Performance previously excluded `Submitted` tasks from the Unfinished count even when the sprint was active, under-reporting unfinished work. 
- The Reports filter label and layout needed small UI/UX tweaks to match terminology and present the filter area as a compact toolbar. 
- Add regression coverage to ensure an active sprint with a `Submitted` assigned task is reported correctly. 

### Description

- Update the sprint Unfinished calculation in `Services/ActionTasks/ActionTaskReportBuilder.cs` so non-closed sprints use `Unfinished = assignedOpen.Count` (count all assigned open tasks including `Submitted`).
- Rename the Reports filter label from `Responsible Person` to `Assignee` in `Pages/ActionTasks/_TaskReports.cshtml` and update related test assertions.
- Reduce vertical padding/gaps for `.at-reports-filter-panel`, `.at-reports-filter-grid`, and `.at-reports-filter-grid label` in `wwwroot/css/action-tracker.css` to make the Reports filter area look like a toolbar.
- Add a regression test `ReportsSprintPerformance_ActiveSubmittedTaskCountsAsOpenAndUnfinished` in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert that for an active sprint with one `Submitted` assigned task the report shows `Open = 1`, `Unfinished = 1`, and `ClosedLate = 0`.
- Update existing Reports partial test assertions to expect the new `Assignee` label.

### Testing

- Ran `git diff --check` and repository checks with no whitespace errors detected. 
- Performed repository searches and validations (`rg`) to confirm updated symbols and template label changes are present. 
- Attempted to run unit tests with `dotnet test --no-restore` but the environment does not have the .NET SDK installed, so tests were not executed here; the new test was added to the test project and should run in CI or a local environment with the SDK available. 
- No other automated test failures were observed from the performed static checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081d13f70c83298767ecf077306597)