### PR TITLE
Change Date drawer: avoid invalid past date inputs and use page-model clock

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -57,6 +57,9 @@ public class IndexModel : PageModel
         SprintInput = CreateSprintInput.FromSprint(_clock.UtcToday);
     }
 
+    // SECTION: Clock-backed view dates keep Razor defaults aligned with server-side validation.
+    public DateTime UtcToday => _clock.UtcToday;
+
     public IReadOnlyList<ActionTaskItem> Tasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> OverdueTasks { get; private set; } = Array.Empty<ActionTaskItem>();

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -11,6 +11,10 @@
     var selectedTaskStatus = Model.SelectedTask?.Status ?? string.Empty;
     var selectedTaskIsClosed = string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
     var selectedTaskDateLabel = selectedTaskIsBacklog ? "Target" : "Due";
+    var minimumChangeDate = Model.UtcToday;
+    var changeDateInputValue = Model.SelectedTask is not null && Model.SelectedTask.DueDate.Date >= minimumChangeDate
+        ? Model.SelectedTask.DueDate.Date
+        : minimumChangeDate;
     var updateButtonText = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePanelTitle = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Add progress details or clarification notes";
@@ -306,9 +310,14 @@
                                 <input type="hidden" asp-for="ChangeDateInput.TaskId" value="@Model.SelectedTask.Id" />
                                 <input type="hidden" asp-for="ChangeDateInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
                                 <div class="at-action-title">Change @selectedTaskDateLabel Date</div>
+                                @* SECTION: Date change values keep overdue tasks visible while enforcing the current minimum date. *@
+                                <div class="mb-2">
+                                    <span class="form-label at-small d-block mb-1">Current @selectedTaskDateLabel Date</span>
+                                    <div class="form-control-plaintext form-control-sm py-0">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div>
+                                </div>
                                 <div class="mb-2">
                                     <label class="form-label at-small" asp-for="ChangeDateInput.NewDate">New @selectedTaskDateLabel Date</label>
-                                    <input class="form-control form-control-sm" asp-for="ChangeDateInput.NewDate" type="date" value="@Model.SelectedTask.DueDate.ToString("yyyy-MM-dd")" min="@DateTime.UtcNow.Date.ToString("yyyy-MM-dd")" />
+                                    <input class="form-control form-control-sm" asp-for="ChangeDateInput.NewDate" type="date" value="@changeDateInputValue.ToString("yyyy-MM-dd")" min="@minimumChangeDate.ToString("yyyy-MM-dd")" />
                                 </div>
                                 <div class="at-action-buttons">
                                     <button type="submit" class="btn btn-primary btn-sm">Save Date</button>


### PR DESCRIPTION
### Motivation
- Prevent the Change Due/Target Date drawer from rendering an invalid (past) date value for overdue tasks while keeping server-side min-date validation consistent. 
- Surface the current task date as read-only so users see the existing Due/Target date when choosing a new date. 
- Use the page-model clock rather than `DateTime.UtcNow` to keep Razor defaults aligned with the server-side validation logic. 

### Description
- Added a `UtcToday` property to `IndexModel` that returns the injected `_clock.UtcToday` for use by Razor defaults. 
- In `Pages/ActionTasks/_TaskDetails.cshtml` computed `minimumChangeDate` from `Model.UtcToday` and `changeDateInputValue` as `Model.SelectedTask.DueDate` unless that date is before the minimum, in which case the input defaults to the minimum. 
- Inserted a read-only `Current Due/Target Date` display formatted as `dd MMM yyyy` above the editable date input and kept the editable label as `New Due/Target Date`. 
- Replaced the direct `DateTime.UtcNow` usage in the view with the page-model clock-backed values for the date input `value` and `min`, and left existing permission and closed-task rules unchanged. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Attempted `dotnet test ProjectManagement.sln`, but `dotnet` was not available in the execution environment so unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0842c246488329a299dc2610180710)