### PR TITLE
Allow planning authority to change Action Task dates

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -181,6 +181,9 @@ public class IndexModel : PageModel
     public AddTaskUpdateInput UpdateInput { get; set; } = new();
 
     [BindProperty]
+    public ChangeTaskDateInput ChangeDateInput { get; set; } = new();
+
+    [BindProperty]
     public CreateSprintInput SprintInput { get; set; } = new();
 
     [BindProperty]
@@ -327,6 +330,11 @@ public class IndexModel : PageModel
     public bool CanUpdateTaskStatus(ActionTaskItem task)
     {
         return _workflowPolicy.CanUpdateTaskStatus(task, CurrentRole, CurrentUserId);
+    }
+
+    public bool CanChangeTaskDate(ActionTaskItem task)
+    {
+        return _workflowPolicy.CanChangeTaskDate(task, CurrentRole);
     }
 
     public string GetStatusBadgeClass(string status)
@@ -535,6 +543,20 @@ public class IndexModel : PageModel
         if (BacklogItemInput.TargetDate.Date < _clock.UtcToday)
         {
             ModelState.AddModelError(nameof(BacklogItemInput.TargetDate), "Target date cannot be in the past.");
+        }
+
+        return ModelState.IsValid;
+    }
+
+    private bool ValidateChangeTaskDateInput()
+    {
+        // SECTION: Page-level date-change validation gives immediate feedback before service-level enforcement.
+        ModelState.Clear();
+        TryValidateModel(ChangeDateInput, nameof(ChangeDateInput));
+
+        if (ChangeDateInput.NewDate.Date < _clock.UtcToday)
+        {
+            ModelState.AddModelError(nameof(ChangeDateInput.NewDate), "Task date cannot be in the past.");
         }
 
         return ModelState.IsValid;
@@ -826,6 +848,44 @@ public class IndexModel : PageModel
         }
 
         return RedirectToTaskPage(id, SelectedSprintId);
+    }
+
+    // SECTION: Change a backlog target date or assigned task due date.
+    public async Task<IActionResult> OnPostChangeTaskDateAsync()
+    {
+        await ResolveIdentityAsync();
+
+        try
+        {
+            if (!ValidateChangeTaskDateInput())
+            {
+                TempData["ToastError"] = ModelState.Values
+                    .SelectMany(value => value.Errors)
+                    .Select(error => error.ErrorMessage)
+                    .FirstOrDefault(error => !string.IsNullOrWhiteSpace(error))
+                    ?? "Enter a valid task date.";
+                return RedirectToTaskPage(ChangeDateInput.TaskId, SelectedSprintId);
+            }
+
+            await _service.UpdateTaskDateAsync(
+                ChangeDateInput.TaskId,
+                DecodeRowVersion(ChangeDateInput.RowVersion),
+                ChangeDateInput.NewDate,
+                CurrentUserId,
+                CurrentRole);
+
+            TempData["ToastMessage"] = "Task date updated.";
+        }
+        catch (ActionTaskConcurrencyException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+        catch (InvalidOperationException ex)
+        {
+            TempData["ToastError"] = ex.Message;
+        }
+
+        return RedirectToTaskPage(ChangeDateInput.TaskId, SelectedSprintId);
     }
 
     // SECTION: Assign backlog or visible task into an available sprint.
@@ -1630,6 +1690,20 @@ public class IndexModel : PageModel
 
         [Required, StringLength(2000)]
         public string Remarks { get; set; } = string.Empty;
+    }
+
+
+    public sealed class ChangeTaskDateInput
+    {
+        [Required]
+        public int TaskId { get; set; }
+
+        [Required]
+        public string RowVersion { get; set; } = string.Empty;
+
+        [Display(Name = "New Date")]
+        [Required]
+        public DateTime NewDate { get; set; }
     }
 
     public sealed class AddTaskUpdateInput

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -283,6 +283,32 @@
                         </details>
                     }
 
+
+                    @if (Model.CanChangeTaskDate(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="change-date">
+                            <summary class="visually-hidden">Open date change panel</summary>
+                            <form method="post" asp-page-handler="ChangeTaskDate" class="at-action-card at-action-card-compact">
+                                <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                                <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
+                                <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" asp-for="ChangeDateInput.TaskId" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" asp-for="ChangeDateInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
+                                <div class="at-action-title">Change @selectedTaskDateLabel Date</div>
+                                <div class="mb-2">
+                                    <label class="form-label at-small" asp-for="ChangeDateInput.NewDate">New @selectedTaskDateLabel Date</label>
+                                    <input class="form-control form-control-sm" asp-for="ChangeDateInput.NewDate" type="date" value="@Model.SelectedTask.DueDate.ToString("yyyy-MM-dd")" min="@DateTime.UtcNow.Date.ToString("yyyy-MM-dd")" />
+                                </div>
+                                <div class="at-action-buttons">
+                                    <button type="submit" class="btn btn-primary btn-sm">Save Date</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="change-date">Cancel</button>
+                                </div>
+                            </form>
+                        </details>
+                    }
+
                     @if (Model.CanSubmitTask(Model.SelectedTask))
                     {
                         <details class="at-action-drawer" data-at-action-panel="submit">
@@ -394,6 +420,11 @@
                             @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask))
                             {
                                 <button type="button" class="btn btn-link btn-sm" data-at-open-action="close">Close Task</button>
+                            }
+
+                            @if (Model.CanChangeTaskDate(Model.SelectedTask))
+                            {
+                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="change-date">Change @selectedTaskDateLabel Date</button>
                             }
                             @if (Model.CanMoveTaskToBacklog(Model.SelectedTask))
                             {

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
@@ -75,6 +75,7 @@ public class ActionTaskPermissionServiceTests
         var canCloseSprint = service.CanCloseSprint(role);
         var canAssignTaskToSprint = service.CanAssignTaskToSprint(role);
         var canMoveTaskToBacklog = service.CanMoveTaskToBacklog(role);
+        var canChangeTaskDate = service.CanChangeTaskDate(role);
 
         // SECTION: Assert
         Assert.Equal(expected, canManageSprints);
@@ -85,6 +86,7 @@ public class ActionTaskPermissionServiceTests
         Assert.Equal(expected, canCloseSprint);
         Assert.Equal(expected, canAssignTaskToSprint);
         Assert.Equal(expected, canMoveTaskToBacklog);
+        Assert.Equal(expected, canChangeTaskDate);
     }
 
 }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -217,6 +217,123 @@ public class ActionTaskServiceTests
         Assert.Contains("submit for closure", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(RoleNames.Comdt)]
+    [InlineData(RoleNames.HoD)]
+    public async Task UpdateTaskDateAsync_AllowsPlanningAuthorities(string role)
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+        var newDate = DateTime.UtcNow.Date.AddDays(5);
+
+        // SECTION: Act
+        await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", role);
+
+        // SECTION: Assert
+        var updated = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(newDate, updated.DueDate.Date);
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_RejectsAssigneeRole()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(3), "assignee", RoleNames.Ta));
+        Assert.Contains("not authorized", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_RejectsClosedTasks()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Closed, "assignee");
+        task.ClosedOn = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(3), "planner", RoleNames.HoD));
+        Assert.Contains("Closed tasks", ex.Message);
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_RejectsPastDates()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(-1), "planner", RoleNames.Comdt));
+        Assert.Contains("past", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_AuditsTargetDateForBacklogAndDueDateForAssignedTasks()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var backlog = await service.CreateBacklogItemAsync(new ActionTaskItem
+        {
+            Title = "Backlog",
+            Description = "Future work",
+            CreatedByUserId = "creator",
+            CreatedByRole = RoleNames.HoD,
+            DueDate = DateTime.UtcNow.Date.AddDays(2),
+            Priority = "Normal"
+        });
+        var assigned = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+
+        // SECTION: Act
+        await service.UpdateTaskDateAsync(backlog.Id, backlog.RowVersion, DateTime.UtcNow.Date.AddDays(6), "planner", RoleNames.HoD);
+        await service.UpdateTaskDateAsync(assigned.Id, assigned.RowVersion, DateTime.UtcNow.Date.AddDays(7), "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        var logs = await db.ActionTaskAuditLogs.ToListAsync();
+        Assert.Contains(logs, x => x.TaskId == backlog.Id && x.ActionType == "TargetDateChanged");
+        Assert.Contains(logs, x => x.TaskId == assigned.Id && x.ActionType == "DueDateChanged");
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_WithStaleRowVersion_ThrowsConcurrencyException()
+    {
+        // SECTION: Arrange
+        var databaseName = Guid.NewGuid().ToString();
+        var databaseRoot = new InMemoryDatabaseRoot();
+        await using var staleDb = CreateDb(databaseName, databaseRoot);
+        var task = await SeedTaskAsync(staleDb, ActionTaskStatuses.Assigned, "assignee");
+        var staleRowVersion = task.RowVersion.ToArray();
+        staleDb.ChangeTracker.Clear();
+        _ = await staleDb.ActionTasks.SingleAsync(x => x.Id == task.Id);
+
+        await using (var concurrentDb = CreateDb(databaseName, databaseRoot))
+        {
+            var concurrentTask = await concurrentDb.ActionTasks.SingleAsync(x => x.Id == task.Id);
+            concurrentTask.RowVersion = [9, 9, 9];
+            concurrentTask.Priority = "High";
+            await concurrentDb.SaveChangesAsync();
+        }
+
+        var service = new ActionTaskService(staleDb, new ActionTaskPermissionService());
+
+        // SECTION: Act + Assert
+        await Assert.ThrowsAsync<ActionTaskConcurrencyException>(() =>
+            service.UpdateTaskDateAsync(task.Id, staleRowVersion, DateTime.UtcNow.Date.AddDays(8), "planner", RoleNames.HoD));
+    }
+
     private static ApplicationDbContext CreateDb()
         => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
 

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -45,6 +45,9 @@ public class ActionTaskPermissionService
     public bool CanClose(string role)
         => IsPlanningAuthority(role);
 
+    public bool CanChangeTaskDate(string role)
+        => IsPlanningAuthority(role);
+
     // SECTION: Sprint lifecycle permission checks
     public bool CanCreateSprint(string role)
         => IsPlanningAuthority(role);

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -351,6 +351,57 @@ public class ActionTaskService : IActionTaskService
         }
     }
 
+    public async Task UpdateTaskDateAsync(int taskId, byte[] rowVersion, DateTime newDate, string userId, string role, CancellationToken cancellationToken = default)
+    {
+        // SECTION: Date-change authorization and task validation
+        if (!_permission.CanChangeTaskDate(role))
+        {
+            throw new InvalidOperationException("You are not authorized to change task dates.");
+        }
+
+        var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+
+        if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Closed tasks cannot have their dates changed.");
+        }
+
+        var normalizedNewDate = newDate.Date;
+        if (normalizedNewDate < DateTime.UtcNow.Date)
+        {
+            throw new InvalidOperationException("Task date cannot be in the past.");
+        }
+
+        if (task.DueDate.Date == normalizedNewDate)
+        {
+            throw new InvalidOperationException("No date change applied because the selected date is already current.");
+        }
+
+        // SECTION: Concurrency token validation
+        _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
+
+        // SECTION: Date mutation and bucket invariant validation
+        var oldDate = task.DueDate.Date;
+        task.DueDate = normalizedNewDate;
+        ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
+
+        // SECTION: Audit Enqueue
+        var auditAction = string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase)
+            ? "TargetDateChanged"
+            : "DueDateChanged";
+        _context.ActionTaskAuditLogs.Add(Log(taskId, auditAction, userId, role, oldDate.ToString("yyyy-MM-dd"), normalizedNewDate.ToString("yyyy-MM-dd"), null));
+
+        // SECTION: Persistence
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ActionTaskConcurrencyException("This task was updated by another user. Please reload the task details and try again.");
+        }
+    }
+
     // SECTION: Audit logging
     private static ActionTaskAuditLog Log(int taskId, string action, string userId, string role, string? oldValue, string? newValue, string? remarks)
     {

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -52,6 +52,12 @@ public sealed class ActionTaskWorkflowPolicy
             && (_permission.CanViewAll(currentRole) || string.Equals(task.AssignedToUserId, currentUserId, StringComparison.Ordinal));
     }
 
+    public bool CanChangeTaskDate(ActionTaskItem task, string currentRole)
+    {
+        return _permission.CanChangeTaskDate(currentRole)
+            && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    }
+
     // SECTION: Transition and remarks validation for command handlers.
     public string? ValidateStatusUpdate(ActionTaskItem task, string targetStatus)
     {

--- a/Services/ActionTasks/IActionTaskService.cs
+++ b/Services/ActionTasks/IActionTaskService.cs
@@ -14,6 +14,7 @@ public interface IActionTaskService
     Task UpdateStatusAsync(int taskId, byte[] rowVersion, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task SubmitTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task UpdateTaskDateAsync(int taskId, byte[] rowVersion, DateTime newDate, string userId, string role, CancellationToken cancellationToken = default);
     Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default);
     Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
     Task<Dictionary<int, DateTime?>> GetLastActivityUtcByTaskIdsAsync(IReadOnlyCollection<int> taskIds, CancellationToken cancellationToken = default);


### PR DESCRIPTION
### Motivation
- Enable planning authorities to adjust backlog target dates and assigned task due dates from the Action Tracker while enforcing workflow, audit and concurrency rules.

### Description
- Added `UpdateTaskDateAsync(int taskId, byte[] rowVersion, DateTime newDate, string userId, string role, CancellationToken cancellationToken = default)` to `IActionTaskService` to expose the date-change operation.
- Added `CanChangeTaskDate(string role)` to `ActionTaskPermissionService` and `CanChangeTaskDate(ActionTaskItem task, string currentRole)` to `ActionTaskWorkflowPolicy` so only planning authorities can see and perform date changes for non-closed tasks.
- Implemented `UpdateTaskDateAsync` in `ActionTaskService` to load a non-deleted task, reject unauthorized roles, reject closed tasks, reject past dates and unchanged dates, apply row-version concurrency via `OriginalValue`, update `ActionTaskItem.DueDate`, re-run `ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task)`, write an audit entry (`TargetDateChanged` for backlog items, `DueDateChanged` for others), and convert `DbUpdateConcurrencyException` to `ActionTaskConcurrencyException` on conflict.
- Added UI/page wiring: `ChangeTaskDateInput` bound model, `ValidateChangeTaskDateInput`, and `OnPostChangeTaskDateAsync` in `Pages/ActionTasks/Index.cshtml.cs` to decode row versions, call the service, set `TempData` messages and preserve workspace route state.
- Updated the inspector partial `Pages/ActionTasks/_TaskDetails.cshtml` with a compact date-change panel and a More-menu action, and preserved `ViewMode`, `SelectedSprintId`, `PlanningTab`, and `PlanningView` as hidden inputs in the form.
- Added unit tests in `ProjectManagement.Tests/ActionTasks` covering planning-authority authorization (Comdt/HoD), assignee rejection, closed-task rejection, past-date rejection, correct audit action names, and row-version concurrency handling.

### Testing
- No automated tests were executed in this environment because the test runner was not available: attempted `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ActionTask` but the `dotnet` command was not present; however, comprehensive unit tests were added under `ProjectManagement.Tests/ActionTasks` for the new feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082ca201388329b603b3821ea18660)