### PR TITLE
Tighten Reports filter CSS and update UI-rendering assertions

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1453,6 +1453,8 @@ public class ActionTaskPageTests
 
         // SECTION: Assert
         Assert.DoesNotContain("<h2>Report Filters</h2>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Report Filters", html, StringComparison.Ordinal);
+        Assert.Contains("Workload by Assignee", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ReportBucket""", html, StringComparison.Ordinal);
         Assert.Contains(@"name=""ReportSprintId""", html, StringComparison.Ordinal);
         Assert.Contains("Decision Sprint", html, StringComparison.Ordinal);
@@ -1522,6 +1524,7 @@ public class ActionTaskPageTests
         Assert.Contains("Ageing and Overdue Analysis", html, StringComparison.Ordinal);
         Assert.Contains("Pending Closure", html, StringComparison.Ordinal);
         Assert.Contains("Workload by Assignee", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Report Filters", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Responsible Person Workload", html, StringComparison.Ordinal);
         Assert.DoesNotContain(@"<th class=""text-center"">Critical</th>", html, StringComparison.Ordinal);
         Assert.Contains(@"<th class=""text-center"">Unfinished</th>", html, StringComparison.Ordinal);

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3412,8 +3412,8 @@ html {
 .at-reports-filter-panel {
     display: flex;
     flex-direction: column;
-    gap: .35rem;
-    padding-block: .45rem;
+    gap: .25rem;
+    padding: .55rem .75rem;
 }
 
 .at-reports-filter-heading {
@@ -3429,15 +3429,15 @@ html {
     border: 0;
     border-radius: 0;
     color: #64748b;
-    font-size: .72rem;
-    font-weight: 650;
-    padding: .2rem 0;
+    font-size: .68rem;
+    font-weight: 600;
+    padding: 0;
     white-space: nowrap;
 }
 
 .at-reports-filter-grid {
     display: grid;
-    gap: .35rem;
+    gap: .3rem .5rem;
     grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
@@ -3445,9 +3445,9 @@ html {
     color: #475569;
     display: flex;
     flex-direction: column;
-    font-size: .72rem;
-    font-weight: 800;
-    gap: .12rem;
+    font-size: .68rem;
+    font-weight: 650;
+    gap: .08rem;
     letter-spacing: .02em;
     text-transform: uppercase;
 }


### PR DESCRIPTION
### Motivation
- Make the Reports filter bar more compact and reduce visual weight of labels and the summary while preserving the existing layout and filter behavior.
- Ensure the Reports partial continues to avoid a literal "Report Filters" heading and that key report content like "Workload by Assignee" remains visible.

### Description
- Adjusted `.at-reports-filter-panel` to use tighter spacing and all-side padding with `gap: .25rem` and `padding: .55rem .75rem` in `wwwroot/css/action-tracker.css`.
- Reduced `.at-reports-filter-grid` gaps to `gap: .3rem .5rem` and tightened label styling to `font-size: .68rem`, `font-weight: 650`, and `gap: .08rem` in `wwwroot/css/action-tracker.css`.
- Lowered `.at-report-filter-summary` prominence to `font-size: .68rem`, `font-weight: 600`, muted color `#64748b`, and removed card-like padding/background in `wwwroot/css/action-tracker.css`.
- Updated UI-rendering assertions in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to assert that `Workload by Assignee` is present and `Report Filters` is absent.

### Testing
- A local Python verification script checked that the CSS values (`padding: .55rem .75rem`, `gap: .3rem .5rem`, `font-size: .68rem`, `font-weight: 650`, and `font-weight: 600`) and the updated test assertions exist and succeeded.
- `git diff --check` was run to validate the working tree changes without issues.
- Attempt to run the xUnit UI/rendering tests via `dotnet test --filter ActionTaskPageTests` could not be executed because `dotnet` is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0833bbccd88329bfe574dcd5504f6e)