### PR TITLE
Fix JavaScript test runner paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node --test wwwroot/js/projects wwwroot/js/pages/action-tasks/index.test.js wwwroot/js/calendar.test.js",
+    "test": "node tools/run-js-tests.js",
     "lint:views": "./tools/check-views.sh"
   },
   "repository": {

--- a/tools/run-js-tests.js
+++ b/tools/run-js-tests.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// -----------------------------------------------------------------------------
+// Test Discovery
+// -----------------------------------------------------------------------------
+const projectTestsRoot = path.join('wwwroot', 'js', 'projects');
+const explicitTests = [
+  path.join('wwwroot', 'js', 'pages', 'action-tasks', 'index.test.js'),
+  path.join('wwwroot', 'js', 'calendar.test.js'),
+];
+
+function findTestFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const testFiles = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      testFiles.push(...findTestFiles(entryPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.test.js')) {
+      testFiles.push(entryPath);
+    }
+  }
+
+  return testFiles.sort();
+}
+
+// -----------------------------------------------------------------------------
+// Test Execution
+// -----------------------------------------------------------------------------
+const testFiles = [...findTestFiles(projectTestsRoot), ...explicitTests];
+const result = spawnSync(process.execPath, ['--test', ...testFiles], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
### Motivation

- The `npm test` script previously passed the `wwwroot/js/projects` directory directly to Node’s test runner, which caused a `MODULE_NOT_FOUND` error on some platforms because Node tried to execute a directory as a module.
- The goal is to invoke `node --test` with concrete test file paths (or discovered test files) so the test runner works consistently across environments including Windows PowerShell.

### Description

- Update `package.json` to run a dedicated runner via `node tools/run-js-tests.js` instead of passing a directory to Node’s test runner. 
- Add `tools/run-js-tests.js`, a small Node script that recursively discovers `.test.js` files under `wwwroot/js/projects` and includes explicit test files `wwwroot/js/pages/action-tasks/index.test.js` and `wwwroot/js/calendar.test.js`.
- The runner invokes `node --test` with concrete file paths (no shell glob expansion) and safely handles a missing projects directory by skipping it.

### Testing

- Ran `npm test`, which executed the new runner and completed successfully with all JavaScript tests passing (19 tests passed and 0 failures). 
- The previous `MODULE_NOT_FOUND` for `wwwroot/js/projects` no longer occurs and the Action Tracker and calendar tests continue to run as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d1b0232c8329b57029d5198df150)