### PR TITLE
Improve Task Details More menu sizing, layering, and label wrapping

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -3949,16 +3949,18 @@ html {
 .at-action-more-list {
     position: absolute;
     right: 0;
-    bottom: calc(100% + 0.35rem);
-    z-index: 20;
+    bottom: calc(100% + 0.45rem);
+    z-index: 50;
     display: grid;
     gap: 0.25rem;
-    min-width: 13.5rem;
+    width: max-content;
+    min-width: 17rem;
+    max-width: min(24rem, calc(100vw - 2rem));
     padding: 0.35rem 0;
     background: var(--at-surface);
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
-    box-shadow: var(--at-shadow-sm);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
 }
 
 .at-action-more-group {
@@ -3988,8 +3990,10 @@ html {
     width: 100%;
     padding: 0.2rem 0.75rem;
     color: var(--at-text);
+    line-height: 1.25;
     text-align: left;
     text-decoration: none;
+    white-space: normal;
 }
 
 .at-action-more-list .btn-link:hover,


### PR DESCRIPTION
### Motivation
- Ensure the Task Details More popover displays above drawer/action panels and provides enough horizontal space for long action labels. 
- Prevent text truncation for long labels like "Remove from Sprint, Keep Assigned" and "Move to Backlog, Remove Assignee" by allowing wrapping and a tighter, readable line-height. 
- Keep the existing grid/group spacing and absolute positioning so menu behavior remains consistent in small viewports and inside the drawer.

### Description
- Updated `.at-action-more-list` in `wwwroot/css/action-tracker.css` to keep `position: absolute` and set `bottom: calc(100% + 0.45rem)` and `z-index: 50` for proper offset and layering. 
- Added sizing constraints on the popover: `width: max-content`, `min-width: 17rem`, and `max-width: min(24rem, calc(100vw - 2rem))` while preserving the grid layout and group spacing. 
- Replaced the light shadow with a stronger production shadow `box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16)` for better contrast over the drawer. 
- Adjusted `.at-action-more-list .btn-link` to allow wrapping with `white-space: normal` and `line-height: 1.25` while keeping full-width, left-aligned button styling.

### Testing
- Ran a `python3` verification script that asserts the updated CSS properties are present and that the long action labels exist in `Pages/ActionTasks/_TaskDetails.cshtml`, and it passed. 
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore` but the `dotnet` CLI was not available in the environment so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0857406dd48329ab3fd7880a951787)