### PR TITLE
Add task closure workflow helper copy

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -10,6 +10,12 @@
     var selectedTaskIsBacklog = Model.SelectedTask is not null && Model.IsBacklogTask(Model.SelectedTask);
     var selectedTaskStatus = Model.SelectedTask?.Status ?? string.Empty;
     var selectedTaskIsClosed = string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    var selectedTaskIsSubmitted = string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+    var selectedTaskClosureHelper = Model.SelectedTask is not null && !selectedTaskIsBacklog && !selectedTaskIsClosed
+        ? selectedTaskIsSubmitted
+            ? "Submitted for closure. Review and close, or return for rework."
+            : "To close this task, the assignee must first submit it for closure."
+        : null;
     var selectedTaskDateLabel = selectedTaskIsBacklog ? "Target" : "Due";
     var minimumChangeDate = Model.UtcToday;
     var changeDateInputValue = Model.SelectedTask is not null && Model.SelectedTask.DueDate.Date >= minimumChangeDate
@@ -378,6 +384,12 @@
                     }
                 </div>
 
+                @* SECTION: Closure workflow helper clarifies two-stage completion without blocking actions. *@
+                @if (!string.IsNullOrWhiteSpace(selectedTaskClosureHelper))
+                {
+                    <div class="text-muted at-small mb-2">@selectedTaskClosureHelper</div>
+                }
+
                 @* SECTION: Primary action rail exposes the next useful action for the task state and tucks other actions away. *@
                 <div class="at-action-toolbar" aria-label="Task actions">
                     @if (selectedTaskIsBacklog)
@@ -393,7 +405,7 @@
                         <button type="button" class="btn btn-primary btn-sm" data-at-open-action="add-outside-to-sprint">Add to Sprint</button>
                         <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="update">Add Update</button>
                     }
-                    else if (string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+                    else if (selectedTaskIsSubmitted)
                     {
                         @if (Model.CanCloseTask(Model.SelectedTask))
                         {


### PR DESCRIPTION
### Motivation
- Clarify the two-stage closure workflow in the Task Details drawer so users understand that assignees must submit tasks before they can be closed. 
- Provide a brief, non-blocking hint for both the not-yet-submitted and submitted states to reduce reviewer confusion. 

### Description
- Added a `selectedTaskIsSubmitted` helper and `selectedTaskClosureHelper` message logic to `Pages/ActionTasks/_TaskDetails.cshtml` to choose the appropriate copy for the current task state. 
- Rendered the helper as small muted text (`class="text-muted at-small mb-2"`) directly above the action toolbar so it is informational and non-blocking. 
- Reused the `selectedTaskIsSubmitted` boolean in the existing toolbar branch to replace the inline string comparison, without changing authorization checks or form behavior for `Submit`/`Close`. 
- Only `Pages/ActionTasks/_TaskDetails.cshtml` was modified. 

### Testing
- Ran `git diff --check` which reported no whitespace issues. 
- Attempted `dotnet test ProjectManagement.sln --no-restore` but it could not run because the `dotnet` SDK is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08453e0080832996bb37db8f9a5ff0)