### PR TITLE
Polish Direct Task assignee placeholder wording

### DIFF
--- a/Pages/ActionTasks/_TaskCreatePanel.cshtml
+++ b/Pages/ActionTasks/_TaskCreatePanel.cshtml
@@ -84,8 +84,8 @@
                                 </div>
                                 <div class="col-12">
                                     <label asp-for="DirectTaskInput.AssignedToUserId" class="form-label"></label>
-                                    <select asp-for="DirectTaskInput.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="[Select user]" required>
-                                        <option value="">[Select user]</option>
+                                    <select asp-for="DirectTaskInput.AssignedToUserId" class="form-select at-searchable-select" data-at-searchable-select="true" data-at-placeholder="Select user" required>
+                                        <option value="">Select user</option>
                                         @foreach (var user in Model.AssignableUsers)
                                         {
                                             <option value="@user.UserId">@user.DisplayName</option>

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -7,6 +7,37 @@ const path = require('node:path');
 const scriptPath = path.resolve(__dirname, 'index.js');
 const scriptContent = fs.readFileSync(scriptPath, 'utf8');
 
+
+// SECTION: Searchable select fixture.
+function createSearchableSelectDom() {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+        <select data-at-searchable-select="true" data-at-placeholder="Select user">
+            <option value="">Select user</option>
+            <option value="user-1">User One</option>
+        </select>
+    </body></html>`, { url: 'https://example.test/ActionTasks', runScripts: 'dangerously' });
+
+    const { window } = dom;
+    const document = window.document;
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+    document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+
+    return { document };
+}
+
+// SECTION: Searchable select placeholder behavior.
+test('searchable select uses the configured Direct Task assignee placeholder', () => {
+    const { document } = createSearchableSelectDom();
+    const searchInput = document.querySelector('.at-select-search-input');
+    const placeholderOption = document.querySelector('select option[value=""]');
+
+    assert.ok(searchInput);
+    assert.equal(searchInput.placeholder, 'Select user');
+    assert.equal(placeholderOption.textContent, 'Select user');
+});
+
 function createReportsFilterDom() {
     const dom = new JSDOM(`<!DOCTYPE html><html><body>
         <form method="get" data-at-reports-filter-form="true">


### PR DESCRIPTION
### Motivation
- Remove bracketed placeholder text to match the app's standard UI phrasing and avoid literal brackets appearing in the rendered placeholder. 
- Ensure the lightweight searchable-select enhancement reads and displays the configured placeholder consistently for the Direct Task assignee picker.

### Description
- Replace `data-at-placeholder="[Select user]"` with `data-at-placeholder="Select user"` in `Pages/ActionTasks/_TaskCreatePanel.cshtml` and update the empty option text from `[Select user]` to `Select user`.
- Add a unit test fixture and assertion in `wwwroot/js/pages/action-tasks/index.test.js` to verify the searchable-select enhancement sets the search input placeholder and preserves the empty option text as `Select user`.
- No runtime JS changes were required because the existing `initSearchableSelects` already reads the `data-at-placeholder` attribute.

### Testing
- Ran `npm test` which executed the JS unit suite and the new searchable-select test, and all tests passed (`17/17` passing).
- Ran `npm run lint:views` which reported pre-existing inline style violations in unrelated files and did not pass, unrelated to this change.
- Verified `git diff --check` showed no whitespace or merge issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0845d23e648329b99b25c1f6bbfa99)