### PR TITLE
Standardize notification timestamps to IST

### DIFF
--- a/Contracts/Notifications/NotificationListItem.cs
+++ b/Contracts/Notifications/NotificationListItem.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace ProjectManagement.Contracts.Notifications;
 
+// SECTION: Notification List Payload
 public sealed record NotificationListItem(
     int Id,
     string? Module,
@@ -15,6 +16,7 @@ public sealed record NotificationListItem(
     string? Title,
     string? Summary,
     DateTime CreatedUtc,
+    string CreatedDisplayIst,
     DateTime? SeenUtc,
     DateTime? ReadUtc,
     bool IsProjectMuted);

--- a/Pages/Notifications/Index.cshtml
+++ b/Pages/Notifications/Index.cshtml
@@ -107,7 +107,7 @@
                                         </div>
                                     </td>
                                     <td>
-                                        <time datetime="@item.CreatedUtc.ToString("O")" data-notification-created>@item.CreatedUtc.ToLocalTime().ToString("g")</time>
+                                        <time datetime="@item.CreatedUtc.ToString("O")" data-notification-created>@item.CreatedDisplayIst</time>
                                     </td>
                                     <td>
                                         <span class="badge rounded-pill @(item.IsRead ? "bg-secondary-subtle text-secondary" : "bg-primary")" data-notification-state>

--- a/Pages/Shared/Components/NotificationBell/Default.cshtml
+++ b/Pages/Shared/Components/NotificationBell/Default.cshtml
@@ -71,7 +71,7 @@
                                     </a>
                                 </div>
                                 <div class="text-end small text-muted" data-notification-meta>
-                                    <time datetime="@item.CreatedUtc.ToString("O")" data-notification-created>@item.CreatedUtc.ToLocalTime().ToString("g")</time>
+                                    <time datetime="@item.CreatedUtc.ToString("O")" data-notification-created>@item.CreatedDisplayIst</time>
                                 </div>
                                 <div class="btn-group btn-group-sm" role="group" aria-label="Manage notification">
                                     <button type="button" class="btn btn-outline-secondary" data-notification-action="toggle-read"

--- a/ProjectManagement.Tests/NotificationIstDisplayTests.cs
+++ b/ProjectManagement.Tests/NotificationIstDisplayTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using ProjectManagement.Contracts.Notifications;
+using ProjectManagement.Infrastructure;
+using ProjectManagement.ViewModels.Notifications;
+using Xunit;
+
+namespace ProjectManagement.Tests;
+
+public sealed class NotificationIstDisplayTests
+{
+    [Fact]
+    public void ToIst_ConvertsUtcToIndianStandardTime()
+    {
+        // SECTION: Arrange
+        var utc = new DateTime(2026, 4, 28, 2, 8, 0, DateTimeKind.Utc);
+
+        // SECTION: Act
+        var result = TimeFmt.ToIst(utc);
+
+        // SECTION: Assert
+        Assert.Equal("28 Apr 2026, 07:38 IST", result);
+    }
+
+    [Fact]
+    public void FromContract_UsesCreatedDisplayIstFromNotificationPayload()
+    {
+        // SECTION: Arrange
+        var utc = new DateTime(2026, 4, 28, 2, 8, 0, DateTimeKind.Utc);
+        var notification = new NotificationListItem(
+            42,
+            "Projects",
+            "Updated",
+            "Project",
+            "7",
+            7,
+            "IST Migration",
+            "actor-user-id",
+            "/Projects/Details/7",
+            "Project updated",
+            "A project notification was updated.",
+            utc,
+            TimeFmt.ToIst(utc),
+            null,
+            null,
+            false);
+
+        // SECTION: Act
+        var display = NotificationDisplayModel.FromContract(notification);
+
+        // SECTION: Assert
+        Assert.Equal(utc, display.CreatedUtc);
+        Assert.Equal("28 Apr 2026, 07:38 IST", display.CreatedDisplayIst);
+    }
+
+    [Fact]
+    public void NotificationUi_UsesServerProvidedIstDisplayText()
+    {
+        // SECTION: Arrange
+        var bellMarkup = ReadRepoFile("Pages", "Shared", "Components", "NotificationBell", "Default.cshtml");
+        var centerMarkup = ReadRepoFile("Pages", "Notifications", "Index.cshtml");
+        var script = ReadRepoFile("wwwroot", "js", "notifications.js");
+
+        // SECTION: Assert
+        Assert.Contains("@item.CreatedDisplayIst", bellMarkup, StringComparison.Ordinal);
+        Assert.Contains("@item.CreatedDisplayIst", centerMarkup, StringComparison.Ordinal);
+        Assert.Contains("createdDisplayIst", script, StringComparison.Ordinal);
+        Assert.Contains("timeZone: 'Asia/Kolkata'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("ToLocalTime", bellMarkup, StringComparison.Ordinal);
+        Assert.DoesNotContain("ToLocalTime", centerMarkup, StringComparison.Ordinal);
+        Assert.DoesNotContain("toLocaleString(undefined", script, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] relativePathParts)
+    {
+        // SECTION: Source assertions locate files from either repository-root or test-output working directories.
+        var relativePath = Path.Combine(relativePathParts);
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate repository file {relativePath}.", relativePath);
+    }
+}

--- a/Services/Notifications/UserNotificationService.cs
+++ b/Services/Notifications/UserNotificationService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Contracts.Notifications;
 using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Notifications;
 using ProjectManagement.Services;
@@ -157,6 +158,7 @@ public sealed class UserNotificationService
                 }
             }
 
+            // SECTION: Notification Display Projection
             var isMuted = notification.ProjectId is int pid && mutedProjectSet?.Contains(pid) == true;
             var normalizedRoute = NotificationPublisher.NormalizeRouteSegments(notification.Route);
 
@@ -173,6 +175,7 @@ public sealed class UserNotificationService
                 notification.Title,
                 notification.Summary,
                 notification.CreatedUtc,
+                TimeFmt.ToIst(notification.CreatedUtc),
                 notification.SeenUtc,
                 notification.ReadUtc,
                 isMuted));

--- a/ViewModels/Notifications/NotificationDisplayModel.cs
+++ b/ViewModels/Notifications/NotificationDisplayModel.cs
@@ -1,5 +1,6 @@
 using System;
 using ProjectManagement.Contracts.Notifications;
+using ProjectManagement.Infrastructure;
 
 namespace ProjectManagement.ViewModels.Notifications;
 
@@ -29,6 +30,9 @@ public sealed record NotificationDisplayModel
 
     public DateTime CreatedUtc { get; init; }
 
+    // SECTION: IST Display Timestamp
+    public string CreatedDisplayIst { get; init; } = string.Empty;
+
     public DateTime? SeenUtc { get; init; }
 
     public DateTime? ReadUtc { get; init; }
@@ -52,6 +56,9 @@ public sealed record NotificationDisplayModel
             Title = notification.Title,
             Summary = notification.Summary,
             CreatedUtc = notification.CreatedUtc,
+            CreatedDisplayIst = string.IsNullOrWhiteSpace(notification.CreatedDisplayIst)
+                ? TimeFmt.ToIst(notification.CreatedUtc)
+                : notification.CreatedDisplayIst,
             SeenUtc = notification.SeenUtc,
             ReadUtc = notification.ReadUtc,
             IsProjectMuted = notification.IsProjectMuted,

--- a/wwwroot/js/notifications.js
+++ b/wwwroot/js/notifications.js
@@ -54,6 +54,9 @@
       title: raw.title ?? null,
       summary: raw.summary ?? null,
       createdUtc: createdUtc ?? createdAt.toISOString(),
+      createdDisplayIst: typeof raw.createdDisplayIst === 'string' && raw.createdDisplayIst.trim().length > 0
+        ? raw.createdDisplayIst
+        : formatIstDateTime(createdAt),
       createdAt,
       seenUtc,
       readUtc,
@@ -592,7 +595,7 @@
         const created = clone.querySelector('[data-notification-created]');
         if (created) {
           created.setAttribute('datetime', item.createdUtc);
-          created.textContent = formatDate(item.createdAt);
+          created.textContent = item.createdDisplayIst;
         }
 
         const toggleButton = clone.querySelector('[data-notification-action="toggle-read"]');
@@ -846,7 +849,7 @@
         const created = row.querySelector('[data-notification-created]');
         if (created) {
           created.setAttribute('datetime', notification.createdUtc);
-          created.textContent = formatDate(notification.createdAt);
+          created.textContent = notification.createdDisplayIst;
         }
 
         const state = row.querySelector('[data-notification-state]');
@@ -960,18 +963,29 @@
     }
   }
 
-  function formatDate(date) {
-    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-      return '';
+  // SECTION: IST Timestamp Formatting
+  function formatIstDateTime(value) {
+    if (!value) {
+      return '—';
     }
 
-    return date.toLocaleString(undefined, {
-      year: 'numeric',
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Asia/Kolkata',
+      day: '2-digit',
       month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
       minute: '2-digit',
-    });
+      hour12: false,
+    }).formatToParts(date);
+
+    const valueFor = type => parts.find(part => part.type === type)?.value ?? '';
+    return `${valueFor('day')} ${valueFor('month')} ${valueFor('year')}, ${valueFor('hour')}:${valueFor('minute')} IST`;
   }
 
   function deriveConfig(elements) {


### PR DESCRIPTION
### Motivation
- Ensure all notification timestamps in the bell, dropdown and notification centre are displayed consistently in Indian Standard Time (IST) rather than depending on server local time or the user's browser timezone. 

### Description
- Add `CreatedDisplayIst` to the notification payload (`Contracts/Notifications/NotificationListItem`) and populate it in the server projection using `TimeFmt.ToIst(notification.CreatedUtc)` in `UserNotificationService`. 
- Add `CreatedDisplayIst` to `NotificationDisplayModel` and use it as the rendered timestamp with a central fallback to `TimeFmt.ToIst(...)` to keep Razor markup simple. 
- Replace server-side `CreatedUtc.ToLocalTime()` usage in the notification bell and notification centre Razor views with `@item.CreatedDisplayIst`. 
- Update `wwwroot/js/notifications.js` to prefer `createdDisplayIst` from the server payload and add a safe client-side fallback `formatIstDateTime(...)` that formats explicitly with `timeZone: 'Asia/Kolkata'` when the server string is missing. 
- Add tests (`ProjectManagement.Tests/NotificationIstDisplayTests.cs`) that assert `TimeFmt.ToIst` conversion, `NotificationDisplayModel.FromContract` IST projection, and source-level checks to prevent reintroduction of `ToLocalTime` or `toLocaleString(undefined)` patterns.

### Testing
- Ran `git diff --check` and the repository diff checks passed. 
- Ran `node --check wwwroot/js/notifications.js` and the JavaScript passed static syntax checks. 
- Searched for forbidden patterns (`ToLocalTime`, `toLocaleString(undefined)`, etc.) across notification UI code and confirmed replacements were applied. 
- Added unit tests for IST formatting and view-model projection but `dotnet test` was not executed in this environment because `dotnet` is not available here (tests are present and should be run in CI/locally with `dotnet test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cd48116083299490142437455c88)