### PR TITLE
Polish create modal: segmented Backlog / Direct flow, assignee label, JS & CSS

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -167,6 +167,10 @@ public class IndexModel : PageModel
     public string CurrentRole { get; private set; } = string.Empty;
     public string CurrentUserId { get; private set; } = string.Empty;
     public bool ShowCreateModal { get; private set; }
+
+    [BindProperty]
+    public string CreateMode { get; set; } = "backlog";
+
     public bool ShowCreateSprintPanel { get; private set; }
     public bool ShowEditSprintPanel { get; private set; }
     public bool ShowCreateNextSprintPanel { get; private set; }
@@ -524,7 +528,7 @@ public class IndexModel : PageModel
 
         if (string.IsNullOrWhiteSpace(DirectTaskInput.AssignedToUserId))
         {
-            ModelState.AddModelError(nameof(DirectTaskInput.AssignedToUserId), "Select a responsible person for a direct task.");
+            ModelState.AddModelError(nameof(DirectTaskInput.AssignedToUserId), "Select an assignee for a direct task.");
         }
 
         if (DirectTaskInput.DueDate.Date < _clock.UtcToday)
@@ -1568,7 +1572,7 @@ public class IndexModel : PageModel
         [Required, StringLength(4000)]
         public string Description { get; set; } = string.Empty;
 
-        [Display(Name = "Responsible Person")]
+        [Display(Name = "Assignee")]
         public string AssignedToUserId { get; set; } = string.Empty;
 
         [Display(Name = "Due Date")]

--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -1,6 +1,11 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
+@{
+    var activeCreateMode = string.Equals(Model.CreateMode, "direct", StringComparison.OrdinalIgnoreCase) ? "direct" : "backlog";
+    var isBacklogCreateMode = activeCreateMode == "backlog";
+    var isDirectCreateMode = activeCreateMode == "direct";
+}
 
-@* SECTION: Create-task modal starts with a two-choice flow, then reveals only the selected form without inline scripts. *@
+@* SECTION: Create-task modal starts with a segmented two-choice flow, then reveals only the selected form without inline scripts. *@
 <div class="modal fade" id="createTaskModal" tabindex="-1" aria-labelledby="createTaskModalLabel" aria-hidden="true" data-bs-backdrop="static" data-at-open-on-load="@(Model.ShowCreateModal ? "true" : "false")">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content">
@@ -14,15 +19,19 @@
                     <div asp-validation-summary="All" class="alert alert-danger mb-3"></div>
                 }
 
-                @* SECTION: Choice screen keeps backlog capture separate from direct assigned work. *@
+                @* SECTION: Segmented create-mode selector keeps backlog capture separate from direct assigned work. *@
                 <div class="at-create-choice-grid" data-at-create-choice-group="true" aria-label="Choose work type">
-                    <details class="at-create-flow-panel at-create-choice-panel" data-at-create-choice="true">
-                        <summary class="btn btn-outline-primary w-100">Create Backlog Item</summary>
-                        <p class="at-panel-note mt-2">Capture future work without assigning a responsible person or sprint.</p>
+                    <div class="at-create-mode-selector" role="tablist" aria-label="Create mode">
+                        <button type="button" class="at-create-mode-button@(isBacklogCreateMode ? " is-active" : string.Empty)" id="at-create-mode-backlog-tab" role="tab" aria-selected="@(isBacklogCreateMode ? "true" : "false")" aria-controls="at-create-mode-backlog-panel" data-at-create-mode-button="backlog">Backlog Item</button>
+                        <button type="button" class="at-create-mode-button@(isDirectCreateMode ? " is-active" : string.Empty)" id="at-create-mode-direct-tab" role="tab" aria-selected="@(isDirectCreateMode ? "true" : "false")" aria-controls="at-create-mode-direct-panel" data-at-create-mode-button="direct">Direct Task</button>
+                    </div>
 
-                        @* SECTION: Backlog item form intentionally has unique model-bound IDs and no assignee fields. *@
+                    @* SECTION: Backlog item form intentionally has unique model-bound IDs and no assignee fields. *@
+                    <section class="at-create-flow-panel" id="at-create-mode-backlog-panel" role="tabpanel" aria-labelledby="at-create-mode-backlog-tab" data-at-create-mode-panel="backlog" hidden="@(!isBacklogCreateMode)">
+                        <p class="at-panel-note">Capture future work without assigning it now.</p>
                         <form method="post" asp-page-handler="CreateBacklogItem" class="at-create-flow-form">
                             <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="CreateMode" value="backlog" />
                             <div class="row g-3">
                                 <div class="col-md-5">
                                     <label asp-for="BacklogItemInput.Title" class="form-label"></label>
@@ -51,18 +60,17 @@
                                 </div>
                             </div>
                             <div class="at-create-flow-actions">
-                                <button type="submit" class="btn btn-primary">Create Backlog Item</button>
+                                <button type="submit" class="btn btn-primary">Save Backlog Item</button>
                             </div>
                         </form>
-                    </details>
+                    </section>
 
-                    <details class="at-create-flow-panel at-create-choice-panel" data-at-create-choice="true">
-                        <summary class="btn btn-outline-primary w-100">Create Direct Task</summary>
-                        <p class="at-panel-note mt-2">Assign to a responsible person now. It remains Outside Sprint until added to a sprint.</p>
-
-                        @* SECTION: Direct task form uses its own input model so generated HTML IDs are unique. *@
+                    @* SECTION: Direct task form uses its own input model so generated HTML IDs are unique. *@
+                    <section class="at-create-flow-panel" id="at-create-mode-direct-panel" role="tabpanel" aria-labelledby="at-create-mode-direct-tab" data-at-create-mode-panel="direct" hidden="@(!isDirectCreateMode)">
+                        <p class="at-panel-note">Assign work to a person now. It remains outside sprint until added to a sprint.</p>
                         <form method="post" asp-page-handler="CreateDirectTask" class="at-create-flow-form">
                             <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="CreateMode" value="direct" />
                             <div class="row g-3">
                                 <div class="col-md-5">
                                     <label asp-for="DirectTaskInput.Title" class="form-label"></label>
@@ -76,8 +84,8 @@
                                 </div>
                                 <div class="col-12">
                                     <label asp-for="DirectTaskInput.AssignedToUserId" class="form-label"></label>
-                                    <select asp-for="DirectTaskInput.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select responsible person" required>
-                                        <option value="">Select user</option>
+                                    <select asp-for="DirectTaskInput.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="[Select user]" required>
+                                        <option value="">[Select user]</option>
                                         @foreach (var user in Model.AssignableUsers)
                                         {
                                             <option value="@user.UserId">@user.DisplayName</option>
@@ -102,10 +110,10 @@
                                 </div>
                             </div>
                             <div class="at-create-flow-actions">
-                                <button type="submit" class="btn btn-primary">Create Direct Task</button>
+                                <button type="submit" class="btn btn-primary">Create Task</button>
                             </div>
                         </form>
-                    </details>
+                    </section>
                 </div>
             </div>
             <div class="modal-footer">

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -165,6 +165,80 @@ html {
     font-size: var(--at-font-sm);
 }
 
+
+/* SECTION: Create modal segmented mode selector */
+.at-create-choice-grid {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.at-create-mode-selector {
+    display: inline-grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.25rem;
+    width: 100%;
+    padding: 0.25rem;
+    border: 1px solid var(--at-border);
+    border-radius: 999px;
+    background: var(--at-surface-soft);
+}
+
+.at-create-mode-button {
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+    line-height: 1.2;
+    padding: 0.55rem 0.8rem;
+    transition: background-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.at-create-mode-button:hover,
+.at-create-mode-button:focus-visible {
+    color: var(--at-text);
+    background: rgba(37, 99, 235, 0.08);
+}
+
+.at-create-mode-button:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, 0.25);
+    outline-offset: 2px;
+}
+
+.at-create-mode-button.is-active {
+    color: #1d4ed8;
+    background: var(--at-surface);
+    box-shadow: var(--at-shadow-sm);
+}
+
+.at-create-flow-panel {
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-lg);
+    background: var(--at-surface);
+    padding: 0.95rem;
+}
+
+.at-create-flow-panel[hidden] {
+    display: none;
+}
+
+.at-create-flow-form {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.at-create-flow-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.at-panel-note {
+    color: var(--at-muted);
+    font-size: var(--at-font-sm);
+    margin: 0 0 0.85rem;
+}
+
 /* SECTION: Inspector collaboration helper text and attachment rows */
 .at-helper-text {
     color: var(--at-muted);

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -246,27 +246,43 @@
         });
     }
 
-    // SECTION: Create modal choice flow keeps only one selected form open at a time.
+    // SECTION: Create modal segmented-control flow keeps one server-rendered form active at a time.
     function initCreateTaskChoiceFlow() {
         const group = document.querySelector("[data-at-create-choice-group='true']");
         if (!group) {
             return;
         }
 
-        const choices = Array.from(group.querySelectorAll("details[data-at-create-choice='true']"));
-        choices.forEach((choice) => {
-            choice.addEventListener("toggle", () => {
-                if (!choice.open) {
-                    return;
-                }
+        const buttons = Array.from(group.querySelectorAll("[data-at-create-mode-button]"));
+        const panels = Array.from(group.querySelectorAll("[data-at-create-mode-panel]"));
+        if (!buttons.length || !panels.length) {
+            return;
+        }
 
-                choices.forEach((candidate) => {
-                    if (candidate !== choice) {
-                        candidate.removeAttribute("open");
-                    }
-                });
+        function activateMode(mode) {
+            buttons.forEach((button) => {
+                const isActive = button.getAttribute("data-at-create-mode-button") === mode;
+                button.classList.toggle("is-active", isActive);
+                button.setAttribute("aria-selected", isActive ? "true" : "false");
+            });
+
+            panels.forEach((panel) => {
+                const isActive = panel.getAttribute("data-at-create-mode-panel") === mode;
+                panel.hidden = !isActive;
+            });
+        }
+
+        buttons.forEach((button) => {
+            button.addEventListener("click", () => {
+                const mode = button.getAttribute("data-at-create-mode-button");
+                if (mode) {
+                    activateMode(mode);
+                }
             });
         });
+
+        const initiallySelected = buttons.find((button) => button.getAttribute("aria-selected") === "true") || buttons[0];
+        activateMode(initiallySelected.getAttribute("data-at-create-mode-button"));
     }
 
     // SECTION: Confirmation prompts for destructive bucket moves remain CSP-safe through data attributes.


### PR DESCRIPTION
### Motivation
- Improve the create-task UX by replacing the details-based choice with a compact segmented/tab-like selector that is more accessible and consistent with the app style. 
- Keep server-side form rendering and existing handlers unchanged while ensuring the correct panel reopens on server validation failures. 
- Replace outdated “responsible person” wording with an `Assignee` label and unify select placeholder copy for clarity.

### Description
- Replaced the two `<details>` choice panels in `Pages/ActionTasks/_TaskCreatePanel.cshtml` with a segmented control using buttons labeled `Backlog Item` and `Direct Task` and attributes `data-at-create-mode-button="backlog"` and `data-at-create-mode-button="direct"`, and rendered both forms server-side in sections with `data-at-create-mode-panel="backlog"` and `data-at-create-mode-panel="direct"` that are hidden when inactive. 
- Added a bound `CreateMode` property to the page model (`Pages/ActionTasks/Index.cshtml.cs`) and included hidden `CreateMode` inputs in each form so server validation failures reopen the submitted mode. 
- Updated helper and action text: backlog helper text `Capture future work without assigning it now.`, direct-task helper text `Assign work to a person now. It remains outside sprint until added to a sprint.`, backlog submit button `Save Backlog Item`, direct-task submit button `Create Task`, and select placeholder changed to `[Select user]` while the field label reads `Assignee`. 
- Changed the display metadata for `CreateDirectTaskInput.AssignedToUserId` from `Responsible Person` to `Assignee` and adjusted the validation message to `Select an assignee for a direct task.` in `Pages/ActionTasks/Index.cshtml.cs`. 
- Replaced the previous details-toggle behavior with a segmented-control implementation in `wwwroot/js/pages/action-tasks/index.js` that toggles the button active state, `aria-selected`, and the `hidden` state on panels while keeping all behavior in the existing external JS file for CSP compliance. 
- Added compact segmented-control and panel styles to `wwwroot/css/action-tracker.css` and ensured the server-side rendering and JS are CSP-friendly with no inline scripts.

### Testing
- ✅ Ran `git diff --check` to surface whitespace/diff issues and it reported no problems. 
- ⚠️ Attempted `dotnet test ProjectManagement.sln` but the `dotnet` CLI is not available in the current environment so full automated tests could not be executed here. 
- Verified static changes by inspecting generated HTML/JS/CSS diffs and ensured the new `CreateMode` binding and hidden inputs are present so server validation can reopen the correct panel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082f036cd483299e0bab79b65ccba8)