### PR TITLE
Action Tracker: IST timestamps, business-day clock, service clock usage, inline More Actions, and drawer CSS

### DIFF
--- a/Infrastructure/TimeFmt.cs
+++ b/Infrastructure/TimeFmt.cs
@@ -6,6 +6,6 @@ namespace ProjectManagement.Infrastructure
     public static class TimeFmt
     {
         public static string ToIst(DateTime? dt) =>
-            dt is null ? "—" : IstClock.ToIst(dt.Value).ToString("dd MMM yyyy, HH:mm", CultureInfo.InvariantCulture);
+            dt is null ? "—" : IstClock.ToIst(dt.Value).ToString("dd MMM yyyy, HH:mm", CultureInfo.InvariantCulture) + " IST";
     }
 }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -52,13 +52,13 @@ public class IndexModel : PageModel
         _userLookup = userLookup;
         _clock = clock;
         _users = users;
-        DirectTaskInput.DueDate = _clock.UtcToday.AddDays(7);
-        BacklogItemInput.TargetDate = _clock.UtcToday.AddDays(7);
-        SprintInput = CreateSprintInput.FromSprint(_clock.UtcToday);
+        DirectTaskInput.DueDate = _clock.IstToday.AddDays(7);
+        BacklogItemInput.TargetDate = _clock.IstToday.AddDays(7);
+        SprintInput = CreateSprintInput.FromSprint(_clock.IstToday);
     }
 
     // SECTION: Clock-backed view dates keep Razor defaults aligned with server-side validation.
-    public DateTime UtcToday => _clock.UtcToday;
+    public DateTime IstToday => _clock.IstToday;
 
     public IReadOnlyList<ActionTaskItem> Tasks { get; private set; } = Array.Empty<ActionTaskItem>();
     public IReadOnlyList<ActionTaskItem> CriticalOpenTasks { get; private set; } = Array.Empty<ActionTaskItem>();
@@ -534,7 +534,7 @@ public class IndexModel : PageModel
             ModelState.AddModelError(nameof(DirectTaskInput.AssignedToUserId), "Select an assignee for a direct task.");
         }
 
-        if (DirectTaskInput.DueDate.Date < _clock.UtcToday)
+        if (DirectTaskInput.DueDate.Date < _clock.IstToday)
         {
             ModelState.AddModelError(nameof(DirectTaskInput.DueDate), "Due date cannot be in the past.");
         }
@@ -547,7 +547,7 @@ public class IndexModel : PageModel
         ModelState.Clear();
         TryValidateModel(BacklogItemInput, nameof(BacklogItemInput));
 
-        if (BacklogItemInput.TargetDate.Date < _clock.UtcToday)
+        if (BacklogItemInput.TargetDate.Date < _clock.IstToday)
         {
             ModelState.AddModelError(nameof(BacklogItemInput.TargetDate), "Target date cannot be in the past.");
         }
@@ -561,7 +561,7 @@ public class IndexModel : PageModel
         ModelState.Clear();
         TryValidateModel(ChangeDateInput, nameof(ChangeDateInput));
 
-        if (ChangeDateInput.NewDate.Date < _clock.UtcToday)
+        if (ChangeDateInput.NewDate.Date < _clock.IstToday)
         {
             ModelState.AddModelError(nameof(ChangeDateInput.NewDate), "Task date cannot be in the past.");
         }
@@ -1739,7 +1739,7 @@ public class IndexModel : PageModel
         IsOpenTask(task)
         && !string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
         && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
-        && task.DueDate.Date < _clock.UtcToday;
+        && task.DueDate.Date < _clock.IstToday;
 
     // SECTION: Shared open-task predicate keeps personal and command projections aligned.
     private static bool IsOpenTask(ActionTaskItem task) =>

--- a/Pages/ActionTasks/_PlanningCloseTab.cshtml
+++ b/Pages/ActionTasks/_PlanningCloseTab.cshtml
@@ -36,7 +36,7 @@
                         {
                             <li>
                                 <div><strong>@entry.ActionType.Replace("Sprint", string.Empty)</strong> by @Model.ResolveSprintActorName(entry.PerformedByUserId)</div>
-                                <small>@entry.PerformedAt.ToString("dd MMM yyyy HH:mm") UTC</small>
+                                <small>@TimeFmt.ToIst(entry.PerformedAt)</small>
                                 @if (!string.IsNullOrWhiteSpace(entry.Remarks))
                                 {
                                     <p>@entry.Remarks</p>

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -17,7 +17,7 @@
             : "To close this task, the assignee must first submit it for closure."
         : null;
     var selectedTaskDateLabel = selectedTaskIsBacklog ? "Target" : "Due";
-    var minimumChangeDate = Model.UtcToday;
+    var minimumChangeDate = Model.IstToday;
     var changeDateInputValue = Model.SelectedTask is not null && Model.SelectedTask.DueDate.Date >= minimumChangeDate
         ? Model.SelectedTask.DueDate.Date
         : minimumChangeDate;
@@ -57,7 +57,7 @@
                         <span class="@Model.GetSprintBadgeClass(Model.SelectedTask)">@Model.GetSprintBadgeText(Model.SelectedTask)</span>
                     </div>
                     <div class="at-inspector-snapshot">
-                        <span>Last update: @((Model.SelectedTaskUpdates.FirstOrDefault()?.CreatedAtUtc ?? Model.SelectedTask.AssignedOn).ToString("dd MMM yyyy, HH:mm"))</span>
+                        <span>Last update: @TimeFmt.ToIst(Model.SelectedTaskUpdates.FirstOrDefault()?.CreatedAtUtc ?? Model.SelectedTask.AssignedOn)</span>
                         <span>@Model.SelectedTaskUpdates.Count() updates</span>
                         <span>@Model.UpdateAttachments.Sum(entry => entry.Value.Count) attachments</span>
                     </div>
@@ -87,7 +87,7 @@
                                 <article class="at-activity-update-card">
                                     <div class="d-flex justify-content-between gap-2 flex-wrap">
                                         <div><strong>@Model.ResolveActorName(update.CreatedByUserId)</strong></div>
-                                        <div class="text-muted small">@update.CreatedAtUtc.ToString("dd MMM yyyy, HH:mm")</div>
+                                        <div class="text-muted small">@TimeFmt.ToIst(update.CreatedAtUtc)</div>
                                     </div>
                                     <div class="at-audit-remarks at-remarks-text">@update.Body</div>
                                     @if (Model.UpdateAttachments.TryGetValue(update.Id, out var files) && files.Count > 0)
@@ -140,7 +140,7 @@
                                             <strong>@log.ActionType</strong>
                                             <span class="text-muted">by @Model.ResolveActorName(log.PerformedByUserId)</span>
                                         </div>
-                                        <div class="text-muted small">@log.PerformedAt.ToString("dd MMM yyyy, HH:mm")</div>
+                                        <div class="text-muted small">@TimeFmt.ToIst(log.PerformedAt)</div>
                                     </div>
                                     @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
                                     {
@@ -160,9 +160,9 @@
                     <summary>Task Details</summary>
                     <div class="at-task-details-grid mt-2">
                         <div class="at-grid-span-2"><span class="text-muted">Description</span><div class="fw-semibold at-description-text">@Model.SelectedTask.Description</div></div>
-                        <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@Model.SelectedTask.AssignedOn.ToString("dd MMM yyyy, HH:mm")</div></div>
-                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@(Model.SelectedTask.SubmittedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
-                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@(Model.SelectedTask.ClosedOn?.ToString("dd MMM yyyy, HH:mm") ?? "—")</div></div>
+                        <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.AssignedOn)</div></div>
+                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.SubmittedOn)</div></div>
+                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.ClosedOn)</div></div>
                         <div><span class="text-muted">Work category</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
                     </div>
                 </details>
@@ -438,9 +438,10 @@
 
                     @if (hasMoreActions)
                     {
-                        <details class="at-action-more-menu">
-                            <summary class="btn btn-outline-secondary btn-sm">More</summary>
-                            <div class="at-action-more-list">
+                        @* SECTION: Inline More Actions panel avoids clipped drawer popovers while grouping secondary actions. *@
+                        <section class="at-more-actions-panel" aria-label="More Actions">
+                            <div class="at-more-actions-title">More Actions</div>
+                            <div class="at-more-actions-grid">
                                 @* SECTION: Workflow action group keeps status and closure transitions together. *@
                                 @if (hasWorkflowActions)
                                 {
@@ -493,7 +494,7 @@
                                 @* SECTION: Danger Zone separates destructive planning actions from routine planning controls. *@
                                 @if (hasDangerActions)
                                 {
-                                    <div class="at-action-more-group" role="group" aria-label="Danger Zone">
+                                    <div class="at-action-more-group at-action-danger-group" role="group" aria-label="Danger Zone">
                                         <div class="at-action-more-heading">Danger Zone</div>
                                         <form method="post" asp-page-handler="MoveToBacklogRemoveAssignee" class="at-card-action-form">
                                             <input type="hidden" name="ViewMode" value="Planning" />
@@ -512,7 +513,7 @@
                                     </div>
                                 }
                             </div>
-                        </details>
+                        </section>
                     }
                 </div>
             </footer>

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Identity
 @using ProjectManagement
 @using ProjectManagement.Data
+@using ProjectManagement.Infrastructure
 @using ProjectManagement.Models.Analytics
 @namespace ProjectManagement.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionSprintServiceTests.cs
@@ -716,9 +716,26 @@ public class ActionSprintServiceTests
         Assert.All(history, x => Assert.Equal(sprint.Id, x.SprintId));
     }
 
+
+    [Fact]
+    public async Task CreateSprintAsync_UsesClockUtcNowForTimestampsAndAudit()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+
+        // SECTION: Act
+        var sprint = await service.CreateSprintAsync(NewSprint(), "planner", RoleNames.Comdt);
+
+        // SECTION: Assert
+        var audit = await db.ActionSprintAuditLogs.SingleAsync(x => x.SprintId == sprint.Id);
+        Assert.Equal(TestActionTrackerClock.FixedUtcNow, sprint.CreatedAtUtc);
+        Assert.Equal(TestActionTrackerClock.FixedUtcNow, audit.PerformedAt);
+    }
+
     // SECTION: Test helpers
     private static ActionSprintService CreateService(ApplicationDbContext db)
-        => new(db, new ActionTaskPermissionService(), new ActionSprintWorkflowPolicy());
+        => new(db, new ActionTaskPermissionService(), new ActionSprintWorkflowPolicy(), new TestActionTrackerClock());
 
     private static ApplicationDbContext CreateDb()
         => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
@@ -786,4 +803,14 @@ public class ActionSprintServiceTests
         await db.SaveChangesAsync();
         return task;
     }
+    private sealed class TestActionTrackerClock : IActionTrackerClock
+    {
+        public static readonly DateTime FixedUtcNow = new(2030, 1, 15, 6, 30, 0);
+
+        public DateTime UtcNow => FixedUtcNow;
+        public DateTime UtcToday => UtcNow.Date;
+        public DateTime IstNow => FixedUtcNow.AddHours(5.5);
+        public DateTime IstToday => IstNow.Date;
+    }
+
 }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
@@ -50,8 +50,24 @@ public class ActionTaskCollaborationServiceTests
             service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Progress, "other", RoleNames.Ta, Array.Empty<IFormFile>()));
     }
 
+
+    [Fact]
+    public async Task AddUpdateAsync_UsesClockUtcNowForUpdateTimestamp()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, "owner");
+
+        // SECTION: Act
+        var update = await service.AddUpdateAsync(task.Id, "body", ActionTaskUpdateTypes.Progress, "owner", RoleNames.Ta, Array.Empty<IFormFile>());
+
+        // SECTION: Assert
+        Assert.Equal(TestActionTrackerClock.FixedUtcNow, update.CreatedAtUtc);
+    }
+
     private static ActionTaskCollaborationService CreateService(ApplicationDbContext db)
-        => new(db, new ActionTaskPermissionService(), new TestUploadRootProvider(), new PassFileSecurityValidator(), new StubUrlBuilder());
+        => new(db, new ActionTaskPermissionService(), new TestUploadRootProvider(), new PassFileSecurityValidator(), new StubUrlBuilder(), new TestActionTrackerClock());
 
     private static ApplicationDbContext CreateDb()
     {
@@ -85,6 +101,17 @@ public class ActionTaskCollaborationServiceTests
     {
         var stream = new MemoryStream(new byte[bytes]);
         return new FormFile(stream, 0, bytes, "files", name) { Headers = new HeaderDictionary(), ContentType = contentType };
+    }
+
+
+    private sealed class TestActionTrackerClock : IActionTrackerClock
+    {
+        public static readonly DateTime FixedUtcNow = new(2030, 1, 15, 6, 30, 0);
+
+        public DateTime UtcNow => FixedUtcNow;
+        public DateTime UtcToday => UtcNow.Date;
+        public DateTime IstNow => FixedUtcNow.AddHours(5.5);
+        public DateTime IstToday => IstNow.Date;
     }
 
     private sealed class TestUploadRootProvider : IUploadRootProvider

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCompositionBuilderTests.cs
@@ -116,11 +116,15 @@ public class ActionTaskCompositionBuilderTests
     {
         public FixedActionTrackerClock(DateTime today)
         {
-            UtcToday = today.Date;
-            UtcNow = UtcToday.AddHours(12);
+            IstToday = today.Date;
+            IstNow = IstToday.AddHours(12);
+            UtcNow = IstNow.AddHours(-5.5);
+            UtcToday = UtcNow.Date;
         }
 
         public DateTime UtcNow { get; }
         public DateTime UtcToday { get; }
+        public DateTime IstNow { get; }
+        public DateTime IstToday { get; }
     }
 }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1811,7 +1811,7 @@ public class ActionTaskPageTests
         var queryService = new ActionTaskQueryService(clock, new ActionTaskReportBuilder(clock));
         var workflowPolicy = new ActionTaskWorkflowPolicy(permission);
         var sprintWorkflowPolicy = new ActionSprintWorkflowPolicy();
-        var sprintService = new ActionSprintService(db, permission, sprintWorkflowPolicy);
+        var sprintService = new ActionSprintService(db, permission, sprintWorkflowPolicy, clock);
         var workspaceBuilder = new ActionTaskWorkspaceBuilder(service, sprintService, queryService);
         var userLookup = new ActionTaskUserLookupService(userManager, permission, clock);
         var page = new IndexModel(service, collab, permission, sprintService, workspaceBuilder, workflowPolicy, new ActionTaskRouteStateHelper(), new ActionTaskMyWorkQueueBuilder(clock), new ActionTaskCommandCentreSummaryBuilder(clock), new ActionTaskSprintWorkspaceSummaryBuilder(clock), new ActionTaskSprintBoardStateBuilder(sprintService, userLookup, clock), new ActionTaskInspectorReadModelBuilder(service, collab, queryService, userLookup), userLookup, clock, userManager);

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskProductionReadinessTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskProductionReadinessTests.cs
@@ -1,0 +1,85 @@
+using ProjectManagement.Infrastructure;
+
+namespace ProjectManagement.Tests.ActionTasks;
+
+public class ActionTaskProductionReadinessTests
+{
+    [Fact]
+    public void TimeFmtToIst_DisplaysUtcTimestampInIndianStandardTime()
+    {
+        // SECTION: Assert production timestamp rendering uses IST with a stable invariant format.
+        var utc = new DateTime(2026, 4, 28, 2, 8, 0, DateTimeKind.Utc);
+
+        var formatted = TimeFmt.ToIst(utc);
+
+        Assert.Equal("28 Apr 2026, 07:38 IST", formatted);
+    }
+
+    [Fact]
+    public void TaskDetailsPartial_UsesIstTimestampsButKeepsDueDateDateOnly()
+    {
+        // SECTION: Assert Action Tracker inspector does not render audit timestamps as raw UTC strings.
+        var html = ReadRepoFile("Pages", "ActionTasks", "_TaskDetails.cshtml");
+
+        Assert.Contains("TimeFmt.ToIst", html, StringComparison.Ordinal);
+        Assert.Contains("SelectedTask.DueDate.ToString(\"dd MMM yyyy\")", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("ToString(\"dd MMM yyyy, HH:mm\")", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TaskDetailsPartial_RendersInlineMoreActionsWithoutFloatingDropdownMarkup()
+    {
+        // SECTION: Assert secondary actions are a stable inline panel grouped by workflow, planning, and danger actions.
+        var html = ReadRepoFile("Pages", "ActionTasks", "_TaskDetails.cshtml");
+
+        Assert.Contains("at-more-actions-panel", html, StringComparison.Ordinal);
+        Assert.Contains("Workflow Actions", html, StringComparison.Ordinal);
+        Assert.Contains("Planning Actions", html, StringComparison.Ordinal);
+        Assert.Contains("Danger Zone", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("at-action-more-menu", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<summary class=\"btn btn-outline-secondary btn-sm\">More</summary>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExecuteBoardCss_UsesSharedDrawerWidthReservation()
+    {
+        // SECTION: Assert Sprint Board Execute containers reserve the fixed inspector width while selected.
+        var css = ReadRepoFile("wwwroot", "css", "action-tracker.css");
+
+        Assert.Contains("--at-planning-drawer-width: 34rem;", css, StringComparison.Ordinal);
+        Assert.Contains(".at-shell.is-planning-board.has-selection .at-planning-execute-panel", css, StringComparison.Ordinal);
+        Assert.Contains(".at-shell.is-planning-board.has-selection .at-execute-status-board", css, StringComparison.Ordinal);
+        Assert.Contains(".at-shell.is-planning-board.has-selection .at-execute-status-grid", css, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TaskDetailsPartial_HidesMutationMoreActionsForClosedTasks()
+    {
+        // SECTION: Assert closed tasks remain view-only by gating date/status/planning mutation groups.
+        var html = ReadRepoFile("Pages", "ActionTasks", "_TaskDetails.cshtml");
+
+        Assert.Contains("var hasWorkflowActions = !selectedTaskIsClosed", html, StringComparison.Ordinal);
+        Assert.Contains("var hasPlanningActions = !selectedTaskIsClosed", html, StringComparison.Ordinal);
+        Assert.Contains("var hasDangerActions = !selectedTaskIsClosed", html, StringComparison.Ordinal);
+        Assert.Contains("View only", html, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] relativePathParts)
+    {
+        // SECTION: Source assertions locate files from either repository-root or test-output working directories.
+        var relativePath = Path.Combine(relativePathParts);
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate repository file {relativePath}.", relativePath);
+    }
+}

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -373,9 +373,52 @@ public class ActionTaskServiceTests
     }
 
 
+    [Fact]
+    public async Task CreateTaskAsync_UsesClockUtcNowForAssignedTimestampAndAudit()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var clock = new MidnightIstActionTrackerClock();
+        var service = CreateService(db, clock);
+
+        // SECTION: Act
+        var task = await service.CreateTaskAsync(new ActionTaskItem
+        {
+            Title = "Clocked task",
+            Description = "Desc",
+            AssignedToUserId = "assignee",
+            CreatedByUserId = "creator",
+            CreatedByRole = RoleNames.HoD,
+            AssignedToRole = RoleNames.Ta,
+            DueDate = clock.IstToday.AddDays(1),
+            Priority = "High"
+        });
+
+        // SECTION: Assert
+        var audit = await db.ActionTaskAuditLogs.SingleAsync(x => x.TaskId == task.Id);
+        Assert.Equal(clock.UtcNow, task.AssignedOn);
+        Assert.Equal(clock.UtcNow, audit.PerformedAt);
+    }
+
+    [Fact]
+    public async Task UpdateTaskDateAsync_RejectsDatesBeforeIstTodayRatherThanUtcToday()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var clock = new MidnightIstActionTrackerClock();
+        var service = CreateService(db, clock);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateTaskDateAsync(task.Id, task.RowVersion, clock.UtcToday, "planner", RoleNames.Comdt));
+        Assert.Contains("past", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
     // SECTION: Test service helpers
-    private static ActionTaskService CreateService(ApplicationDbContext db)
-        => new(db, new ActionTaskPermissionService(), new TestActionTrackerClock());
+    private static ActionTaskService CreateService(ApplicationDbContext db, IActionTrackerClock? clock = null)
+        => new(db, new ActionTaskPermissionService(), clock ?? new TestActionTrackerClock());
 
     private static ApplicationDbContext CreateDb()
         => CreateDb(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot());
@@ -410,12 +453,24 @@ public class ActionTaskServiceTests
         return task;
     }
 
+    private sealed class MidnightIstActionTrackerClock : IActionTrackerClock
+    {
+        public DateTime UtcNow => new(2026, 4, 27, 19, 0, 0);
+        public DateTime UtcToday => UtcNow.Date;
+        public DateTime IstNow => new(2026, 4, 28, 0, 30, 0);
+        public DateTime IstToday => IstNow.Date;
+    }
+
     private sealed class TestActionTrackerClock : IActionTrackerClock
     {
         public static readonly DateTime FixedToday = new(2030, 1, 15);
 
         public DateTime UtcNow => FixedToday.AddHours(12);
 
-        public DateTime UtcToday => FixedToday;
+        public DateTime UtcToday => UtcNow.Date;
+
+        public DateTime IstNow => FixedToday.AddHours(12);
+
+        public DateTime IstToday => FixedToday;
     }
 }

--- a/Services/ActionTasks/ActionSprintService.cs
+++ b/Services/ActionTasks/ActionSprintService.cs
@@ -17,15 +17,18 @@ public class ActionSprintService
     private readonly ApplicationDbContext _context;
     private readonly ActionTaskPermissionService _permission;
     private readonly ActionSprintWorkflowPolicy _workflow;
+    private readonly IActionTrackerClock _clock;
 
     public ActionSprintService(
         ApplicationDbContext context,
         ActionTaskPermissionService permission,
-        ActionSprintWorkflowPolicy workflow)
+        ActionSprintWorkflowPolicy workflow,
+        IActionTrackerClock clock)
     {
         _context = context;
         _permission = permission;
         _workflow = workflow;
+        _clock = clock;
     }
 
 
@@ -62,7 +65,7 @@ public class ActionSprintService
         EnsureCanCreateSprint(role);
         _workflow.ValidateDateRange(sprint.StartDate, sprint.EndDate);
 
-        var performedAt = DateTime.UtcNow;
+        var performedAt = _clock.UtcNow;
         sprint.Status = ActionSprintStatus.Planned;
         sprint.RowVersion = NewSprintRowVersion();
         sprint.CreatedByUserId = userId;
@@ -90,7 +93,7 @@ public class ActionSprintService
         _workflow.EnsureCanUpdate(sprint);
         ApplySprintRowVersion(sprint, rowVersion);
 
-        var performedAt = DateTime.UtcNow;
+        var performedAt = _clock.UtcNow;
         var oldValue = DescribeSprint(sprint);
 
         sprint.Name = name;
@@ -125,7 +128,7 @@ public class ActionSprintService
             throw new InvalidOperationException("Only one active sprint is allowed.");
         }
 
-        var performedAt = DateTime.UtcNow;
+        var performedAt = _clock.UtcNow;
         var oldStatus = sprint.Status.ToString();
 
         sprint.Status = ActionSprintStatus.Active;
@@ -156,7 +159,7 @@ public class ActionSprintService
             throw new InvalidOperationException("Sprint contains unfinished tasks. Use the closure review to carry forward, remove from sprint while keeping assignee, or move unfinished tasks to backlog before closing.");
         }
 
-        var performedAt = DateTime.UtcNow;
+        var performedAt = _clock.UtcNow;
         var oldStatus = sprint.Status.ToString();
 
         sprint.Status = ActionSprintStatus.Closed;
@@ -239,7 +242,7 @@ public class ActionSprintService
             throw new InvalidOperationException("Tasks with invalid sprint assignment must be returned to backlog or corrected before sprint closure.");
         }
 
-        var performedAt = DateTime.UtcNow;
+        var performedAt = _clock.UtcNow;
         foreach (var task in unfinishedTasks.Where(t => carryIds.Contains(t.Id)))
         {
             var oldValue = DescribeTaskBucket(task);
@@ -306,7 +309,7 @@ public class ActionSprintService
         var oldValue = DescribeTaskBucket(task);
         task.AssignedToUserId = responsibleUserId;
         task.AssignedToRole = responsibleRole;
-        task.AssignedOn = DateTime.UtcNow;
+        task.AssignedOn = _clock.UtcNow;
         task.SprintId = sprint.Id;
         task.Status = ActionTaskStatuses.Assigned;
         task.SubmittedOn = null;
@@ -517,7 +520,7 @@ public class ActionSprintService
             ActionType = actionType,
             PerformedByUserId = userId,
             PerformedByRole = role,
-            PerformedAt = performedAt ?? DateTime.UtcNow,
+            PerformedAt = performedAt ?? _clock.UtcNow,
             OldValue = oldValue,
             NewValue = newValue,
             Remarks = TrimAuditRemarks(remarks)

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -35,14 +35,16 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
     private readonly IUploadRootProvider _uploadRootProvider;
     private readonly IFileSecurityValidator _fileSecurityValidator;
     private readonly IProtectedFileUrlBuilder _urlBuilder;
+    private readonly IActionTrackerClock _clock;
 
-    public ActionTaskCollaborationService(ApplicationDbContext context, ActionTaskPermissionService permission, IUploadRootProvider uploadRootProvider, IFileSecurityValidator fileSecurityValidator, IProtectedFileUrlBuilder urlBuilder)
+    public ActionTaskCollaborationService(ApplicationDbContext context, ActionTaskPermissionService permission, IUploadRootProvider uploadRootProvider, IFileSecurityValidator fileSecurityValidator, IProtectedFileUrlBuilder urlBuilder, IActionTrackerClock clock)
     {
         _context = context;
         _permission = permission;
         _uploadRootProvider = uploadRootProvider;
         _fileSecurityValidator = fileSecurityValidator;
         _urlBuilder = urlBuilder;
+        _clock = clock;
     }
 
     // SECTION: Add update with optional attachments
@@ -91,7 +93,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             {
                 TaskId = taskId,
                 CreatedByUserId = userId,
-                CreatedAtUtc = DateTime.UtcNow,
+                CreatedAtUtc = _clock.UtcNow,
                 UpdateType = ActionTaskUpdateTypes.All.First(x => string.Equals(x, updateType, StringComparison.OrdinalIgnoreCase)),
                 Body = hasBody ? body.Trim() : "Attachment update",
                 IsDeleted = false
@@ -172,7 +174,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         }
 
         var sanitizedFileName = Path.GetFileName(file.FileName);
-        var storageKey = BuildStorageKey(taskId, sanitizedFileName);
+        var storageKey = BuildStorageKey(taskId, sanitizedFileName, _clock.UtcNow);
         var absolutePath = ResolveAbsolutePath(storageKey);
         var tempFile = Path.GetTempFileName();
 
@@ -202,7 +204,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             TaskId = taskId,
             UpdateId = updateId,
             UploadedByUserId = userId,
-            UploadedAtUtc = DateTime.UtcNow,
+            UploadedAtUtc = _clock.UtcNow,
             OriginalFileName = sanitizedFileName,
             StorageKey = storageKey,
             ContentType = file.ContentType,
@@ -255,9 +257,9 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             attachment.UploadedByUserId);
     }
 
-    private static string BuildStorageKey(int taskId, string fileName)
+    private static string BuildStorageKey(int taskId, string fileName, DateTime utcNow)
     {
-        var token = $"{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}-{fileName}";
+        var token = $"{utcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}-{fileName}";
         return Path.Combine("action-tasks", taskId.ToString(CultureInfo.InvariantCulture), token).Replace('\\', '/');
     }
 

--- a/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskCommandCentreSummaryBuilder.cs
@@ -71,7 +71,7 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
     // SECTION: Report top-attention prioritization keeps urgent overdue and critical work first.
     private IReadOnlyList<ActionTaskItem> BuildTopAttentionItems(IReadOnlyList<ActionTaskItem> tasks)
     {
-        var today = _clock.UtcToday;
+        var today = _clock.IstToday;
         return tasks
             .Where(IsOpenTask)
             .Select(t => new
@@ -117,7 +117,7 @@ public sealed class ActionTaskCommandCentreSummaryBuilder
            && ActionTaskCategorization.HasAssignedUser(task)
            && !ActionTaskCategorization.IsBacklogTask(task)
            && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
-           && task.DueDate.Date < _clock.UtcToday;
+           && task.DueDate.Date < _clock.IstToday;
 
     private static int CountByStatus(IReadOnlyList<ActionTaskItem> tasks, string status)
         => tasks.Count(t => string.Equals(t.Status, status, StringComparison.OrdinalIgnoreCase));

--- a/Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs
+++ b/Services/ActionTasks/ActionTaskMyWorkQueueBuilder.cs
@@ -63,7 +63,7 @@ public sealed class ActionTaskMyWorkQueueBuilder
 
     private IReadOnlyList<ActionTaskItem> BuildDueTodayTasks(IReadOnlyList<ActionTaskItem> tasks)
         => tasks
-            .Where(t => IsOpenTask(t) && t.DueDate.Date == _clock.UtcToday)
+            .Where(t => IsOpenTask(t) && t.DueDate.Date == _clock.IstToday)
             .OrderBy(t => StatusOrder(t.Status))
             .ThenBy(t => t.DueDate)
             .ThenBy(t => t.Id)
@@ -136,8 +136,8 @@ public sealed class ActionTaskMyWorkQueueBuilder
     }
 
     // SECTION: Shared My Work predicates keep queue grouping aligned with open-task lifecycle rules.
-    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date < _clock.UtcToday;
-    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date == _clock.UtcToday;
+    private bool IsTaskOverdue(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date < _clock.IstToday;
+    private bool IsTaskDueToday(ActionTaskItem task) => IsOpenTask(task) && !IsTaskSubmitted(task) && task.DueDate.Date == _clock.IstToday;
     private static bool IsTaskBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
     private static bool IsTaskInProgress(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase);
     private static bool IsTaskSubmitted(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -42,7 +42,7 @@ public sealed class ActionTaskQueryService
             SprintReadModel = sprintReadModel,
             ActiveSprintMetrics = activeSprintMetrics,
             CriticalOpenTasks = tasks.Where(t => IsCriticalOpen(t)).OrderBy(t => t.DueDate).Take(5).ToList(),
-            OverdueTasks = tasks.Where(t => IsOperationallyOverdue(t, _clock.UtcToday)).OrderBy(t => t.DueDate).Take(5).ToList(),
+            OverdueTasks = tasks.Where(t => IsOperationallyOverdue(t, _clock.IstToday)).OrderBy(t => t.DueDate).Take(5).ToList(),
             RecentlySubmittedTasks = tasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && t.SubmittedOn.HasValue).OrderByDescending(t => t.SubmittedOn ?? DateTime.MinValue).Take(5).ToList(),
             RecentlyUpdatedTasks = tasks.Where(t => ResolveLastActivityUtc(t, activityByTaskId).HasValue).OrderByDescending(t => ResolveLastActivityUtc(t, activityByTaskId) ?? DateTime.MinValue).ThenByDescending(t => t.Id).Take(5).ToList(),
             DueBuckets = BuildDueBuckets(tasks),
@@ -194,7 +194,7 @@ public sealed class ActionTaskQueryService
         var activeSprintTasks = activeSprint is null
             ? new List<ActionTaskItem>()
             : tasks.Where(t => t.SprintId == activeSprint.Id).ToList();
-        var today = _clock.UtcToday;
+        var today = _clock.IstToday;
 
         return new ActiveSprintOperationalMetrics
         {
@@ -213,7 +213,7 @@ public sealed class ActionTaskQueryService
 
     private ActionTaskDueBuckets BuildDueBuckets(IReadOnlyList<ActionTaskItem> tasks)
     {
-        var today = _clock.UtcToday;
+        var today = _clock.IstToday;
         var endOfWeek = today.AddDays(7);
         return new ActionTaskDueBuckets
         {

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -17,11 +17,11 @@ public sealed class ActionTaskReportBuilder
     // SECTION: Filter-aware report projection for management analysis without changing workflow rules.
     public ActionTaskQueryService.ActionTaskReportReadModel BuildReportModel(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryService.ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
     {
-        var utcToday = _clock.UtcToday;
+        var istToday = _clock.IstToday;
         var reportTasks = ApplyReportFilters(tasks, request).ToList();
         var openTasks = reportTasks.Where(IsOpen).ToList();
         var assignedOpenTasks = openTasks.Where(IsAssignedReportWork).ToList();
-        var overdueAssignedTasks = assignedOpenTasks.Where(t => IsAssignedTaskOverdue(t, utcToday)).ToList();
+        var overdueAssignedTasks = assignedOpenTasks.Where(t => IsAssignedTaskOverdue(t, istToday)).ToList();
         var submittedTasks = assignedOpenTasks.Where(IsSubmitted).ToList();
         var backlogTasks = reportTasks.Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.Backlog).ToList();
         var blockedTasks = assignedOpenTasks.Where(t => string.Equals(t.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -33,20 +33,20 @@ public sealed class ActionTaskReportBuilder
             WorkloadSummary = BuildWorkloadSummary(openTasks, overdueAssignedTasks, blockedTasks, submittedTasks, backlogTasks),
             BucketDistribution = BuildBucketDistribution(reportTasks),
             ResponsiblePersonWorkloads = BuildResponsiblePersonWorkloads(assignedOpenTasks, overdueAssignedTasks, assigneeNames),
-            BacklogAgeingBuckets = BuildBacklogAgeingBuckets(backlogTasks.Where(IsOpen).ToList(), utcToday),
-            AssignedTaskAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, utcToday),
-            OverdueAgeingBuckets = BuildOverdueAgeingBuckets(overdueAssignedTasks, utcToday),
-            SubmittedPendingClosureAgeingBuckets = BuildSubmittedPendingClosureAgeingBuckets(submittedTasks, utcToday),
-            SprintPerformanceRows = BuildSprintPerformanceRows(reportTasks, request.Sprints, utcToday),
+            BacklogAgeingBuckets = BuildBacklogAgeingBuckets(backlogTasks.Where(IsOpen).ToList(), istToday),
+            AssignedTaskAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, istToday),
+            OverdueAgeingBuckets = BuildOverdueAgeingBuckets(overdueAssignedTasks, istToday),
+            SubmittedPendingClosureAgeingBuckets = BuildSubmittedPendingClosureAgeingBuckets(submittedTasks, istToday),
+            SprintPerformanceRows = BuildSprintPerformanceRows(reportTasks, request.Sprints, istToday),
             InvalidStateRows = BuildInvalidStateRows(reportTasks),
 
             // SECTION: Legacy report summaries remain populated for existing consumers while the Reports UI uses the management model above.
             AssigneePendingCounts = BuildAssigneePendingCounts(assignedOpenTasks, assigneeNames),
             PriorityCounts = openTasks.GroupBy(t => t.Priority).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count())).ToList(),
             StatusCounts = reportTasks.GroupBy(t => t.Status).OrderByDescending(g => g.Count()).ThenBy(g => g.Key).Select(g => new ActionTaskQueryService.CountSummary(g.Key, g.Count())).ToList(),
-            OpenAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, utcToday),
+            OpenAgeingBuckets = BuildAssignedTaskAgeingBuckets(assignedOpenTasks, istToday),
             OutsideSprintWorkloadCounts = BuildOutsideSprintWorkloadCounts(assignedOpenTasks.Where(t => ActionTaskCategorization.ResolveBucket(t) == ActionTaskBucket.OutsideSprint).ToList(), assigneeNames),
-            BlockedAgeingBuckets = BuildAssignedTaskAgeingBuckets(blockedTasks, utcToday),
+            BlockedAgeingBuckets = BuildAssignedTaskAgeingBuckets(blockedTasks, istToday),
             CarryForwardBySprint = BuildCarryForwardBySprint(openTasks, request.Sprints)
         };
     }
@@ -151,45 +151,45 @@ public sealed class ActionTaskReportBuilder
     }
 
     // SECTION: Backlog ageing is planning-inventory ageing; AssignedOn is a temporary backlog-entry proxy until a CreatedOnUtc or EnteredBacklogOnUtc field exists.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBacklogAgeingBuckets(IReadOnlyList<ActionTaskItem> backlogTasks, DateTime utcToday)
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBacklogAgeingBuckets(IReadOnlyList<ActionTaskItem> backlogTasks, DateTime istToday)
         => new[]
         {
-            new ActionTaskQueryService.CountSummary("0-3 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 0 and <= 3)),
-            new ActionTaskQueryService.CountSummary("4-7 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 4 and <= 7)),
-            new ActionTaskQueryService.CountSummary("8-14 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 8 and <= 14)),
-            new ActionTaskQueryService.CountSummary("15+ days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, utcToday) >= 15))
+            new ActionTaskQueryService.CountSummary("0-3 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 0 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8-14 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 8 and <= 14)),
+            new ActionTaskQueryService.CountSummary("15+ days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, istToday) >= 15))
         };
 
     // SECTION: Assigned task ageing applies only to Outside Sprint and Sprint work, never backlog or closed tasks.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedTaskAgeingBuckets(IReadOnlyList<ActionTaskItem> assignedTasks, DateTime utcToday)
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedTaskAgeingBuckets(IReadOnlyList<ActionTaskItem> assignedTasks, DateTime istToday)
         => new[]
         {
-            new ActionTaskQueryService.CountSummary("0-3 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 0 and <= 3)),
-            new ActionTaskQueryService.CountSummary("4-7 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 4 and <= 7)),
-            new ActionTaskQueryService.CountSummary("8-14 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) is >= 8 and <= 14)),
-            new ActionTaskQueryService.CountSummary("15+ days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, utcToday) >= 15))
+            new ActionTaskQueryService.CountSummary("0-3 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 0 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8-14 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 8 and <= 14)),
+            new ActionTaskQueryService.CountSummary("15+ days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, istToday) >= 15))
         };
 
     // SECTION: Overdue analysis applies only to assigned work and excludes submitted pending-closure tasks.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildOverdueAgeingBuckets(IReadOnlyList<ActionTaskItem> overdueTasks, DateTime utcToday)
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildOverdueAgeingBuckets(IReadOnlyList<ActionTaskItem> overdueTasks, DateTime istToday)
         => new[]
         {
-            new ActionTaskQueryService.CountSummary("1-3 days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) is >= 1 and <= 3)),
-            new ActionTaskQueryService.CountSummary("4-7 days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) is >= 4 and <= 7)),
-            new ActionTaskQueryService.CountSummary("8+ days overdue", overdueTasks.Count(t => DaysOverdue(t, utcToday) >= 8))
+            new ActionTaskQueryService.CountSummary("1-3 days overdue", overdueTasks.Count(t => DaysOverdue(t, istToday) is >= 1 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4-7 days overdue", overdueTasks.Count(t => DaysOverdue(t, istToday) is >= 4 and <= 7)),
+            new ActionTaskQueryService.CountSummary("8+ days overdue", overdueTasks.Count(t => DaysOverdue(t, istToday) >= 8))
         };
 
     // SECTION: Pending closure ageing is separated from assignee overdue exposure.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildSubmittedPendingClosureAgeingBuckets(IReadOnlyList<ActionTaskItem> submittedTasks, DateTime utcToday)
+    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildSubmittedPendingClosureAgeingBuckets(IReadOnlyList<ActionTaskItem> submittedTasks, DateTime istToday)
         => new[]
         {
-            new ActionTaskQueryService.CountSummary("0-1 day pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) is >= 0 and <= 1)),
-            new ActionTaskQueryService.CountSummary("2-3 days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) is >= 2 and <= 3)),
-            new ActionTaskQueryService.CountSummary("4+ days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, utcToday) >= 4))
+            new ActionTaskQueryService.CountSummary("0-1 day pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, istToday) is >= 0 and <= 1)),
+            new ActionTaskQueryService.CountSummary("2-3 days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, istToday) is >= 2 and <= 3)),
+            new ActionTaskQueryService.CountSummary("4+ days pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, istToday) >= 4))
         };
 
     // SECTION: Sprint performance is compact trend-style summary, not a Sprint Board duplicate.
-    private static IReadOnlyList<ActionTaskQueryService.SprintPerformanceSummary> BuildSprintPerformanceRows(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, DateTime utcToday)
+    private static IReadOnlyList<ActionTaskQueryService.SprintPerformanceSummary> BuildSprintPerformanceRows(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, DateTime istToday)
     {
         var sprintTasks = tasks.Where(t => t.SprintId.HasValue).ToLookup(t => t.SprintId!.Value);
         return sprints
@@ -207,7 +207,7 @@ public sealed class ActionTaskReportBuilder
                     Status = s.Status.ToString(),
                     Open = assignedOpen.Count,
                     Closed = scopedTasks.Count(t => string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)),
-                    OverdueNow = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => IsAssignedTaskOverdue(t, utcToday)),
+                    OverdueNow = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count(t => IsAssignedTaskOverdue(t, istToday)),
                     Unfinished = s.Status == ActionSprintStatus.Closed ? 0 : assignedOpen.Count,
                     ClosedLate = s.Status == ActionSprintStatus.Closed ? scopedTasks.Count(IsClosedLate) : 0
                 };
@@ -262,10 +262,10 @@ public sealed class ActionTaskReportBuilder
         return bucket is (ActionTaskBucket.OutsideSprint or ActionTaskBucket.Sprint) && IsOpen(task);
     }
 
-    private static bool IsAssignedTaskOverdue(ActionTaskItem task, DateTime utcToday)
+    private static bool IsAssignedTaskOverdue(ActionTaskItem task, DateTime istToday)
         => IsAssignedReportWork(task)
            && !IsSubmitted(task)
-           && task.DueDate.Date < utcToday
+           && task.DueDate.Date < istToday
            && ActionTaskCategorization.HasAssignedUser(task);
 
     private static bool IsSubmitted(ActionTaskItem task)
@@ -278,9 +278,9 @@ public sealed class ActionTaskReportBuilder
 
     private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
 
-    private static int DaysSince(DateTime date, DateTime utcToday) => (int)(utcToday - date.Date).TotalDays;
+    private static int DaysSince(DateTime date, DateTime istToday) => (int)(istToday - date.Date).TotalDays;
 
-    private static int DaysOverdue(ActionTaskItem task, DateTime utcToday) => (int)(utcToday - task.DueDate.Date).TotalDays;
+    private static int DaysOverdue(ActionTaskItem task, DateTime istToday) => (int)(istToday - task.DueDate.Date).TotalDays;
 
     private static string BuildInvalidIssue(ActionTaskItem task)
     {

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -119,7 +119,7 @@ public class ActionTaskService : IActionTaskService
         }
 
         // SECTION: State Mutation
-        task.AssignedOn = DateTime.UtcNow;
+        task.AssignedOn = _clock.UtcNow;
         task.Status = ActionTaskStatuses.Assigned;
         task.SprintId = null;
         task.SubmittedOn = null;
@@ -147,7 +147,7 @@ public class ActionTaskService : IActionTaskService
     public async Task<ActionTaskItem> CreateBacklogItemAsync(ActionTaskItem task, CancellationToken cancellationToken = default)
     {
         // SECTION: Backlog creation enforces backlog items state rather than generic assigned-task defaults.
-        task.AssignedOn = DateTime.UtcNow;
+        task.AssignedOn = _clock.UtcNow;
         task.Status = ActionTaskStatuses.Backlog;
         task.SprintId = null;
         task.AssignedToUserId = string.Empty;
@@ -228,11 +228,11 @@ public class ActionTaskService : IActionTaskService
         task.Status = status;
         if (string.Equals(status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
         {
-            task.SubmittedOn = DateTime.UtcNow;
+            task.SubmittedOn = _clock.UtcNow;
         }
         if (string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
         {
-            task.ClosedOn = DateTime.UtcNow;
+            task.ClosedOn = _clock.UtcNow;
         }
         ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
 
@@ -293,7 +293,7 @@ public class ActionTaskService : IActionTaskService
         // SECTION: State Mutation
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Submitted;
-        task.SubmittedOn = DateTime.UtcNow;
+        task.SubmittedOn = _clock.UtcNow;
         ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
 
         // SECTION: Audit Enqueue
@@ -336,7 +336,7 @@ public class ActionTaskService : IActionTaskService
         // SECTION: State Mutation
         var oldStatus = task.Status;
         task.Status = ActionTaskStatuses.Closed;
-        task.ClosedOn = DateTime.UtcNow;
+        task.ClosedOn = _clock.UtcNow;
         ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
 
         // SECTION: Audit Enqueue
@@ -369,7 +369,7 @@ public class ActionTaskService : IActionTaskService
         }
 
         var normalizedNewDate = newDate.Date;
-        if (normalizedNewDate < _clock.UtcToday)
+        if (normalizedNewDate < _clock.IstToday)
         {
             throw new InvalidOperationException("Task date cannot be in the past.");
         }
@@ -405,7 +405,7 @@ public class ActionTaskService : IActionTaskService
     }
 
     // SECTION: Audit logging
-    private static ActionTaskAuditLog Log(int taskId, string action, string userId, string role, string? oldValue, string? newValue, string? remarks)
+    private ActionTaskAuditLog Log(int taskId, string action, string userId, string role, string? oldValue, string? newValue, string? remarks)
     {
         return new ActionTaskAuditLog
         {
@@ -413,14 +413,14 @@ public class ActionTaskService : IActionTaskService
             ActionType = action,
             PerformedByUserId = userId,
             PerformedByRole = role,
-            PerformedAt = DateTime.UtcNow,
+            PerformedAt = _clock.UtcNow,
             OldValue = oldValue,
             NewValue = newValue,
             Remarks = remarks
         };
     }
 
-    private static ActionTaskAuditLog Log(string action, string userId, string role, string? oldValue, string? newValue, string? remarks, ActionTaskItem task)
+    private ActionTaskAuditLog Log(string action, string userId, string role, string? oldValue, string? newValue, string? remarks, ActionTaskItem task)
     {
         return new ActionTaskAuditLog
         {
@@ -428,7 +428,7 @@ public class ActionTaskService : IActionTaskService
             ActionType = action,
             PerformedByUserId = userId,
             PerformedByRole = role,
-            PerformedAt = DateTime.UtcNow,
+            PerformedAt = _clock.UtcNow,
             OldValue = oldValue,
             NewValue = newValue,
             Remarks = remarks

--- a/Services/ActionTasks/ActionTaskSprintBoardStateBuilder.cs
+++ b/Services/ActionTasks/ActionTaskSprintBoardStateBuilder.cs
@@ -27,7 +27,7 @@ public sealed class ActionTaskSprintBoardStateBuilder
             : await _userLookup.LoadSprintActorNamesAsync(auditHistory);
 
         return new ActionTaskSprintBoardState(
-            request.ShowCreateSprintPanel ? null : CreateSprintDefaults.FromDate(_clock.UtcToday),
+            request.ShowCreateSprintPanel ? null : CreateSprintDefaults.FromDate(_clock.IstToday),
             request.SelectedSprint is not null && !request.ShowEditSprintPanel ? UpdateSprintDefaults.FromSprint(request.SelectedSprint) : null,
             request.SelectedSprint is not null && !request.ShowCreateNextSprintPanel ? CreateNextSprintDefaults.FromSourceSprint(request.SelectedSprint) : null,
             auditHistory,

--- a/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
+++ b/Services/ActionTasks/ActionTaskSprintWorkspaceSummaryBuilder.cs
@@ -43,11 +43,11 @@ public sealed class ActionTaskSprintWorkspaceSummaryBuilder
            && !IsSubmitted(task)
            && ActionTaskCategorization.HasAssignedUser(task)
            && ActionTaskBucketClassifier.ResolveBucket(task) != ActionTaskBucket.Invalid
-           && task.DueDate.Date < _clock.UtcToday;
+           && task.DueDate.Date < _clock.IstToday;
 
     private bool IsBacklogPastTarget(ActionTaskItem task)
         => ActionTaskCategorization.IsBacklogTask(task)
-           && task.DueDate.Date < _clock.UtcToday;
+           && task.DueDate.Date < _clock.IstToday;
 
     private static bool IsHighPriorityBacklogTask(ActionTaskItem task) => string.Equals(task.Priority, "High", StringComparison.OrdinalIgnoreCase) || string.Equals(task.Priority, "Critical", StringComparison.OrdinalIgnoreCase);
     private static bool IsBlocked(ActionTaskItem task) => string.Equals(task.Status, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);

--- a/Services/ActionTasks/IActionTrackerClock.cs
+++ b/Services/ActionTasks/IActionTrackerClock.cs
@@ -1,4 +1,5 @@
 using System;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.Services.ActionTasks;
 
@@ -7,13 +8,23 @@ public interface IActionTrackerClock
     // SECTION: UtcNow provides timestamp access for Action Tracker date and lockout decisions.
     DateTime UtcNow { get; }
 
-    // SECTION: UtcToday keeps date-only Action Tracker calculations consistent across builders and pages.
+    // SECTION: UtcToday preserves legacy UTC calendar access for persisted-time diagnostics.
     DateTime UtcToday { get; }
+
+    // SECTION: IstNow converts the canonical UTC instant into the Action Tracker business timezone.
+    DateTime IstNow { get; }
+
+    // SECTION: IstToday drives date-only business rules on the Indian calendar date.
+    DateTime IstToday { get; }
 }
 
 public sealed class SystemActionTrackerClock : IActionTrackerClock
 {
     public DateTime UtcNow => DateTime.UtcNow;
 
-    public DateTime UtcToday => DateTime.UtcNow.Date;
+    public DateTime UtcToday => UtcNow.Date;
+
+    public DateTime IstNow => IstClock.ToIst(UtcNow);
+
+    public DateTime IstToday => IstNow.Date;
 }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -22,6 +22,7 @@
     --at-weight-medium: 500;
     --at-weight-semibold: 600;
     --at-weight-bold: 700;
+    --at-planning-drawer-width: 34rem;
 }
 
 /* SECTION: Action Tracker shell */
@@ -2756,7 +2757,7 @@ html {
     right: 1rem;
     bottom: 1rem;
     z-index: 1040;
-    width: min(34rem, calc(100vw - 2rem));
+    width: min(var(--at-planning-drawer-width), calc(100vw - 2rem));
     box-shadow: 0 24px 70px rgba(15, 23, 42, 0.2);
 }
 
@@ -2948,7 +2949,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-planning-view-toggle {
-    padding-right: min(35rem, calc(100vw - 1rem));
+    padding-right: min(calc(var(--at-planning-drawer-width) + 1rem), calc(100vw - 1rem));
 }
 
 .at-planning-views-panel .at-planning-due-exceptions-grid,
@@ -3000,6 +3001,34 @@ html {
     }
 }
 
+
+/* SECTION: Drawer-open Execute board reservation keeps status columns clear of the fixed inspector. */
+.at-shell.is-planning-board.has-selection .at-planning-execute-panel,
+.at-shell.is-planning-board.has-selection .at-execute-status-board {
+    max-width: calc(100vw - 88px - var(--at-planning-drawer-width) - 3.5rem);
+    min-width: 0;
+}
+
+.at-shell.is-planning-board.has-selection .at-execute-status-grid {
+    width: 100%;
+    min-width: 0;
+}
+
+@media (max-width: 1200px) {
+    .at-shell.is-planning-board.has-selection .at-planning-execute-panel,
+    .at-shell.is-planning-board.has-selection .at-execute-status-board {
+        max-width: 100%;
+        padding-right: min(calc(var(--at-planning-drawer-width) + 1rem), calc(100vw - 1rem));
+    }
+}
+
+@media (max-width: 767px) {
+    .at-shell.is-planning-board.has-selection .at-planning-execute-panel,
+    .at-shell.is-planning-board.has-selection .at-execute-status-board {
+        padding-right: 0;
+    }
+}
+
 /* SECTION: Phase 3A-3 exclusive Planning views and card-density refinement. */
 .at-planning-due-exceptions-view,
 .at-planning-kanban-view {
@@ -3047,7 +3076,7 @@ html {
 }
 
 .at-shell.is-planning-board.has-selection .at-kanban-scroll {
-    padding-right: min(35rem, calc(100vw - 1rem));
+    padding-right: min(calc(var(--at-planning-drawer-width) + 1rem), calc(100vw - 1rem));
 }
 
 .at-sprint-task-card .at-task-card-link {
@@ -3941,43 +3970,48 @@ html {
     }
 }
 
-/* SECTION: Task Details More menu popover and group refinement. */
-.at-action-more-menu {
-    position: relative;
-}
-
-.at-action-more-list {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 0.45rem);
-    z-index: 50;
+/* SECTION: Task Details inline More Actions panel and group refinement. */
+.at-more-actions-panel {
     display: grid;
-    gap: 0.25rem;
-    width: max-content;
-    min-width: 17rem;
-    max-width: min(24rem, calc(100vw - 2rem));
-    padding: 0.35rem 0;
-    background: var(--at-surface);
+    gap: 0.45rem;
+    margin-top: 0.65rem;
     border: 1px solid var(--at-border);
     border-radius: var(--at-radius-md);
-    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+    background: var(--at-surface-soft);
+    padding: 0.65rem;
+}
+
+.at-more-actions-title {
+    color: var(--at-text);
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-bold);
+}
+
+.at-more-actions-grid {
+    display: grid;
+    gap: 0.45rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
 }
 
 .at-action-more-group {
     display: grid;
-    gap: 0.1rem;
-    padding: 0.1rem 0;
+    align-content: start;
+    gap: 0.15rem;
+    min-width: 0;
+    border: 1px solid var(--at-border);
+    border-radius: 10px;
+    background: var(--at-surface);
+    padding: 0.45rem;
 }
 
-.at-action-more-group + .at-action-more-group {
-    border-top: 1px solid var(--at-border);
-    margin-top: 0.25rem;
-    padding-top: 0.35rem;
+.at-action-danger-group {
+    border-color: #fecaca;
+    background: #fffafa;
 }
 
 .at-action-more-heading,
 .at-action-more-separator {
-    padding: 0.15rem 0.75rem 0.05rem;
+    padding: 0 0.2rem 0.15rem;
     color: var(--at-muted);
     font-size: var(--at-font-xs);
     font-weight: var(--at-weight-bold);
@@ -3986,9 +4020,9 @@ html {
     letter-spacing: 0.04em;
 }
 
-.at-action-more-list .btn-link {
+.at-more-actions-panel .btn-link {
     width: 100%;
-    padding: 0.2rem 0.75rem;
+    padding: 0.25rem 0.2rem;
     color: var(--at-text);
     line-height: 1.25;
     text-align: left;
@@ -3996,23 +4030,23 @@ html {
     white-space: normal;
 }
 
-.at-action-more-list .btn-link:hover,
-.at-action-more-list .btn-link:focus {
+.at-more-actions-panel .btn-link:hover,
+.at-more-actions-panel .btn-link:focus {
     background: #f8fafc;
     color: var(--at-text);
     text-decoration: none;
 }
 
-.at-action-more-list .at-card-action-form {
+.at-more-actions-panel .at-card-action-form {
     margin: 0;
 }
 
-.at-action-more-list .at-action-more-destructive {
+.at-more-actions-panel .at-action-more-destructive {
     color: #b91c1c;
 }
 
-.at-action-more-list .at-action-more-destructive:hover,
-.at-action-more-list .at-action-more-destructive:focus {
+.at-more-actions-panel .at-action-more-destructive:hover,
+.at-more-actions-panel .at-action-more-destructive:focus {
     background: #fef2f2;
     color: #991b1b;
 }

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -452,13 +452,6 @@
             panels.forEach((panel) => panel.removeAttribute("open"));
         };
 
-        // SECTION: More menu cleanup keeps overlapping action controls mutually exclusive.
-        const closeAllMoreMenus = () => {
-            shell.querySelectorAll(".at-action-more-menu[open]").forEach((menu) => {
-                menu.removeAttribute("open");
-            });
-        };
-
         // SECTION: Intent-specific status actions can seed the status panel selection.
         const applyStatusActionTarget = (name, targetStatus) => {
             if (name !== "status" || !targetStatus) {
@@ -475,7 +468,6 @@
         };
 
         const openPanel = (name, targetStatus) => {
-            closeAllMoreMenus();
             closeAllPanels();
             const panel = shell.querySelector(`[data-at-action-panel='${name}']`);
             if (!panel) {
@@ -508,14 +500,12 @@
                 return;
             }
             const hasOpenPanel = panels.some((panel) => panel.hasAttribute("open"));
-            const hasOpenMoreMenu = Boolean(shell.querySelector(".at-action-more-menu[open]"));
-            if (!hasOpenPanel && !hasOpenMoreMenu) {
+            if (!hasOpenPanel) {
                 return;
             }
             event.preventDefault();
             event.stopPropagation();
             closeAllPanels();
-            closeAllMoreMenus();
         });
     }
 

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -126,10 +126,9 @@ function createInspectorActionDom(currentStatus = 'Open') {
             </details>
             <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="mark-progress">Mark In Progress</button>
             <button type="button" data-at-open-action="status" data-at-target-status="In Progress" data-test-action="return-rework">Return for Rework</button>
-            <details class="at-action-more-menu" data-test-menu>
-                <summary>More</summary>
+            <section class="at-more-actions-panel" data-test-more-panel>
                 <button type="button">Other action</button>
-            </details>
+            </section>
         </div>
     </body></html>`, { url: 'https://example.test/ActionTasks?TaskId=1', runScripts: 'dangerously' });
 
@@ -145,25 +144,23 @@ function createInspectorActionDom(currentStatus = 'Open') {
 }
 
 
-// SECTION: Inspector action panel and More menu exclusivity.
-test('inspector actions close More menus when panels open or Escape is pressed', () => {
+// SECTION: Inspector action panel behavior with inline More Actions panel.
+test('inspector actions keep inline More Actions visible while Escape closes action panels', () => {
     const { window, document } = createInspectorActionDom();
     const shell = document.querySelector('[data-at-action-shell]');
     const panel = document.querySelector('[data-at-action-panel="status"]');
-    const moreMenu = document.querySelector('[data-test-menu]');
+    const morePanel = document.querySelector('[data-test-more-panel]');
     const openButton = document.querySelector('[data-test-action="mark-progress"]');
 
-    moreMenu.setAttribute('open', 'open');
     openButton.dispatchEvent(new window.Event('click', { bubbles: true }));
 
     assert.equal(panel.hasAttribute('open'), true);
-    assert.equal(moreMenu.hasAttribute('open'), false);
+    assert.ok(morePanel);
 
-    moreMenu.setAttribute('open', 'open');
     shell.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
     assert.equal(panel.hasAttribute('open'), false);
-    assert.equal(moreMenu.hasAttribute('open'), false);
+    assert.ok(morePanel);
 });
 
 // SECTION: Status intent action behavior.


### PR DESCRIPTION
### Motivation

- Ensure Action Tracker UI displays persisted timestamps in IST and that all date-only business rules use the Indian business day rather than UTC calendar dates.\
- Remove remaining direct system-time calls from Action Tracker services so persisted timestamps are derived from an injected clock.\
- Fix clipped/hidden floating "More" dropdown inside the task inspector drawer and reserve space for a widened drawer in the Sprint Board Execute view.\

### Description

- Added IST helpers and formatting: used existing `IstClock` via `TimeFmt.ToIst(...)` for all inspector/audit/attachment timestamps and appended a stable "IST" suffix in `Infrastructure/TimeFmt.cs`.\
- Extended `IActionTrackerClock` to expose `UtcNow`, `UtcToday`, `IstNow` and `IstToday`, implemented in `SystemActionTrackerClock` using `IstClock.ToIst(UtcNow)`.\
- Converted all Action Tracker business-day logic from `_clock.UtcToday` to `_clock.IstToday` for overdue checks, due-today logic, ageing buckets, date validations and sprint default generation (`Index.cshtml.cs`, `ActionTaskQueryService`, `ActionTaskReportBuilder`, `ActionTaskMyWorkQueueBuilder`, `ActionTaskCommandCentreSummaryBuilder`, `ActionTaskSprintWorkspaceSummaryBuilder`, `ActionTaskSprintBoardStateBuilder`).\
- Replaced direct `DateTime.UtcNow` usages in services with the injected clock where appropriate for persisted timestamps: `ActionTaskService`, `ActionSprintService`, and `ActionTaskCollaborationService` now use `_clock.UtcNow` (the only direct system-time call left is inside the clock implementation itself).\
- Replaced the floating More dropdown with an inline grouped `More Actions` panel inside `Pages/ActionTasks/_TaskDetails.cshtml` (groups: Workflow Actions, Planning Actions, Danger Zone) and removed popover mechanics; updated client-side panel orchestration in `wwwroot/js/pages/action-tasks/index.js`.\
- Added CSS variable `--at-planning-drawer-width: 34rem` and drawer-reservation rules targeting `.at-planning-execute-panel`, `.at-execute-status-board` and `.at-execute-status-grid` to ensure the widened inspector drawer does not obscure Execute board columns (`wwwroot/css/action-tracker.css`).\
- Updated storage-key generation and attachment timestamp creation in `ActionTaskCollaborationService` to use clock-backed UTC for stable keys and timestamps.\
- Added production-readiness unit tests validating: `TimeFmt.ToIst` formatting, that task inspector uses `TimeFmt.ToIst` and keeps due dates date-only, that the inspector contains the inline More Actions panel (no floating dropdown), that the Execute board CSS declares the drawer width variable and reservations, and that closed tasks keep mutation groups gated. Also added service-level tests asserting services use clock-backed timestamps and IST-based date validation for date changes. Tests were added under `ProjectManagement.Tests/ActionTasks/*`.

### Testing

- Ran `npm test` (JavaScript unit tests for the inspector behaviors and utilities); all JS tests passed.\
- Performed grep/diff sanity checks (`rg` / `git diff --check`) to confirm no remaining raw `ToString("dd MMM yyyy, HH:mm")` usages in Action Tracker Razor partials and that direct system-time usage no longer appears in `Services/ActionTasks` or `Pages/ActionTasks` outside the clock implementation; the only `DateTime.UtcNow` usage remaining is inside the `SystemActionTrackerClock` implementation as intended.\
- Added and saved multiple xUnit tests in `ProjectManagement.Tests/ActionTasks` covering IST formatting, date-only preservation, inline More Actions markup, drawer CSS reservation, and service clock usage; these tests were added to the test project, but `dotnet test` for the test suite was not executed in this environment because the `dotnet` CLI is not available here.\

If you want, I can run the full dotnet test suite in your CI environment or on a machine with the .NET SDK and report the results there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08883a19bc8329828a80b03a3298c7)