### PR TITLE
Replace Action Tracker browser confirms with app-styled confirmation modal

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -437,7 +437,13 @@
                                         <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                         <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                         <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
-                                        <button type="submit" class="btn btn-link btn-sm">Remove from Sprint, Keep Assigned</button>
+                                        <button type="submit"
+                                                class="btn btn-link btn-sm"
+                                                data-at-confirm="true"
+                                                data-at-confirm-title="Remove task from Sprint?"
+                                                data-at-confirm-body="This will keep the assignee but remove the task from the selected sprint."
+                                                data-at-confirm-cancel-label="Cancel"
+                                                data-at-confirm-accept-label="Remove from Sprint">Remove from Sprint, Keep Assigned</button>
                                     </form>
                                 }
                                 <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
@@ -446,7 +452,13 @@
                                     <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                     <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                     <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
-                                    <button type="submit" class="btn btn-link btn-sm text-danger" data-at-confirm="This will remove the responsible person and return the work to Backlog. Continue?">Move to Backlog, Remove Assignee</button>
+                                    <button type="submit"
+                                            class="btn btn-link btn-sm text-danger"
+                                            data-at-confirm="true"
+                                            data-at-confirm-title="Return task to Backlog?"
+                                            data-at-confirm-body="This will remove the assignee and return the task to Backlog."
+                                            data-at-confirm-cancel-label="Cancel"
+                                            data-at-confirm-accept-label="Return to Backlog">Move to Backlog, Remove Assignee</button>
                                 </form>
                             }
                             </div>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1115,7 +1115,7 @@ public class ActionTaskPageTests
     }
 
     [Fact]
-    public async Task TaskDetails_KeepsMovementActionsAndBacklogConfirmationInInspector()
+    public async Task TaskDetails_KeepsMovementActionsWithAppStyledConfirmationMetadataInInspector()
     {
         // SECTION: Arrange
         var setup = await CreateSetupAsync(RoleNames.HoD);
@@ -1137,7 +1137,28 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Contains("Remove from Sprint, Keep Assigned", html, StringComparison.Ordinal);
         Assert.Contains("Move to Backlog, Remove Assignee", html, StringComparison.Ordinal);
-        Assert.Contains("This will remove the responsible person and return the work to Backlog. Continue?", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm=""true""", html, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(html, @"data-at-confirm-cancel-label=""Cancel"""));
+        Assert.Contains(@"data-at-confirm-title=""Remove task from Sprint?""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm-body=""This will keep the assignee but remove the task from the selected sprint.""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm-accept-label=""Remove from Sprint""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm-title=""Return task to Backlog?""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm-body=""This will remove the assignee and return the task to Backlog.""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-confirm-accept-label=""Return to Backlog""", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("This will remove the responsible person and return the work to Backlog. Continue?", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActionTasksScript_UsesAppStyledConfirmationModalWithoutBrowserConfirm()
+    {
+        // SECTION: Arrange
+        var script = File.ReadAllText(Path.Combine(GetContentRoot(), "wwwroot", "js", "pages", "action-tasks", "index.js"));
+
+        // SECTION: Assert
+        Assert.Contains("ensureActionConfirmationModal", script, StringComparison.Ordinal);
+        Assert.Contains("actionTaskConfirmModal", script, StringComparison.Ordinal);
+        Assert.Contains("requestSubmit", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("window.confirm", script, StringComparison.Ordinal);
     }
 
 

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -285,9 +285,32 @@
         activateMode(initiallySelected.getAttribute("data-at-create-mode-button"));
     }
 
-    // SECTION: Confirmation prompts for destructive bucket moves remain CSP-safe through data attributes.
+    // SECTION: Application-styled confirmation modal for destructive Action Tracker form submissions.
     function initActionConfirmations() {
-        const triggers = document.querySelectorAll("[data-at-confirm]");
+        const triggers = document.querySelectorAll("[data-at-confirm='true']");
+        if (!triggers.length) {
+            return;
+        }
+
+        const modalElement = ensureActionConfirmationModal();
+        if (!modalElement) {
+            return;
+        }
+
+        const titleElement = modalElement.querySelector("[data-at-confirm-modal-title]");
+        const bodyElement = modalElement.querySelector("[data-at-confirm-modal-body]");
+        const cancelButton = modalElement.querySelector("[data-at-confirm-modal-cancel]");
+        const acceptButton = modalElement.querySelector("[data-at-confirm-modal-accept]");
+        const modal = typeof window.bootstrap !== "undefined" && window.bootstrap.Modal
+            ? window.bootstrap.Modal.getOrCreateInstance(modalElement)
+            : null;
+        let pendingForm = null;
+        let pendingSubmitter = null;
+
+        if (!titleElement || !bodyElement || !cancelButton || !acceptButton || !modal) {
+            return;
+        }
+
         triggers.forEach((trigger) => {
             const form = trigger.closest("form");
             if (!form || form.dataset.atConfirmReady === "true") {
@@ -295,14 +318,122 @@
             }
 
             form.addEventListener("submit", (event) => {
-                const submitter = event.submitter || trigger;
-                const message = submitter.getAttribute("data-at-confirm") || trigger.getAttribute("data-at-confirm");
-                if (message && !window.confirm(message)) {
-                    event.preventDefault();
+                if (form.dataset.atConfirmAccepted === "true") {
+                    delete form.dataset.atConfirmAccepted;
+                    return;
                 }
+
+                const submitter = event.submitter || trigger;
+                if (submitter.getAttribute("data-at-confirm") !== "true") {
+                    return;
+                }
+
+                event.preventDefault();
+                pendingForm = form;
+                pendingSubmitter = submitter;
+                titleElement.textContent = submitter.getAttribute("data-at-confirm-title") || "Confirm action";
+                bodyElement.textContent = submitter.getAttribute("data-at-confirm-body") || "Please confirm that you want to continue.";
+                cancelButton.textContent = submitter.getAttribute("data-at-confirm-cancel-label") || "Cancel";
+                acceptButton.textContent = submitter.getAttribute("data-at-confirm-accept-label") || "Continue";
+                modal.show();
             });
             form.dataset.atConfirmReady = "true";
         });
+
+        acceptButton.addEventListener("click", () => {
+            if (!pendingForm) {
+                return;
+            }
+
+            const formToSubmit = pendingForm;
+            const submitterToUse = pendingSubmitter;
+            pendingForm = null;
+            pendingSubmitter = null;
+            formToSubmit.dataset.atConfirmAccepted = "true";
+            modal.hide();
+
+            if (typeof formToSubmit.requestSubmit === "function" && submitterToUse) {
+                formToSubmit.requestSubmit(submitterToUse);
+                return;
+            }
+
+            formToSubmit.submit();
+        });
+
+        modalElement.addEventListener("hidden.bs.modal", () => {
+            pendingForm = null;
+            pendingSubmitter = null;
+        });
+    }
+
+    // SECTION: Build the shared confirmation modal without inline scripts to preserve CSP compliance.
+    function ensureActionConfirmationModal() {
+        const existingModal = document.getElementById("actionTaskConfirmModal");
+        if (existingModal) {
+            return existingModal;
+        }
+
+        const modalElement = document.createElement("div");
+        modalElement.className = "modal fade";
+        modalElement.id = "actionTaskConfirmModal";
+        modalElement.tabIndex = -1;
+        modalElement.setAttribute("aria-labelledby", "actionTaskConfirmModalTitle");
+        modalElement.setAttribute("aria-hidden", "true");
+
+        const dialog = document.createElement("div");
+        dialog.className = "modal-dialog modal-dialog-centered";
+
+        const content = document.createElement("div");
+        content.className = "modal-content";
+
+        const header = document.createElement("div");
+        header.className = "modal-header";
+
+        const title = document.createElement("h2");
+        title.className = "modal-title h5 mb-0";
+        title.id = "actionTaskConfirmModalTitle";
+        title.setAttribute("data-at-confirm-modal-title", "true");
+
+        const closeButton = document.createElement("button");
+        closeButton.type = "button";
+        closeButton.className = "btn-close";
+        closeButton.setAttribute("data-bs-dismiss", "modal");
+        closeButton.setAttribute("aria-label", "Close");
+
+        const body = document.createElement("div");
+        body.className = "modal-body";
+
+        const bodyText = document.createElement("p");
+        bodyText.className = "mb-0";
+        bodyText.setAttribute("data-at-confirm-modal-body", "true");
+
+        const footer = document.createElement("div");
+        footer.className = "modal-footer";
+
+        const cancelButton = document.createElement("button");
+        cancelButton.type = "button";
+        cancelButton.className = "btn btn-outline-secondary";
+        cancelButton.setAttribute("data-bs-dismiss", "modal");
+        cancelButton.setAttribute("data-at-confirm-modal-cancel", "true");
+
+        const acceptButton = document.createElement("button");
+        acceptButton.type = "button";
+        acceptButton.className = "btn btn-danger";
+        acceptButton.setAttribute("data-at-confirm-modal-accept", "true");
+
+        header.appendChild(title);
+        header.appendChild(closeButton);
+        body.appendChild(bodyText);
+        footer.appendChild(cancelButton);
+        footer.appendChild(acceptButton);
+        content.appendChild(header);
+        content.appendChild(body);
+        content.appendChild(footer);
+        dialog.appendChild(content);
+        modalElement.appendChild(dialog);
+        document.body.appendChild(modalElement);
+
+        return modalElement;
     }
 
 


### PR DESCRIPTION
### Motivation
- Remove use of `window.confirm` in the Action Tracker inspector to provide a consistent, accessible, and CSP-safe confirmation experience. 
- Replace browser-native confirm dialogs with an application-styled Bootstrap modal driven by `data-at-confirm-*` attributes so copy and labels can be controlled in markup. 
- Ensure destructive actions only submit their original server-rendered forms after the user explicitly accepts. 

### Description
- Replaced inline `window.confirm` flow with a programmatic, shared modal in `wwwroot/js/pages/action-tasks/index.js` via `ensureActionConfirmationModal()` and an updated `initActionConfirmations()` that reads `data-at-confirm-*` attributes and submits the original form only after acceptance using `requestSubmit`/`submit` as available. 
- Updated `Pages/ActionTasks/_TaskDetails.cshtml` to add `data-at-confirm="true"` and the requested confirmation metadata for the two destructive actions: `RemoveFromSprintKeepAssigned` with title `Remove task from Sprint?` and body `This will keep the assignee but remove the task from the selected sprint.`, and `MoveToBacklogRemoveAssignee` with title `Return task to Backlog?` and body `This will remove the assignee and return the task to Backlog.`; cancel and accept button labels were added per requirements. 
- Kept all JavaScript in `wwwroot/js/pages/action-tasks/index.js` (no inline scripts) to preserve CSP compliance and offline deployment constraints. 
- Updated UI tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert the presence of the new `data-at-confirm-*` metadata and that the Action Tracker script no longer contains `window.confirm`, and to verify the confirmation labels appear as expected. 

### Testing
- Ran a JS syntax check with `node --check wwwroot/js/pages/action-tasks/index.js`, which succeeded. 
- Ran repository checks with `git diff --check` and searched for `window.confirm` with ripgrep to confirm removal, which found no remaining usages in the updated surfaces. 
- Updated unit/UI assertions in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to validate the new metadata and the absence of `window.confirm`. 
- Attempted to run `dotnet test` for the modified test class, but `dotnet` is not available in this environment so automated test execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0830282de48329bc11109b0293ea17)