### PR TITLE
Fix ongoing project query type mismatch

### DIFF
--- a/Services/Projects/OngoingProjectsReadService.cs
+++ b/Services/Projects/OngoingProjectsReadService.cs
@@ -41,7 +41,7 @@ namespace ProjectManagement.Services.Projects
             CancellationToken cancellationToken)
         {
             // SECTION: Base project scope
-            var q = BuildActiveProjectsQuery()
+            IQueryable<Project> q = BuildActiveProjectsQuery()
                 .Include(p => p.Category)
                 .Include(p => p.LeadPoUser);
 


### PR DESCRIPTION
### Motivation
- Resolve a CS0266 type conversion error caused by `var` inferring an EF Core includable query type which could not be reassigned from a filtered `IQueryable<Project>`.

### Description
- Explicitly declare the base query as `IQueryable<Project>` instead of `var` in `Services/Projects/OngoingProjectsReadService.cs` so the variable can be reassigned after calling `ApplyProjectScopeFiltersAsync`.

### Testing
- `dotnet build` was not executed because the `dotnet` CLI is not available in this environment, so no automated build or test run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e41d0dc748329b8e6a5951b1e71cf)