### PR TITLE
Close action More menus with inspector panels

### DIFF
--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -452,6 +452,13 @@
             panels.forEach((panel) => panel.removeAttribute("open"));
         };
 
+        // SECTION: More menu cleanup keeps overlapping action controls mutually exclusive.
+        const closeAllMoreMenus = () => {
+            shell.querySelectorAll(".at-action-more-menu[open]").forEach((menu) => {
+                menu.removeAttribute("open");
+            });
+        };
+
         // SECTION: Intent-specific status actions can seed the status panel selection.
         const applyStatusActionTarget = (name, targetStatus) => {
             if (name !== "status" || !targetStatus) {
@@ -468,6 +475,7 @@
         };
 
         const openPanel = (name, targetStatus) => {
+            closeAllMoreMenus();
             closeAllPanels();
             const panel = shell.querySelector(`[data-at-action-panel='${name}']`);
             if (!panel) {
@@ -500,12 +508,14 @@
                 return;
             }
             const hasOpenPanel = panels.some((panel) => panel.hasAttribute("open"));
-            if (!hasOpenPanel) {
+            const hasOpenMoreMenu = Boolean(shell.querySelector(".at-action-more-menu[open]"));
+            if (!hasOpenPanel && !hasOpenMoreMenu) {
                 return;
             }
             event.preventDefault();
             event.stopPropagation();
             closeAllPanels();
+            closeAllMoreMenus();
         });
     }
 

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -126,6 +126,10 @@ function createInspectorActionDom(currentStatus = 'Open') {
             </details>
             <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="mark-progress">Mark In Progress</button>
             <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="return-rework">Return for Rework</button>
+            <details class="at-action-more-menu" data-test-menu>
+                <summary>More</summary>
+                <button type="button">Other action</button>
+            </details>
         </div>
     </body></html>`, { url: 'https://example.test/ActionTasks?TaskId=1', runScripts: 'dangerously' });
 
@@ -139,6 +143,28 @@ function createInspectorActionDom(currentStatus = 'Open') {
 
     return { window, document };
 }
+
+
+// SECTION: Inspector action panel and More menu exclusivity.
+test('inspector actions close More menus when panels open or Escape is pressed', () => {
+    const { window, document } = createInspectorActionDom();
+    const shell = document.querySelector('[data-at-action-shell]');
+    const panel = document.querySelector('[data-at-action-panel="status"]');
+    const moreMenu = document.querySelector('[data-test-menu]');
+    const openButton = document.querySelector('[data-test-action="mark-progress"]');
+
+    moreMenu.setAttribute('open', 'open');
+    openButton.dispatchEvent(new window.Event('click', { bubbles: true }));
+
+    assert.equal(panel.hasAttribute('open'), true);
+    assert.equal(moreMenu.hasAttribute('open'), false);
+
+    moreMenu.setAttribute('open', 'open');
+    shell.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    assert.equal(panel.hasAttribute('open'), false);
+    assert.equal(moreMenu.hasAttribute('open'), false);
+});
 
 // SECTION: Status intent action behavior.
 test('intent-specific status actions preselect In Progress and refresh save guard', () => {


### PR DESCRIPTION
### Motivation
- Prevent overlapping interactive controls by ensuring open inspector panels and More menus are mutually exclusive in the action inspector UI.
- Keep behavior in the existing external JS file for CSP compliance and offline deployment requirements.

### Description
- Added a helper `closeAllMoreMenus()` that queries `shell.querySelectorAll(".at-action-more-menu[open]")` and removes the `open` attribute from each matching menu in `initInspectorActionPanels()`.
- Call `closeAllMoreMenus()` at the start of `openPanel(name, targetStatus)` before `closeAllPanels()` so opening a panel closes any open More menus.
- Updated the Escape key handler to check both `panels.some((panel) => panel.hasAttribute("open"))` and `shell.querySelector(".at-action-more-menu[open]")`, returning only when neither is open, and to call both `closeAllPanels()` and `closeAllMoreMenus()` when handling Escape.
- Added a unit test to `wwwroot/js/pages/action-tasks/index.test.js` that exercises More-menu/panel exclusivity and Escape behavior.

### Testing
- Ran `npm test` and all tests passed (`18/18` passing).
- Attempted `dotnet test ProjectManagement.sln` but the environment lacks the `dotnet` CLI, so that run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085630af108329ae2b850fc3c8df5f)