### PR TITLE
Stabilize Action Tracker Task Details drawer

### DIFF
--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -344,6 +344,33 @@ public class IndexModel : PageModel
         return _workflowPolicy.CanChangeTaskDate(task, CurrentRole);
     }
 
+    public bool CanViewSelectedTaskSystemHistory()
+    {
+        return _workflowPolicy.CanViewSystemHistory(CurrentRole);
+    }
+
+    public string DisplayAuditActionLabel(string actionType)
+    {
+        if (string.IsNullOrWhiteSpace(actionType))
+        {
+            return "System Event";
+        }
+
+        return actionType switch
+        {
+            "OutsideSprintTaskAssignedToSprint" => "Added to Sprint",
+            "TaskRemovedFromSprintKeepAssigned" => "Removed from Sprint",
+            "TaskCarriedForward" => "Carried Forward",
+            "Task Created" => "Task Created",
+            "TaskUpdated" => "Task Updated",
+            "TaskStatusChanged" => "Status Changed",
+            "TaskSubmitted" => "Submitted for Closure",
+            "TaskClosed" => "Task Closed",
+            "TaskDueDateChanged" => "Due Date Changed",
+            _ => Regex.Replace(actionType, "(?<!^)([A-Z])", " $1")
+        };
+    }
+
     public string GetStatusBadgeClass(string status)
     {
         return _workflowPolicy.GetStatusBadgeClass(status);

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -25,8 +25,8 @@
     var updatePanelTitle = selectedTaskIsBacklog ? "Add Planning Note" : "Add Update";
     var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Add progress details or clarification notes";
     var canOpenStatusAction = Model.SelectedTask is not null && !selectedTaskIsBacklog && Model.CanUpdateTaskStatus(Model.SelectedTask);
-    var canOpenSubmitAction = Model.SelectedTask is not null && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase) && Model.CanSubmitTask(Model.SelectedTask);
-    var canOpenCloseAction = Model.SelectedTask is not null && !string.Equals(selectedTaskStatus, ProjectManagement.Models.ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && Model.CanCloseTask(Model.SelectedTask);
+    var canOpenSubmitAction = Model.SelectedTask is not null && Model.CanSubmitTask(Model.SelectedTask);
+    var canOpenCloseAction = Model.SelectedTask is not null && selectedTaskIsSubmitted && Model.CanCloseTask(Model.SelectedTask);
     var canOpenChangeDateAction = Model.SelectedTask is not null && Model.CanChangeTaskDate(Model.SelectedTask);
     var canMoveTaskToBacklogAction = Model.SelectedTask is not null && Model.CanMoveTaskToBacklog(Model.SelectedTask);
     var canRemoveFromSprintKeepAssignedAction = canMoveTaskToBacklogAction && Model.SelectedTask?.SprintId.HasValue == true;
@@ -34,10 +34,13 @@
     var hasPlanningActions = !selectedTaskIsClosed && (canOpenChangeDateAction || canRemoveFromSprintKeepAssignedAction);
     var hasDangerActions = !selectedTaskIsClosed && canMoveTaskToBacklogAction;
     var hasMoreActions = hasWorkflowActions || hasPlanningActions || hasDangerActions;
+    var canViewSystemHistory = Model.SelectedTask is not null && Model.CanViewSelectedTaskSystemHistory();
     var selectedTaskClosureHelper = Model.SelectedTask is not null && !selectedTaskIsBacklog && !selectedTaskIsClosed
         ? selectedTaskIsSubmitted
-            ? "Submitted for closure. Review and close, or return for rework."
-            : "The assignee must submit this task before it can be closed."
+            ? "Close Task is available to Comdt/HoD reviewers. Return for Rework if more action is needed."
+            : canOpenSubmitAction
+                ? "Submit for Closure when the work is ready for review."
+                : "Close Task stays hidden until the assignee submits this task for closure."
         : null;
     var taskBrief = string.IsNullOrWhiteSpace(Model.SelectedTask?.Description)
         ? "No task brief has been added."
@@ -56,7 +59,7 @@
 }
 
 <section id="task-details" class="at-panel at-task-details-panel at-task-command-drawer" tabindex="-1">
-    <div class="at-inspector-shell at-task-command-shell">
+    <div class="at-inspector-shell at-task-command-shell" data-at-action-shell="true">
         <header class="at-inspector-header at-task-command-header">
             <div class="at-detail-hero at-task-command-hero">
                 <h2 class="at-panel-title mb-0">AT-@(Model.SelectedTask?.Id.ToString() ?? Model.TaskId?.ToString() ?? "—") · @(Model.SelectedTask?.Title ?? "Task")</h2>
@@ -143,13 +146,62 @@
                             {
                                 <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="status" data-at-target-status="In Progress">Mark In Progress</button>
                             }
-                            @if (Model.CanSubmitTask(Model.SelectedTask) && selectedTaskIsInProgress)
+                            @if (canOpenSubmitAction)
                             {
                                 <button type="button" class="btn btn-warning btn-sm" data-at-open-action="submit">Submit for Closure</button>
                             }
                         }
                     </div>
                 </section>
+
+            <section class="at-command-section at-action-form-section" aria-label="Task action form area">
+                <div class="at-context-panel-host" data-at-action-host="true">
+                    <details class="at-action-drawer" data-at-action-panel="update">
+                        <summary class="visually-hidden">Open update panel</summary>
+                        <form method="post" asp-page-handler="AddUpdate" class="at-action-card at-journal-card" enctype="multipart/form-data">
+                            <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
+                            <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                            <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                            <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
+                            <div class="at-action-title">@updatePanelTitle</div>
+                            <div class="mb-2"><label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label><textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="@updatePlaceholder"></textarea></div>
+                            <div class="mb-2"><label class="form-label at-small" asp-for="UpdateInput.Files">Supporting files</label><input class="form-control form-control-sm" asp-for="UpdateInput.Files" type="file" multiple /><div class="form-text at-small">Allowed: PDF, Word, Excel, JPG, PNG, TXT.</div></div>
+                            <div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Post Update</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="update">Cancel</button></div>
+                        </form>
+                    </details>
+
+                    @if (selectedTaskIsBacklog && Model.CanAssignTaskToSprint(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="add-to-sprint"><summary class="visually-hidden">Open add to sprint panel</summary><form method="post" asp-page-handler="AssignToSprint" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="Planning" /><input type="hidden" name="PlanningTab" value="Execute" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><div class="at-action-title">Add to Sprint</div><div class="mb-2"><label class="form-label at-small">Responsible Person</label><select class="form-select form-select-sm" name="responsibleUserId" required><option value="">Select responsible person</option>@foreach (var user in Model.AssignableUsers){<option value="@user.UserId">@user.DisplayName</option>}</select></div><div class="mb-2"><label class="form-label at-small">Sprint</label><select class="form-select form-select-sm" name="sprintId" required><option value="">Select Sprint</option>@foreach (var sprint in Model.AssignableSprints){<option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>}</select></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-to-sprint">Cancel</button></div></form></details>
+                    }
+
+                    @if (!selectedTaskIsBacklog && Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="add-outside-to-sprint"><summary class="visually-hidden">Open add to sprint panel</summary><form method="post" asp-page-handler="AddOutsideSprintTaskToSprint" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="Planning" /><input type="hidden" name="PlanningTab" value="Execute" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><div class="at-action-title">Add to Sprint</div><div class="mb-2"><label class="form-label at-small">Sprint</label><select class="form-select form-select-sm" name="sprintId" required><option value="">Select Sprint</option>@foreach (var sprint in Model.AssignableSprints){<option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>}</select></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-outside-to-sprint">Cancel</button></div></form></details>
+                    }
+
+                    @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="status"><summary class="visually-hidden">Open status panel</summary><form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Change Status</div><div class="mb-2"><label class="form-label at-small">Target Status</label><select name="status" class="form-select form-select-sm" data-at-status-select data-current-status="@Model.SelectedTask.Status">@foreach (var status in Model.AllowedStatusOptions){if (Model.SelectedTask.Status == status){<option value="@status" selected>@status</option>}else{<option value="@status">@status</option>}}</select></div><div class="mb-2"><label class="form-label at-small">Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Status update remarks"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm" data-at-status-submit>Save Status</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="status">Cancel</button></div></form></details>
+                    }
+
+                    @if (Model.CanChangeTaskDate(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="change-date"><summary class="visually-hidden">Open date change panel</summary><form method="post" asp-page-handler="ChangeTaskDate" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" asp-for="ChangeDateInput.TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" asp-for="ChangeDateInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Change @selectedTaskDateLabel Date</div><div class="mb-2"><span class="form-label at-small d-block mb-1">Current @selectedTaskDateLabel Date</span><div class="form-control-plaintext form-control-sm py-0">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div></div><div class="mb-2"><label class="form-label at-small" asp-for="ChangeDateInput.NewDate">New @selectedTaskDateLabel Date</label><input class="form-control form-control-sm" asp-for="ChangeDateInput.NewDate" type="date" value="@changeDateInputValue.ToString("yyyy-MM-dd")" min="@minimumChangeDate.ToString("yyyy-MM-dd")" /></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Save Date</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="change-date">Cancel</button></div></form></details>
+                    }
+
+                    @if (Model.CanSubmitTask(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="submit"><summary class="visually-hidden">Open submit panel</summary><form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Submit for Closure</div><div class="mb-2"><label class="form-label at-small">Submission Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add submission notes"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-warning btn-sm">Submit for Closure</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="submit">Cancel</button></div></form></details>
+                    }
+
+                    @if (Model.CanCloseTask(Model.SelectedTask))
+                    {
+                        <details class="at-action-drawer" data-at-action-panel="close"><summary class="visually-hidden">Open close panel</summary><form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Close Task</div><div class="mb-2"><label class="form-label at-small">Closure Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add closure notes"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-success btn-sm">Close Task</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="close">Cancel</button></div></form></details>
+                    }
+                </div>
+            </section>
 
                 <section class="at-command-section at-progress-timeline" aria-label="Progress Timeline">
                     <div class="at-inspector-section-heading">
@@ -203,8 +255,20 @@
                     }
                 </section>
 
-                <details class="at-command-section at-details-collapsible at-audit-collapsible">
-                    <summary>Audit Trail <span class="at-count-chip">@Model.SelectedTaskLogs.Count</span></summary>
+
+                <details class="at-command-section at-details-collapsible">
+                    <summary>Task Details</summary>
+                    <div class="at-task-details-grid mt-2">
+                        <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.AssignedOn)</div></div>
+                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.SubmittedOn)</div></div>
+                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.ClosedOn)</div></div>
+                        <div><span class="text-muted">Work category</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
+                    </div>
+                </details>
+                @if (canViewSystemHistory)
+                {
+                    <details class="at-command-section at-details-collapsible at-audit-collapsible">
+                    <summary>System History <span class="at-count-chip">@Model.SelectedTaskLogs.Count</span></summary>
                     @if (!Model.SelectedTaskLogs.Any())
                     {
                         <div class="at-empty-inline mt-2">No audit entries recorded.</div>
@@ -216,7 +280,7 @@
                             {
                                 <article class="at-activity-system-row @(log.ActionType == "Task Created" ? "at-system-event-created" : "")">
                                     <div class="d-flex justify-content-between gap-2 flex-wrap">
-                                        <div><strong>@log.ActionType</strong><span class="text-muted"> by @Model.ResolveActorName(log.PerformedByUserId)</span></div>
+                                        <div><strong>@Model.DisplayAuditActionLabel(log.ActionType)</strong><span class="text-muted"> by @Model.ResolveActorName(log.PerformedByUserId)</span></div>
                                         <div class="text-muted small">@TimeFmt.ToIst(log.PerformedAt)</div>
                                     </div>
                                     @if (!string.IsNullOrWhiteSpace(log.OldValue) || !string.IsNullOrWhiteSpace(log.NewValue))
@@ -231,17 +295,8 @@
                             }
                         </div>
                     }
-                </details>
-
-                <details class="at-command-section at-details-collapsible">
-                    <summary>Task Details</summary>
-                    <div class="at-task-details-grid mt-2">
-                        <div><span class="text-muted">Assigned On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.AssignedOn)</div></div>
-                        <div><span class="text-muted">Submitted On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.SubmittedOn)</div></div>
-                        <div><span class="text-muted">Closed On</span><div class="fw-semibold">@TimeFmt.ToIst(Model.SelectedTask.ClosedOn)</div></div>
-                        <div><span class="text-muted">Work category</span><div class="fw-semibold">@Model.GetSprintBadgeText(Model.SelectedTask)</div></div>
-                    </div>
-                </details>
+                    </details>
+                }
 
                 @if (hasMoreActions)
                 {
@@ -306,54 +361,6 @@
                 }
             </div>
 
-            <footer class="at-inspector-footer at-task-command-footer" data-at-action-shell="true">
-                <div class="at-context-panel-host" data-at-action-host="true">
-                    <details class="at-action-drawer" data-at-action-panel="update">
-                        <summary class="visually-hidden">Open update panel</summary>
-                        <form method="post" asp-page-handler="AddUpdate" class="at-action-card at-journal-card" enctype="multipart/form-data">
-                            <input type="hidden" asp-for="UpdateInput.TaskId" value="@Model.SelectedTask.Id" />
-                            <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
-                            <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
-                            <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
-                            <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
-                            <div class="at-action-title">@updatePanelTitle</div>
-                            <div class="mb-2"><label class="form-label at-small" asp-for="UpdateInput.Body">Update details</label><textarea class="form-control form-control-sm" rows="4" asp-for="UpdateInput.Body" maxlength="4000" placeholder="@updatePlaceholder"></textarea></div>
-                            <div class="mb-2"><label class="form-label at-small" asp-for="UpdateInput.Files">Supporting files</label><input class="form-control form-control-sm" asp-for="UpdateInput.Files" type="file" multiple /><div class="form-text at-small">Allowed: PDF, Word, Excel, JPG, PNG, TXT.</div></div>
-                            <div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Post Update</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="update">Cancel</button></div>
-                        </form>
-                    </details>
-
-                    @if (selectedTaskIsBacklog && Model.CanAssignTaskToSprint(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="add-to-sprint"><summary class="visually-hidden">Open add to sprint panel</summary><form method="post" asp-page-handler="AssignToSprint" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="Planning" /><input type="hidden" name="PlanningTab" value="Execute" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><div class="at-action-title">Add to Sprint</div><div class="mb-2"><label class="form-label at-small">Responsible Person</label><select class="form-select form-select-sm" name="responsibleUserId" required><option value="">Select responsible person</option>@foreach (var user in Model.AssignableUsers){<option value="@user.UserId">@user.DisplayName</option>}</select></div><div class="mb-2"><label class="form-label at-small">Sprint</label><select class="form-select form-select-sm" name="sprintId" required><option value="">Select Sprint</option>@foreach (var sprint in Model.AssignableSprints){<option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>}</select></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-to-sprint">Cancel</button></div></form></details>
-                    }
-
-                    @if (!selectedTaskIsBacklog && Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="add-outside-to-sprint"><summary class="visually-hidden">Open add to sprint panel</summary><form method="post" asp-page-handler="AddOutsideSprintTaskToSprint" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="Planning" /><input type="hidden" name="PlanningTab" value="Execute" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><div class="at-action-title">Add to Sprint</div><div class="mb-2"><label class="form-label at-small">Sprint</label><select class="form-select form-select-sm" name="sprintId" required><option value="">Select Sprint</option>@foreach (var sprint in Model.AssignableSprints){<option value="@sprint.Id">@Model.DisplaySprintName(sprint) (@sprint.Status)</option>}</select></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Add to Sprint</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="add-outside-to-sprint">Cancel</button></div></form></details>
-                    }
-
-                    @if (Model.CanUpdateTaskStatus(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="status"><summary class="visually-hidden">Open status panel</summary><form method="post" asp-page-handler="UpdateStatus" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Change Status</div><div class="mb-2"><label class="form-label at-small">Target Status</label><select name="status" class="form-select form-select-sm" data-at-status-select data-current-status="@Model.SelectedTask.Status">@foreach (var status in Model.AllowedStatusOptions){if (Model.SelectedTask.Status == status){<option value="@status" selected>@status</option>}else{<option value="@status">@status</option>}}</select></div><div class="mb-2"><label class="form-label at-small">Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Status update remarks"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm" data-at-status-submit>Save Status</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="status">Cancel</button></div></form></details>
-                    }
-
-                    @if (Model.CanChangeTaskDate(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="change-date"><summary class="visually-hidden">Open date change panel</summary><form method="post" asp-page-handler="ChangeTaskDate" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" asp-for="ChangeDateInput.TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" asp-for="ChangeDateInput.RowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Change @selectedTaskDateLabel Date</div><div class="mb-2"><span class="form-label at-small d-block mb-1">Current @selectedTaskDateLabel Date</span><div class="form-control-plaintext form-control-sm py-0">@Model.SelectedTask.DueDate.ToString("dd MMM yyyy")</div></div><div class="mb-2"><label class="form-label at-small" asp-for="ChangeDateInput.NewDate">New @selectedTaskDateLabel Date</label><input class="form-control form-control-sm" asp-for="ChangeDateInput.NewDate" type="date" value="@changeDateInputValue.ToString("yyyy-MM-dd")" min="@minimumChangeDate.ToString("yyyy-MM-dd")" /></div><div class="at-action-buttons"><button type="submit" class="btn btn-primary btn-sm">Save Date</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="change-date">Cancel</button></div></form></details>
-                    }
-
-                    @if (Model.CanSubmitTask(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="submit"><summary class="visually-hidden">Open submit panel</summary><form method="post" asp-page-handler="Submit" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Submit for Closure</div><div class="mb-2"><label class="form-label at-small">Submission Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add submission notes"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-warning btn-sm">Submit for Closure</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="submit">Cancel</button></div></form></details>
-                    }
-
-                    @if (Model.CanCloseTask(Model.SelectedTask))
-                    {
-                        <details class="at-action-drawer" data-at-action-panel="close"><summary class="visually-hidden">Open close panel</summary><form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Close Task</div><div class="mb-2"><label class="form-label at-small">Closure Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add closure notes"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-success btn-sm">Close Task</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="close">Cancel</button></div></form></details>
-                    }
-                </div>
-            </footer>
         }
     </div>
 </section>

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 
 namespace ProjectManagement.Services.ActionTasks;
@@ -56,6 +57,13 @@ public sealed class ActionTaskWorkflowPolicy
     {
         return _permission.CanChangeTaskDate(currentRole)
             && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool CanViewSystemHistory(string currentRole)
+    {
+        return string.Equals(currentRole, RoleNames.Comdt, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentRole, RoleNames.HoD, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentRole, RoleNames.Admin, StringComparison.OrdinalIgnoreCase);
     }
 
     // SECTION: Transition and remarks validation for command handlers.

--- a/wwwroot/css/action-task-details-redesign.css
+++ b/wwwroot/css/action-task-details-redesign.css
@@ -1,6 +1,6 @@
 /* SECTION: Action Tracker Task Details pane redesign */
 :root {
-    --at-planning-drawer-width: 38rem;
+    --at-planning-drawer-width: 46rem;
 }
 
 .at-task-command-drawer {
@@ -10,12 +10,16 @@
 
 .at-shell.has-selection .at-drawer-host,
 .at-shell.is-planning-board.has-selection .at-drawer-host {
-    width: min(38rem, calc(100vw - 2rem));
+    width: min(46rem, calc(100vw - 2rem));
+}
+
+.at-shell.is-planning-board.has-selection .at-workspace {
+    padding-right: min(46rem, calc(100vw - 2rem));
 }
 
 .at-task-command-shell {
     display: grid;
-    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-rows: auto minmax(0, 1fr);
     height: 100%;
     max-height: 100%;
     background: #ffffff;
@@ -300,31 +304,52 @@
     color: #b91c1c;
 }
 
-.at-task-command-footer {
-    border-top: 1px solid var(--at-border);
-    background: rgba(255, 255, 255, 0.96);
-    padding: 0.65rem 1.05rem;
+/* SECTION: Single in-body action form host keeps drawer actions stable and visible. */
+.at-action-form-section {
+    border-color: #cbd5e1;
+    background: #f8fbff;
+    display: none;
 }
 
-.at-task-command-footer .at-context-panel-host {
+.at-action-form-section.is-active {
+    display: block;
+}
+
+.at-action-form-section:has(.at-action-drawer[open]) {
+    display: block;
+}
+
+.at-action-form-section .at-context-panel-host {
     display: grid;
     gap: 0.55rem;
 }
 
-.at-task-command-footer .at-action-drawer[open] {
+.at-action-form-section .at-action-drawer[open] {
     display: block;
 }
 
-.at-task-command-footer .at-action-card {
+.at-action-form-section .at-action-card {
     border-color: #cbd5e1;
     border-radius: 14px;
-    background: #fbfdff;
+    background: #ffffff;
     padding: 0.65rem;
 }
 
-.at-task-command-footer:empty,
-.at-task-command-footer .at-context-panel-host:empty {
-    display: none;
+/* SECTION: System history is intentionally secondary to the progress timeline. */
+.at-task-command-body .at-audit-collapsible {
+    background: #f8fafc;
+    border-color: #e2e8f0;
+}
+
+.at-task-command-body .at-audit-collapsible > summary {
+    color: var(--at-muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.at-task-command-body .at-audit-collapsible .at-activity-system-row {
+    background: #ffffff;
+    color: #475569;
 }
 
 @media (max-width: 1500px) {
@@ -349,12 +374,15 @@
         right: 0.75rem;
         width: auto;
     }
+
+    .at-shell.is-planning-board.has-selection .at-workspace {
+        padding-right: 0;
+    }
 }
 
 @media (max-width: 575px) {
     .at-task-command-header,
-    .at-task-command-body,
-    .at-task-command-footer {
+    .at-task-command-body {
         padding-left: 0.75rem;
         padding-right: 0.75rem;
     }

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -22,7 +22,7 @@
     --at-weight-medium: 500;
     --at-weight-semibold: 600;
     --at-weight-bold: 700;
-    --at-planning-drawer-width: 34rem;
+    --at-planning-drawer-width: 46rem;
 }
 
 /* SECTION: Action Tracker shell */

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -437,7 +437,7 @@
     }
 
 
-    // SECTION: Sticky inspector action panel orchestration and keyboard behavior.
+    // SECTION: Inspector-wide action panel orchestration and keyboard behavior.
     function initInspectorActionPanels() {
         const shell = document.querySelector("[data-at-action-shell='true']");
         if (!shell) {
@@ -447,14 +447,19 @@
         const panels = Array.from(shell.querySelectorAll("[data-at-action-panel]"));
         const openButtons = shell.querySelectorAll("[data-at-open-action]");
         const closeButtons = shell.querySelectorAll("[data-at-close-action]");
+        const actionHost = shell.querySelector("[data-at-action-host='true']");
+        const actionSection = actionHost ? actionHost.closest(".at-action-form-section") : null;
 
         const closeAllPanels = () => {
             panels.forEach((panel) => panel.removeAttribute("open"));
+            if (actionSection) {
+                actionSection.classList.remove("is-active");
+            }
         };
 
         // SECTION: Intent-specific status actions can seed the status panel selection.
         const applyStatusActionTarget = (name, targetStatus) => {
-            if (name !== "status" || !targetStatus) {
+            if (name !== "status") {
                 return;
             }
 
@@ -463,7 +468,8 @@
                 return;
             }
 
-            statusSelect.value = targetStatus;
+            const currentStatus = statusSelect.getAttribute("data-current-status") || statusSelect.value;
+            statusSelect.value = targetStatus || currentStatus;
             statusSelect.dispatchEvent(new Event("change", { bubbles: true }));
         };
 
@@ -474,6 +480,9 @@
                 return;
             }
             panel.setAttribute("open", "open");
+            if (actionSection) {
+                actionSection.classList.add("is-active");
+            }
             applyStatusActionTarget(name, targetStatus);
             const focusTarget = panel.querySelector("textarea, select, input, button");
             if (focusTarget) {


### PR DESCRIPTION
### Motivation

- Action buttons in the Task Details pane were not wired because the JavaScript action shell was scoped to the footer only, leaving visible buttons outside the binding scope. 
- The drawer was too narrow for the amount of content and inline action forms, causing overflow and interaction instability. 
- Audit Trail was too prominent and showed technical event names to all users, and submit/close visibility logic was inconsistent for normal assignees and reviewers. 

### Description

- Move the action shell to the full inspector container by adding `data-at-action-shell="true"` to the inspector wrapper and remove footer-only reliance, and update `initInspectorActionPanels()` to bind action buttons and panels across the shell (changes in `Pages/ActionTasks/_TaskDetails.cshtml` and `wwwroot/js/pages/action-tasks/index.js`).
- Render action forms in a single in-body action host under the "Next Action" card (`.at-action-form-section`) instead of the sticky footer, and add JavaScript to activate the host area when panels open (changes in `Pages/ActionTasks/_TaskDetails.cshtml`, `wwwroot/css/action-task-details-redesign.css`, and `wwwroot/js/pages/action-tasks/index.js`).
- Make submit/close visibility consistent by using `CanSubmitTask()` for Submit visibility and restricting Close to submitted tasks that the role can close, and add helper methods to present human-friendly audit labels and to gate System History visibility (changes in `Pages/ActionTasks/_TaskDetails.cshtml`, `Pages/ActionTasks/Index.cshtml.cs`, and `Services/ActionTasks/ActionTaskWorkflowPolicy.cs`).
- Increase drawer width to `46rem`, reserve matching right-side workspace padding for the Sprint Board, and align the shared drawer width token (`wwwroot/css/action-task-details-redesign.css` and `wwwroot/css/action-tracker.css`).
- Convert "Audit Trail" into a secondary "System History" section, collapse it by default and show it only for command/admin roles, and map technical action names into readable labels via `DisplayAuditActionLabel()` (changes in `Pages/ActionTasks/_TaskDetails.cshtml` and `Pages/ActionTasks/Index.cshtml.cs`).

### Testing

- Ran `npm test` which executed the JS test suite and all tests passed (`18` tests, `0` failures). 
- Ran `git diff --check` and local whitespace/merge checks reported no new problems after the changes. 
- Ran `npm run lint:views` which failed due to pre-existing inline style attributes elsewhere in the codebase that are outside this change set. 
- `dotnet clean`, `dotnet build`, and `dotnet run` were not executed here because the `dotnet` CLI is not available in this environment, so server-side compile/run verification must be performed locally or in CI before shipping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08982c3fe48329a7c2cf0c6b1847a8)