### PR TITLE
Fix ActionTask notification test options binding

### DIFF
--- a/ProjectManagement.Tests/ActionTasks/ActionTaskNotificationServiceTests.cs
+++ b/ProjectManagement.Tests/ActionTasks/ActionTaskNotificationServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Notifications;
@@ -226,7 +225,8 @@ public sealed class ActionTaskNotificationServiceTests
         public FakeUserManager(IReadOnlyDictionary<string, IReadOnlyList<ApplicationUser>>? usersByRole = null)
             : base(
                 new FakeUserStore(),
-                Options.Create(new IdentityOptions()),
+                // SECTION: Identity options
+                Microsoft.Extensions.Options.Options.Create(new IdentityOptions()),
                 new PasswordHasher<ApplicationUser>(),
                 Array.Empty<IUserValidator<ApplicationUser>>(),
                 Array.Empty<IPasswordValidator<ApplicationUser>>(),


### PR DESCRIPTION
### Motivation
- Resolve a `CS0120` build error caused by `Options.Create(...)` being resolved against the inherited `UserManager<ApplicationUser>.Options` instance property in the test fake `UserManager` constructor.

### Description
- Fully qualify the options factory call as `Microsoft.Extensions.Options.Options.Create(new IdentityOptions())` inside `ProjectManagement.Tests/ActionTasks/ActionTaskNotificationServiceTests.cs` so it does not reference the instance `Options` property, and remove the now-unused `using Microsoft.Extensions.Options;` directive.

### Testing
- Ran `PATH=/tmp/dotnet:$PATH dotnet build` and the build succeeded; then ran `PATH=/tmp/dotnet:$PATH dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-build --filter ActionTaskNotificationServiceTests` and the filtered tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8a4605948329bb4fa798ace9815c)