### PR TITLE
Show latest internal remark as fallback on Ongoing Projects timeline

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -557,7 +557,7 @@ else
                                 <div class="ongoing-remarks__title-wrap">
                                     <span class="ongoing-remarks__title">Remarks summary</span>
                                     <span class="ongoing-remarks__title-sep">·</span>
-                                    <span class="ongoing-remarks__subtitle">Internal remarks (last 10 days)</span>
+                                    <span class="ongoing-remarks__subtitle">Internal remarks</span>
                                 </div>
                                 @if (hasExpandableInternalRemarks)
                                 {
@@ -577,7 +577,7 @@ else
                                 <div class="ongoing-remarks__column ongoing-remarks__column--internal">
                                     @if (item.RecentInternalRemarks.Count == 0)
                                     {
-                                        <p class="small text-muted mb-0">No internal remarks in the last 10 days.</p>
+                                        <p class="small text-muted mb-0">No internal remarks available.</p>
                                     }
                                     else
                                     {

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -378,13 +378,31 @@ namespace ProjectManagement.Services.Projects
                     .Where(r => r.ProjectId == proj.Id)
                     .ToList();
 
-                // last 10 INTERNAL in last 10 days
-                var recentInternal = remarksForProject
+                // SECTION: Internal remarks for ongoing project timeline card
+                // Default: show up to 10 internal remarks from the last 10 days.
+                // Fallback: if none exist in the last 10 days, show the latest one internal remark.
+                var recentInternalRemarks = remarksForProject
                     .Where(r =>
                         r.Type == RemarkType.Internal &&
                         r.CreatedAtUtc >= tenDaysAgoUtc)
                     .OrderByDescending(r => r.CreatedAtUtc)
                     .Take(10)
+                    .ToList();
+
+                if (recentInternalRemarks.Count == 0)
+                {
+                    var latestInternalFallback = remarksForProject
+                        .Where(r => r.Type == RemarkType.Internal)
+                        .OrderByDescending(r => r.CreatedAtUtc)
+                        .FirstOrDefault();
+
+                    if (latestInternalFallback != null)
+                    {
+                        recentInternalRemarks.Add(latestInternalFallback);
+                    }
+                }
+
+                var recentInternal = recentInternalRemarks
                     .Select(r => new OngoingProjectRemarkDto
                     {
                         CreatedAtUtc = r.CreatedAtUtc,


### PR DESCRIPTION
### Motivation
- The Ongoing Projects timeline currently shows only internal remarks from the last 10 days, which leaves cards empty when no recent remark exists even though older internal remarks may be useful.
- The goal is to surface at least one internal remark when there are no recent ones so reviewers have some internal context without changing external remark behavior.

### Description
- Implemented two-step selection in `Services/Projects/OngoingProjectsReadService.cs` to first select up to 10 internal remarks from the last 10 days and, if none exist, add the latest single internal remark as a fallback while preserving reverse-chronological ordering.
- Kept the limit at `Take(10)` for recent remarks and restricted the fallback to `RemarkType.Internal` so external remarks remain excluded from the internal summary.
- Updated the UI text in `Pages/Projects/Ongoing/Index.cshtml` to simplify the subtitle to `Internal remarks` and changed the empty state copy to `No internal remarks available.` to reflect the new fallback behavior.
- Preserved the existing DTO mapping and rendering logic so no change is made to how remarks are displayed beyond selection and labels.

### Testing
- Attempted to run unit tests with `dotnet test ProjectManagement.sln` but the `dotnet` CLI is not available in this environment so automated tests could not be executed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e34b75fe48329a80444f3e783d0f9)