### PR TITLE
Fix task details More menu positioning

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -636,6 +636,7 @@ html {
 
 .at-action-toolbar {
     display: flex;
+    align-items: flex-start;
     gap: 0.4rem;
     flex-wrap: wrap;
 }
@@ -3940,12 +3941,24 @@ html {
     }
 }
 
-/* SECTION: Task Details More menu group refinement. */
+/* SECTION: Task Details More menu popover and group refinement. */
+.at-action-more-menu {
+    position: relative;
+}
+
 .at-action-more-list {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.35rem);
+    z-index: 20;
     display: grid;
     gap: 0.25rem;
     min-width: 13.5rem;
     padding: 0.35rem 0;
+    background: var(--at-surface);
+    border: 1px solid var(--at-border);
+    border-radius: var(--at-radius-md);
+    box-shadow: var(--at-shadow-sm);
 }
 
 .at-action-more-group {


### PR DESCRIPTION
### Motivation
- Prevent the Task Details `More` menu from expanding the document flow and causing primary action buttons to stretch vertically when it is open.
- Keep the action toolbar visually stable so buttons like `Add Update`, `Mark In Progress`, `Submit for Closure`, and `Close Task` do not change height when the menu is toggled.
- Preserve CSP compliance by making a CSS-only change without adding inline scripts or markup changes.

### Description
- Added `align-items: flex-start` to `.at-action-toolbar` to anchor toolbar controls to the top and avoid vertical stretching.
- Introduced `.at-action-more-menu { position: relative; }` to create an anchor for an absolutely positioned menu.
- Converted `.at-action-more-list` into an absolutely positioned popover with `position: absolute`, `right: 0`, `bottom: calc(100% + .35rem)`, `z-index: 20`, and added surface styling (`background`, `border`, `border-radius`, `box-shadow`) to match the UI design.
- Only `wwwroot/css/action-tracker.css` was modified and no markup (`Pages/ActionTasks/_TaskDetails.cshtml`) or JS changes were required to remain CSP-safe.

### Testing
- Ran `git diff --check` to validate whitespace and formatting issues, which succeeded.
- Attempted `dotnet test ProjectManagement.sln` but it could not be executed in the environment because the `dotnet` CLI is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083fa3186c832998e51fe298866fa9)