### PR TITLE
Harden action task update validation and direct-closure remarks

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs
@@ -66,6 +66,75 @@ public class ActionTaskCollaborationServiceTests
         Assert.Equal(TestActionTrackerClock.FixedUtcNow, update.CreatedAtUtc);
     }
 
+
+    [Fact]
+    public async Task AddUpdateAndMaybeChangeStatusAsync_RejectsMoreThanMaximumAttachmentsWithoutPartialSave()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, "owner");
+        var manyFiles = Enumerable.Range(1, 11).Select(i => BuildFile($"f{i}.txt", "text/plain", 10)).ToArray();
+
+        // SECTION: Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAndMaybeChangeStatusAsync(task.Id, "moving forward", ActionTaskStatuses.InProgress, "owner", RoleNames.Ta, manyFiles, task.RowVersion));
+
+        // SECTION: Assert
+        Assert.Equal("A maximum of 10 files can be attached per update.", ex.Message);
+        var unchanged = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.Assigned, unchanged.Status);
+        Assert.Empty(await db.ActionTaskUpdates.Where(x => x.TaskId == task.Id).ToListAsync());
+        Assert.Empty(await db.ActionTaskAttachments.Where(x => x.TaskId == task.Id).ToListAsync());
+        Assert.Empty(await db.ActionTaskAuditLogs.Where(x => x.TaskId == task.Id).ToListAsync());
+    }
+
+    [Fact]
+    public async Task AddUpdateAndMaybeChangeStatusAsync_AllowsMaximumPermittedAttachments()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, "owner");
+        var maxFiles = Enumerable.Range(1, 10).Select(i => BuildFile($"f{i}.txt", "text/plain", 10)).ToArray();
+
+        // SECTION: Act
+        var update = await service.AddUpdateAndMaybeChangeStatusAsync(task.Id, "moving forward", ActionTaskStatuses.InProgress, "owner", RoleNames.Ta, maxFiles, task.RowVersion);
+
+        // SECTION: Assert
+        Assert.NotNull(update);
+        Assert.Equal(ActionTaskUpdateTypes.Progress, update.UpdateType);
+        Assert.Equal("moving forward", update.Body);
+        var changed = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.InProgress, changed.Status);
+        Assert.Equal(1, await db.ActionTaskUpdates.CountAsync(x => x.TaskId == task.Id));
+        Assert.Equal(10, await db.ActionTaskAttachments.CountAsync(x => x.TaskId == task.Id));
+    }
+
+    [Fact]
+    public async Task AddUpdateAndMaybeChangeStatusAsync_PreservesFileTypeAndSizeValidation()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var badTypeTask = await SeedTaskAsync(db, "owner");
+        var overSizeTask = await SeedTaskAsync(db, "owner");
+        var badType = BuildFile("bad.exe", "application/octet-stream", 128);
+        var overSize = BuildFile("big.txt", "text/plain", 26L * 1024 * 1024);
+
+        // SECTION: Act + Assert
+        var badTypeEx = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAndMaybeChangeStatusAsync(badTypeTask.Id, "body", null, "owner", RoleNames.Ta, [badType], badTypeTask.RowVersion));
+        Assert.Equal("This file type is not allowed.", badTypeEx.Message);
+
+        var overSizeEx = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddUpdateAndMaybeChangeStatusAsync(overSizeTask.Id, "body", null, "owner", RoleNames.Ta, [overSize], overSizeTask.RowVersion));
+        Assert.Equal("File size exceeds the 25 MB limit.", overSizeEx.Message);
+
+        Assert.Empty(await db.ActionTaskUpdates.ToListAsync());
+        Assert.Empty(await db.ActionTaskAttachments.ToListAsync());
+    }
+
     private static ActionTaskCollaborationService CreateService(ApplicationDbContext db)
         => new(db, new ActionTaskPermissionService(), new TestUploadRootProvider(), new PassFileSecurityValidator(), new StubUrlBuilder(), new TestActionTrackerClock());
 

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs
@@ -169,6 +169,37 @@ public class ActionTaskPageTests
         Assert.Equal(task.Id, redirect.RouteValues[nameof(IndexModel.TaskId)]);
     }
 
+
+    [Fact]
+    public async Task OnPostAddUpdateAsync_UsesAtomicUpdateStatusWorkflow()
+    {
+        // SECTION: Arrange
+        var setup = await CreateSetupAsync(RoleNames.HoD);
+        var page = setup.Page;
+        var task = await setup.Db.ActionTasks.SingleAsync();
+        page.UpdateInput = new IndexModel.AddTaskUpdateInput
+        {
+            TaskId = task.Id,
+            RowVersion = Convert.ToBase64String(task.RowVersion),
+            Body = "Progress made",
+            NewStatus = ActionTaskStatuses.InProgress,
+            Files = new List<IFormFile>()
+        };
+
+        // SECTION: Act
+        var result = await page.OnPostAddUpdateAsync();
+
+        // SECTION: Assert
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal(task.Id, redirect.RouteValues![nameof(IndexModel.TaskId)]);
+        Assert.Equal(1, setup.Collab.AtomicUpdateCallCount);
+        Assert.Equal(task.Id, setup.Collab.LastAtomicUpdateTaskId);
+        Assert.Equal("Progress made", setup.Collab.LastAtomicUpdateBody);
+        Assert.Equal(ActionTaskStatuses.InProgress, setup.Collab.LastAtomicUpdateStatus);
+        Assert.NotNull(setup.Collab.LastAtomicUpdateFiles);
+        Assert.Equal("Progress update saved and task status updated.", page.TempData["ToastMessage"]);
+    }
+
     [Fact]
     public async Task MyWorkPartial_RendersOpenPersonalQueueWithoutCommandNoise()
     {
@@ -1791,7 +1822,7 @@ public class ActionTaskPageTests
         return services.BuildServiceProvider();
     }
 
-    private static async Task<(IndexModel Page, ApplicationDbContext Db)> CreateSetupAsync(string currentRole = RoleNames.HoD)
+    private static async Task<(IndexModel Page, ApplicationDbContext Db, StubCollabService Collab)> CreateSetupAsync(string currentRole = RoleNames.HoD)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
         var db = new ApplicationDbContext(options);
@@ -1836,7 +1867,7 @@ public class ActionTaskPageTests
 
         page.PageContext = new PageContext(new ActionContext(httpContext, new RouteData(), new ActionDescriptor()));
         page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
-        return (page, db);
+        return (page, db, collab);
     }
 
 
@@ -1891,7 +1922,42 @@ public class ActionTaskPageTests
 
     private sealed class StubCollabService : IActionTaskCollaborationService
     {
+        public int AtomicUpdateCallCount { get; private set; }
+        public int? LastAtomicUpdateTaskId { get; private set; }
+        public string? LastAtomicUpdateBody { get; private set; }
+        public string? LastAtomicUpdateStatus { get; private set; }
+        public IReadOnlyList<IFormFile>? LastAtomicUpdateFiles { get; private set; }
+
         public Task<ActionTaskUpdate> AddUpdateAsync(int taskId, string body, string updateType, string userId, string role, IReadOnlyList<IFormFile> files, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public Task<ActionTaskUpdate?> AddUpdateAndMaybeChangeStatusAsync(
+            int taskId,
+            string body,
+            string? newStatus,
+            string userId,
+            string role,
+            IReadOnlyList<IFormFile> files,
+            byte[] rowVersion,
+            CancellationToken cancellationToken = default)
+        {
+            // SECTION: Track atomic update submissions for page-handler assertions.
+            AtomicUpdateCallCount++;
+            LastAtomicUpdateTaskId = taskId;
+            LastAtomicUpdateBody = body;
+            LastAtomicUpdateStatus = newStatus;
+            LastAtomicUpdateFiles = files;
+
+            return Task.FromResult<ActionTaskUpdate?>(new ActionTaskUpdate
+            {
+                TaskId = taskId,
+                Body = string.IsNullOrWhiteSpace(body) ? "Status updated." : body.Trim(),
+                UpdateType = ActionTaskUpdateTypes.Progress,
+                CreatedByUserId = userId,
+                CreatedAtUtc = DateTime.UtcNow,
+                IsDeleted = false
+            });
+        }
+
         public Task<IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>> GetAttachmentMetadataByUpdateAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default) => Task.FromResult((IReadOnlyDictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>)new Dictionary<int, IReadOnlyList<ActionTaskAttachmentMetadata>>());
         public Task<List<ActionTaskUpdate>> GetUpdatesAsync(int taskId, string userId, string role, CancellationToken cancellationToken = default) => Task.FromResult(new List<ActionTaskUpdate>());
     }

--- a/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs
@@ -139,6 +139,77 @@ public class ActionTaskServiceTests
         Assert.Contains("already closed", alreadyClosed.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("     ")]
+    public async Task CloseTaskDirectlyAsync_RejectsBlankClosureRemarks(string remarks)
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
+
+        // SECTION: Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, remarks, "authority", RoleNames.HoD));
+
+        // SECTION: Assert
+        Assert.Equal("Closure remarks are required when closing a task.", ex.Message);
+        var unchanged = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.InProgress, unchanged.Status);
+        Assert.Null(unchanged.ClosedOn);
+        Assert.Null(unchanged.ClosedByUserId);
+        Assert.Null(unchanged.ClosureRemarks);
+    }
+
+    [Fact]
+    public async Task CloseTaskDirectlyAsync_RejectsOverlengthClosureRemarksBeforeSaving()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
+        var overlengthRemarks = new string('x', 2001);
+
+        // SECTION: Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, overlengthRemarks, "authority", RoleNames.HoD));
+
+        // SECTION: Assert
+        Assert.Equal("Closure remarks cannot exceed 2000 characters.", ex.Message);
+        var unchanged = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.InProgress, unchanged.Status);
+        Assert.Null(unchanged.ClosedOn);
+        Assert.Null(unchanged.ClosedByUserId);
+        Assert.Null(unchanged.ClosureRemarks);
+        Assert.Empty(await db.ActionTaskAuditLogs.Where(x => x.TaskId == task.Id).ToListAsync());
+    }
+
+    [Fact]
+    public async Task CloseTaskDirectlyAsync_SavesValidClosureRemarksAndAuditFields()
+    {
+        // SECTION: Arrange
+        await using var db = CreateDb();
+        var service = CreateService(db);
+        var task = await SeedTaskAsync(db, ActionTaskStatuses.InProgress, "assignee");
+
+        // SECTION: Act
+        await service.CloseTaskDirectlyAsync(task.Id, task.RowVersion, "  Closed by command decision after review.  ", "authority", RoleNames.HoD);
+
+        // SECTION: Assert
+        var updated = await db.ActionTasks.SingleAsync(x => x.Id == task.Id);
+        Assert.Equal(ActionTaskStatuses.Closed, updated.Status);
+        Assert.Equal(new TestActionTrackerClock().UtcNow, updated.ClosedOn);
+        Assert.Equal("authority", updated.ClosedByUserId);
+        Assert.Equal("Closed by command decision after review.", updated.ClosureRemarks);
+
+        var audit = await db.ActionTaskAuditLogs.SingleAsync(x => x.TaskId == task.Id && x.ActionType == "TaskClosedByCommandAuthority");
+        Assert.Equal(ActionTaskStatuses.InProgress, audit.OldValue);
+        Assert.Equal(ActionTaskStatuses.Closed, audit.NewValue);
+        Assert.Equal("Closed by command decision after review.", audit.Remarks);
+    }
+
     [Fact]
     public async Task UpdateStatusAsync_WithStaleRowVersion_ThrowsConcurrencyException()
     {

--- a/Services/ActionTasks/ActionTaskCollaborationService.cs
+++ b/Services/ActionTasks/ActionTaskCollaborationService.cs
@@ -81,13 +81,8 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
             throw new InvalidOperationException("Update text is required unless at least one attachment is uploaded.");
         }
 
-        if (files.Count > MaxAttachmentsPerUpdate)
-        {
-            throw new InvalidOperationException($"A maximum of {MaxAttachmentsPerUpdate} files can be attached per update.");
-        }
-
         // SECTION: Validate all uploaded files before persisting update
-        ValidateAttachments(files);
+        ValidateAttachmentCollection(files);
 
         await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
         var committedFiles = new List<string>();
@@ -149,7 +144,7 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
         }
 
         ValidateUpdatePermissions(task, userId, role, hasFiles);
-        ValidateAttachments(files);
+        ValidateAttachmentCollection(files);
         ValidateAtomicStatusChange(task, requestedStatus, userId, role, body);
 
         await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
@@ -437,6 +432,16 @@ public sealed class ActionTaskCollaborationService : IActionTaskCollaborationSer
     }
 
     // SECTION: Attachment validation helpers
+    private static void ValidateAttachmentCollection(IReadOnlyList<IFormFile> files)
+    {
+        if (files.Count > MaxAttachmentsPerUpdate)
+        {
+            throw new InvalidOperationException($"A maximum of {MaxAttachmentsPerUpdate} files can be attached per update.");
+        }
+
+        ValidateAttachments(files);
+    }
+
     private static void ValidateAttachments(IReadOnlyList<IFormFile> files)
     {
         foreach (var file in files)

--- a/Services/ActionTasks/ActionTaskService.cs
+++ b/Services/ActionTasks/ActionTaskService.cs
@@ -11,6 +11,8 @@ namespace ProjectManagement.Services.ActionTasks;
 
 public class ActionTaskService : IActionTaskService
 {
+    private const int MaxClosureRemarksLength = 2000;
+
     private readonly ApplicationDbContext _context;
     private readonly ActionTaskPermissionService _permission;
     private readonly IActionTrackerClock _clock;
@@ -328,9 +330,15 @@ public class ActionTaskService : IActionTaskService
         }
 
         // SECTION: Remarks validation for direct command closure
-        if (IsBlank(closureRemarks))
+        var trimmedRemarks = closureRemarks?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(trimmedRemarks))
         {
             throw new InvalidOperationException("Closure remarks are required when closing a task.");
+        }
+
+        if (trimmedRemarks.Length > MaxClosureRemarksLength)
+        {
+            throw new InvalidOperationException($"Closure remarks cannot exceed {MaxClosureRemarksLength} characters.");
         }
 
         // SECTION: Concurrency token validation
@@ -338,7 +346,6 @@ public class ActionTaskService : IActionTaskService
 
         // SECTION: State Mutation
         var oldStatus = task.Status;
-        var trimmedRemarks = closureRemarks.Trim();
         var closedAtUtc = _clock.UtcNow;
         task.Status = ActionTaskStatuses.Closed;
         task.ClosedOn = closedAtUtc;


### PR DESCRIPTION
### Motivation
- Fix a test compilation failure caused by the new atomic collaboration API and harden server-side validation so task closure and combined update/status-change workflows cannot produce DB errors or inconsistent attachment behaviour.
- Ensure the per-update attachment cap and closure-remarks length are enforced server-side rather than relying only on UI constraints.

### Description
- Add a shared helper `ValidateAttachmentCollection` in `Services/ActionTasks/ActionTaskCollaborationService.cs` and replace direct calls to `ValidateAttachments` so both `AddUpdateAsync` and `AddUpdateAndMaybeChangeStatusAsync` enforce `MaxAttachmentsPerUpdate` before persistence.
- Add `MaxClosureRemarksLength = 2000` and server-side validation in `Services/ActionTasks/ActionTaskService.cs` so `CloseTaskDirectlyAsync` trims input, rejects blank/whitespace remarks, and rejects overlength remarks before mutating state or calling `SaveChangesAsync`.
- Update the test page stub in `ProjectManagement.Tests/ActionTasks/ActionTaskPageTests.cs` to implement `AddUpdateAndMaybeChangeStatusAsync`, add tracking properties for assertions, and add a page-handler test `OnPostAddUpdateAsync_UsesAtomicUpdateStatusWorkflow` that verifies the unified form uses the atomic workflow.
- Add unit tests in `ProjectManagement.Tests/ActionTasks/ActionTaskCollaborationServiceTests.cs` to cover atomic-path attachment limits and in `ProjectManagement.Tests/ActionTasks/ActionTaskServiceTests.cs` to cover direct-closure remark validation and behavior on valid remarks.

### Testing
- Attempted to run `dotnet clean`, `dotnet build`, and `dotnet test` in this environment but execution failed because the `dotnet` CLI is not installed here, so no automated tests were executed.
- New/updated tests added (not executed here) include `AddUpdateAndMaybeChangeStatusAsync_RejectsMoreThanMaximumAttachmentsWithoutPartialSave`, `AddUpdateAndMaybeChangeStatusAsync_AllowsMaximumPermittedAttachments`, `AddUpdateAndMaybeChangeStatusAsync_PreservesFileTypeAndSizeValidation`, `CloseTaskDirectlyAsync_RejectsBlankClosureRemarks`, `CloseTaskDirectlyAsync_RejectsOverlengthClosureRemarksBeforeSaving`, `CloseTaskDirectlyAsync_SavesValidClosureRemarksAndAuditFields`, and `OnPostAddUpdateAsync_UsesAtomicUpdateStatusWorkflow`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a793237483298695f0f8882db80d)