### PR TITLE
Enable direct Action Task closure by Comdt/HoD with mandatory remarks and audit

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1827,6 +1827,9 @@ namespace ProjectManagement.Data
                 e.Property(x => x.AssignedToRole).IsRequired().HasMaxLength(64);
                 e.Property(x => x.Priority).IsRequired().HasMaxLength(24);
                 e.Property(x => x.Status).IsRequired().HasMaxLength(32);
+                // SECTION: Closure authority metadata is optional for pre-existing open tasks.
+                e.Property(x => x.ClosedByUserId).HasMaxLength(450);
+                e.Property(x => x.ClosureRemarks).HasMaxLength(2000);
                 // SECTION: Action task due dates are stored as date-only values
                 e.Property(x => x.DueDate).HasColumnType("date");
                 e.Property(x => x.IsDeleted).HasDefaultValue(false);

--- a/Migrations/20261125210000_AddActionTaskClosureAuthorityMetadata.cs
+++ b/Migrations/20261125210000_AddActionTaskClosureAuthorityMetadata.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125210000_AddActionTaskClosureAuthorityMetadata")]
+    public partial class AddActionTaskClosureAuthorityMetadata : Migration
+    {
+        // SECTION: Add command-closure metadata fields to action tasks.
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ClosedByUserId",
+                table: "ActionTasks",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ClosureRemarks",
+                table: "ActionTasks",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        // SECTION: Remove command-closure metadata fields from action tasks.
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClosedByUserId",
+                table: "ActionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "ClosureRemarks",
+                table: "ActionTasks");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2380,8 +2380,16 @@ namespace ProjectManagement.Migrations
                         .HasMaxLength(450)
                         .HasColumnType("character varying(450)");
 
+                    b.Property<string>("ClosedByUserId")
+                        .HasMaxLength(450)
+                        .HasColumnType("character varying(450)");
+
                     b.Property<DateTime?>("ClosedOn")
                         .HasColumnType("timestamp without time zone");
+
+                    b.Property<string>("ClosureRemarks")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
 
                     b.Property<string>("CreatedByRole")
                         .IsRequired()

--- a/Models/ActionTaskItem.cs
+++ b/Models/ActionTaskItem.cs
@@ -71,6 +71,13 @@ public class ActionTaskItem
     public DateTime? SubmittedOn { get; set; }
     public DateTime? ClosedOn { get; set; }
 
+    // SECTION: Closure authority metadata for reviewer and command-directed closures
+    [StringLength(450)]
+    public string? ClosedByUserId { get; set; }
+
+    [StringLength(2000)]
+    public string? ClosureRemarks { get; set; }
+
     // SECTION: Optional sprint assignment; null represents the backlog
     public int? SprintId { get; set; }
     public ActionSprint? Sprint { get; set; }

--- a/Pages/ActionTasks/Index.cshtml.cs
+++ b/Pages/ActionTasks/Index.cshtml.cs
@@ -356,6 +356,11 @@ public class IndexModel : PageModel
         return _workflowPolicy.CanCloseTask(task, CurrentRole);
     }
 
+    public bool CanCloseTaskDirectly(ActionTaskItem task)
+    {
+        return _permission.CanCloseTaskDirectly(task, CurrentRole);
+    }
+
     public bool CanUpdateTaskStatus(ActionTaskItem task)
     {
         return _workflowPolicy.CanUpdateTaskStatus(task, CurrentRole, CurrentUserId);
@@ -404,6 +409,7 @@ public class IndexModel : PageModel
             "TaskMovedToBacklogRemoveAssignee" => "Moved to backlog",
             "TaskCarriedForward" => "Carried forward",
             "TaskUpdated" => "Task updated",
+            "TaskClosedByCommandAuthority" => "Closed by command authority",
             "Submitted" => "Submitted for closure",
             "TaskSubmitted" => "Submitted for closure",
             "Closed" => "Closed",
@@ -425,6 +431,7 @@ public class IndexModel : PageModel
             "StatusUpdated" or "TaskStatusChanged" => $"Status changed from {log.OldValue ?? "previous status"} to {log.NewValue ?? "new status"}.",
             "Submitted" or "TaskSubmitted" => "Task submitted for closure review.",
             "Closed" or "TaskClosed" => "Task closed after review.",
+            "TaskClosedByCommandAuthority" => "Closed by command authority.",
             "DueDateChanged" or "TaskDueDateChanged" => $"Due date changed from {FormatAuditDate(log.OldValue)} to {FormatAuditDate(log.NewValue)}.",
             "TargetDateChanged" => $"Target date changed from {FormatAuditDate(log.OldValue)} to {FormatAuditDate(log.NewValue)}.",
             "TaskAssignedToSprint" or "OutsideSprintTaskAssignedToSprint" => "Task added to sprint. Responsible person retained.",
@@ -531,6 +538,13 @@ public class IndexModel : PageModel
         return TaskActorNames.TryGetValue(performedByUserId, out var actorName)
             ? actorName
             : "User";
+    }
+
+    public string ResolveClosedByName(ActionTaskItem task)
+    {
+        return !string.IsNullOrWhiteSpace(task.ClosedByUserId) && TaskActorNames.TryGetValue(task.ClosedByUserId, out var actorName)
+            ? actorName
+            : "Command authority";
     }
 
     public string ResolveSprintActorName(string performedByUserId)
@@ -902,8 +916,8 @@ public class IndexModel : PageModel
         await ResolveIdentityAsync();
         try
         {
-            await _service.CloseTaskAsync(id, DecodeRowVersion(rowVersion), CurrentUserId, CurrentRole, remarks);
-            TempData["ToastMessage"] = "Task closed.";
+            await _service.CloseTaskDirectlyAsync(id, DecodeRowVersion(rowVersion), remarks ?? string.Empty, CurrentUserId, CurrentRole);
+            TempData["ToastMessage"] = "Task closed successfully.";
         }
         catch (ActionTaskConcurrencyException ex)
         {

--- a/Pages/ActionTasks/_TaskDetails.cshtml
+++ b/Pages/ActionTasks/_TaskDetails.cshtml
@@ -24,7 +24,7 @@
     var updatePlaceholder = selectedTaskIsBacklog ? "Add planning note or clarification" : "Record progress, blocker details, completion notes, or status-change context";
     var canOpenStatusAction = Model.SelectedTask is not null && !selectedTaskIsBacklog && Model.CanUpdateTaskStatus(Model.SelectedTask);
     var canOpenSubmitAction = Model.SelectedTask is not null && Model.CanSubmitTask(Model.SelectedTask);
-    var canOpenCloseAction = Model.SelectedTask is not null && selectedTaskIsSubmitted && Model.CanCloseTask(Model.SelectedTask);
+    var canOpenCloseAction = Model.SelectedTask is not null && Model.CanCloseTaskDirectly(Model.SelectedTask);
     var canOpenChangeDateAction = Model.SelectedTask is not null && Model.CanChangeTaskDate(Model.SelectedTask);
     var canMoveTaskToBacklogAction = Model.SelectedTask is not null && Model.CanMoveTaskToBacklog(Model.SelectedTask);
     var canRemoveFromSprintKeepAssignedAction = canMoveTaskToBacklogAction && Model.SelectedTask?.SprintId.HasValue == true;
@@ -33,10 +33,12 @@
     var hasDangerActions = !selectedTaskIsClosed && canMoveTaskToBacklogAction;
     var hasMoreActions = hasPlanningActions || hasDangerActions;
     var canViewSystemHistory = Model.SelectedTask is not null && Model.CanViewSelectedTaskSystemHistory();
-    var selectedTaskClosureHelper = Model.SelectedTask is not null && !selectedTaskIsBacklog && !selectedTaskIsClosed
-        ? selectedTaskIsSubmitted
-            ? "Close Task is available to authorised reviewers."
-            : "Close Task will appear after the assignee submits this task for closure."
+    var selectedTaskClosureHelper = Model.SelectedTask is not null && !selectedTaskIsClosed
+        ? canOpenCloseAction
+            ? "Command authorities may close this task directly with mandatory closure remarks."
+            : selectedTaskIsSubmitted
+                ? "This task is submitted for closure review."
+                : null
         : null;
     var taskBrief = string.IsNullOrWhiteSpace(Model.SelectedTask?.Description)
         ? "No task brief recorded."
@@ -46,7 +48,7 @@
         : selectedTaskIsClosed
             ? "This task is closed. No further action is required."
             : selectedTaskIsSubmitted
-                ? "This task is awaiting closure review."
+                ? "This task is awaiting closure review. Command authorities may close it directly after recording remarks."
                 : selectedTaskIsBlocked
                     ? "This task is blocked. Record blocker details or change status once the issue is resolved."
                     : selectedTaskIsInProgress
@@ -95,55 +97,80 @@
                     <div class="at-task-brief-text @(string.IsNullOrWhiteSpace(Model.SelectedTask.Description) ? "is-muted" : string.Empty)">@taskBrief</div>
                 </section>
 
-                <section class="at-command-section at-next-action-section" aria-label="Next action">
-                    <div class="at-next-action-copy">
-                        <div class="at-command-section-heading">Next Action</div>
-                        <p>@nextActionText</p>
-                        @if (!string.IsNullOrWhiteSpace(selectedTaskClosureHelper))
-                        {
-                            <small>@selectedTaskClosureHelper</small>
-                        }
-                    </div>
-                    <div class="at-next-action-buttons">
-                        @if (selectedTaskIsBacklog)
-                        {
-                            <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Add Planning Note</button>
-                            @if (Model.CanAssignTaskToSprint(Model.SelectedTask))
+                @if (selectedTaskIsClosed)
+                {
+                    <section class="at-command-section at-closed-task-summary" aria-label="Closure details">
+                        <div class="at-command-section-heading">Closure Details</div>
+                        <dl class="at-task-closure-list">
+                            <div>
+                                <dt>Status</dt>
+                                <dd><span class="@Model.GetStatusBadgeClass(Model.SelectedTask.Status)">@Model.SelectedTask.Status</span></dd>
+                            </div>
+                            <div>
+                                <dt>Closed on</dt>
+                                <dd>@(Model.SelectedTask.ClosedOn.HasValue ? TimeFmt.ToIst(Model.SelectedTask.ClosedOn.Value) : "Not recorded")</dd>
+                            </div>
+                            <div>
+                                <dt>Closed by</dt>
+                                <dd>@Model.ResolveClosedByName(Model.SelectedTask)</dd>
+                            </div>
+                            <div>
+                                <dt>Closure remarks</dt>
+                                <dd class="at-remarks-text">@(string.IsNullOrWhiteSpace(Model.SelectedTask.ClosureRemarks) ? "No closure remarks recorded." : Model.SelectedTask.ClosureRemarks)</dd>
+                            </div>
+                        </dl>
+                    </section>
+                }
+                else
+                {
+                    <section class="at-command-section at-next-action-section" aria-label="Next action">
+                        <div class="at-next-action-copy">
+                            <div class="at-command-section-heading">Next Action</div>
+                            <p>@nextActionText</p>
+                            @if (!string.IsNullOrWhiteSpace(selectedTaskClosureHelper))
                             {
-                                <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="add-to-sprint">Add to Sprint</button>
+                                <small>@selectedTaskClosureHelper</small>
                             }
-                        }
-                        else if (Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
-                        {
-                            <button type="button" class="btn btn-primary btn-sm" data-at-open-action="add-outside-to-sprint">Add to Sprint</button>
-                            <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="update">Update Progress</button>
-                        }
-                        else if (selectedTaskIsSubmitted)
-                        {
-                            @if (canUseUpdateWorkflow)
+                        </div>
+                        <div class="at-next-action-buttons">
+                            @if (selectedTaskIsBacklog)
                             {
+                                <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Add Planning Note</button>
+                                @if (Model.CanAssignTaskToSprint(Model.SelectedTask))
+                                {
+                                    <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="add-to-sprint">Add to Sprint</button>
+                                }
+                            }
+                            else if (Model.CanAddOutsideSprintTaskToSprint(Model.SelectedTask))
+                            {
+                                <button type="button" class="btn btn-primary btn-sm" data-at-open-action="add-outside-to-sprint">Add to Sprint</button>
                                 <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="update">Update Progress</button>
                             }
-                            @if (Model.CanCloseTask(Model.SelectedTask))
+                            else if (selectedTaskIsSubmitted)
                             {
-                                <button type="button" class="btn btn-success btn-sm" data-at-open-action="close" data-at-close-task>Close Task</button>
+                                @if (canUseUpdateWorkflow)
+                                {
+                                    <button type="button" class="btn btn-outline-primary btn-sm" data-at-open-action="update">Update Progress</button>
+                                }
+                                else if (!canOpenCloseAction)
+                                {
+                                    <span class="text-muted small">Submitted for closure</span>
+                                }
                             }
-                            else if (!canUseUpdateWorkflow)
+                            else
                             {
-                                <span class="text-muted small">Submitted for closure</span>
+                                <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Update Progress</button>
                             }
-                        }
-                        else if (selectedTaskIsClosed)
-                        {
-                            <span class="text-muted small">View only</span>
-                        }
-                        else
-                        {
-                            <button type="button" class="btn btn-primary btn-sm" data-at-open-action="update">Update Progress</button>
-                        }
-                    </div>
-                </section>
+                            @if (canOpenCloseAction)
+                            {
+                                <button type="button" class="btn btn-outline-danger btn-sm" data-at-open-action="close" data-at-close-task>Close Task</button>
+                            }
+                        </div>
+                    </section>
+                }
 
+                @if (!selectedTaskIsClosed)
+                {
             <section class="at-command-section at-action-form-section" aria-label="Task action form area">
                 <div class="at-context-panel-host" data-at-action-host="true">
                     <details class="at-action-drawer" data-at-action-panel="update">
@@ -268,12 +295,33 @@
                         </details>
                     }
 
-                    @if (Model.CanCloseTask(Model.SelectedTask))
+                    @if (canOpenCloseAction)
                     {
-                        <details class="at-action-drawer" data-at-action-panel="close"><summary class="visually-hidden">Open close panel</summary><form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact"><input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" /><input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" /><input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" /><input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" /><input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" /><input type="hidden" name="id" value="@Model.SelectedTask.Id" /><input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" /><div class="at-action-title">Close Task</div><div class="mb-2"><label class="form-label at-small">Closure Remarks</label><textarea name="remarks" rows="3" class="form-control form-control-sm" maxlength="1000" placeholder="Add closure notes"></textarea></div><div class="at-action-buttons"><button type="submit" class="btn btn-success btn-sm">Close Task</button><button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="close">Cancel</button></div></form></details>
+                        <details class="at-action-drawer" data-at-action-panel="close">
+                            <summary class="visually-hidden">Open close panel</summary>
+                            <form method="post" asp-page-handler="Close" class="at-action-card at-action-card-compact" data-at-direct-close-form="true">
+                                <input type="hidden" name="ViewMode" value="@Model.ResolvedViewMode" />
+                                <input type="hidden" name="SelectedSprintId" value="@Model.SelectedSprintId" />
+                                <input type="hidden" name="PlanningTab" value="@Model.ResolvedPlanningTab" />
+                                <input type="hidden" name="PlanningView" value="@Model.ResolvedPlanningView" />
+                                <input type="hidden" name="TaskId" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" name="id" value="@Model.SelectedTask.Id" />
+                                <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(Model.SelectedTask.RowVersion)" />
+                                <div class="at-action-title">Close Task</div>
+                                <div class="mb-2">
+                                    <label class="form-label at-small" for="closureRemarks-@Model.SelectedTask.Id">Closure remarks</label>
+                                    <textarea id="closureRemarks-@Model.SelectedTask.Id" name="remarks" rows="4" class="form-control form-control-sm" maxlength="2000" required data-at-direct-close-remarks="true" placeholder="Enter closure decision, completion confirmation, or command rationale."></textarea>
+                                </div>
+                                <div class="at-action-buttons">
+                                    <button type="submit" class="btn btn-danger btn-sm" data-at-direct-close-submit="true" disabled>Close Task</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" data-at-close-action="close">Cancel</button>
+                                </div>
+                            </form>
+                        </details>
                     }
                 </div>
             </section>
+                }
 
                 <section class="at-command-section at-progress-timeline" aria-label="Progress Timeline">
                     <div class="at-inspector-section-heading">

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -1283,7 +1283,9 @@ public class ActionTaskPageTests
         var html = await RenderPartialAsync(page, "/Pages/ActionTasks/_TaskDetails.cshtml");
 
         // SECTION: Assert
-        Assert.Contains("View only", html, StringComparison.Ordinal);
+        Assert.Contains("Closure Details", html, StringComparison.Ordinal);
+        Assert.Contains("Closed on", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Next Action", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Workflow Actions", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Planning Actions", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Change Due Date", html, StringComparison.Ordinal);
@@ -1292,6 +1294,7 @@ public class ActionTaskPageTests
         Assert.DoesNotContain("Remove from Sprint, Keep Assigned", html, StringComparison.Ordinal);
         Assert.DoesNotContain("Move to Backlog, Remove Assignee", html, StringComparison.Ordinal);
         Assert.DoesNotContain(@"data-at-action-panel=""change-date""", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"data-at-action-panel=""close""", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPermissionServiceTests.cs
@@ -1,4 +1,5 @@
 using ProjectManagement.Configuration;
+using ProjectManagement.Models;
 using ProjectManagement.Services.ActionTasks;
 
 namespace ProjectManagement.Tests.ActionTasks;
@@ -76,6 +77,8 @@ public class ActionTaskPermissionServiceTests
         var canAssignTaskToSprint = service.CanAssignTaskToSprint(role);
         var canMoveTaskToBacklog = service.CanMoveTaskToBacklog(role);
         var canChangeTaskDate = service.CanChangeTaskDate(role);
+        var canCloseAssignedTaskDirectly = service.CanCloseTaskDirectly(new ActionTaskItem { Status = ActionTaskStatuses.Assigned }, role);
+        var canCloseClosedTaskDirectly = service.CanCloseTaskDirectly(new ActionTaskItem { Status = ActionTaskStatuses.Closed }, role);
 
         // SECTION: Assert
         Assert.Equal(expected, canManageSprints);
@@ -87,6 +90,8 @@ public class ActionTaskPermissionServiceTests
         Assert.Equal(expected, canAssignTaskToSprint);
         Assert.Equal(expected, canMoveTaskToBacklog);
         Assert.Equal(expected, canChangeTaskDate);
+        Assert.Equal(expected, canCloseAssignedTaskDirectly);
+        Assert.False(canCloseClosedTaskDirectly);
     }
 
 }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -54,9 +54,11 @@ public class ActionTaskServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.SubmitTaskAsync(task.Id, task.RowVersion, "other-user", RoleNames.Ta, "submit"));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.CloseTaskAsync(task.Id, task.RowVersion, "cmd", RoleNames.Comdt, "close"));
+        await service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, "command close", "cmd", RoleNames.Comdt);
+        var directlyClosed = await service.GetTaskAsync(task.Id);
+        Assert.Equal(ActionTaskStatuses.Closed, directlyClosed!.Status);
 
+        task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
         await service.SubmitTaskAsync(task.Id, task.RowVersion, "assignee", RoleNames.Ta, "ready");
         var submitted = await service.GetTaskAsync(task.Id);
         Assert.Equal(ActionTaskStatuses.Submitted, submitted!.Status);
@@ -67,6 +69,74 @@ public class ActionTaskServiceTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.CloseTaskAsync(task.Id, submitted.RowVersion, "non-cmd", RoleNames.Ta, "close"));
+    }
+
+
+    [Theory]
+    [InlineData(RoleNames.Comdt, ActionTaskStatuses.Assigned)]
+    [InlineData(RoleNames.Comdt, ActionTaskStatuses.InProgress)]
+    [InlineData(RoleNames.Comdt, ActionTaskStatuses.Blocked)]
+    [InlineData(RoleNames.HoD, ActionTaskStatuses.Assigned)]
+    [InlineData(RoleNames.HoD, ActionTaskStatuses.InProgress)]
+    [InlineData(RoleNames.HoD, ActionTaskStatuses.Blocked)]
+    public async Task PlanningAuthority_CanCloseNonClosedTaskDirectly(string role, string status)
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, status, "assignee");
+
+        // SECTION: Act
+        await service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, "Task reviewed and closed as per command decision.", "authority", role);
+
+        // SECTION: Assert
+        var updated = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.Closed, updated.Status);
+        Assert.Equal(new TestActionTrackerClock().UtcNow, updated.ClosedOn);
+        Assert.Equal("authority", updated.ClosedByUserId);
+        Assert.Equal("Task reviewed and closed as per command decision.", updated.ClosureRemarks);
+        Assert.DoesNotContain(await db.ActionTasks.Where(x => x.Status != ActionTaskStatuses.Closed).ToListAsync(), x => x.Id == task.Id);
+
+        var audit = await db.ActionTaskAuditLogs.SingleAsync(x => x.TaskId == task.Id && x.ActionType == "TaskClosedByCommandAuthority");
+        Assert.Equal(status, audit.OldValue);
+        Assert.Equal(ActionTaskStatuses.Closed, audit.NewValue);
+        Assert.Equal("authority", audit.PerformedByUserId);
+        Assert.Equal(role, audit.PerformedByRole);
+        Assert.Equal("Task reviewed and closed as per command decision.", audit.Remarks);
+    }
+
+    [Fact]
+    public async Task Assignee_CannotDirectlyCloseTask()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Assigned, "assignee");
+
+        // SECTION: Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, "close", "assignee", RoleNames.Ta));
+        Assert.Contains("not authorised", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DirectClosure_RequiresRemarksAndRejectsAlreadyClosedTask()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.Blocked, "assignee");
+
+        // SECTION: Act + Assert
+        var missingRemarks = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, " ", "authority", RoleNames.HoD));
+        Assert.Contains("Closure remarks are required when closing a task.", missingRemarks.Message);
+
+        await service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, "Valid closure", "authority", RoleNames.HoD);
+        var closed = await service.GetTaskAsync(task.Id);
+        var alreadyClosed = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskDirectlyAsync(task.Id, closed!.RowVersion, "again", "authority", RoleNames.HoD));
+        Assert.Contains("already closed", alreadyClosed.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/Services/ActionTasks/ActionTaskPermissionService.cs
+++ b/Services/ActionTasks/ActionTaskPermissionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using ProjectManagement.Configuration;
+using ProjectManagement.Models;
 
 namespace ProjectManagement.Services.ActionTasks;
 
@@ -44,6 +45,12 @@ public class ActionTaskPermissionService
 
     public bool CanClose(string role)
         => IsPlanningAuthority(role);
+
+    // SECTION: Direct command closure is limited to planning authorities and non-closed tasks.
+    public bool CanCloseTaskDirectly(ActionTaskItem? task, string role)
+        => task is not null
+            && !string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+            && IsPlanningAuthority(role);
 
     public bool CanChangeTaskDate(string role)
         => IsPlanningAuthority(role);

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -312,22 +312,25 @@ public class ActionTaskService : IActionTaskService
 
     public async Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default)
     {
+        // SECTION: Submitted-task closure is retained as a compatibility wrapper over the command closure path.
+        await CloseTaskDirectlyAsync(taskId, rowVersion, remarks ?? string.Empty, userId, role, cancellationToken);
+    }
+
+    public async Task CloseTaskDirectlyAsync(int taskId, byte[] rowVersion, string closureRemarks, string closedByUserId, string role, CancellationToken cancellationToken = default)
+    {
         // SECTION: Validation
-        if (!_permission.CanClose(role))
-        {
-            throw new InvalidOperationException("You are not authorized to close this task.");
-        }
-
         var task = await GetTaskAsync(taskId, cancellationToken) ?? throw new InvalidOperationException("Task not found.");
-        if (!string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase))
+        if (!_permission.CanCloseTaskDirectly(task, role))
         {
-            throw new InvalidOperationException("Only submitted tasks can be closed.");
+            throw new InvalidOperationException(string.Equals(task.Status, ActionTaskStatuses.Closed, StringComparison.OrdinalIgnoreCase)
+                ? "This task is already closed."
+                : "You are not authorised to close this task.");
         }
 
-        // SECTION: Remarks validation for close action
-        if (IsBlank(remarks))
+        // SECTION: Remarks validation for direct command closure
+        if (IsBlank(closureRemarks))
         {
-            throw new InvalidOperationException("Closure remarks are required.");
+            throw new InvalidOperationException("Closure remarks are required when closing a task.");
         }
 
         // SECTION: Concurrency token validation
@@ -335,12 +338,16 @@ public class ActionTaskService : IActionTaskService
 
         // SECTION: State Mutation
         var oldStatus = task.Status;
+        var trimmedRemarks = closureRemarks.Trim();
+        var closedAtUtc = _clock.UtcNow;
         task.Status = ActionTaskStatuses.Closed;
-        task.ClosedOn = _clock.UtcNow;
+        task.ClosedOn = closedAtUtc;
+        task.ClosedByUserId = closedByUserId;
+        task.ClosureRemarks = trimmedRemarks;
         ActionTaskBucketInvariantValidator.ValidateTaskBucketInvariant(task);
 
         // SECTION: Audit Enqueue
-        _context.ActionTaskAuditLogs.Add(Log(taskId, "Closed", userId, role, oldStatus, task.Status, remarks));
+        _context.ActionTaskAuditLogs.Add(Log(taskId, "TaskClosedByCommandAuthority", closedByUserId, role, oldStatus, task.Status, trimmedRemarks));
 
         // SECTION: Persistence
         try

--- a/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
+++ b/Services/ActionTasks/ActionTaskWorkflowPolicy.cs
@@ -51,9 +51,7 @@ public sealed class ActionTaskWorkflowPolicy
 
     public bool CanCloseTask(ActionTaskItem task, string currentRole)
     {
-        return _permission.CanClose(currentRole)
-            && !string.Equals(task.Status, ActionTaskStatuses.Backlog, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(task.Status, ActionTaskStatuses.Submitted, StringComparison.OrdinalIgnoreCase);
+        return _permission.CanCloseTaskDirectly(task, currentRole);
     }
 
     public bool CanUpdateTaskStatus(ActionTaskItem task, string currentRole, string currentUserId)

--- a/Services/ActionTasks/IActionTaskService.cs
+++ b/Services/ActionTasks/IActionTaskService.cs
@@ -14,6 +14,7 @@ public interface IActionTaskService
     Task UpdateStatusAsync(int taskId, byte[] rowVersion, string status, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task SubmitTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task CloseTaskAsync(int taskId, byte[] rowVersion, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
+    Task CloseTaskDirectlyAsync(int taskId, byte[] rowVersion, string closureRemarks, string closedByUserId, string role, CancellationToken cancellationToken = default);
     Task UpdateTaskDateAsync(int taskId, byte[] rowVersion, DateTime newDate, string userId, string role, string? remarks = null, CancellationToken cancellationToken = default);
     Task<ActionTaskItem?> GetTaskAsync(int taskId, CancellationToken cancellationToken = default);
     Task<List<ActionTaskAuditLog>> GetTaskLogsAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default);

--- a/wwwroot/css/action-task-details-redesign.css
+++ b/wwwroot/css/action-task-details-redesign.css
@@ -504,3 +504,28 @@
         border-radius: 1rem 1rem 0 0;
     }
 }
+
+/* SECTION: Closed task summary metadata */
+.at-task-closure-list {
+    display: grid;
+    gap: .75rem;
+    margin: .75rem 0 0;
+}
+
+.at-task-closure-list > div {
+    display: grid;
+    gap: .2rem;
+}
+
+.at-task-closure-list dt {
+    color: var(--bs-secondary-color, #6c757d);
+    font-size: .78rem;
+    font-weight: 700;
+    letter-spacing: .04em;
+    margin: 0;
+    text-transform: uppercase;
+}
+
+.at-task-closure-list dd {
+    margin: 0;
+}

--- a/wwwroot/js/pages/action-tasks/index.js
+++ b/wwwroot/js/pages/action-tasks/index.js
@@ -559,6 +559,25 @@
         });
     }
 
+    // SECTION: Direct closure remarks gate keeps command closure deliberate without inline script.
+    function initDirectClosureValidation() {
+        document.querySelectorAll("[data-at-direct-close-form='true']").forEach((form) => {
+            const remarks = form.querySelector("[data-at-direct-close-remarks='true']");
+            const submit = form.querySelector("[data-at-direct-close-submit='true']");
+            if (!remarks || !submit) {
+                return;
+            }
+
+            const sync = () => {
+                submit.disabled = remarks.value.trim().length === 0;
+            };
+
+            remarks.addEventListener("input", sync);
+            remarks.addEventListener("change", sync);
+            sync();
+        });
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
         openCreateTaskModalOnLoad();
         initSearchableSelects();
@@ -570,5 +589,6 @@
         initSprintClosureReview();
         initActionConfirmations();
         initInspectorActionPanels();
+        initDirectClosureValidation();
     });
 })();

--- a/wwwroot/js/pages/action-tasks/index.test.js
+++ b/wwwroot/js/pages/action-tasks/index.test.js
@@ -192,3 +192,31 @@ test('intent-specific status actions preselect In Progress and refresh save guar
         assert.equal(bubbledChangeCount, 1);
     });
 });
+
+// SECTION: Direct close remarks guard behavior.
+test('direct close submit stays disabled until closure remarks are entered', () => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+        <form data-at-direct-close-form="true">
+            <textarea data-at-direct-close-remarks="true"></textarea>
+            <button type="submit" data-at-direct-close-submit="true">Close Task</button>
+        </form>
+    </body></html>`, { url: 'https://example.test/ActionTasks?TaskId=1', runScripts: 'dangerously' });
+
+    const { window } = dom;
+    const document = window.document;
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+    document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+
+    const remarks = document.querySelector('[data-at-direct-close-remarks]');
+    const submit = document.querySelector('[data-at-direct-close-submit]');
+
+    assert.equal(submit.disabled, true);
+    remarks.value = 'Closed after command review.';
+    remarks.dispatchEvent(new window.Event('input', { bubbles: true }));
+    assert.equal(submit.disabled, false);
+    remarks.value = '   ';
+    remarks.dispatchEvent(new window.Event('input', { bubbles: true }));
+    assert.equal(submit.disabled, true);
+});


### PR DESCRIPTION
### Motivation

- Command-level roles (Comdt / HoD) must be able to directly close any non-closed task without requiring the assignee to submit it first, while preserving audit/history and enforcing mandatory closure rationale.
- The change centralises permission logic and enforces server-side validation so UI shortcuts cannot bypass business rules.

### Description

- Added server-side direct-close capability: new service API `CloseTaskDirectlyAsync` enforces permission, non-closed eligibility and mandatory `closureRemarks`, updates `Status`, `ClosedOn`, `ClosedByUserId`, `ClosureRemarks`, and writes a `TaskClosedByCommandAuthority` audit entry; the existing `CloseTask` call now delegates to this path. (see `Services/ActionTasks/ActionTaskService.cs` and `Services/ActionTasks/IActionTaskService.cs`).
- Added central permission helper `CanCloseTaskDirectly` to the `ActionTaskPermissionService` and wired the workflow policy to use it so views and service use a single source of truth (see `Services/ActionTasks/ActionTaskPermissionService.cs` and `Services/ActionTasks/ActionTaskWorkflowPolicy.cs`).
- Persisted closure metadata: added `ClosedByUserId` and `ClosureRemarks` properties to the `ActionTaskItem` model, EF mapping in `ApplicationDbContext`, and an EF migration scaffold `AddActionTaskClosureAuthorityMetadata` to create those columns. (see `Models/ActionTaskItem.cs`, `Data/ApplicationDbContext.cs`, `Migrations/20261125210000_AddActionTaskClosureAuthorityMetadata.cs`).
- UI/UX updates: the task details drawer now shows a command-only inline `Close Task` action on non-closed tasks and a read-only closure summary for closed tasks; the close panel requires multi-line remarks and uses the existing in-drawer action pattern (see `Pages/ActionTasks/_TaskDetails.cshtml`).
- Page handler: `OnPostCloseAsync` invokes the direct-close service path (`CloseTaskDirectlyAsync`) and surfaces friendly toast messages (see `Pages/ActionTasks/Index.cshtml.cs`).
- Client-side safety: added unobtrusive client-side gating in `wwwroot/js/pages/action-tasks/index.js` so the direct-close submit button stays disabled until non-blank remarks are entered; no inline scripts were introduced and the pattern follows existing action-panel behaviour. A small stylesheet was added for closed-task summary presentation (`wwwroot/css/action-task-details-redesign.css`).
- Tests and coverage updates: added/updated unit tests covering planning-authority direct-closure across statuses, assignee denial, required remarks, already-closed rejection and audit assertions (see `ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs`), and a JS test to assert the client-side remarks guard (see `wwwroot/js/pages/action-tasks/index.test.js`).

### Testing

- Ran the frontend unit tests with `npm test`; all JS tests passed locally (19 tests, 0 failures). The added client-side test verifies the direct-close submit button remains disabled until closure remarks are present. (`wwwroot/js/pages/action-tasks/index.test.js`).
- Performed `git diff --check` and verified no whitespace/line-ending issues introduced by these edits.
- Ran view linting via `npm run lint:views`; this surfaced an existing/unrelated `inline style` rule in other Razor views (pre-existing in the project) and is not caused by this change, so views linting reports that unrelated files need cleanup in a separate fix.
- Attempted `dotnet test` in this environment but `dotnet` was not available so C# unit test execution could not be run here; C# tests were added/updated to exercise the new direct-close behaviour and should be run in CI or a dev environment with .NET SDK to confirm green results.

If you want, I can split the EF migration and model changes into a separate PR, or run the full test matrix in a CI environment with the .NET SDK available and report back the results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a17b29e08329b0500f0b29ff06c6)