### PR TITLE
Use action tracker clock for task date validation

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1805,9 +1805,9 @@ public class ActionTaskPageTests
 
         // SECTION: Action task page services
         var permission = new ActionTaskPermissionService();
-        var service = new ActionTaskService(db, permission);
         var collab = new StubCollabService();
         var clock = new SystemActionTrackerClock();
+        var service = new ActionTaskService(db, permission, clock);
         var queryService = new ActionTaskQueryService(clock, new ActionTaskReportBuilder(clock));
         var workflowPolicy = new ActionTaskWorkflowPolicy(permission);
         var sprintWorkflowPolicy = new ActionSprintWorkflowPolicy();

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -14,7 +14,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await service.CreateTaskAsync(new ActionTaskItem
         {
             Title = "Task A",
@@ -44,7 +44,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
 
         // SECTION: Act + Assert
@@ -89,7 +89,7 @@ public class ActionTaskServiceTests
             await concurrentDb.SaveChangesAsync();
         }
 
-        var service = new ActionTaskService(staleDb, new ActionTaskPermissionService());
+        var service = CreateService(staleDb);
 
         // SECTION: Act + Assert
         await Assert.ThrowsAsync<ActionTaskConcurrencyException>(() =>
@@ -101,7 +101,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "owner");
 
         // SECTION: Act + Assert
@@ -118,7 +118,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
 
         // SECTION: Act
         var task = await service.CreateBacklogItemAsync(new ActionTaskItem
@@ -150,7 +150,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
 
         // SECTION: Act
         var task = await service.CreateTaskAsync(new ActionTaskItem
@@ -187,7 +187,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await service.CreateBacklogItemAsync(new ActionTaskItem
         {
             Title = "Backlog",
@@ -208,7 +208,7 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
 
         // SECTION: Act + Assert
@@ -222,9 +222,9 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
-        var newDate = DateTime.UtcNow.Date.AddDays(5);
+        var newDate = TestActionTrackerClock.FixedToday.AddDays(5);
 
         // SECTION: Act
         await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", RoleNames.Comdt);
@@ -239,9 +239,9 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
-        var newDate = DateTime.UtcNow.Date.AddDays(5);
+        var newDate = TestActionTrackerClock.FixedToday.AddDays(5);
 
         // SECTION: Act
         await service.UpdateTaskDateAsync(task.Id, task.RowVersion, newDate, "planner", RoleNames.HoD);
@@ -256,12 +256,12 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(3), "assignee", RoleNames.Ta));
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, TestActionTrackerClock.FixedToday.AddDays(3), "assignee", RoleNames.Ta));
         Assert.Contains("not authorized", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -270,14 +270,14 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Closed, "assignee");
         task.ClosedOn = DateTime.UtcNow;
         await db.SaveChangesAsync();
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(3), "planner", RoleNames.HoD));
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, TestActionTrackerClock.FixedToday.AddDays(3), "planner", RoleNames.HoD));
         Assert.Contains("Closed tasks", ex.Message);
     }
 
@@ -286,12 +286,12 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
 
         // SECTION: Act + Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.UpdateTaskDateAsync(task.Id, task.RowVersion, DateTime.UtcNow.Date.AddDays(-1), "planner", RoleNames.Comdt));
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, TestActionTrackerClock.FixedToday.AddDays(-1), "planner", RoleNames.Comdt));
         Assert.Contains("past", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -300,8 +300,8 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
-        var originalTargetDate = DateTime.UtcNow.Date.AddDays(2);
+        var service = CreateService(db);
+        var originalTargetDate = TestActionTrackerClock.FixedToday.AddDays(2);
         var backlog = await service.CreateBacklogItemAsync(new ActionTaskItem
         {
             Title = "Backlog",
@@ -311,7 +311,7 @@ public class ActionTaskServiceTests
             DueDate = originalTargetDate,
             Priority = "Normal"
         });
-        var newDate = DateTime.UtcNow.Date.AddDays(6);
+        var newDate = TestActionTrackerClock.FixedToday.AddDays(6);
 
         // SECTION: Act
         await service.UpdateTaskDateAsync(backlog.Id, backlog.RowVersion, newDate, "planner", RoleNames.HoD);
@@ -329,10 +329,10 @@ public class ActionTaskServiceTests
     {
         // SECTION: Arrange
         await using var db = CreateDb();
-        var service = new ActionTaskService(db, new ActionTaskPermissionService());
+        var service = CreateService(db);
         var assigned = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
         var oldDate = assigned.DueDate.Date;
-        var newDate = DateTime.UtcNow.Date.AddDays(7);
+        var newDate = TestActionTrackerClock.FixedToday.AddDays(7);
 
         // SECTION: Act
         await service.UpdateTaskDateAsync(assigned.Id, assigned.RowVersion, newDate, "planner", RoleNames.Comdt);
@@ -365,12 +365,17 @@ public class ActionTaskServiceTests
             await concurrentDb.SaveChangesAsync();
         }
 
-        var service = new ActionTaskService(staleDb, new ActionTaskPermissionService());
+        var service = CreateService(staleDb);
 
         // SECTION: Act + Assert
         await Assert.ThrowsAsync<ActionTaskConcurrencyException>(() =>
-            service.UpdateTaskDateAsync(task.Id, staleRowVersion, DateTime.UtcNow.Date.AddDays(8), "planner", RoleNames.HoD));
+            service.UpdateTaskDateAsync(task.Id, staleRowVersion, TestActionTrackerClock.FixedToday.AddDays(8), "planner", RoleNames.HoD));
     }
+
+
+    // SECTION: Test service helpers
+    private static ActionTaskService CreateService(ApplicationDbContext db)
+        => new(db, new ActionTaskPermissionService(), new TestActionTrackerClock());
 
     private static ApplicationDbContext CreateDb()
         => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
@@ -403,5 +408,14 @@ public class ActionTaskServiceTests
         db.ActionTasks.Add(task);
         await db.SaveChangesAsync();
         return task;
+    }
+
+    private sealed class TestActionTrackerClock : IActionTrackerClock
+    {
+        public static readonly DateTime FixedToday = new(2030, 1, 15);
+
+        public DateTime UtcNow => FixedToday.AddHours(12);
+
+        public DateTime UtcToday => FixedToday;
     }
 }

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -13,11 +13,13 @@ public class ActionTaskService : IActionTaskService
 {
     private readonly ApplicationDbContext _context;
     private readonly ActionTaskPermissionService _permission;
+    private readonly IActionTrackerClock _clock;
 
-    public ActionTaskService(ApplicationDbContext context, ActionTaskPermissionService permission)
+    public ActionTaskService(ApplicationDbContext context, ActionTaskPermissionService permission, IActionTrackerClock clock)
     {
         _context = context;
         _permission = permission;
+        _clock = clock;
     }
 
     // SECTION: Task read APIs
@@ -367,7 +369,7 @@ public class ActionTaskService : IActionTaskService
         }
 
         var normalizedNewDate = newDate.Date;
-        if (normalizedNewDate < DateTime.UtcNow.Date)
+        if (normalizedNewDate < _clock.UtcToday)
         {
             throw new InvalidOperationException("Task date cannot be in the past.");
         }


### PR DESCRIPTION
### Motivation
- Ensure service-level past-date validation uses the same date abstraction as pages so date-only logic is consistent across the Action Tracker.
- Make date-change validation deterministic in tests by injecting a test clock rather than relying on `DateTime.UtcNow`.

### Description
- Injected `IActionTrackerClock` into `ActionTaskService` and stored it in a private readonly `_clock` field (modified `Services/ActionTasks/ActionTaskService.cs`).
- Replaced the past-date check in `UpdateTaskDateAsync()` from `DateTime.UtcNow.Date` to `_clock.UtcToday`.
- Updated tests to construct the service with a deterministic test clock and to use a fixed test date for date-related assertions (modified `ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs`).
- Updated action task page test setup to pass the existing `SystemActionTrackerClock` into the service constructor so page tests and the service share the same clock (modified `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs`).
- No DI registration change required because `IActionTrackerClock` is already registered (`Program.cs` registers `SystemActionTrackerClock`).

### Testing
- Updated unit tests under `ProjectManagement.Tests/ActionTasks` to use `TestActionTrackerClock` for deterministic date scenarios; tests were modified but not executed here.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ActionTaskServiceTests` but the `dotnet` CLI is not available in this environment, so automated tests could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08446aae248329a3048e47b566086c)