### PR TITLE
Adjust planning board drawer sizing and reserved offsets

### DIFF
--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -2756,7 +2756,7 @@ html {
     right: 1rem;
     bottom: 1rem;
     z-index: 1040;
-    width: min(28rem, calc(100vw - 2rem));
+    width: min(34rem, calc(100vw - 2rem));
     box-shadow: 0 24px 70px rgba(15, 23, 42, 0.2);
 }
 
@@ -2948,7 +2948,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-view-toggle {
-    padding-right: min(29rem, calc(100vw - 1rem));
+    padding-right: min(35rem, calc(100vw - 1rem));
 }
 
 .at-planning-views-panel .at-planning-due-exceptions-grid,
@@ -3047,7 +3047,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-kanban-scroll {
-    padding-right: min(29rem, calc(100vw - 1rem));
+    padding-right: min(35rem, calc(100vw - 1rem));
 }
 
 .at-sprint-task-card .at-task-card-link {
@@ -3217,7 +3217,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-kanban-view {
-    max-width: min(100%, calc(100vw - 88px - 31rem));
+    max-width: min(100%, calc(100vw - 88px - 37rem));
 }
 
 .at-shell.is-planning-board.has-selection .at-kanban-scroll {


### PR DESCRIPTION
### Motivation
- Widen the selected planning-board drawer to provide more space for details panels and avoid truncating information when a selection is open.
- Ensure adjacent planning-board layout rules reserve matching right-side space so board content is not hidden by the wider drawer.

### Description
- Update ` .at-shell.is-planning-board.has-selection .at-drawer-host` `width` from `min(28rem, calc(100vw - 2rem))` to `min(34rem, calc(100vw - 2rem))` in `wwwroot/css/action-tracker.css`.
- Update ` .at-shell.is-planning-board.has-selection .at-planning-view-toggle` and ` .at-shell.is-planning-board.has-selection .at-kanban-scroll` `padding-right` from `min(29rem, calc(100vw - 1rem))` to `min(35rem, calc(100vw - 1rem))` to reserve the wider drawer plus gutter.
- Update ` .at-shell.is-planning-board.has-selection .at-planning-kanban-view` `max-width` calculation from `calc(100vw - 88px - 31rem)` to `calc(100vw - 88px - 37rem)` to keep consistent reserved space in later rules.
- All changes are confined to `wwwroot/css/action-tracker.css` and adjust only sizing/math values so no behavioral changes outside layout are introduced.

### Testing
- Ran `git diff --check` which completed successfully and reported no whitespace or diff issues.
- Attempted to run `dotnet test` but the `dotnet` CLI is not available in the environment, so unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0857f525608329bd4f3ee455cd001e)