### PR TITLE
Preselect intended task status actions

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -389,7 +389,7 @@
                         @if (Model.CanCloseTask(Model.SelectedTask))
                         {
                             <button type="button" class="btn btn-success btn-sm" data-at-open-action="close">Close Task</button>
-                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Return for Rework</button>
+                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status" data-at-target-status="In Progress">Return for Rework</button>
                         }
                         else
                         {
@@ -405,7 +405,7 @@
                         <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Add Update</button>
                         @if (Model.CanUpdateTaskStatus(Model.SelectedTask) && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
                         {
-                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status">Mark In Progress</button>
+                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status" data-at-target-status="In Progress">Mark In Progress</button>
                         }
                         @if (Model.CanSubmitTask(Model.SelectedTask) && string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase))
                         {

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -452,13 +452,29 @@
             panels.forEach((panel) => panel.removeAttribute("open"));
         };
 
-        const openPanel = (name) => {
+        // SECTION: Intent-specific status actions can seed the status panel selection.
+        const applyStatusActionTarget = (name, targetStatus) => {
+            if (name !== "status" || !targetStatus) {
+                return;
+            }
+
+            const statusSelect = shell.querySelector("[data-at-status-select]");
+            if (!statusSelect) {
+                return;
+            }
+
+            statusSelect.value = targetStatus;
+            statusSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        };
+
+        const openPanel = (name, targetStatus) => {
             closeAllPanels();
             const panel = shell.querySelector(`[data-at-action-panel='${name}']`);
             if (!panel) {
                 return;
             }
             panel.setAttribute("open", "open");
+            applyStatusActionTarget(name, targetStatus);
             const focusTarget = panel.querySelector("textarea, select, input, button");
             if (focusTarget) {
                 focusTarget.focus();
@@ -468,7 +484,8 @@
         openButtons.forEach((button) => {
             button.addEventListener("click", () => {
                 const target = button.getAttribute("data-at-open-action");
-                openPanel(target);
+                const targetStatus = button.getAttribute("data-at-target-status");
+                openPanel(target, targetStatus);
             });
         });
 

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -79,3 +79,62 @@ test('reports date filters submit on change or blur but not every typed input ev
     fromDate.dispatchEvent(new window.Event('change', { bubbles: true }));
     assert.equal(submissions.length, 1);
 });
+
+// SECTION: Inspector status action fixture.
+function createInspectorActionDom(currentStatus = 'Open') {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+        <div data-at-action-shell="true">
+            <details data-at-action-panel="status">
+                <summary>Status</summary>
+                <select name="status" data-at-status-select data-current-status="${currentStatus}">
+                    <option value="Open">Open</option>
+                    <option value="In Progress">In Progress</option>
+                    <option value="Submitted">Submitted</option>
+                </select>
+                <button type="submit" data-at-status-submit>Save Status</button>
+            </details>
+            <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="mark-progress">Mark In Progress</button>
+            <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="return-rework">Return for Rework</button>
+        </div>
+    </body></html>`, { url: 'https://example.test/ActionTasks?TaskId=1', runScripts: 'dangerously' });
+
+    const { window } = dom;
+    const document = window.document;
+    document.querySelector('[data-at-status-select]').value = currentStatus;
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+    document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+
+    return { window, document };
+}
+
+// SECTION: Status intent action behavior.
+test('intent-specific status actions preselect In Progress and refresh save guard', () => {
+    [
+        { action: 'mark-progress', currentStatus: 'Open' },
+        { action: 'return-rework', currentStatus: 'Submitted' }
+    ].forEach(({ action, currentStatus }) => {
+        const { window, document } = createInspectorActionDom(currentStatus);
+        const shell = document.querySelector('[data-at-action-shell]');
+        const panel = document.querySelector('[data-at-action-panel="status"]');
+        const select = document.querySelector('[data-at-status-select]');
+        const saveButton = document.querySelector('[data-at-status-submit]');
+        const openButton = document.querySelector(`[data-test-action="${action}"]`);
+        let bubbledChangeCount = 0;
+
+        assert.equal(select.value, currentStatus);
+        assert.equal(saveButton.disabled, true);
+
+        shell.addEventListener('change', () => {
+            bubbledChangeCount += 1;
+        });
+
+        openButton.dispatchEvent(new window.Event('click', { bubbles: true }));
+
+        assert.equal(panel.hasAttribute('open'), true);
+        assert.equal(select.value, 'In Progress');
+        assert.equal(saveButton.disabled, false);
+        assert.equal(bubbledChangeCount, 1);
+    });
+});


### PR DESCRIPTION
### Motivation
- Provide a better UX by having intent-specific actions open the status panel with their intended target status already selected so users don't need to re-select it.
- Ensure the existing Save/guard logic updates immediately when an intent action seeds a different status choice.

### Description
- Added `data-at-target-status="In Progress"` to the `Return for Rework` and `Mark In Progress` buttons in `Pages/ActionTasks/_TaskDetails.cshtml` so intent is encoded in the markup.
- Updated `initInspectorActionPanels()` in `wwwroot/js/pages/action-tasks/index.js` to read `data-at-target-status` from the opening button, set the value of the element with `[data-at-status-select]`, and dispatch a bubbling `change` event so the existing status-submit guard refreshes the Save button state.
- Added JS unit tests in `wwwroot/js/pages/action-tasks/index.test.js` that exercise both intent-specific buttons and assert the status panel opens, the select is changed to `In Progress`, the Save button state updates, and a bubbling `change` event occurred.

### Testing
- Ran `npm test` which executed the JS suite and completed successfully with all tests passing (JS tests: 16 passed).
- Ran the targeted JS test with `node --test wwwroot/js/pages/action-tasks/index.test.js` and it passed, confirming the new behavior for both intent-specific buttons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084121a8f08329b79aea10d9cd84d4)