### PR TITLE
Remove manual Filter button and standardise auto-apply filters on Ongoing Projects page

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -254,7 +254,10 @@
             </div>
             <div class="cmdbar__field cmdbar__field--search">
                 <label asp-for="Search" class="cmdbar__label">Search by project name</label>
-                <input asp-for="Search" class="form-control form-control-sm" />
+                <input asp-for="Search"
+                       class="form-control form-control-sm"
+                       placeholder="Type and press Enter"
+                       title="Press Enter to search" />
             </div>
         </div>
 
@@ -318,15 +321,13 @@
                    asp-route-PresentStageCode=""
                    asp-route-ProjectOfficerId=""
                    asp-route-Search=""
+                   asp-route-StageBucket=""
+                   asp-route-StageFlow="forward"
                    asp-route-View="@Model.View"
                    class="cmdbar__link-button">
                     Clear filters
                 </a>
             }
-            <button type="submit" class="btn btn-sm btn-outline-primary">
-                <i class="bi bi-funnel" aria-hidden="true"></i>
-                <span>Filter</span>
-            </button>
             <a asp-page="./Index"
                asp-page-handler="Export"
                asp-route-ProjectCategoryId="@Model.ProjectCategoryId"

--- a/wwwroot/js/projects/ongoing.js
+++ b/wwwroot/js/projects/ongoing.js
@@ -72,9 +72,10 @@
   officerSelect?.addEventListener('change', submitFilters);
   stageFlowSelect?.addEventListener('change', submitFilters);
 
-  // Pressing Enter in the search box already submits the form, but this keeps behaviour explicit
+  // SECTION: Search submits only when Enter is pressed
   searchInput?.addEventListener('keydown', (event) => {
     if (event.key === 'Enter') {
+      event.preventDefault();
       submitFilters();
     }
   });


### PR DESCRIPTION
### Motivation

- Improve UX consistency by removing the redundant manual `Filter` submit button since most filters already auto-apply.  
- Make search behaviour explicit for keyboard users by requiring Enter to submit and giving a brief hint.  
- Ensure Clear and Export actions continue to behave and that clearing filters also clears `StageBucket` and resets `StageFlow` to the default.

### Description

- Removed the visible manual Filter submit button from `Pages/Projects/Ongoing/Index.cshtml` and left the form and GET behaviour intact.  
- Added placeholder and `title` to the search input to read `Type and press Enter` for clearer keyboard guidance in `Pages/Projects/Ongoing/Index.cshtml`.  
- Updated the Clear filters link to include `asp-route-StageBucket=""` and `asp-route-StageFlow="forward"` so clearing resets the bucket and stage flow.  
- Adjusted `wwwroot/js/projects/ongoing.js` so the search handler calls `event.preventDefault()` and then `submitFilters()` when Enter is pressed, preserving the auto-submit model and existing dropdown/chip auto-apply logic.

### Testing

- Ran a repository search for relevant tokens with `rg` to verify the new placeholder, `StageBucket` clearing, and `event.preventDefault()` change, and the checks found the expected edits (success).  
- Ran `git diff --check` to catch whitespace/diff issues, which reported no problems (success).  
- Attempted to run `dotnet test` but the `dotnet` CLI is not available in this environment so unit tests could not be executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3eedc030832993ab9d0869e0358e)