### PR TITLE
Separate destructive 'Move to Backlog' action into Danger Zone group

### DIFF
--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -29,9 +29,11 @@
     var canOpenCloseAction = Model.SelectedTask is not null && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask);
     var canOpenChangeDateAction = Model.SelectedTask is not null && Model.CanChangeTaskDate(Model.SelectedTask);
     var canMoveTaskToBacklogAction = Model.SelectedTask is not null && Model.CanMoveTaskToBacklog(Model.SelectedTask);
+    var canRemoveFromSprintKeepAssignedAction = canMoveTaskToBacklogAction && Model.SelectedTask?.SprintId.HasValue == true;
     var hasWorkflowActions = !selectedTaskIsClosed && (canOpenStatusAction || canOpenSubmitAction || canOpenCloseAction);
-    var hasPlanningActions = !selectedTaskIsClosed && (canOpenChangeDateAction || canMoveTaskToBacklogAction);
-    var hasMoreActions = hasWorkflowActions || hasPlanningActions;
+    var hasPlanningActions = !selectedTaskIsClosed && (canOpenChangeDateAction || canRemoveFromSprintKeepAssignedAction);
+    var hasDangerActions = !selectedTaskIsClosed && canMoveTaskToBacklogAction;
+    var hasMoreActions = hasWorkflowActions || hasPlanningActions || hasDangerActions;
 }
 
 @* SECTION: Right-side task inspector drawer content. *@
@@ -459,7 +461,7 @@
                                     </div>
                                 }
 
-                                @* SECTION: Planning action group keeps schedule and sprint-placement actions together. *@
+                                @* SECTION: Planning action group keeps schedule and non-destructive sprint-placement actions together. *@
                                 @if (hasPlanningActions)
                                 {
                                     <div class="at-action-more-group" role="group" aria-label="Planning Actions">
@@ -468,40 +470,45 @@
                                         {
                                             <button type="button" class="btn btn-link btn-sm" data-at-open-action="change-date">Change @selectedTaskDateLabel Date</button>
                                         }
-                                        @if (canMoveTaskToBacklogAction)
+                                        @if (canRemoveFromSprintKeepAssignedAction)
                                         {
-                                            @if (Model.SelectedTask.SprintId.HasValue)
-                                            {
-                                                <form method="post" asp-page-handler="RemoveFromSprintKeepAssigned" class="at-card-action-form">
-                                                    <input type="hidden" name="ViewMode" value="Planning" />
-                                                    <input type="hidden" name="PlanningTab" value="Execute" />
-                                                    <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                                                    <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
-                                                    <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
-                                                    <button type="submit"
-                                                            class="btn btn-link btn-sm"
-                                                            data-at-confirm="true"
-                                                            data-at-confirm-title="Remove task from Sprint?"
-                                                            data-at-confirm-body="This will keep the assignee but remove the task from the selected sprint."
-                                                            data-at-confirm-cancel-label="Cancel"
-                                                            data-at-confirm-accept-label="Remove from Sprint">Remove from Sprint, Keep Assigned</button>
-                                                </form>
-                                            }
-                                            <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
+                                            <form method="post" asp-page-handler="RemoveFromSprintKeepAssigned" class="at-card-action-form">
                                                 <input type="hidden" name="ViewMode" value="Planning" />
-                                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                                                <input type="hidden" name="PlanningTab" value="Execute" />
                                                 <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
                                                 <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
                                                 <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
                                                 <button type="submit"
-                                                        class="btn btn-link btn-sm at-action-more-destructive"
+                                                        class="btn btn-link btn-sm"
                                                         data-at-confirm="true"
-                                                        data-at-confirm-title="Return task to Backlog?"
-                                                        data-at-confirm-body="This will remove the assignee and return the task to Backlog."
+                                                        data-at-confirm-title="Remove task from Sprint?"
+                                                        data-at-confirm-body="This will keep the assignee but remove the task from the selected sprint."
                                                         data-at-confirm-cancel-label="Cancel"
-                                                        data-at-confirm-accept-label="Return to Backlog">Move to Backlog, Remove Assignee</button>
+                                                        data-at-confirm-accept-label="Remove from Sprint">Remove from Sprint, Keep Assigned</button>
                                             </form>
                                         }
+                                    </div>
+                                }
+
+                                @* SECTION: Danger Zone separates destructive planning actions from routine planning controls. *@
+                                @if (hasDangerActions)
+                                {
+                                    <div class="at-action-more-group" role="group" aria-label="Danger Zone">
+                                        <div class="at-action-more-heading">Danger Zone</div>
+                                        <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
+                                            <input type="hidden" name="ViewMode" value="Planning" />
+                                            <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                            <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                                            <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                            <button type="submit"
+                                                    class="btn btn-link btn-sm at-action-more-destructive"
+                                                    data-at-confirm="true"
+                                                    data-at-confirm-title="Return task to Backlog?"
+                                                    data-at-confirm-body="This will remove the assignee and return the task to Backlog."
+                                                    data-at-confirm-cancel-label="Cancel"
+                                                    data-at-confirm-accept-label="Return to Backlog">Move to Backlog, Remove Assignee</button>
+                                        </form>
                                     </div>
                                 }
                             </div>


### PR DESCRIPTION
### Motivation
- Improve UX and safety by grouping destructive backlog-moving actions separately from routine planning actions in the More menu.
- Keep routine planning controls visually grouped and accessible while making destructive actions more explicit and discoverable.

### Description
- Added `canRemoveFromSprintKeepAssignedAction`, `hasDangerActions`, and updated `hasPlanningActions`/`hasMoreActions` flags to separate non-destructive and destructive planning actions in `Pages/ActionTasks/_TaskDetails.cshtml`.
- Kept `Change @selectedTaskDateLabel Date` and the `Remove from Sprint, Keep Assigned` form/button inside the existing `Planning Actions` `.at-action-more-group` and adjusted the `RemoveFromSprintKeepAssigned` form to be non-destructive.
- Moved the `MoveToBacklogRemoveAssignee` form/button into a new `.at-action-more-group` with `role="group" aria-label="Danger Zone"` and a visible heading `Danger Zone` while preserving the `data-at-confirm="true"` confirmation attributes and the `at-action-more-destructive` class on the destructive button.
- Updated inline section comments and kept markup and hidden inputs intact to preserve existing behavior and routing context.

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity which passed.
- Attempted to run `dotnet test ProjectManagement.sln` but the `dotnet` CLI is not available in the environment so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0859ec6dd08329bfbe78904f2ab560)