### PR TITLE
Optimize ongoing stage bucket counts

### DIFF
--- a/Pages/Projects/Ongoing/Index.cshtml
+++ b/Pages/Projects/Ongoing/Index.cshtml
@@ -90,7 +90,7 @@
 
         <!-- SECTION: Stage pipeline -->
         <div class="ongoing-top__pipeline" aria-label="Stage bucket distribution">
-            @if (Model.BucketCountItems.Count > 0)
+            @if (Model.BucketCounts.Total > 0)
             {
                 <div class="stage-pipeline-wrap" aria-label="Stage distribution">
                     <div class="stage-pipeline-wrap__caption">Stage distribution</div>

--- a/Pages/Projects/Ongoing/Index.cshtml.cs
+++ b/Pages/Projects/Ongoing/Index.cshtml.cs
@@ -104,8 +104,8 @@ namespace ProjectManagement.Pages.Projects.Ongoing
         public IReadOnlyList<OngoingProjectRowDto> Items { get; private set; }
             = Array.Empty<OngoingProjectRowDto>();
 
-        public IReadOnlyList<OngoingProjectRowDto> BucketCountItems { get; private set; }
-            = Array.Empty<OngoingProjectRowDto>();
+        // SECTION: Stage bucket counts source
+        public OngoingStageBucketCountsDto BucketCounts { get; private set; } = OngoingStageBucketCountsDto.Empty;
 
         // SECTION: Inline external remark editing metadata
         public bool CanInlineEditExternalRemarks { get; private set; }
@@ -141,13 +141,10 @@ namespace ProjectManagement.Pages.Projects.Ongoing
                 StageFlow,
                 cancellationToken);
 
-            BucketCountItems = await _ongoingService.GetAsync(
+            BucketCounts = await _ongoingService.GetStageBucketCountsAsync(
                 ProjectCategoryId,
                 officerId,
                 search,
-                null,
-                null,
-                StageFlow,
                 cancellationToken);
 
             // SECTION: Inline external remark editing access + IST date
@@ -226,35 +223,11 @@ namespace ProjectManagement.Pages.Projects.Ongoing
             ChipTotalCount = Items.Count;
 
             // SECTION: Stage bucket breakdown
-            BucketApvlCount = 0;
-            BucketAonCount = 0;
-            BucketProcCount = 0;
-            BucketDevpCount = 0;
-            BucketUnknownCount = 0;
-
-            foreach (var item in BucketCountItems)
-            {
-                var bucket = StageBuckets.Of(item.CurrentStageCode);
-
-                switch (bucket)
-                {
-                    case ProjectManagement.Models.Stages.StageBucket.Approval:
-                        BucketApvlCount++;
-                        break;
-                    case ProjectManagement.Models.Stages.StageBucket.Aon:
-                        BucketAonCount++;
-                        break;
-                    case ProjectManagement.Models.Stages.StageBucket.Procurement:
-                        BucketProcCount++;
-                        break;
-                    case ProjectManagement.Models.Stages.StageBucket.Development:
-                        BucketDevpCount++;
-                        break;
-                    default:
-                        BucketUnknownCount++;
-                        break;
-                }
-            }
+            BucketApvlCount = BucketCounts.Approval;
+            BucketAonCount = BucketCounts.Aon;
+            BucketProcCount = BucketCounts.Procurement;
+            BucketDevpCount = BucketCounts.Development;
+            BucketUnknownCount = BucketCounts.Unknown;
 
             var categoryLookup = _categories.ToDictionary(c => c.Id);
 

--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -40,36 +40,17 @@ namespace ProjectManagement.Services.Projects
             string? stageFlow,
             CancellationToken cancellationToken)
         {
-            // base query – active projects only
-            var q = _db.Projects
-                .AsNoTracking()
+            // SECTION: Base project scope
+            var q = BuildActiveProjectsQuery()
                 .Include(p => p.Category)
-                .Include(p => p.LeadPoUser)
-                .Where(p => p.LifecycleStatus == ProjectLifecycleStatus.Active
-                            && !p.IsArchived
-                            && !p.IsDeleted);
+                .Include(p => p.LeadPoUser);
 
-            // -------------------- Category filtering --------------------
-            if (projectCategoryId is { } catId && catId > 0)
-            {
-                var categoryScopeIds = await GetCategoryScopeIdsAsync(catId, cancellationToken);
-                q = q.Where(p => p.CategoryId.HasValue && categoryScopeIds.Contains(p.CategoryId.Value));
-            }
-
-            if (!string.IsNullOrWhiteSpace(leadPoUserId))
-            {
-                var officerId = leadPoUserId.Trim();
-                q = q.Where(p => p.LeadPoUserId == officerId);
-            }
-
-            // -------------------- Search filtering (case-insensitive) --------------------
-            if (!string.IsNullOrWhiteSpace(search))
-            {
-                var term = search.Trim();
-                var like = $"%{term}%";
-
-                q = q.Where(p => EF.Functions.ILike(p.Name, like));
-            }
+            q = await ApplyProjectScopeFiltersAsync(
+                q,
+                projectCategoryId,
+                leadPoUserId,
+                search,
+                cancellationToken);
 
             var projects = await q
                 .OrderBy(p => p.Id)
@@ -508,6 +489,72 @@ namespace ProjectManagement.Services.Projects
                 .ToList();
         }
 
+        public async Task<OngoingStageBucketCountsDto> GetStageBucketCountsAsync(
+            int? projectCategoryId,
+            string? leadPoUserId,
+            string? search,
+            CancellationToken cancellationToken)
+        {
+            // SECTION: Build the same project scope as the row query without loading row-only details
+            var q = BuildActiveProjectsQuery();
+
+            q = await ApplyProjectScopeFiltersAsync(
+                q,
+                projectCategoryId,
+                leadPoUserId,
+                search,
+                cancellationToken);
+
+            var projects = await q
+                .OrderBy(p => p.Id)
+                .Select(p => new
+                {
+                    p.Id,
+                    p.WorkflowVersion
+                })
+                .ToListAsync(cancellationToken);
+
+            if (projects.Count == 0)
+            {
+                return OngoingStageBucketCountsDto.Empty;
+            }
+
+            var projectIds = projects.Select(p => p.Id).ToArray();
+
+            // SECTION: Read only stage fields required to resolve each project's current stage
+            var allStages = await _db.ProjectStages
+                .AsNoTracking()
+                .Where(s => projectIds.Contains(s.ProjectId))
+                .Select(s => new
+                {
+                    s.ProjectId,
+                    s.StageCode,
+                    s.Status
+                })
+                .ToListAsync(cancellationToken);
+
+            var stagesByProject = allStages
+                .GroupBy(s => s.ProjectId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.ToDictionary(s => s.StageCode, s => s.Status, StringComparer.OrdinalIgnoreCase));
+
+            var counts = new OngoingStageBucketCountsDto();
+
+            foreach (var project in projects)
+            {
+                var currentStageCode = ResolveCurrentStageCode(
+                    project.WorkflowVersion,
+                    stagesByProject.TryGetValue(project.Id, out var stageStatuses)
+                        ? stageStatuses
+                        : EmptyStageStatuses);
+
+                counts.Add(StageBuckets.Of(currentStageCode));
+            }
+
+            return counts;
+        }
+
         /// <summary>
         /// Build officer dropdown from all active projects that have a LeadPoUser.
         /// </summary>
@@ -547,6 +594,98 @@ namespace ProjectManagement.Services.Projects
             }
 
             return items;
+        }
+
+        // SECTION: Active project query helpers
+        private static readonly IReadOnlyDictionary<string, StageStatus> EmptyStageStatuses =
+            new Dictionary<string, StageStatus>(StringComparer.OrdinalIgnoreCase);
+
+        private IQueryable<Project> BuildActiveProjectsQuery()
+            => _db.Projects
+                .AsNoTracking()
+                .Where(p => p.LifecycleStatus == ProjectLifecycleStatus.Active
+                            && !p.IsArchived
+                            && !p.IsDeleted);
+
+        private async Task<IQueryable<Project>> ApplyProjectScopeFiltersAsync(
+            IQueryable<Project> query,
+            int? projectCategoryId,
+            string? leadPoUserId,
+            string? search,
+            CancellationToken cancellationToken)
+        {
+            // SECTION: Category filtering
+            if (projectCategoryId is { } catId && catId > 0)
+            {
+                var categoryScopeIds = await GetCategoryScopeIdsAsync(catId, cancellationToken);
+                query = query.Where(p => p.CategoryId.HasValue && categoryScopeIds.Contains(p.CategoryId.Value));
+            }
+
+            // SECTION: Project officer filtering
+            if (!string.IsNullOrWhiteSpace(leadPoUserId))
+            {
+                var officerId = leadPoUserId.Trim();
+                query = query.Where(p => p.LeadPoUserId == officerId);
+            }
+
+            // SECTION: Search filtering (case-insensitive)
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                var term = search.Trim();
+                var like = $"%{term}%";
+
+                query = query.Where(p => EF.Functions.ILike(p.Name, like));
+            }
+
+            return query;
+        }
+
+        // SECTION: Current stage resolver for lightweight counts
+        private static string ResolveCurrentStageCode(
+            string? workflowVersion,
+            IReadOnlyDictionary<string, StageStatus> stageStatuses)
+        {
+            var stageCodes = ProcurementWorkflow.StageCodesFor(workflowVersion);
+            var currentIndex = ResolveCurrentStageIndex(stageCodes, stageStatuses);
+
+            return stageCodes[currentIndex];
+        }
+
+        private static int ResolveCurrentStageIndex(
+            IReadOnlyList<string> stageCodes,
+            IReadOnlyDictionary<string, StageStatus> stageStatuses)
+        {
+            int? inProgressIndex = null;
+            var lastCompletedIndex = -1;
+
+            for (var i = 0; i < stageCodes.Count; i++)
+            {
+                var status = stageStatuses.TryGetValue(stageCodes[i], out var stageStatus)
+                    ? stageStatus
+                    : StageStatus.NotStarted;
+
+                if (status == StageStatus.InProgress && inProgressIndex == null)
+                {
+                    inProgressIndex = i;
+                }
+
+                if (status == StageStatus.Completed)
+                {
+                    lastCompletedIndex = i;
+                }
+            }
+
+            if (inProgressIndex.HasValue)
+            {
+                return inProgressIndex.Value;
+            }
+
+            if (lastCompletedIndex >= 0 && lastCompletedIndex + 1 < stageCodes.Count)
+            {
+                return lastCompletedIndex + 1;
+            }
+
+            return 0;
         }
 
         // -------------------- Category scope helpers --------------------
@@ -618,6 +757,41 @@ namespace ProjectManagement.Services.Projects
                 string.Equals(s.Code, stageCode, StringComparison.OrdinalIgnoreCase));
 
             return stage?.ActualCompletedOn;
+        }
+    }
+
+    public sealed class OngoingStageBucketCountsDto
+    {
+        public static OngoingStageBucketCountsDto Empty => new();
+
+        public int Approval { get; private set; }
+        public int Aon { get; private set; }
+        public int Procurement { get; private set; }
+        public int Development { get; private set; }
+        public int Unknown { get; private set; }
+        public int Total => Approval + Aon + Procurement + Development + Unknown;
+
+        public void Add(StageBucket bucket)
+        {
+            // SECTION: Increment bucket totals
+            switch (bucket)
+            {
+                case StageBucket.Approval:
+                    Approval++;
+                    break;
+                case StageBucket.Aon:
+                    Aon++;
+                    break;
+                case StageBucket.Procurement:
+                    Procurement++;
+                    break;
+                case StageBucket.Development:
+                    Development++;
+                    break;
+                default:
+                    Unknown++;
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Avoid executing the full ongoing-project row load twice just to compute stage-bucket totals and reduce unnecessary data reads and CPU work. 
- Keep filtering logic DRY and consistent between the main row query and the bucket-count computation. 
- Provide a lightweight, maintainable path to compute stage-distribution metrics for the UI without loading remarks, costs or photos.

### Description
- Added a lightweight `GetStageBucketCountsAsync` method to `Services/Projects/OngoingProjectsReadService.cs` that reads only project IDs/workflow versions and minimal stage status fields to compute bucket totals. 
- Introduced query helpers `BuildActiveProjectsQuery` and `ApplyProjectScopeFiltersAsync` and current-stage helpers `ResolveCurrentStageCode` / `ResolveCurrentStageIndex` to share filtering and stage resolution logic. 
- Added `OngoingStageBucketCountsDto` to carry bucket totals and updated `Pages/Projects/Ongoing/Index.cshtml.cs` to call `GetStageBucketCountsAsync` and populate the page model `BucketCounts`. 
- Updated the Razor view `Pages/Projects/Ongoing/Index.cshtml` to check `Model.BucketCounts.Total` and the page model to map bucket DTO fields into the existing `BucketApvlCount`, `BucketAonCount`, `BucketProcCount`, `BucketDevpCount` and `BucketUnknownCount` properties.

### Testing
- Ran `git diff --check` to verify there are no whitespace/conflict issues and it passed. 
- Attempted `dotnet build ProjectManagement.csproj --no-restore` but the environment does not have `dotnet` installed so an in-container build could not be executed. 
- Changes were committed (commit message: `Optimize ongoing stage bucket counts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3f6e9024832994b09f975db695b1)