### PR TITLE
Harden Action Tracker task lifecycle

### DIFF
--- a/Pages/ActionTasks/Index.cshtml
+++ b/Pages/ActionTasks/Index.cshtml
@@ -6,6 +6,7 @@
 }
 @section Styles {
     <link rel="stylesheet" href="~/css/action-tracker.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/action-task-details-redesign.css" asp-append-version="true" />
 }
 
 @section Scripts {

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -82,6 +82,7 @@ public class IndexModel : PageModel
     public IReadOnlyList<ActionTaskAuditLog> SelectedTaskLogs { get; private set; } = Array.Empty<ActionTaskAuditLog>();
     public IReadOnlyList<ActionSprintAuditLog> SprintAuditHistory { get; private set; } = Array.Empty<ActionSprintAuditLog>();
     public IReadOnlyList<ActionTaskUpdate> SelectedTaskUpdates { get; private set; } = Array.Empty<ActionTaskUpdate>();
+    public DateTime? SelectedTaskLastActivityAtUtc { get; private set; }
     public IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>> UpdateAttachments { get; private set; } = new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>();
     public IReadOnlyList<UserOption> AssignableUsers { get; private set; } = Array.Empty<UserOption>();
     public IReadOnlyDictionary<string, string> TaskAssigneeNames { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -339,6 +340,16 @@ public class IndexModel : PageModel
         return _workflowPolicy.CanUpdateTaskStatus(task, CurrentRole, CurrentUserId);
     }
 
+    public IReadOnlyList<string> GetAllowedStatusTargets(ActionTaskItem task)
+    {
+        return _workflowPolicy.GetAllowedStatusTargets(task, CurrentRole, CurrentUserId);
+    }
+
+    public DateTime GetSelectedTaskLastActivityUtc()
+    {
+        return SelectedTaskLastActivityAtUtc ?? SelectedTask?.AssignedOn ?? DateTime.MinValue;
+    }
+
     public bool CanChangeTaskDate(ActionTaskItem task)
     {
         return _workflowPolicy.CanChangeTaskDate(task, CurrentRole);
@@ -358,15 +369,23 @@ public class IndexModel : PageModel
 
         return actionType switch
         {
-            "OutsideSprintTaskAssignedToSprint" => "Added to Sprint",
-            "TaskRemovedFromSprintKeepAssigned" => "Removed from Sprint",
-            "TaskCarriedForward" => "Carried Forward",
-            "Task Created" => "Task Created",
-            "TaskUpdated" => "Task Updated",
-            "TaskStatusChanged" => "Status Changed",
-            "TaskSubmitted" => "Submitted for Closure",
-            "TaskClosed" => "Task Closed",
-            "TaskDueDateChanged" => "Due Date Changed",
+            "TaskCreated" => "Task created",
+            "BacklogItemCreated" => "Backlog item created",
+            "TaskAssignedToSprint" => "Added to sprint",
+            "OutsideSprintTaskAssignedToSprint" => "Added to sprint",
+            "TaskRemovedFromSprintKeepAssigned" => "Removed from sprint, kept assigned",
+            "TaskMovedToBacklogRemoveAssignee" => "Moved to backlog",
+            "TaskCarriedForward" => "Carried forward",
+            "TaskUpdated" => "Task updated",
+            "Submitted" => "Submitted for closure",
+            "TaskSubmitted" => "Submitted for closure",
+            "Closed" => "Closed",
+            "TaskClosed" => "Closed",
+            "StatusUpdated" => "Status changed",
+            "TaskStatusChanged" => "Status changed",
+            "DueDateChanged" => "Due date changed",
+            "TargetDateChanged" => "Target date changed",
+            "TaskDueDateChanged" => "Due date changed",
             _ => Regex.Replace(actionType, "(?<!^)([A-Z])", " $1")
         };
     }
@@ -1071,22 +1090,14 @@ public class IndexModel : PageModel
 
         try
         {
-            if (hasProgressNote || hasFiles)
-            {
-                await _collaborationService.AddUpdateAsync(UpdateInput.TaskId, UpdateInput.Body, ActionTaskUpdateTypes.Progress, CurrentUserId, CurrentRole, UpdateInput.Files ?? new List<IFormFile>());
-            }
-
-            if (hasStatusChange)
-            {
-                if (string.Equals(requestedStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
-                {
-                    await _service.SubmitTaskAsync(UpdateInput.TaskId, DecodeRowVersion(UpdateInput.RowVersion), CurrentUserId, CurrentRole, UpdateInput.Body);
-                }
-                else
-                {
-                    await _service.UpdateStatusAsync(UpdateInput.TaskId, DecodeRowVersion(UpdateInput.RowVersion), requestedStatus!, CurrentUserId, CurrentRole, UpdateInput.Body);
-                }
-            }
+            await _collaborationService.AddUpdateAndMaybeChangeStatusAsync(
+                UpdateInput.TaskId,
+                UpdateInput.Body,
+                requestedStatus,
+                CurrentUserId,
+                CurrentRole,
+                UpdateInput.Files ?? new List<IFormFile>(),
+                DecodeRowVersion(UpdateInput.RowVersion));
 
             TempData["ToastMessage"] = hasStatusChange ? "Progress update saved and task status updated." : "Progress update saved.";
         }
@@ -1183,6 +1194,7 @@ public class IndexModel : PageModel
         SelectedTask = inspector.SelectedTask;
         SelectedTaskLogs = inspector.Logs;
         SelectedTaskUpdates = inspector.Updates;
+        SelectedTaskLastActivityAtUtc = inspector.LastActivityAtUtc;
         UpdateAttachments = inspector.UpdateAttachments;
         TaskActorNames = inspector.ActorNames;
     }

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -1,7 +1,5 @@
 @model ProjectManagement.Pages.ActionTasks.IndexModel
 
-<link rel="stylesheet" href="~/css/action-task-details-redesign.css" asp-append-version="true" />
-
 @{
     // SECTION: Inspector actions preserve the active Sprint Board tab, alternate view, and Sprint route state.
     var planningTabRouteValue = Model.IsPlanningView ? Model.ResolvedPlanningTab : null;
@@ -83,7 +81,7 @@
                         <span class="at-muted-meta">@Model.GetSprintBadgeText(Model.SelectedTask)</span>
                     </div>
                     <div class="at-inspector-snapshot at-command-snapshot">
-                        <span>Last update: @TimeFmt.ToIst(Model.SelectedTaskUpdates.FirstOrDefault()?.CreatedAtUtc ?? Model.SelectedTask.AssignedOn)</span>
+                        <span>Last update: @TimeFmt.ToIst(Model.GetSelectedTaskLastActivityUtc())</span>
                         <span>@Model.SelectedTaskUpdates.Count() updates</span>
                         <span>@Model.UpdateAttachments.Sum(entry => entry.Value.Count) attachments</span>
                     </div>
@@ -176,7 +174,7 @@
                                     <label class="form-label at-small" asp-for="UpdateInput.NewStatus">Change status</label>
                                     <select class="form-select form-select-sm" asp-for="UpdateInput.NewStatus" data-at-progress-status-select data-current-status="@Model.SelectedTask.Status">
                                         <option value="">No status change</option>
-                                        @foreach (var status in Model.AllowedStatusOptions.Where(status => !string.Equals(status, ProjectManagement.Models.ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase) && !string.Equals(status, ProjectManagement.Models.ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)))
+                                        @foreach (var status in Model.GetAllowedStatusTargets(Model.SelectedTask))
                                         {
                                             <option value="@status">@status</option>
                                         }

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -126,6 +126,94 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         }
     }
 
+    // SECTION: Atomic progress update with optional workflow status change
+    public async Task<ActionTaskUpdate?> AddUpdateAndMaybeChangeStatusAsync(int taskId, string body, string? newStatus, string userId, string role, IReadOnlyList<IFormFile> files, byte[] rowVersion, CancellationToken cancellationToken = default)
+    {
+        files ??= Array.Empty<IFormFile>();
+
+        // SECTION: Load and validate the full command before any update or attachment is persisted.
+        var task = await _context.ActionTasks.FirstOrDefaultAsync(x => x.Id == taskId && !x.IsDeleted, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
+        var hasBody = !string.IsNullOrWhiteSpace(body);
+        var hasFiles = files is { Count: > 0 } && files.Any(x => x.Length > 0);
+        var requestedStatus = string.IsNullOrWhiteSpace(newStatus) ? null : ResolveStatus(newStatus.Trim());
+        var hasStatusChange = !string.IsNullOrWhiteSpace(requestedStatus);
+
+        if (!hasBody && !hasFiles && !hasStatusChange)
+        {
+            throw new InvalidOperationException("Update text is required unless at least one attachment is uploaded.");
+        }
+
+        ValidateUpdatePermissions(task, userId, role, hasFiles);
+        ValidateAttachments(files);
+        ValidateAtomicStatusChange(task, requestedStatus, userId, role, body);
+
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        var committedFiles = new List<string>();
+
+        try
+        {
+            // SECTION: Create the human progress timeline entry and mutate workflow state in the same EF transaction.
+            ActionTaskUpdate? update = null;
+            if (hasBody || hasFiles)
+            {
+                update = new ActionTaskUpdate
+                {
+                    TaskId = taskId,
+                    CreatedByUserId = userId,
+                    CreatedAtUtc = _clock.UtcNow,
+                    UpdateType = ActionTaskUpdateTypes.Progress,
+                    Body = hasBody ? body.Trim() : "Attachment update",
+                    IsDeleted = false
+                };
+                _context.ActionTaskUpdates.Add(update);
+            }
+
+            if (hasStatusChange && !string.Equals(task.Status, requestedStatus, StringComparison.OrdinalIgnoreCase))
+            {
+                _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
+                ApplyStatusChange(task, requestedStatus!, userId, role, body);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+
+            // SECTION: Attachment metadata remains inside the same database transaction; physical files are cleaned up on rollback.
+            if (update is not null)
+            {
+                foreach (var file in files.Where(x => x.Length > 0))
+                {
+                    var storedPath = await AddAttachmentAsync(taskId, update.Id, userId, file, cancellationToken);
+                    if (!string.IsNullOrWhiteSpace(storedPath))
+                    {
+                        committedFiles.Add(storedPath);
+                    }
+                }
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return update;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            foreach (var filePath in committedFiles)
+            {
+                SafeDelete(filePath);
+            }
+
+            throw new ActionTaskConcurrencyException("This task was updated by another user. Please reload the task details and try again.");
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            foreach (var filePath in committedFiles)
+            {
+                SafeDelete(filePath);
+            }
+
+            throw;
+        }
+    }
+
     // SECTION: Read updates for inspector thread
     public async Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default)
     {
@@ -213,6 +301,129 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         });
         await _context.SaveChangesAsync(cancellationToken);
         return absolutePath;
+    }
+
+    // SECTION: Atomic command validation helpers
+    private void ValidateUpdatePermissions(ActionTaskItem task, string userId, string role, bool hasFiles)
+    {
+        if (!_permission.CanAddTaskUpdate(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to add updates for this task.");
+        }
+
+        if (hasFiles && !_permission.CanUploadTaskAttachment(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to add updates for this task.");
+        }
+    }
+
+    private void ValidateAtomicStatusChange(ActionTaskItem task, string? requestedStatus, string userId, string role, string? remarks)
+    {
+        if (string.IsNullOrWhiteSpace(requestedStatus))
+        {
+            return;
+        }
+
+        if (string.Equals(task.Status, requestedStatus, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (string.Equals(requestedStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        {
+            ValidateSubmitCommand(task, userId, role, remarks);
+            return;
+        }
+
+        if (!_permission.CanUpdateTask(role, userId, task.AssignedToUserId))
+        {
+            throw new InvalidOperationException("You are not authorized to update this task.");
+        }
+
+        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(requestedStatus, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Backlog items can only be changed through planning actions.");
+        }
+
+        if (string.Equals(requestedStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Use the close action to close a task.");
+        }
+
+        if (!ActionTaskStatusWorkflow.IsAllowedTransition(task.Status, requestedStatus))
+        {
+            throw new InvalidOperationException($"Invalid status transition from {task.Status} to {requestedStatus}.");
+        }
+
+        ActionTaskStatusWorkflow.ValidateRemarksForStatusTransition(task.Status, requestedStatus, remarks);
+    }
+
+    private void ValidateSubmitCommand(ActionTaskItem task, string userId, string role, string? remarks)
+    {
+        if (!string.Equals(task.AssignedToUserId, userId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Only the assigned user can submit this task.");
+        }
+
+        if (!_permission.CanSubmit(role))
+        {
+            throw new InvalidOperationException("You are not authorized to submit this task.");
+        }
+
+        if (string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Backlog items cannot be submitted.");
+        }
+
+        if (string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Closed tasks cannot be submitted.");
+        }
+
+        if (!ActionTaskStatusWorkflow.CanSubmitFromStatus(task.Status))
+        {
+            throw new InvalidOperationException("Only assigned, in-progress, or blocked tasks can be submitted.");
+        }
+
+        ActionTaskStatusWorkflow.ValidateRemarksForStatusTransition(task.Status, ActionTaskStatuses.Submitted, remarks);
+    }
+
+    private void ApplyStatusChange(ActionTaskItem task, string requestedStatus, string userId, string role, string? remarks)
+    {
+        var oldStatus = task.Status;
+        task.Status = requestedStatus;
+        if (string.Equals(requestedStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        {
+            task.SubmittedOn = _clock.UtcNow;
+        }
+
+        ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
+        var auditAction = string.Equals(requestedStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            ? "Submitted"
+            : "StatusUpdated";
+        _context.ActionTaskAuditLogs.Add(new ActionTaskAuditLog
+        {
+            TaskId = task.Id,
+            ActionType = auditAction,
+            PerformedByUserId = userId,
+            PerformedByRole = role,
+            PerformedAt = _clock.UtcNow,
+            OldValue = oldStatus,
+            NewValue = task.Status,
+            Remarks = remarks
+        });
+    }
+
+    private static string ResolveStatus(string status)
+    {
+        var resolved = ActionTaskStatuses.All.FirstOrDefault(candidate => string.Equals(candidate, status, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            throw new InvalidOperationException("Invalid status transition.");
+        }
+
+        return resolved;
     }
 
     // SECTION: Attachment validation helpers

--- a/Services/ActionTasks/ActionTaskInspectorReadModelBuilder.cs
+++ b/Services/ActionTasks/ActionTaskInspectorReadModelBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ProjectManagement.Models;
 
@@ -43,8 +44,28 @@ public sealed class ActionTaskInspectorReadModelBuilder
         var attachments = await _collaborationService.GetAttachmentMetadataByUpdateAsync(selectedTask.Id, request.CurrentUserId, request.CurrentRole);
         var actorNames = await _userLookup.LoadTaskActorNamesAsync(logs);
         actorNames = await _userLookup.MergeUpdateActorNamesAsync(actorNames, updates);
+        var lastActivityUtc = ResolveLastActivityUtc(selectedTask, logs, updates);
 
-        return new ActionTaskInspectorReadModel(selectedTask, logs, updates, attachments, actorNames, false);
+        return new ActionTaskInspectorReadModel(selectedTask, logs, updates, attachments, actorNames, false, lastActivityUtc);
+    }
+
+    // SECTION: Last activity combines human updates, system history and task lifecycle timestamps for the drawer header.
+    private static DateTime ResolveLastActivityUtc(ActionTaskItem task, IReadOnlyList<ActionTaskAuditLog> logs, IReadOnlyList<ActionTaskUpdate> updates)
+    {
+        var activityCandidates = new List<DateTime> { task.AssignedOn };
+        if (task.SubmittedOn.HasValue)
+        {
+            activityCandidates.Add(task.SubmittedOn.Value);
+        }
+
+        if (task.ClosedOn.HasValue)
+        {
+            activityCandidates.Add(task.ClosedOn.Value);
+        }
+
+        activityCandidates.AddRange(logs.Select(log => log.PerformedAt));
+        activityCandidates.AddRange(updates.Select(update => update.CreatedAtUtc));
+        return activityCandidates.Max();
     }
 }
 
@@ -60,7 +81,8 @@ public sealed record ActionTaskInspectorReadModel(
     IReadOnlyList<ActionTaskUpdate> Updates,
     IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>> UpdateAttachments,
     IReadOnlyDictionary<string, string> ActorNames,
-    bool IsUnavailable)
+    bool IsUnavailable,
+    DateTime? LastActivityAtUtc)
 {
     public static ActionTaskInspectorReadModel Empty { get; } = new(
         null,
@@ -68,7 +90,8 @@ public sealed record ActionTaskInspectorReadModel(
         Array.Empty<ActionTaskUpdate>(),
         new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>(),
         new Dictionary<string, string>(StringComparer.Ordinal),
-        false);
+        false,
+        null);
 
     public static ActionTaskInspectorReadModel Unavailable { get; } = Empty with { IsUnavailable = true };
 }

--- a/Services/ActionTasks/ActionTaskReportBuilder.cs
+++ b/Services/ActionTasks/ActionTaskReportBuilder.cs
@@ -151,7 +151,7 @@ public sealed class ActionTaskReportBuilder
     }
 
     // SECTION: Backlog ageing is planning-inventory ageing; AssignedOn is a temporary backlog-entry proxy until a CreatedOnUtc or EnteredBacklogOnUtc field exists.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBacklogAgeingBuckets(IReadOnlyList<ActionTaskItem> backlogTasks, DateTime istToday)
+    private IReadOnlyList<ActionTaskQueryService.CountSummary> BuildBacklogAgeingBuckets(IReadOnlyList<ActionTaskItem> backlogTasks, DateTime istToday)
         => new[]
         {
             new ActionTaskQueryService.CountSummary("0-3 days in backlog", backlogTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 0 and <= 3)),
@@ -161,7 +161,7 @@ public sealed class ActionTaskReportBuilder
         };
 
     // SECTION: Assigned task ageing applies only to Outside Sprint and Sprint work, never backlog or closed tasks.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedTaskAgeingBuckets(IReadOnlyList<ActionTaskItem> assignedTasks, DateTime istToday)
+    private IReadOnlyList<ActionTaskQueryService.CountSummary> BuildAssignedTaskAgeingBuckets(IReadOnlyList<ActionTaskItem> assignedTasks, DateTime istToday)
         => new[]
         {
             new ActionTaskQueryService.CountSummary("0-3 days assigned", assignedTasks.Count(t => DaysSince(t.AssignedOn, istToday) is >= 0 and <= 3)),
@@ -180,7 +180,7 @@ public sealed class ActionTaskReportBuilder
         };
 
     // SECTION: Pending closure ageing is separated from assignee overdue exposure.
-    private static IReadOnlyList<ActionTaskQueryService.CountSummary> BuildSubmittedPendingClosureAgeingBuckets(IReadOnlyList<ActionTaskItem> submittedTasks, DateTime istToday)
+    private IReadOnlyList<ActionTaskQueryService.CountSummary> BuildSubmittedPendingClosureAgeingBuckets(IReadOnlyList<ActionTaskItem> submittedTasks, DateTime istToday)
         => new[]
         {
             new ActionTaskQueryService.CountSummary("0-1 day pending closure", submittedTasks.Count(t => DaysSince(t.SubmittedOn ?? t.AssignedOn, istToday) is >= 0 and <= 1)),
@@ -189,7 +189,7 @@ public sealed class ActionTaskReportBuilder
         };
 
     // SECTION: Sprint performance is compact trend-style summary, not a Sprint Board duplicate.
-    private static IReadOnlyList<ActionTaskQueryService.SprintPerformanceSummary> BuildSprintPerformanceRows(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, DateTime istToday)
+    private IReadOnlyList<ActionTaskQueryService.SprintPerformanceSummary> BuildSprintPerformanceRows(IReadOnlyList<ActionTaskItem> tasks, IReadOnlyList<ActionSprint> sprints, DateTime istToday)
     {
         var sprintTasks = tasks.Where(t => t.SprintId.HasValue).ToLookup(t => t.SprintId!.Value);
         return sprints
@@ -271,14 +271,24 @@ public sealed class ActionTaskReportBuilder
     private static bool IsSubmitted(ActionTaskItem task)
         => string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsClosedLate(ActionTaskItem task)
-        => string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
-           && task.ClosedOn.HasValue
-           && task.ClosedOn.Value.Date > task.DueDate.Date;
+    private bool IsClosedLate(ActionTaskItem task)
+    {
+        if (!string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase) || !task.ClosedOn.HasValue)
+        {
+            return false;
+        }
+
+        var closedIstDate = _clock.ConvertUtcToIst(task.ClosedOn.Value).Date;
+        return closedIstDate > task.DueDate.Date;
+    }
 
     private static bool IsOpen(ActionTaskItem task) => ActionTaskCategorization.IsOpenTask(task);
 
-    private static int DaysSince(DateTime date, DateTime istToday) => (int)(istToday - date.Date).TotalDays;
+    private int DaysSince(DateTime utcDateTime, DateTime istToday)
+    {
+        var istDate = _clock.ConvertUtcToIst(utcDateTime).Date;
+        return (int)(istToday.Date - istDate).TotalDays;
+    }
 
     private static int DaysOverdue(ActionTaskItem task, DateTime istToday) => (int)(istToday - task.DueDate.Date).TotalDays;
 

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -212,13 +212,13 @@ public class ActionTaskService : IActionTaskService
         }
 
         // SECTION: Enforce lifecycle transitions
-        if (!IsAllowedTransition(task.Status, status))
+        if (!ActionTaskStatusWorkflow.IsAllowedTransition(task.Status, status))
         {
             throw new InvalidOperationException($"Invalid status transition from {task.Status} to {status}.");
         }
 
         // SECTION: Remarks validation for key transitions
-        ValidateRemarksForStatusTransition(task.Status, status, remarks);
+        ActionTaskStatusWorkflow.ValidateRemarksForStatusTransition(task.Status, status, remarks);
 
         // SECTION: Concurrency token validation
         _context.Entry(task).Property(x => x.RowVersion).OriginalValue = rowVersion;
@@ -276,7 +276,7 @@ public class ActionTaskService : IActionTaskService
             throw new InvalidOperationException("Closed tasks cannot be submitted.");
         }
 
-        if (!CanSubmitFromStatus(task.Status))
+        if (!ActionTaskStatusWorkflow.CanSubmitFromStatus(task.Status))
         {
             throw new InvalidOperationException("Only assigned, in-progress, or blocked tasks can be submitted.");
         }
@@ -435,62 +435,6 @@ public class ActionTaskService : IActionTaskService
         };
     }
 
-    // SECTION: Remarks rule helpers
-    private static void ValidateRemarksForStatusTransition(string currentStatus, string nextStatus, string? remarks)
-    {
-        if (string.Equals(nextStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
-        {
-            throw new InvalidOperationException("Remarks are required when marking a task as blocked.");
-        }
-
-        if (string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
-        {
-            throw new InvalidOperationException("Remarks are required when submitting a task.");
-        }
-
-        if (string.Equals(currentStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
-            && IsBlank(remarks))
-        {
-            throw new InvalidOperationException("Remarks are required when returning a submitted task for further action.");
-        }
-    }
-
+    // SECTION: Shared blank-value guard for required workflow remarks.
     private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
-
-    // SECTION: Submit workflow guard
-    private static bool CanSubmitFromStatus(string currentStatus)
-    {
-        return string.Equals(currentStatus, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(currentStatus, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(currentStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
-    }
-
-    // SECTION: Workflow transition guard
-    private static bool IsAllowedTransition(string currentStatus, string nextStatus)
-    {
-        if (string.Equals(currentStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (string.Equals(nextStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (string.Equals(currentStatus, nextStatus, StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return currentStatus switch
-        {
-            ActionTaskStatuses.Assigned => nextStatus is ActionTaskStatuses.InProgress or ActionTaskStatuses.Blocked,
-            ActionTaskStatuses.InProgress => nextStatus is ActionTaskStatuses.Blocked,
-            ActionTaskStatuses.Blocked => nextStatus is ActionTaskStatuses.InProgress,
-            ActionTaskStatuses.Submitted => nextStatus is ActionTaskStatuses.InProgress or ActionTaskStatuses.Blocked,
-            _ => false
-        };
-    }
 }

--- a/Services/ActionTasks/ActionTaskStatusWorkflow.cs
+++ b/Services/ActionTasks/ActionTaskStatusWorkflow.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ProjectManagement.Models;
+
+namespace ProjectManagement.Services.ActionTasks;
+
+internal static class ActionTaskStatusWorkflow
+{
+    // SECTION: Canonical status transition targets shared by services and Razor read models.
+    public static IReadOnlyList<string> GetAllowedStatusTargets(string currentStatus)
+    {
+        if (string.Equals(currentStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentStatus, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase))
+        {
+            return Array.Empty<string>();
+        }
+
+        return currentStatus switch
+        {
+            ActionTaskStatuses.Assigned => new[] { ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked },
+            ActionTaskStatuses.InProgress => new[] { ActionTaskStatuses.Blocked },
+            ActionTaskStatuses.Blocked => new[] { ActionTaskStatuses.InProgress },
+            ActionTaskStatuses.Submitted => new[] { ActionTaskStatuses.InProgress, ActionTaskStatuses.Blocked },
+            _ => Array.Empty<string>()
+        };
+    }
+
+    // SECTION: Submit transition is intentionally separate from generic status updates.
+    public static bool CanSubmitFromStatus(string currentStatus)
+    {
+        return string.Equals(currentStatus, ActionTaskStatuses.Assigned, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentStatus, ActionTaskStatuses.InProgress, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(currentStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // SECTION: Transition guard mirrors the allowed target list and permits only true no-ops.
+    public static bool IsAllowedTransition(string currentStatus, string nextStatus)
+    {
+        if (string.Equals(currentStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(nextStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(currentStatus, nextStatus, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return GetAllowedStatusTargets(currentStatus).Contains(nextStatus, StringComparer.OrdinalIgnoreCase);
+    }
+
+    // SECTION: Human context is mandatory for operationally important workflow moves.
+    public static void ValidateRemarksForStatusTransition(string currentStatus, string nextStatus, string? remarks)
+    {
+        if (string.Equals(nextStatus, ActionTaskStatuses.Blocked, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when marking a task as blocked.");
+        }
+
+        if (string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase) && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when submitting a task.");
+        }
+
+        if (string.Equals(currentStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(nextStatus, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase)
+            && IsBlank(remarks))
+        {
+            throw new InvalidOperationException("Remarks are required when returning a submitted task for further action.");
+        }
+    }
+
+    private static bool IsBlank(string? value) => string.IsNullOrWhiteSpace(value);
+}

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -22,6 +22,16 @@ public sealed class ActionTaskWorkflowPolicy
         ActionTaskStatuses.Blocked
     };
 
+    public IReadOnlyList<string> GetAllowedStatusTargets(ActionTaskItem task, string currentRole, string currentUserId)
+    {
+        if (!CanUpdateTaskStatus(task, currentRole, currentUserId))
+        {
+            return Array.Empty<string>();
+        }
+
+        return ActionTaskStatusWorkflow.GetAllowedStatusTargets(task.Status);
+    }
+
     public IReadOnlyList<string> PriorityOptions => new[]
     {
         "Low",

--- a/Services/ActionTasks/IActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/IActionTaskCollaborationService.cs
@@ -9,6 +9,7 @@ namespace ProjectManagement.Services.ActionTasks;
 public interface IActionTaskCollaborationService
 {
     Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default);
+    Task<ActionTaskUpdate?> AddUpdateAndMaybeChangeStatusAsync(int taskId, string body, string? newStatus, string userId, string role, IReadOnlyList<IFormFile> files, byte[] rowVersion, CancellationToken cancellationToken = default);
     Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
     Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);
 }

--- a/wwwroot/css/action-task-details-redesign.css
+++ b/wwwroot/css/action-task-details-redesign.css
@@ -1,21 +1,9 @@
 /* SECTION: Action Tracker Task Details pane redesign */
-:root {
-    --at-planning-drawer-width: 46rem;
-}
-
 .at-task-command-drawer {
     padding: 0;
     overflow: hidden;
 }
 
-.at-shell.has-selection .at-drawer-host,
-.at-shell.is-planning-board.has-selection .at-drawer-host {
-    width: min(46rem, calc(100vw - 2rem));
-}
-
-.at-shell.is-planning-board.has-selection .at-workspace {
-    padding-right: min(46rem, calc(100vw - 2rem));
-}
 
 .at-task-command-shell {
     display: grid;
@@ -398,16 +386,6 @@
 }
 
 /* SECTION: Production drawer overlay constraints prevent page-wide horizontal scrolling. */
-:root {
-    --at-planning-drawer-width: 38rem;
-    --at-task-drawer-width: min(38rem, calc(100vw - 2rem));
-}
-
-html,
-body {
-    overflow-x: hidden;
-}
-
 .at-shell,
 .at-workspace,
 .at-page,

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -22,7 +22,8 @@
     --at-weight-medium: 500;
     --at-weight-semibold: 600;
     --at-weight-bold: 700;
-    --at-planning-drawer-width: 46rem;
+    --at-planning-drawer-width: 38rem;
+    --at-task-drawer-width: min(38rem, calc(100vw - 2rem));
 }
 
 /* SECTION: Action Tracker shell */


### PR DESCRIPTION
### Motivation
- Reduce data-consistency and UX issues in the Action Tracker by making the combined "Add Update + Change Status" flow atomic, exposing backend-accurate allowed status targets to the UI, fixing IST-based ageing/late-closure calculations, and improving task inspector header and history labels.

### Description
- Added `ActionTaskStatusWorkflow` to centralize allowed status targets and transition guards and wired service checks to use it instead of duplicated logic.
- Implemented `AddUpdateAndMaybeChangeStatusAsync` in `ActionTaskCollaborationService` and exposed it on the collaboration interface; this method writes progress update, attachments, status mutation and audit rows inside a single DB transaction with rollback/cleanup on failure.
- Updated the drawer post handler to call the new atomic method and removed the legacy two-step flow from the page model.
- Made Reports ageing and closed-late calculations convert UTC timestamps to IST before taking `.Date` boundaries by converting `DaysSince` and `IsClosedLate` logic to use the injected clock.
- Moved the task-details CSS link out of the partial into the page-level `Styles` section and consolidated drawer sizing tokens into `action-tracker.css` (standardize to 38rem and `--at-task-drawer-width`) while removing conflicting rules from the partial stylesheet.
- Added a last-activity computation in the inspector read-model builder and surfaced it to the page model; updated task header to show the computed `LastActivityAtUtc` via `TimeFmt.ToIst()`.
- Standardized system-history display labels in the page model to map service action names to human-friendly labels.
- Small refactors: removed duplicate transition helpers from service and delegated to the workflow helper; updated workflow policy to return allowed targets for the UI.

### Testing
- Ran unit-style JS tests with `npm test` and all included JS tests passed (18/18) in this environment.
- Ran `git diff --check` to ensure no whitespace conflicts; no issues reported.
- `npm run lint:views` was executed and reported pre-existing inline-style rule violations outside these changes; this is not introduced by this PR.
- Attempted `dotnet build` but it could not run because `dotnet` is not installed in the container (manual/CI build required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092cd6d7a48329b03697dd12d7bdaf)