### PR TITLE
Add register Open/All task scope toggle

### DIFF
--- a/Models/ActionTaskItem.cs
+++ b/Models/ActionTaskItem.cs
@@ -23,6 +23,19 @@ public static class ActionTaskStatuses
     };
 }
 
+
+public static class ActionTaskRegisterScopes
+{
+    public const string Open = "Open";
+    public const string All = "All";
+
+    public static string Normalize(string? scope)
+        => string.Equals((scope ?? string.Empty).Trim(), All, StringComparison.OrdinalIgnoreCase) ? All : Open;
+
+    public static bool IsOpenScope(string? scope)
+        => string.Equals(Normalize(scope), Open, StringComparison.OrdinalIgnoreCase);
+}
+
 public class ActionTaskItem
 {
     [Key]

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -126,6 +126,9 @@ public class IndexModel : PageModel
     public string? PlanningTab { get; set; }
 
     [BindProperty(SupportsGet = true)]
+    public string? TaskScope { get; set; } = ActionTaskRegisterScopes.Open;
+
+    [BindProperty(SupportsGet = true)]
     public string? FilterStatus { get; set; }
 
     [BindProperty(SupportsGet = true)]
@@ -245,7 +248,25 @@ public class IndexModel : PageModel
 
     public IReadOnlyList<string> AssignmentRoles => ActionTaskRoleResolver.AllowedAssignmentRoles();
     public IReadOnlyList<string> AllowedStatusOptions => _workflowPolicy.AllowedStatusOptions;
-    public IReadOnlyList<string> RegisterStatusOptions => ActionTaskStatuses.All.ToList();
+    public string ResolvedTaskScope => ActionTaskRegisterScopes.Normalize(TaskScope);
+    public bool IsOpenTaskScope => ActionTaskRegisterScopes.IsOpenScope(ResolvedTaskScope);
+    public IReadOnlyList<string> RegisterStatusOptions => new[]
+    {
+        ActionTaskStatuses.Backlog,
+        ActionTaskStatuses.Assigned,
+        ActionTaskStatuses.InProgress,
+        ActionTaskStatuses.Blocked,
+        ActionTaskStatuses.Submitted,
+        ActionTaskStatuses.Closed
+    }.Where(status => !IsOpenTaskScope || !string.Equals(status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)).ToList();
+    public IReadOnlyList<(string Value, string Label)> RegisterBucketOptions => new[]
+    {
+        (Value: "Backlog", Label: "Backlog"),
+        (Value: "OutsideSprint", Label: "Outside Sprint"),
+        (Value: "Sprint", Label: "Sprint"),
+        (Value: "Closed", Label: "Closed"),
+        (Value: "Invalid", Label: "Invalid State")
+    }.Where(bucket => !IsOpenTaskScope || !string.Equals(bucket.Value, "Closed", StringComparison.OrdinalIgnoreCase)).ToList();
     public IReadOnlyList<string> ReportStatusOptions => new[]
     {
         ActionTaskStatuses.Backlog,
@@ -1178,6 +1199,7 @@ public class IndexModel : PageModel
     private async Task LoadDataAsync()
     {
         await ResolveIdentityAsync();
+        NormalizeRegisterScopeFilters();
 
         var sourceTasks = await _service.GetTasksAsync(CurrentUserId, CurrentRole);
 
@@ -1255,6 +1277,27 @@ public class IndexModel : PageModel
         TaskActorNames = inspector.ActorNames;
     }
 
+    // SECTION: Register scope normalization prevents contradictory open/closed filter combinations.
+    private void NormalizeRegisterScopeFilters()
+    {
+        TaskScope = ActionTaskRegisterScopes.Normalize(TaskScope);
+
+        if (!IsRegisterView || !IsOpenTaskScope)
+        {
+            return;
+        }
+
+        if (string.Equals(FilterStatus, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase))
+        {
+            FilterStatus = null;
+        }
+
+        if (string.Equals(FilterBucket, "Closed", StringComparison.OrdinalIgnoreCase))
+        {
+            FilterBucket = null;
+        }
+    }
+
     // SECTION: Workspace request isolates GET filter, report and sprint state before builder orchestration.
     private ActionTaskWorkspaceRequest BuildWorkspaceRequest()
         => new(
@@ -1278,7 +1321,8 @@ public class IndexModel : PageModel
             ReportFromDate,
             ReportToDate,
             ReportStatus,
-            ReportPriority);
+            ReportPriority,
+            ResolvedTaskScope);
 
 
     // SECTION: Sprint Board panel defaults and audit state are composed by the Sprint Board state builder.
@@ -1477,6 +1521,7 @@ public class IndexModel : PageModel
     public bool HasActiveFilters =>
         (IsTaskListView || IsBacklogView) &&
         (!string.IsNullOrWhiteSpace(FilterStatus)
+            || !string.Equals(ResolvedTaskScope, ActionTaskRegisterScopes.Open, StringComparison.OrdinalIgnoreCase)
             || !string.IsNullOrWhiteSpace(FilterBucket)
          || !string.IsNullOrWhiteSpace(FilterPriority)
          || !string.IsNullOrWhiteSpace(FilterAssigneeUserId)
@@ -1663,7 +1708,7 @@ public class IndexModel : PageModel
             BuildFilterRouteState()));
 
     private ActionTaskFilterRouteState BuildFilterRouteState()
-        => new(FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir, FilterBucket);
+        => new(FilterStatus, FilterPriority, FilterAssigneeUserId, FilterDueDate, FilterSearch, SortBy, SortDir, FilterBucket, ResolvedTaskScope);
 
     private ActionTaskReportFilterRouteState BuildReportFilterRouteState()
         => new(ReportBucket, ReportSprintId, ReportAssigneeUserId, ReportFromDate, ReportToDate, ReportStatus, ReportPriority);

--- a/Pages/ActionTasks/_TaskRegister.cshtml
+++ b/Pages/ActionTasks/_TaskRegister.cshtml
@@ -31,6 +31,14 @@
 <section class="at-panel at-register-filter-panel mb-3">
     <form id="taskFilterForm" method="get" class="at-register-filter-toolbar" data-at-task-filter-form="true">
         <input type="hidden" name="viewMode" value="Register" />
+        <input type="hidden" name="TaskScope" value="@Model.ResolvedTaskScope" data-at-register-scope-input="true" />
+        <div class="at-register-scope-field" aria-label="Task scope">
+            @* SECTION: Register scope toggle submits the base dataset before any refinement filters. *@
+            <div class="at-register-scope-toggle" role="group" aria-label="Task scope">
+                <button type="button" class="at-register-scope-option @(Model.IsOpenTaskScope ? "active" : string.Empty)" data-at-register-scope-option="Open" aria-pressed="@(Model.IsOpenTaskScope ? "true" : "false")">Open Tasks</button>
+                <button type="button" class="at-register-scope-option @(!Model.IsOpenTaskScope ? "active" : string.Empty)" data-at-register-scope-option="All" aria-pressed="@(!Model.IsOpenTaskScope ? "true" : "false")">All Tasks</button>
+            </div>
+        </div>
         <div class="at-register-filter-field at-register-filter-field-search">
             <label class="form-label" for="RegisterFilterSearch">Search</label>
             <input type="text" class="form-control form-control-sm" id="RegisterFilterSearch" name="FilterSearch" value="@Model.FilterSearch" placeholder="Search task title or AT number" data-at-filter-search="true" />
@@ -97,7 +105,7 @@
             <label class="form-label" for="RegisterFilterBucket">Bucket</label>
             <select class="form-select form-select-sm" id="RegisterFilterBucket" name="FilterBucket">
                 <option value="">All</option>
-                @foreach (var bucket in new[] { (Value: "Backlog", Label: "Backlog"), (Value: "OutsideSprint", Label: "Outside Sprint"), (Value: "Sprint", Label: "Sprint"), (Value: "Closed", Label: "Closed"), (Value: "Invalid", Label: "Invalid State") })
+                @foreach (var bucket in Model.RegisterBucketOptions)
                 {
                     @if (string.Equals(Model.FilterBucket, bucket.Value, StringComparison.OrdinalIgnoreCase))
                     {
@@ -132,13 +140,17 @@
             <input type="date" class="form-control form-control-sm" id="RegisterFilterDueDate" name="FilterDueDate" value="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" />
         </div>
         <div class="at-register-filter-action">
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm">Reset</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="Open" class="btn btn-outline-secondary btn-sm">Reset</a>
         </div>
     </form>
 
     @if (Model.HasActiveFilters)
     {
         <div class="at-active-filters at-register-active-filters" aria-label="Active filters">
+            @if (!Model.IsOpenTaskScope)
+            {
+                <span class="at-filter-chip">Scope: All Tasks</span>
+            }
             @if (!string.IsNullOrWhiteSpace(Model.FilterStatus))
             {
                 <span class="at-filter-chip">Status: @Model.FilterStatus</span>
@@ -163,7 +175,7 @@
             {
                 <span class="at-filter-chip">Search: @Model.FilterSearch</span>
             }
-            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="at-filter-clear">Clear all</a>
+            <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="Open" class="at-filter-clear">Clear all</a>
         </div>
     }
 </section>
@@ -177,7 +189,7 @@
             <div class="fw-semibold">No tasks match the selected filters.</div>
                 @if (Model.HasActiveFilters)
                 {
-                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" class="btn btn-outline-secondary btn-sm mt-2">Clear filters</a>
+                    <a asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="Open" class="btn btn-outline-secondary btn-sm mt-2">Clear filters</a>
                 }
         </div>
     }
@@ -188,22 +200,22 @@
                 <thead>
                     <tr>
                         @* SECTION: Register sorting links preserve active filters for audit-friendly review. *@
-                        <th scope="col" aria-sort='@SortAriaSort("id")'><a class='@SortLinkClass("id")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("id")</span></a></th>
-                        <th scope="col" aria-sort='@SortAriaSort("title")'><a class='@SortLinkClass("title")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("title")</span></a></th>
-                        <th scope="col" aria-sort='@SortAriaSort("assignee")'><a class='@SortLinkClass("assignee")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("assignee")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("id")'><a class='@SortLinkClass("id")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="id" asp-route-SortDir="@(Model.SortBy == "id" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">ID<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("id")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("title")'><a class='@SortLinkClass("title")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="title" asp-route-SortDir="@(Model.SortBy == "title" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Task<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("title")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("assignee")'><a class='@SortLinkClass("assignee")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="assignee" asp-route-SortDir="@(Model.SortBy == "assignee" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Responsible Person<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("assignee")</span></a></th>
                         <th scope="col" class="at-register-sprint-heading">Bucket</th>
-                        <th scope="col" aria-sort='@SortAriaSort("due")'><a class='@SortLinkClass("due")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due / Target Date<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("due")</span></a></th>
-                        <th scope="col" aria-sort='@SortAriaSort("status")'><a class='@SortLinkClass("status")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("status")</span></a></th>
-                        <th scope="col" aria-sort='@SortAriaSort("priority")'><a class='@SortLinkClass("priority")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("priority")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("due")'><a class='@SortLinkClass("due")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="due" asp-route-SortDir="@(Model.SortBy == "due" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Due / Target Date<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("due")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("status")'><a class='@SortLinkClass("status")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="status" asp-route-SortDir="@(Model.SortBy == "status" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Status<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("status")</span></a></th>
+                        <th scope="col" aria-sort='@SortAriaSort("priority")'><a class='@SortLinkClass("priority")' asp-page="/ActionTasks/Index" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope" asp-route-FilterStatus="@Model.FilterStatus" asp-route-FilterBucket="@Model.FilterBucket" asp-route-FilterPriority="@Model.FilterPriority" asp-route-FilterAssigneeUserId="@Model.FilterAssigneeUserId" asp-route-FilterDueDate="@(Model.FilterDueDate?.ToString("yyyy-MM-dd"))" asp-route-FilterSearch="@Model.FilterSearch" asp-route-SortBy="priority" asp-route-SortDir="@(Model.SortBy == "priority" && !string.Equals(Model.SortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc")">Priority<span class="at-sort-indicator" aria-hidden="true">@SortIndicator("priority")</span></a></th>
                     </tr>
                 </thead>
                 <tbody>
                     @foreach (var task in Model.Tasks)
                     {
                         <tr class="@(Model.IsSelectedTask(task) ? "is-selected" : string.Empty)">
-                            <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">AT-@task.Id</a></td>
+                            <td><a class="at-task-id-link" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope">AT-@task.Id</a></td>
                             <td class="at-register-task-cell">
-                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register">@task.Title</a>
+                                <a class="at-task-title" asp-page="/ActionTasks/Index" asp-route-taskId="@task.Id" asp-route-viewMode="Register" asp-route-TaskScope="@Model.ResolvedTaskScope">@task.Title</a>
                                 <div class="at-task-desc-preview">@task.Description</div>
                             </td>
                             <td class="at-register-person-cell">@(Model.IsBacklogTask(task) ? "—" : Model.ResolveAssigneeName(task.AssignedToUserId))</td>

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -431,10 +431,12 @@ public class ActionTaskPageTests
         // SECTION: Arrange
         var setup = await CreateSetupAsync();
         var page = setup.Page;
-        var selectedTaskId = await setup.Db.ActionTasks.Select(t => t.Id).SingleAsync();
+        var selectedTask = await setup.Db.ActionTasks.SingleAsync();
+        selectedTask.Status = ActionTaskStatuses.Closed;
+        await setup.Db.SaveChangesAsync();
         page.ViewMode = "Register";
-        page.FilterStatus = ActionTaskStatuses.Closed;
-        page.TaskId = selectedTaskId;
+        page.TaskScope = ActionTaskRegisterScopes.Open;
+        page.TaskId = selectedTask.Id;
 
         // SECTION: Act
         await page.OnGetAsync();
@@ -442,7 +444,7 @@ public class ActionTaskPageTests
         // SECTION: Assert
         Assert.Empty(page.Tasks);
         Assert.NotNull(page.SelectedTask);
-        Assert.Equal(selectedTaskId, page.SelectedTask!.Id);
+        Assert.Equal(selectedTask.Id, page.SelectedTask!.Id);
     }
 
     [Fact]
@@ -468,9 +470,13 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskRegister.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("<th scope=\"col\" class=\"at-register-sprint-heading\">Scope</th>", html, StringComparison.Ordinal);
+        Assert.Contains("data-at-register-scope-option=\"Open\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-at-register-scope-option=\"All\"", html, StringComparison.Ordinal);
+        Assert.Contains("aria-pressed=\"true\">Open Tasks", html, StringComparison.Ordinal);
+        Assert.Contains("<th scope=\"col\" class=\"at-register-sprint-heading\">Bucket</th>", html, StringComparison.Ordinal);
         Assert.Contains("Due / Target Date", html, StringComparison.Ordinal);
         Assert.DoesNotContain("<th scope=\"col\" class=\"at-register-sprint-heading\">Sprint</th>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(">Closed</option>", html, StringComparison.Ordinal);
         Assert.Contains("at-register-sprint-cell", html, StringComparison.Ordinal);
         Assert.Contains("Enterprise Sprint", html, StringComparison.Ordinal);
         Assert.Contains("Target 20 May 2026", html, StringComparison.Ordinal);

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskQueryServiceSprintMetricsTests.cs
@@ -87,6 +87,56 @@ public class ActionTaskQueryServiceSprintMetricsTests
         Assert.Equal(new[] { new ActionTaskQueryService.CountSummary("Filtered Sprint", 1) }, model.Reports.CarryForwardBySprint);
     }
 
+
+    [Fact]
+    public void BuildReadModel_RegisterOpenScopeExcludesClosedBeforeFilters()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 41, Name = "Register Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var tasks = new[]
+        {
+            NewTask(31, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(1)),
+            NewTask(32, sprint.Id, ActionTaskStatuses.Closed, today.AddDays(1)),
+            NewTask(33, null, ActionTaskStatuses.Backlog, today.AddDays(1), assignedToUserId: string.Empty)
+        };
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null, TaskScope: ActionTaskRegisterScopes.Open),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(new[] { 31, 33 }, model.TaskListTasks.Select(t => t.Id));
+    }
+
+    [Fact]
+    public void BuildReadModel_RegisterAllScopeIncludesClosedAndAllowsClosedStatusFilter()
+    {
+        // SECTION: Arrange
+        var today = DateTime.UtcNow.Date;
+        var sprint = new ActionSprint { Id = 42, Name = "Register Sprint", Status = ActionSprintStatus.Active, StartDate = today, EndDate = today.AddDays(7) };
+        var tasks = new[]
+        {
+            NewTask(34, sprint.Id, ActionTaskStatuses.Assigned, today.AddDays(1)),
+            NewTask(35, sprint.Id, ActionTaskStatuses.Closed, today.AddDays(1))
+        };
+        var service = CreateQueryService();
+
+        // SECTION: Act
+        var model = service.BuildReadModel(
+            tasks,
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, ActionTaskStatuses.Closed, null, null, null, null, null, null, TaskScope: ActionTaskRegisterScopes.All),
+            new Dictionary<string, string> { ["assignee"] = "Assignee" },
+            new Dictionary<int, DateTime?>());
+
+        // SECTION: Assert
+        Assert.Equal(new[] { 35 }, model.TaskListTasks.Select(t => t.Id));
+    }
+
     [Fact]
     public void BuildReadModel_ReportBacklogSprintFilter_RendersBacklogAgeingOnly()
     {
@@ -348,7 +398,7 @@ public class ActionTaskQueryServiceSprintMetricsTests
     private static ActionTaskQueryService.ActionTaskReadModel BuildWithBucket(ActionTaskQueryService service, IReadOnlyList<ActionTaskItem> tasks, ActionSprint sprint, string bucket)
         => service.BuildReadModel(
             tasks,
-            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null, FilterBucket: bucket),
+            new ActionTaskQueryService.ActionTaskQueryRequest("user", false, true, false, sprint.Id, new[] { sprint }, null, null, null, null, null, null, null, FilterBucket: bucket, TaskScope: ActionTaskRegisterScopes.All),
             new Dictionary<string, string> { ["assignee"] = "Assignee" },
             new Dictionary<int, DateTime?>());
 

--- a/Services/ActionTasks/ActionTaskQueryService.cs
+++ b/Services/ActionTasks/ActionTaskQueryService.cs
@@ -227,11 +227,13 @@ public sealed class ActionTaskQueryService
     private static IEnumerable<ActionTaskItem> ApplyTaskListFilters(IReadOnlyList<ActionTaskItem> tasks, ActionTaskQueryRequest request, IReadOnlyDictionary<string, string> assigneeNames)
     {
         var query = tasks.AsEnumerable();
-        if (!string.IsNullOrWhiteSpace(request.FilterStatus)) query = query.Where(t => string.Equals(t.Status, request.FilterStatus, StringComparison.OrdinalIgnoreCase));
-        if (!string.IsNullOrWhiteSpace(request.FilterBucket)) query = query.Where(t => MatchesBucketFilter(t, request.FilterBucket));
-        if (!string.IsNullOrWhiteSpace(request.FilterPriority)) query = query.Where(t => string.Equals(t.Priority, request.FilterPriority, StringComparison.OrdinalIgnoreCase));
-        if (!string.IsNullOrWhiteSpace(request.FilterAssigneeUserId)) query = query.Where(t => string.Equals(t.AssignedToUserId, request.FilterAssigneeUserId, StringComparison.Ordinal));
-        if (request.FilterDueDate.HasValue) { var d = request.FilterDueDate.Value.Date; query = query.Where(t => t.DueDate.Date == d); }
+
+        // SECTION: Register task scope establishes the base dataset before user refinements.
+        if (ActionTaskRegisterScopes.IsOpenScope(request.TaskScope))
+        {
+            query = query.Where(t => !string.Equals(t.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase));
+        }
+
         if (!string.IsNullOrWhiteSpace(request.FilterSearch))
         {
             var s = request.FilterSearch.Trim();
@@ -241,6 +243,12 @@ public sealed class ActionTaskQueryService
 
             query = query.Where(t => MatchesRegisterSearch(t, s, normalizedTaskNumber, assigneeNames));
         }
+
+        if (!string.IsNullOrWhiteSpace(request.FilterAssigneeUserId)) query = query.Where(t => string.Equals(t.AssignedToUserId, request.FilterAssigneeUserId, StringComparison.Ordinal));
+        if (!string.IsNullOrWhiteSpace(request.FilterStatus)) query = query.Where(t => string.Equals(t.Status, request.FilterStatus, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(request.FilterBucket)) query = query.Where(t => MatchesBucketFilter(t, request.FilterBucket));
+        if (!string.IsNullOrWhiteSpace(request.FilterPriority)) query = query.Where(t => string.Equals(t.Priority, request.FilterPriority, StringComparison.OrdinalIgnoreCase));
+        if (request.FilterDueDate.HasValue) { var d = request.FilterDueDate.Value.Date; query = query.Where(t => t.DueDate.Date == d); }
 
         var sortBy = (request.SortBy ?? "due").Trim().ToLowerInvariant();
         var descending = string.Equals(request.SortDir, "desc", StringComparison.OrdinalIgnoreCase);
@@ -327,7 +335,8 @@ public sealed class ActionTaskQueryService
         string? ReportStatus = null,
         string? ReportPriority = null,
         string? ReportBucket = null,
-        string? FilterBucket = null);
+        string? FilterBucket = null,
+        string? TaskScope = null);
 
     public sealed class ActionTaskReadModel
     {

--- a/Services/ActionTasks/ActionTaskRouteStateHelper.cs
+++ b/Services/ActionTasks/ActionTaskRouteStateHelper.cs
@@ -126,12 +126,14 @@ public sealed class ActionTaskRouteStateHelper
             request.FilterState.FilterSearch,
             request.FilterState.SortBy,
             request.FilterState.SortDir,
-            request.FilterState.FilterBucket);
+            request.FilterState.FilterBucket,
+            request.FilterState.TaskScope);
     }
 
     // SECTION: Shared filter-state detection covers GET bookmarks and postback route preservation.
     public bool HasTaskFilterRouteState(ActionTaskFilterRouteState state)
         => !string.IsNullOrWhiteSpace(state.FilterStatus)
+            || string.Equals(state.TaskScope, ProjectManagement.Models.ActionTaskRegisterScopes.All, StringComparison.OrdinalIgnoreCase)
             || !string.IsNullOrWhiteSpace(state.FilterBucket)
             || !string.IsNullOrWhiteSpace(state.FilterPriority)
             || !string.IsNullOrWhiteSpace(state.FilterAssigneeUserId)
@@ -191,6 +193,7 @@ public sealed class ActionTaskRouteStateHelper
     // SECTION: Filter route values are added only when populated so canonical links stay compact.
     private static void AddTaskFilterRouteValues(RouteValueDictionary routeValues, ActionTaskRouteState state)
     {
+        AddRouteValueIfPresent(routeValues, nameof(ActionTaskRouteState.TaskScope), state.TaskScope);
         AddRouteValueIfPresent(routeValues, nameof(ActionTaskRouteState.FilterStatus), state.FilterStatus);
         AddRouteValueIfPresent(routeValues, nameof(ActionTaskRouteState.FilterBucket), state.FilterBucket);
         AddRouteValueIfPresent(routeValues, nameof(ActionTaskRouteState.FilterPriority), state.FilterPriority);
@@ -245,7 +248,8 @@ public sealed record ActionTaskRouteState(
     string? FilterSearch,
     string? SortBy,
     string? SortDir,
-    string? FilterBucket = null);
+    string? FilterBucket = null,
+    string? TaskScope = null);
 
 public sealed record ActionTaskFilterRouteState(
     string? FilterStatus,
@@ -255,7 +259,8 @@ public sealed record ActionTaskFilterRouteState(
     string? FilterSearch,
     string? SortBy,
     string? SortDir,
-    string? FilterBucket = null);
+    string? FilterBucket = null,
+    string? TaskScope = null);
 
 public sealed record ActionTaskReportFilterRouteState(
     string? ReportBucket,

--- a/Services/ActionTasks/ActionTaskWorkspaceBuilder.cs
+++ b/Services/ActionTasks/ActionTaskWorkspaceBuilder.cs
@@ -45,7 +45,8 @@ public sealed class ActionTaskWorkspaceBuilder
             request.ReportStatus,
             request.ReportPriority,
             request.ReportBucket,
-            request.FilterBucket);
+            request.FilterBucket,
+            TaskScope: request.TaskScope);
 
         return new ActionTaskWorkspaceReadModel(sourceTasks, _queryService.BuildReadModel(sourceTasks, queryRequest, assigneeNames, activityByTaskId));
     }
@@ -72,6 +73,7 @@ public sealed record ActionTaskWorkspaceRequest(
     DateTime? ReportFromDate,
     DateTime? ReportToDate,
     string? ReportStatus,
-    string? ReportPriority);
+    string? ReportPriority,
+    string? TaskScope = null);
 
 public sealed record ActionTaskWorkspaceReadModel(IReadOnlyList<ActionTaskItem> SourceTasks, ActionTaskQueryService.ActionTaskReadModel ReadModel);

--- a/wwwroot/css/action-tracker.css
+++ b/wwwroot/css/action-tracker.css
@@ -690,9 +690,48 @@ html {
 
 .at-register-filter-toolbar {
     display: grid;
-    grid-template-columns: minmax(15rem, 1.45fr) minmax(14rem, 1.25fr) repeat(3, minmax(8rem, 0.75fr)) minmax(10rem, 0.9fr) auto;
+    grid-template-columns: auto minmax(15rem, 1.45fr) minmax(14rem, 1.25fr) repeat(3, minmax(8rem, 0.75fr)) minmax(10rem, 0.9fr) auto;
     gap: 0.45rem;
     align-items: end;
+}
+
+
+.at-register-scope-field {
+    display: flex;
+    align-items: end;
+    min-height: 2rem;
+}
+
+.at-register-scope-toggle {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--at-border);
+    border-radius: 999px;
+    background: var(--at-surface-soft);
+    padding: 2px;
+    white-space: nowrap;
+}
+
+.at-register-scope-option {
+    border: 0;
+    background: transparent;
+    border-radius: 999px;
+    padding: 0.32rem 0.72rem;
+    font-size: var(--at-font-sm);
+    font-weight: var(--at-weight-semibold);
+    color: var(--at-muted);
+    line-height: 1.2;
+}
+
+.at-register-scope-option:focus-visible {
+    outline: 2px solid rgba(37, 99, 235, 0.35);
+    outline-offset: 2px;
+}
+
+.at-register-scope-option.active {
+    background: var(--at-blue);
+    color: #fff;
+    box-shadow: var(--at-shadow-sm);
 }
 
 .at-register-filter-field-search {

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -73,6 +73,20 @@
             });
         });
 
+        const scopeInput = form.querySelector("[data-at-register-scope-input='true']");
+        const scopeOptions = form.querySelectorAll("[data-at-register-scope-option]");
+        scopeOptions.forEach((option) => {
+            option.addEventListener("click", () => {
+                const selectedScope = option.getAttribute("data-at-register-scope-option");
+                if (!scopeInput || !selectedScope || scopeInput.value === selectedScope) {
+                    return;
+                }
+
+                scopeInput.value = selectedScope;
+                form.requestSubmit();
+            });
+        });
+
         const searchInput = form.querySelector("[data-at-filter-search='true']");
         if (searchInput) {
             let searchDebounceHandle;


### PR DESCRIPTION
### Motivation
- Reduce noise in the Register by hiding closed tasks by default and allow users to switch the base scope between `Open Tasks` and `All Tasks` with a compact control preserved in the URL. 
- Ensure the scope defines the base dataset (applied before other filters) so counts, paging and exports remain consistent and to avoid contradictory filter states such as `TaskScope=Open` combined with `FilterStatus=Closed`.

### Description
- Introduced `ActionTaskRegisterScopes` constants and normalization to canonicalise `TaskScope` values and default missing/invalid values to `Open`.
- Added `TaskScope` to the page model (`IndexModel`) with `ResolvedTaskScope`/`IsOpenTaskScope` helpers and `NormalizeRegisterScopeFilters()` which resets contradictory `FilterStatus`/`FilterBucket` when `Open` is selected.
- Applied scope filtering at the query layer by updating `ApplyTaskListFilters` in `ActionTaskQueryService` so `TaskScope` is applied first (exclude `Closed` when `Open`), then search, assignee, status, bucket, priority and due-date filters.
- Propagated `TaskScope` through the workspace builder and route-state helper so scope is preserved across navigation, sorting, inspector links and shared URLs.
- UI: added a compact, accessible segmented toggle (pills) to the Register filter bar in `_TaskRegister.cshtml`, a hidden `TaskScope` input, and JS to submit the form when the scope changes; added matching CSS to keep the control low-profile and keyboard-accessible.
- Tests: updated/added unit tests for query behavior and register partial rendering to cover Open/All semantics and the default behaviour in the Register partial.

### Testing
- Ran frontend unit tests with `npm test` (node jsdom tests); all JS tests passed (18 subtests, 0 failures). 
- Ran `git diff --check` and it returned no whitespace errors. 
- Attempted `dotnet test` but `dotnet` is not available in this environment so .NET unit tests could not be executed here. 
- Ran `npm run lint:views`; this command failed due to pre-existing inline style attributes outside the scope of these changes, not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094932807c83298fb75be4a7398217)