### PR TITLE
Refine Task Details More menu grouping

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -9,10 +9,19 @@
     var selectedSprintRouteValue = Model.IsPlanningView ? Model.SelectedSprintId : null;
     var selectedTaskIsBacklog = Model.SelectedTask is not null && Model.IsBacklogTask(Model.SelectedTask);
     var selectedTaskStatus = Model.SelectedTask?.Status ?? string.Empty;
+    var selectedTaskIsClosed = string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
     var selectedTaskDateLabel = selectedTaskIsBacklog ? "Target" : "Due";
     var updateButtonText = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePanelTitle = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Add progress details or clarification notes";
+    var canOpenStatusAction = Model.SelectedTask is not null && !selectedTaskIsBacklog && Model.CanUpdateTaskStatus(Model.SelectedTask);
+    var canOpenSubmitAction = Model.SelectedTask is not null && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase) && Model.CanSubmitTask(Model.SelectedTask);
+    var canOpenCloseAction = Model.SelectedTask is not null && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask);
+    var canOpenChangeDateAction = Model.SelectedTask is not null && Model.CanChangeTaskDate(Model.SelectedTask);
+    var canMoveTaskToBacklogAction = Model.SelectedTask is not null && Model.CanMoveTaskToBacklog(Model.SelectedTask);
+    var hasWorkflowActions = !selectedTaskIsClosed && (canOpenStatusAction || canOpenSubmitAction || canOpenCloseAction);
+    var hasPlanningActions = !selectedTaskIsClosed && (canOpenChangeDateAction || canMoveTaskToBacklogAction);
+    var hasMoreActions = hasWorkflowActions || hasPlanningActions;
 }
 
 @* SECTION: Right-side task inspector drawer content. *@
@@ -404,63 +413,76 @@
                         }
                     }
 
-                    @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+                    @if (hasMoreActions)
                     {
                         <details class="at-action-more-menu">
                             <summary class="btn btn-outline-secondary btn-sm">More</summary>
                             <div class="at-action-more-list">
-                            @if (!selectedTaskIsBacklog && Model.CanUpdateTaskStatus(Model.SelectedTask))
-                            {
-                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="status">Change Status</button>
-                            }
-                            @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase) && Model.CanSubmitTask(Model.SelectedTask))
-                            {
-                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="submit">Submit for Closure</button>
-                            }
-                            @if (!string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask))
-                            {
-                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="close">Close Task</button>
-                            }
-
-                            @if (Model.CanChangeTaskDate(Model.SelectedTask))
-                            {
-                                <button type="button" class="btn btn-link btn-sm" data-at-open-action="change-date">Change @selectedTaskDateLabel Date</button>
-                            }
-                            @if (Model.CanMoveTaskToBacklog(Model.SelectedTask))
-                            {
-                                <div class="at-action-more-separator">Planning Actions</div>
-                                @if (Model.SelectedTask.SprintId.HasValue)
+                                @* SECTION: Workflow action group keeps status and closure transitions together. *@
+                                @if (hasWorkflowActions)
                                 {
-                                    <form method="post" asp-page-handler="RemoveFromSprintKeepAssigned" class="at-card-action-form">
-                                        <input type="hidden" name="ViewMode" value="Planning" />
-                                        <input type="hidden" name="PlanningTab" value="Execute" />
-                                        <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                        <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
-                                        <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
-                                        <button type="submit"
-                                                class="btn btn-link btn-sm"
-                                                data-at-confirm="true"
-                                                data-at-confirm-title="Remove task from Sprint?"
-                                                data-at-confirm-body="This will keep the assignee but remove the task from the selected sprint."
-                                                data-at-confirm-cancel-label="Cancel"
-                                                data-at-confirm-accept-label="Remove from Sprint">Remove from Sprint, Keep Assigned</button>
-                                    </form>
+                                    <div class="at-action-more-group" role="group" aria-label="Workflow Actions">
+                                        <div class="at-action-more-heading">Workflow Actions</div>
+                                        @if (canOpenStatusAction)
+                                        {
+                                            <button type="button" class="btn btn-link btn-sm" data-at-open-action="status">Change Status</button>
+                                        }
+                                        @if (canOpenSubmitAction)
+                                        {
+                                            <button type="button" class="btn btn-link btn-sm" data-at-open-action="submit">Submit for Closure</button>
+                                        }
+                                        @if (canOpenCloseAction)
+                                        {
+                                            <button type="button" class="btn btn-link btn-sm" data-at-open-action="close">Close Task</button>
+                                        }
+                                    </div>
                                 }
-                                <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
-                                    <input type="hidden" name="ViewMode" value="Planning" />
-                                    <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
-                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
-                                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
-                                    <button type="submit"
-                                            class="btn btn-link btn-sm text-danger"
-                                            data-at-confirm="true"
-                                            data-at-confirm-title="Return task to Backlog?"
-                                            data-at-confirm-body="This will remove the assignee and return the task to Backlog."
-                                            data-at-confirm-cancel-label="Cancel"
-                                            data-at-confirm-accept-label="Return to Backlog">Move to Backlog, Remove Assignee</button>
-                                </form>
-                            }
+
+                                @* SECTION: Planning action group keeps schedule and sprint-placement actions together. *@
+                                @if (hasPlanningActions)
+                                {
+                                    <div class="at-action-more-group" role="group" aria-label="Planning Actions">
+                                        <div class="at-action-more-heading">Planning Actions</div>
+                                        @if (canOpenChangeDateAction)
+                                        {
+                                            <button type="button" class="btn btn-link btn-sm" data-at-open-action="change-date">Change @selectedTaskDateLabel Date</button>
+                                        }
+                                        @if (canMoveTaskToBacklogAction)
+                                        {
+                                            @if (Model.SelectedTask.SprintId.HasValue)
+                                            {
+                                                <form method="post" asp-page-handler="RemoveFromSprintKeepAssigned" class="at-card-action-form">
+                                                    <input type="hidden" name="ViewMode" value="Planning" />
+                                                    <input type="hidden" name="PlanningTab" value="Execute" />
+                                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                                                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                                    <button type="submit"
+                                                            class="btn btn-link btn-sm"
+                                                            data-at-confirm="true"
+                                                            data-at-confirm-title="Remove task from Sprint?"
+                                                            data-at-confirm-body="This will keep the assignee but remove the task from the selected sprint."
+                                                            data-at-confirm-cancel-label="Cancel"
+                                                            data-at-confirm-accept-label="Remove from Sprint">Remove from Sprint, Keep Assigned</button>
+                                                </form>
+                                            }
+                                            <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
+                                                <input type="hidden" name="ViewMode" value="Planning" />
+                                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                                <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                                                <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                                <button type="submit"
+                                                        class="btn btn-link btn-sm at-action-more-destructive"
+                                                        data-at-confirm="true"
+                                                        data-at-confirm-title="Return task to Backlog?"
+                                                        data-at-confirm-body="This will remove the assignee and return the task to Backlog."
+                                                        data-at-confirm-cancel-label="Cancel"
+                                                        data-at-confirm-accept-label="Return to Backlog">Move to Backlog, Remove Assignee</button>
+                                            </form>
+                                        }
+                                    </div>
+                                }
                             </div>
                         </details>
                     }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1148,6 +1148,93 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("This will remove the responsible person and return the work to Backlog. Continue?", html, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(RoleNames.Comdt)]
+    [InlineData(RoleNames.HoD)]
+    public async Task TaskDetails_MoreMenu_PlanningAuthoritiesRenderChangeDueDate(string role)
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(role);
+        var sprint = AddSprint(setup.Db, "Date Sprint", ActionSprintStatus.Active);
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.SprintId = sprint.Id;
+        task.Status = ActionTaskStatuses.Assigned;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Execute";
+        page.SelectedSprintId = sprint.Id;
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Workflow Actions", html, StringComparison.Ordinal);
+        Assert.Contains("Planning Actions", html, StringComparison.Ordinal);
+        Assert.Contains("Change Due Date", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-action-panel=""change-date""", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-open-action=""change-date""", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TaskDetails_MoreMenu_NormalAssigneeHidesChangeDueDate()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.Ta);
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.Status = ActionTaskStatuses.Assigned;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "MyWork";
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("Workflow Actions", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Planning Actions", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Change Due Date", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"data-at-action-panel=""change-date""", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"data-at-open-action=""change-date""", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TaskDetails_MoreMenu_ClosedTaskHidesChangeDateWorkflowAndPlanningActions()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var sprint = AddSprint(setup.Db, "Closed Sprint", ActionSprintStatus.Active);
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        task.SprintId = sprint.Id;
+        task.Status = ActionTaskStatuses.Closed;
+        task.ClosedOn = DateTime.UtcNow;
+        await setup.Db.SaveChangesAsync();
+        var page = setup.Page;
+        page.ViewMode = "Planning";
+        page.PlanningTab = "Execute";
+        page.SelectedSprintId = sprint.Id;
+        page.TaskId = task.Id;
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("View only", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Workflow Actions", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Planning Actions", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Change Due Date", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Change Target Date", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Change Status", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Remove from Sprint, Keep Assigned", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Move to Backlog, Remove Assignee", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"data-at-action-panel=""change-date""", html, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void ActionTasksScript_UsesAppStyledConfirmationModalWithoutBrowserConfirm()
     {

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3939,3 +3939,63 @@ html {
         grid-template-columns: 1fr;
     }
 }
+
+/* SECTION: Task Details More menu group refinement. */
+.at-action-more-list {
+    display: grid;
+    gap: 0.25rem;
+    min-width: 13.5rem;
+    padding: 0.35rem 0;
+}
+
+.at-action-more-group {
+    display: grid;
+    gap: 0.1rem;
+    padding: 0.1rem 0;
+}
+
+.at-action-more-group + .at-action-more-group {
+    border-top: 1px solid var(--at-border);
+    margin-top: 0.25rem;
+    padding-top: 0.35rem;
+}
+
+.at-action-more-heading,
+.at-action-more-separator {
+    padding: 0.15rem 0.75rem 0.05rem;
+    color: var(--at-muted);
+    font-size: var(--at-font-xs);
+    font-weight: var(--at-weight-bold);
+    line-height: 1.2;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.at-action-more-list .btn-link {
+    width: 100%;
+    padding: 0.2rem 0.75rem;
+    color: var(--at-text);
+    text-align: left;
+    text-decoration: none;
+}
+
+.at-action-more-list .btn-link:hover,
+.at-action-more-list .btn-link:focus {
+    background: #f8fafc;
+    color: var(--at-text);
+    text-decoration: none;
+}
+
+.at-action-more-list .at-card-action-form {
+    margin: 0;
+}
+
+.at-action-more-list .at-action-more-destructive {
+    color: #b91c1c;
+}
+
+.at-action-more-list .at-action-more-destructive:hover,
+.at-action-more-list .at-action-more-destructive:focus {
+    background: #fef2f2;
+    color: #991b1b;
+}


### PR DESCRIPTION
### Motivation
- Clarify the Task Details "More" menu by grouping related actions so workflow transitions and planning adjustments are visually distinct and easier to scan. 
- Ensure date-change and planning-only actions are shown only to planning authorities and suppressed for closed tasks. 
- Preserve existing action-panel plumbing (`data-at-action-panel` / `data-at-open-action`) and keep primary footer buttons normal-sized so behaviour remains unchanged.

### Description
- Added availability flags and a closed-task guard to `Pages/ActionTasks/_TaskDetails.cshtml` and reorganised the "More" menu into two groups: `Workflow Actions` and `Planning Actions`, with status/submit/close in the Workflow group and `Change Due/Target Date` plus sprint/backlog movement in the Planning group. 
- Kept the existing `data-at-action-panel="change-date"` drawer and `data-at-open-action="change-date"` triggers so action panels still open above the footer via the existing pattern. 
- Moved conditional rendering for `Change Due Date` to the Planning group and made it depend on `Model.CanChangeTaskDate(Model.SelectedTask)` while ensuring no workflow or planning actions render for closed tasks. 
- Added compact styling to `wwwroot/css/action-tracker.css` for grouped menu headers, separators, full-width link buttons inside the menu, and destructive secondary styling for the "Move to Backlog" action. 
- Added Razor rendering tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` covering: planning authorities (Comdt/HoD) seeing Change Due Date, normal assignee (Ta) not seeing it, and closed tasks hiding change-date/workflow/planning actions.

### Testing
- Added tests: `TaskDetails_MoreMenu_PlanningAuthoritiesRenderChangeDueDate`, `TaskDetails_MoreMenu_NormalAssigneeHidesChangeDueDate`, and `TaskDetails_MoreMenu_ClosedTaskHidesChangeDateWorkflowAndPlanningActions` in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` (not executed here). 
- Ran `git diff --check` to sanity-check the edits and found no whitespace errors. 
- Attempted to run `dotnet test` for the `ActionTaskPageTests` but the environment does not have `dotnet` installed, so the test run could not be executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083267c16c8329b0b330a7cf607dd9)