### PR TITLE
Add action task date and create modal regression tests

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -92,6 +92,59 @@ public class ActionTaskPageTests
     }
 
     [Fact]
+    public async Task CreateModal_RendersBacklogItemAndDirectTaskModeLabels()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.CreateMode = "backlog";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskCreatePanel.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains(@"data-at-create-mode-button=""backlog"">Backlog Item</button>", html, StringComparison.Ordinal);
+        Assert.Contains(@"data-at-create-mode-button=""direct"">Direct Task</button>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateModal_DoesNotDuplicateCreateBacklogItemAsSelectorAndSubmitAction()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.CreateMode = "backlog";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskCreatePanel.cshtml");
+
+        // SECTION: Assert
+        Assert.Equal(1, CountOccurrences(html, @">Backlog Item</button>"));
+        Assert.Contains(@">Save Backlog Item</button>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@">Create Backlog Item</button>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateModal_DirectTaskFormRendersAssignee()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        page.CreateMode = "direct";
+        await page.OnGetAsync();
+
+        // SECTION: Act
+        var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskCreatePanel.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains(@"for=""DirectTaskInput_AssignedToUserId"">Assignee</label>", html, StringComparison.Ordinal);
+        Assert.Contains(@"name=""DirectTaskInput.AssignedToUserId""", html, StringComparison.Ordinal);
+        Assert.Contains("User One", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task PlanningKanban_StatusNoOpRedirect_ResolvesToExecute()
     {
         // SECTION: Arrange

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -217,10 +217,8 @@ public class ActionTaskServiceTests
         Assert.Contains("submit for closure", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [InlineData(RoleNames.Comdt)]
-    [InlineData(RoleNames.HoD)]
-    public async Task UpdateTaskDateAsync_AllowsPlanningAuthorities(string role)
+    [Fact]
+    public async Task Comdt_CanChangeAssignedTaskDueDate()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -229,7 +227,7 @@ public class ActionTaskServiceTests
         var newDate = DateTime.UtcNow.Date.AddDays(5);
 
         // SECTION: Act
-        await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", role);
+        await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", RoleNames.Comdt);
 
         // SECTION: Assert
         var updated = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
@@ -237,7 +235,24 @@ public class ActionTaskServiceTests
     }
 
     [Fact]
-    public async Task UpdateTaskDateAsync_RejectsAssigneeRole()
+    public async Task HoD_CanChangeAssignedTaskDueDate()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+        var newDate = DateTime.UtcNow.Date.AddDays(5);
+
+        // SECTION: Act
+        await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", RoleNames.HoD);
+
+        // SECTION: Assert
+        var updated = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(newDate, updated.DueDate.Date);
+    }
+
+    [Fact]
+    public async Task Assignee_CannotChangeOwnDueDate()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -251,7 +266,7 @@ public class ActionTaskServiceTests
     }
 
     [Fact]
-    public async Task UpdateTaskDateAsync_RejectsClosedTasks()
+    public async Task ClosedTask_DateCannotBeChanged()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -267,7 +282,7 @@ public class ActionTaskServiceTests
     }
 
     [Fact]
-    public async Task UpdateTaskDateAsync_RejectsPastDates()
+    public async Task ChangeTaskDate_RejectsPastDate()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
@@ -281,34 +296,57 @@ public class ActionTaskServiceTests
     }
 
     [Fact]
-    public async Task UpdateTaskDateAsync_AuditsTargetDateForBacklogAndDueDateForAssignedTasks()
+    public async Task BacklogItem_ChangeDate_AuditsTargetDateChanged()
     {
         // SECTION: Arrange
         await using var db = CreateDb();
         var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var originalTargetDate = DateTime.UtcNow.Date.AddDays(2);
         var backlog = await service.CreateBacklogItemAsync(new ActionTaskItem
         {
             Title = "Backlog",
             Description = "Future work",
             CreatedByUserId = "creator",
             CreatedByRole = RoleNames.HoD,
-            DueDate = DateTime.UtcNow.Date.AddDays(2),
+            DueDate = originalTargetDate,
             Priority = "Normal"
         });
-        var assigned = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+        var newDate = DateTime.UtcNow.Date.AddDays(6);
 
         // SECTION: Act
-        await service.UpdateTaskDateAsync(backlog.Id, backlog.RowVersion, DateTime.UtcNow.Date.AddDays(6), "planner", RoleNames.HoD);
-        await service.UpdateTaskDateAsync(assigned.Id, assigned.RowVersion, DateTime.UtcNow.Date.AddDays(7), "planner", RoleNames.Comdt);
+        await service.UpdateTaskDateAsync(backlog.Id, backlog.RowVersion, newDate, "planner", RoleNames.HoD);
 
         // SECTION: Assert
         var logs = await db.ActionTaskAuditLogs.ToListAsync();
-        Assert.Contains(logs, x => x.TaskId == backlog.Id && x.ActionType == "TargetDateChanged");
-        Assert.Contains(logs, x => x.TaskId == assigned.Id && x.ActionType == "DueDateChanged");
+        Assert.Contains(logs, x => x.TaskId == backlog.Id
+            && x.ActionType == "TargetDateChanged"
+            && x.OldValue == originalTargetDate.ToString("yyyy-MM-dd")
+            && x.NewValue == newDate.ToString("yyyy-MM-dd"));
     }
 
     [Fact]
-    public async Task UpdateTaskDateAsync_WithStaleRowVersion_ThrowsConcurrencyException()
+    public async Task AssignedTask_ChangeDate_AuditsDueDateChanged()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var assigned = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+        var oldDate = assigned.DueDate.Date;
+        var newDate = DateTime.UtcNow.Date.AddDays(7);
+
+        // SECTION: Act
+        await service.UpdateTaskDateAsync(assigned.Id, assigned.RowVersion, newDate, "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        var logs = await db.ActionTaskAuditLogs.ToListAsync();
+        Assert.Contains(logs, x => x.TaskId == assigned.Id
+            && x.ActionType == "DueDateChanged"
+            && x.OldValue == oldDate.ToString("yyyy-MM-dd")
+            && x.NewValue == newDate.ToString("yyyy-MM-dd"));
+    }
+
+    [Fact]
+    public async Task ChangeTaskDate_EnforcesRowVersion()
     {
         // SECTION: Arrange
         var databaseName = Guid.NewGuid().ToString();


### PR DESCRIPTION
### Motivation
- Restore missing regression coverage for action-task date-change flows and create-modal rendering to prevent regressions in permissions, auditing, and UI.
- Ensure planning authorities (Comdt/HoD) can change due dates while assignees and closed/past-date cases are rejected, and that audit events and concurrency are enforced.

### Description
- Added service tests in `ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs` for: `Comdt_CanChangeAssignedTaskDueDate`, `HoD_CanChangeAssignedTaskDueDate`, `Assignee_CannotChangeOwnDueDate`, `ClosedTask_DateCannotBeChanged`, `BacklogItem_ChangeDate_AuditsTargetDateChanged`, `AssignedTask_ChangeDate_AuditsDueDateChanged`, `ChangeTaskDate_RejectsPastDate`, and `ChangeTaskDate_EnforcesRowVersion`.
- Added UI rendering tests in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` that verify the create modal shows `Backlog Item` and `Direct Task` labels, does not duplicate the backlog submit wording, and that the direct-task form renders the `Assignee` field; kept existing drawer assertions for `Change Due Date` visibility and the static script check avoiding `window.confirm`.
- Preserved and relied on existing report/sprint assertions around `Workload by Assignee`, absence of a `Critical` workload column, `Unfinished` header instead of `Carried Forward`, and Active Sprint Exceptions behavior.
- Changes touch two test files: `ActionTaskServiceTests.cs` and `ActionTaskPageTests.cs` to add the requested regressions and audit validations.

### Testing
- Ran `git diff --check` and static repository checks with no issues detected.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ProjectManagement.Tests.ActionTasks"` but it could not be executed in this environment because `dotnet` is not installed, so test execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0834785e64832995478863bd118b13)