### PR TITLE
Fix ongoing project stage bucket enum references

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml.cs
+++ b/Pages/Projects/Ongoing/Index.cshtml.cs
@@ -238,16 +238,16 @@ namespace ProjectManagement.Pages.Projects.Ongoing
 
                 switch (bucket)
                 {
-                    case StageBucket.Approval:
+                    case ProjectManagement.Models.Stages.StageBucket.Approval:
                         BucketApvlCount++;
                         break;
-                    case StageBucket.Aon:
+                    case ProjectManagement.Models.Stages.StageBucket.Aon:
                         BucketAonCount++;
                         break;
-                    case StageBucket.Procurement:
+                    case ProjectManagement.Models.Stages.StageBucket.Procurement:
                         BucketProcCount++;
                         break;
-                    case StageBucket.Development:
+                    case ProjectManagement.Models.Stages.StageBucket.Development:
                         BucketDevpCount++;
                         break;
                     default:


### PR DESCRIPTION
### Motivation
- Resolve CS1061 IntelliSense/compile errors in the ongoing projects page where `StageBucket` enum references were being shadowed by the page model's `StageBucket` string property, causing member resolution failures.

### Description
- Disambiguated enum usage by fully qualifying enum members in `Pages/Projects/Ongoing/Index.cshtml.cs` switch cases to `ProjectManagement.Models.Stages.StageBucket.*` so the compiler picks the enum type instead of the model property.
- No changes were made to the bucket mapping logic or behavior beyond the qualification fix.

### Testing
- Attempted to run `dotnet build` to validate compilation but it could not be executed because the .NET SDK/CLI is not available in this environment (`dotnet: command not found`).
- No automated tests were run in this environment; please run `dotnet build` and the project test suite in CI or a local development environment to confirm the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3c8029888329aa3e98a4a29b73f0)