### PR TITLE
Redesign Activities module: review-first card view with search, media filters & previews

### DIFF
--- a/Contracts/Activities/ActivityListModels.cs
+++ b/Contracts/Activities/ActivityListModels.cs
@@ -19,6 +19,16 @@ public enum ActivityAttachmentTypeFilter
     Video
 }
 
+public enum ActivityMediaFilter
+{
+    Any,
+    WithMedia,
+    WithoutMedia,
+    Photos,
+    Videos,
+    Documents
+}
+
 public sealed record ActivityListRequest(
     int Page = 1,
     int PageSize = 25,
@@ -28,7 +38,9 @@ public sealed record ActivityListRequest(
     DateOnly? ToDate = null,
     int? ActivityTypeId = null,
     string? CreatedByUserId = null,
-    ActivityAttachmentTypeFilter AttachmentType = ActivityAttachmentTypeFilter.Any);
+    ActivityAttachmentTypeFilter AttachmentType = ActivityAttachmentTypeFilter.Any,
+    string? Search = null,
+    ActivityMediaFilter MediaFilter = ActivityMediaFilter.Any);
 
 public sealed record ActivityListItem(
     int Id,
@@ -36,6 +48,7 @@ public sealed record ActivityListItem(
     string ActivityTypeName,
     int ActivityTypeId,
     string? Location,
+    string? RemarksPreview,
     DateTimeOffset? ScheduledStartUtc,
     DateTimeOffset? ScheduledEndUtc,
     DateTimeOffset CreatedAtUtc,
@@ -46,7 +59,16 @@ public sealed record ActivityListItem(
     int PdfAttachmentCount,
     int PhotoAttachmentCount,
     int VideoAttachmentCount,
+    IReadOnlyList<ActivityMediaPreview> MediaPreviews,
     bool HasPendingDelete);
+
+public sealed record ActivityMediaPreview(
+    int AttachmentId,
+    string FileName,
+    string ContentType,
+    string MediaKind,
+    string StorageKey,
+    long SizeBytes);
 
 public sealed record ActivityListResult(
     IReadOnlyList<ActivityListItem> Items,

--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -68,6 +68,17 @@ namespace ProjectManagement.Infrastructure.Activities
                 query = query.Where(x => x.CreatedByUserId == request.CreatedByUserId);
             }
 
+            // SECTION: Review-first search filters
+            if (!string.IsNullOrWhiteSpace(request.Search))
+            {
+                var term = request.Search.Trim();
+                query = query.Where(x =>
+                    x.Title.Contains(term) ||
+                    (x.Description != null && x.Description.Contains(term)) ||
+                    (x.Location != null && x.Location.Contains(term)) ||
+                    x.ActivityType.Name.Contains(term));
+            }
+
             if (request.FromDate.HasValue)
             {
                 var from = new DateTimeOffset(request.FromDate.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
@@ -88,6 +99,22 @@ namespace ProjectManagement.Infrastructure.Activities
                     a.OriginalFileName.EndsWith(".pdf"))),
                 ActivityAttachmentTypeFilter.Photo => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
                 ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
+                _ => query
+            };
+
+            // SECTION: Media availability filters
+            query = request.MediaFilter switch
+            {
+                ActivityMediaFilter.WithMedia => query.Where(x => x.Attachments.Any()),
+                ActivityMediaFilter.WithoutMedia => query.Where(x => !x.Attachments.Any()),
+                ActivityMediaFilter.Photos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
+                ActivityMediaFilter.Videos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
+                ActivityMediaFilter.Documents => query.Where(x => x.Attachments.Any(a =>
+                    a.ContentType == "application/pdf" ||
+                    a.OriginalFileName.EndsWith(".pdf") ||
+                    a.ContentType.Contains("document") ||
+                    a.ContentType.Contains("spreadsheet") ||
+                    a.ContentType.Contains("presentation"))),
                 _ => query
             };
 
@@ -131,6 +158,7 @@ namespace ProjectManagement.Infrastructure.Activities
                     x.ActivityType.Name,
                     x.ActivityTypeId,
                     x.Location,
+                    x.Description,
                     x.ScheduledStartUtc,
                     x.ScheduledEndUtc,
                     x.CreatedAtUtc,
@@ -141,6 +169,20 @@ namespace ProjectManagement.Infrastructure.Activities
                     x.Attachments.Count(a => a.ContentType == "application/pdf" || a.OriginalFileName.EndsWith(".pdf")),
                     x.Attachments.Count(a => a.ContentType.StartsWith("image/")),
                     x.Attachments.Count(a => a.ContentType.StartsWith("video/")),
+                    x.Attachments
+                        .OrderByDescending(a => a.ContentType.StartsWith("image/"))
+                        .ThenByDescending(a => a.ContentType.StartsWith("video/"))
+                        .ThenByDescending(a => a.ContentType == "application/pdf" || a.OriginalFileName.EndsWith(".pdf"))
+                        .ThenByDescending(a => a.UploadedAtUtc)
+                        .Take(3)
+                        .Select(a => new ActivityMediaPreview(
+                            a.Id,
+                            a.OriginalFileName,
+                            a.ContentType,
+                            a.ContentType.StartsWith("image/") ? "Photo" : a.ContentType.StartsWith("video/") ? "Video" : "Document",
+                            a.StorageKey,
+                            a.FileSize))
+                        .ToList(),
                     x.DeleteRequests.Any(r => r.ApprovedAtUtc == null && r.RejectedAtUtc == null)))
                 .ToListAsync(cancellationToken);
 

--- a/Pages/Activities/Details.cshtml
+++ b/Pages/Activities/Details.cshtml
@@ -111,12 +111,12 @@
 
     <div class="pm-card pm-shadow mb-4">
         <div class="pm-card-header">
-            <h2 class="h5 mb-0">Description</h2>
+            <h2 class="h5 mb-0">Remarks / Brief</h2>
         </div>
         <div class="pm-card-body">
             @if (string.IsNullOrWhiteSpace(activity.Description))
             {
-                <p class="text-muted mb-0">No description provided.</p>
+                <p class="text-muted mb-0">No remarks added.</p>
             }
             else
             {
@@ -128,7 +128,7 @@
     <div class="pm-card pm-shadow mb-4">
         <div class="pm-card-header d-flex flex-column flex-lg-row gap-3 align-items-start align-items-lg-center">
             <div>
-                <h2 class="h5 mb-1">Attachments</h2>
+                <h2 class="h5 mb-1">Media / Documents</h2>
                 <p class="text-muted mb-0">@Model.Attachments.Count attachment@(Model.Attachments.Count == 1 ? string.Empty : "s"). Allowed types: @Model.AllowedAttachmentSummary. Max size: @(Math.Ceiling(Model.MaxAttachmentSizeBytes / 1048576.0)) MB.</p>
             </div>
             @if (Model.CanManage)

--- a/Pages/Activities/Edit.cshtml
+++ b/Pages/Activities/Edit.cshtml
@@ -26,7 +26,7 @@
         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
         <div class="card mb-3">
-            <div class="card-header">Activity details</div>
+            <div class="card-header">Basic details</div>
             <div class="card-body">
                 <div class="mb-3">
                     <label asp-for="Input.Title" class="form-label"></label>
@@ -58,8 +58,8 @@
                     </div>
                 </div>
                 <div class="mt-3">
-                    <label asp-for="Input.Description" class="form-label"></label>
-                    <textarea asp-for="Input.Description" class="form-control" rows="4" maxlength="2000"></textarea>
+                    <label asp-for="Input.Description" class="form-label">Remarks / Brief</label>
+                    <textarea asp-for="Input.Description" class="form-control" rows="6" maxlength="2000" placeholder="Record key points, outcome, decisions, follow-up or brief summary of the activity."></textarea>
                     <div class="form-text" data-char-count-for="Input_Description">0/2000</div>
                     <span asp-validation-for="Input.Description" class="text-danger"></span>
                 </div>
@@ -67,12 +67,12 @@
         </div>
 
         <div class="card mb-4">
-            <div class="card-header">Attachments</div>
+            <div class="card-header">Media / Documents</div>
             <div class="card-body">
                 @if (canUpload)
                 {
                     <div class="mb-3" data-doc-dropzone>
-                        <label class="form-label" asp-for="Input.Files">Upload supporting files</label>
+                        <label class="form-label" asp-for="Input.Files">Attach photos, videos or documents related to the activity</label>
                         <div class="doc-request-drop border border-2 border-secondary-subtle rounded-3 p-4 text-center" data-doc-drop-target tabindex="0" role="button" aria-describedby="activity-upload-help">
                             <div class="fw-semibold" data-doc-drop-label>Drag &amp; drop files or browse</div>
                             <div class="text-muted small" data-doc-drop-filename></div>
@@ -104,7 +104,7 @@
 
         <div class="d-flex justify-content-between">
             <a asp-page="/Activities/Index" class="btn btn-outline-secondary">Cancel</a>
-            <button type="submit" class="btn btn-primary">@(isEdit ? "Save changes" : "Create activity")</button>
+            <button type="submit" class="btn btn-primary">@(isEdit ? "Save activity" : "Save activity")</button>
         </div>
     </form>
 </div>

--- a/Pages/Activities/Index.cshtml
+++ b/Pages/Activities/Index.cshtml
@@ -7,359 +7,143 @@
     var hasRows = vm is not null && vm.Rows.Count > 0;
     var pageSize = vm?.PageSize ?? Model.PageSize;
     var currentPage = vm?.Page ?? Model.Page;
-    var totalCount = vm?.TotalCount ?? 0;
-    var resultsStart = hasRows ? ((currentPage - 1) * pageSize) + 1 : 0;
-    var resultsEnd = hasRows ? resultsStart + vm!.Rows.Count - 1 : 0;
     string FormatEventDate(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy", System.Globalization.CultureInfo.CurrentCulture) ?? "—";
-    string FormatTimestamp(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy, HH:mm", System.Globalization.CultureInfo.CurrentCulture) ?? "—";
 }
 
-@section Styles
-{
-    <link rel="stylesheet" href="~/css/activities/index.css" asp-append-version="true" />
-}
-
-@section Scripts
-{
-    <script src="~/js/pages/activities-index.js" asp-append-version="true"></script>
-}
+@section Styles { <link rel="stylesheet" href="~/css/activities/index.css" asp-append-version="true" /> }
+@section Scripts { <script src="~/js/pages/activities-index.js" asp-append-version="true"></script> }
 
 <div class="container-xxl activities-page" data-module="activities-index">
-    <div class="activities-header">
-        <div class="activities-header__heading">
-            <span class="pm-card-icon" aria-hidden="true"><i class="bi bi-calendar-event"></i></span>
-            <div>
-                <h1 class="pm-card-title mb-1">Activities</h1>
-                <p class="pm-card-subtitle mb-0">Record and review misc activities with photos, videos and documents.</p>
-            </div>
+    <!-- SECTION: Page header and primary actions -->
+    <div class="activities-page-header">
+        <div>
+            <h1 class="pm-card-title mb-1">Activities</h1>
+            <p class="pm-card-subtitle mb-0">Review activities with remarks and media.</p>
         </div>
-        <div class="activities-header__actions">
-            <button type="button"
-                    class="btn btn-outline-primary btn-sm"
-                    data-bs-toggle="offcanvas"
-                    data-bs-target="#activitiesFilterOffcanvas"
-                    aria-controls="activitiesFilterOffcanvas">
-                <i class="bi bi-funnel" aria-hidden="true"></i>
-                <span>Filters</span>
-            </button>
-            @if (Model.IsDeleteApprover)
+        <div class="activities-actions">
+            @if (Model.CanCreateActivities)
             {
-                <a class="btn btn-outline-secondary btn-sm" asp-page="./Approvals">
-                    <i class="bi bi-check2-square" aria-hidden="true"></i>
-                    <span>Approvals</span>
-                </a>
+                <a class="btn btn-primary" asp-page="./Edit"><i class="bi bi-plus-lg" aria-hidden="true"></i> Add activity</a>
             }
-
-            <form method="post"
-                  asp-page-handler="Export"
-                  class="d-inline"
-                  data-activities-export-form>
+            <form method="post" asp-page-handler="Export" class="d-inline" data-activities-export-form>
                 @Html.AntiForgeryToken()
+                <input type="hidden" name="Search" value="@Model.Search" />
                 <input type="hidden" name="FromDate" value="@(Model.FromDate?.ToString("yyyy-MM-dd"))" />
                 <input type="hidden" name="ToDate" value="@(Model.ToDate?.ToString("yyyy-MM-dd"))" />
                 <input type="hidden" name="ActivityTypeId" value="@(Model.ActivityTypeId?.ToString())" />
                 <input type="hidden" name="AttachmentType" value="@Model.AttachmentType" />
+                <input type="hidden" name="MediaFilter" value="@Model.MediaFilter" />
                 <input type="hidden" name="SortBy" value="@Model.SortBy" />
                 <input type="hidden" name="SortDir" value="@Model.SortDirection" />
-                <input type="hidden" name="PageSize" value="@Model.PageSize" />
-                <button type="submit"
-                        class="btn btn-outline-secondary btn-sm"
-                        @(Model.CanExportActivities ? null : "disabled")>
-                    <i class="bi bi-download" aria-hidden="true"></i>
-                    <span>Export spreadsheet</span>
+                <button type="submit" class="btn btn-outline-secondary" @(Model.CanExportActivities ? null : "disabled")>
+                    <i class="bi bi-download" aria-hidden="true"></i> Export
                 </button>
             </form>
-            @if (Model.CanCreateActivities)
+            @if (Model.IsDeleteApprover)
             {
-                <a class="btn btn-primary btn-sm" asp-page="./Edit">
-                    <i class="bi bi-plus-lg" aria-hidden="true"></i>
-                    <span>Add activity</span>
-                </a>
+                <a class="btn btn-outline-secondary" asp-page="./Approvals"><i class="bi bi-shield-check" aria-hidden="true"></i> Approvals</a>
             }
         </div>
     </div>
 
-    <div class="offcanvas offcanvas-end activities-filter-offcanvas"
-         tabindex="-1"
-         id="activitiesFilterOffcanvas"
-         aria-labelledby="activitiesFilterOffcanvasLabel">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="activitiesFilterOffcanvasLabel">Activity filters</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-        </div>
-        <div class="offcanvas-body">
-            <form method="get" class="row g-3 activities-filter-form" aria-label="Activity filters">
-                <input type="hidden" name="Page" value="1" />
-                <input type="hidden" asp-for="SortBy" />
-                <div class="col-12 col-sm-6">
-                    <label class="form-label" asp-for="FromDate">From date</label>
-                    <input asp-for="FromDate" class="form-control" type="date" />
-                </div>
-                <div class="col-12 col-sm-6">
-                    <label class="form-label" asp-for="ToDate">To date</label>
-                    <input asp-for="ToDate" class="form-control" type="date" />
-                </div>
-                <div class="col-12">
-                    <label class="form-label" asp-for="ActivityTypeId">Activity type</label>
-                    <select asp-for="ActivityTypeId" class="form-select" asp-items="Model.ActivityTypeOptions"></select>
-                </div>
-                <div class="col-12 col-sm-6">
-                    <label class="form-label" asp-for="AttachmentType">Attachment type</label>
-                    <select asp-for="AttachmentType" class="form-select" asp-items="Model.AttachmentTypeOptions" data-activities-autosubmit></select>
-                </div>
-                <div class="col-12 col-sm-6">
-                    <label class="form-label" for="SortDir">Order</label>
-                    <select id="SortDir" name="SortDir" class="form-select" data-activities-autosubmit>
-                        <option value="desc" selected="@(Model.IsSortDescending ? "selected" : null)">Descending</option>
-                        <option value="asc" selected="@(!Model.IsSortDescending ? "selected" : null)">Ascending</option>
-                    </select>
-                </div>
-                <div class="col-12 col-sm-6">
-                    <label class="form-label" asp-for="PageSize">Page size</label>
-                    <select asp-for="PageSize" class="form-select" asp-items="Model.PageSizeOptions" data-activities-autosubmit></select>
-                </div>
-                <div class="col-12 d-flex flex-wrap gap-2 justify-content-end">
-                    <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-funnel" aria-hidden="true"></i>
-                        <span>Apply</span>
-                    </button>
-                    <a asp-page="./Index" class="btn btn-outline-secondary">Reset</a>
-                </div>
-            </form>
-        </div>
+    <!-- SECTION: Visible review filters and view switcher -->
+    <form method="get" id="activitiesFilterForm" class="activities-filterbar" aria-label="Activity filters">
+        <input type="hidden" name="Page" value="1" />
+        <input type="hidden" asp-for="SortBy" />
+        <input type="hidden" asp-for="SortDir" />
+        <input asp-for="Search" class="form-control activities-filterbar__search" placeholder="Search activity..." autocomplete="off" />
+        <select asp-for="ActivityTypeId" class="form-select" asp-items="Model.ActivityTypeOptions" data-activities-autosubmit></select>
+        <input asp-for="FromDate" class="form-control" type="date" data-activities-autosubmit aria-label="From date" />
+        <input asp-for="ToDate" class="form-control" type="date" data-activities-autosubmit aria-label="To date" />
+        <select asp-for="MediaFilter" class="form-select" data-activities-autosubmit>
+            <option value="Any">Any media</option>
+            <option value="WithMedia">With media</option>
+            <option value="WithoutMedia">Without media</option>
+            <option value="Photos">Photos</option>
+            <option value="Videos">Videos</option>
+            <option value="Documents">Documents</option>
+        </select>
+        <input type="hidden" asp-for="View" />
+        <button type="submit" class="btn btn-outline-primary"><i class="bi bi-search" aria-hidden="true"></i> Search</button>
+        <a asp-page="./Index" class="btn btn-outline-secondary">Reset</a>
+    </form>
+
+    <div class="activities-view-toggle" role="group" aria-label="Activity view">
+        <a asp-page="./Index" asp-route-Page="1" asp-route-PageSize="@Model.PageSize" asp-route-SortBy="@Model.SortBy" asp-route-SortDir="@Model.SortDirection" asp-route-Search="@Model.Search" asp-route-FromDate="@Model.FromDate" asp-route-ToDate="@Model.ToDate" asp-route-ActivityTypeId="@Model.ActivityTypeId" asp-route-MediaFilter="@Model.MediaFilter" asp-route-View="cards" class="btn @(Model.View == "cards" ? "btn-primary" : "btn-outline-secondary")"><i class="bi bi-grid" aria-hidden="true"></i> Cards</a>
+        <a asp-page="./Index" asp-route-Page="1" asp-route-PageSize="@Model.PageSize" asp-route-SortBy="@Model.SortBy" asp-route-SortDir="@Model.SortDirection" asp-route-Search="@Model.Search" asp-route-FromDate="@Model.FromDate" asp-route-ToDate="@Model.ToDate" asp-route-ActivityTypeId="@Model.ActivityTypeId" asp-route-MediaFilter="@Model.MediaFilter" asp-route-View="table" class="btn @(Model.View == "table" ? "btn-primary" : "btn-outline-secondary")"><i class="bi bi-list" aria-hidden="true"></i> Table</a>
     </div>
 
-    <div class="activities-summary pm-card pm-shadow mt-3">
-        <div class="pm-card-body d-flex flex-column flex-md-row gap-3 align-items-md-center">
-            <div class="activities-summary__metric">
-                <span class="activities-summary__label">Total activities</span>
-                <span class="activities-summary__value">@totalCount</span>
-            </div>
-            <div class="activities-summary__metric">
-                <span class="activities-summary__label">Showing</span>
-                <span class="activities-summary__value">@(hasRows ? $"{resultsStart:N0}–{resultsEnd:N0}" : "0")</span>
-            </div>
-            <div class="activities-summary__metric">
-                <span class="activities-summary__label">Filters</span>
-                <span class="activities-summary__value">@GetActiveFilterCount()</span>
-            </div>
-            <div class="ms-md-auto text-muted small">
-                Updated @(DateTime.Now.ToString("dd MMM yyyy, HH:mm", System.Globalization.CultureInfo.CurrentCulture)).
-            </div>
-        </div>
+    <!-- SECTION: Review summary chips -->
+    <div class="activities-summary-strip" aria-label="Activity media summary">
+        <span>All <strong>@(vm?.Summary.All ?? 0)</strong></span>
+        <span>With media <strong>@(vm?.Summary.WithMedia ?? 0)</strong></span>
+        <span>Photos <strong>@(vm?.Summary.Photos ?? 0)</strong></span>
+        <span>Documents <strong>@(vm?.Summary.Documents ?? 0)</strong></span>
+        <span>Videos <strong>@(vm?.Summary.Videos ?? 0)</strong></span>
     </div>
 
-    <div class="pm-card pm-shadow activities-table-card mt-3">
-        <div class="pm-card-body">
-            @if (!hasRows)
+    @if (!hasRows)
+    {
+        <div class="pm-card pm-shadow activities-empty text-center py-5">
+            <i class="bi bi-inbox activities-empty__icon" aria-hidden="true"></i>
+            <h2 class="h5 mt-3">No activities found</h2>
+            <p class="text-muted">Try adjusting the filters or add a new activity.</p>
+        </div>
+    }
+    else if (Model.View == "table")
+    {
+        <!-- SECTION: Secondary compact table view -->
+        <div class="pm-card pm-shadow activities-table-card">
+            <div class="pm-card-body table-responsive">
+                <table class="table table-hover align-middle activities-table">
+                    <thead><tr><th>Activity</th><th>Type</th><th>Event date</th><th>Remarks</th><th>Media</th><th class="text-end">Actions</th></tr></thead>
+                    <tbody>
+                    @foreach (var row in vm!.Rows)
+                    {
+                        <tr>
+                            <td><div class="activities-table__title">@row.Title</div>@if (!string.IsNullOrWhiteSpace(row.Location)){<div class="activities-table__meta text-muted"><i class="bi bi-geo-alt" aria-hidden="true"></i> @row.Location</div>}</td>
+                            <td><span class="badge rounded-pill activities-type-badge">@row.ActivityType</span></td>
+                            <td>@FormatEventDate(row.ScheduledStartUtc)</td>
+                            <td class="activities-table__remarks">@(string.IsNullOrWhiteSpace(row.RemarksPreview) ? "No remarks added." : row.RemarksPreview)</td>
+                            <td>@if (row.HasMedia){<span class="badge text-bg-secondary"><i class="bi bi-paperclip" aria-hidden="true"></i> @row.AttachmentCount</span>} else {<span class="text-muted small">No media</span>}</td>
+                            <td class="text-end"><a class="btn btn-outline-secondary btn-sm" asp-page="./Details" asp-route-id="@row.Id">View</a>@if(row.CanEdit){<a class="btn btn-outline-primary btn-sm" asp-page="./Edit" asp-route-id="@row.Id">Edit</a>}</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+    else
+    {
+        <!-- SECTION: Default review card timeline -->
+        <div class="activities-timeline">
+            @foreach (var group in vm!.Groups)
             {
-                <div class="activities-empty text-center py-5">
-                    <i class="bi bi-inbox activities-empty__icon" aria-hidden="true"></i>
-                    <h2 class="h5 mt-3">No activities found</h2>
-                    <p class="text-muted">Try adjusting the filters or add a new activity.</p>
-                </div>
-            }
-            else
-            {
-                <div class="table-responsive activities-table-wrapper">
-                    <table class="table table-hover align-middle activities-table">
-                        <thead>
-                            <tr>
-                                <th scope="col">Activity</th>
-                                <th scope="col">
-                                    <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.ActivityType, sortDir: Model.GetSortDirectionFor(ActivityListSort.ActivityType))">
-                                        Type
-                                        <i class="@Model.GetSortIconClass(ActivityListSort.ActivityType)" aria-hidden="true"></i>
-                                    </a>
-                                </th>
-                                <th scope="col">
-                                    <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.ScheduledStart, sortDir: Model.GetSortDirectionFor(ActivityListSort.ScheduledStart))">
-                                        Event date
-                                        <i class="@Model.GetSortIconClass(ActivityListSort.ScheduledStart)" aria-hidden="true"></i>
-                                    </a>
-                                </th>
-                                <th scope="col">
-                                    <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.CreatedAt, sortDir: Model.GetSortDirectionFor(ActivityListSort.CreatedAt))">
-                                        Created
-                                        <i class="@Model.GetSortIconClass(ActivityListSort.CreatedAt)" aria-hidden="true"></i>
-                                    </a>
-                                </th>
-                                <th scope="col">Attachments</th>
-                                <th scope="col" class="text-end">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var row in vm!.Rows)
-                            {
-                                <tr>
-                                    <td>
-                                        <div class="activities-table__title">@row.Title</div>
-                                        @if (!string.IsNullOrWhiteSpace(row.Location))
-                                        {
-                                            <div class="activities-table__meta text-muted">
-                                                <i class="bi bi-geo-alt" aria-hidden="true"></i>
-                                                <span>@row.Location</span>
-                                            </div>
-                                        }
-                                        @if (row.HasPendingDelete)
-                                        {
-                                            <div class="mt-2">
-                                                <span class="badge text-bg-warning text-dark">Pending delete approval</span>
-                                            </div>
-                                        }
-                                    </td>
-                                    <td>
-                                        <span class="badge rounded-pill text-bg-light activities-type-badge">@row.ActivityType</span>
-                                    </td>
-                                    <td>
-                                        <div class="activities-table__schedule">
-                                            <div><i class="bi bi-clock" aria-hidden="true"></i> <span>@FormatEventDate(row.ScheduledStartUtc)</span></div>
-                                            @if (row.ScheduledEndUtc.HasValue)
-                                            {
-                                                <div class="text-muted"><i class="bi bi-arrow-right" aria-hidden="true"></i> <span>@FormatEventDate(row.ScheduledEndUtc)</span></div>
-                                            }
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="activities-table__creator">@row.CreatedByDisplayName</div>
-                                        <div class="text-muted small">@FormatTimestamp(row.CreatedAtUtc)</div>
-                                    </td>
-                                    <td>
-                                        <div class="d-flex flex-wrap gap-2 align-items-center">
-                                            <span class="badge text-bg-secondary activities-attachment-total" title="Total attachments">
-                                                <i class="bi bi-paperclip" aria-hidden="true"></i>
-                                                <span>@row.AttachmentCount</span>
-                                            </span>
-                                            @if (row.HasPdf)
-                                            {
-                                                <span class="badge text-bg-danger-subtle text-danger activities-attachment-badge" title="PDF attachments">
-                                                    <i class="bi bi-file-earmark-pdf" aria-hidden="true"></i>
-                                                    <span>@row.PdfAttachmentCount</span>
-                                                </span>
-                                            }
-                                            @if (row.HasPhoto)
-                                            {
-                                                <span class="badge text-bg-primary-subtle text-primary activities-attachment-badge" title="Photo attachments">
-                                                    <i class="bi bi-camera" aria-hidden="true"></i>
-                                                    <span>@row.PhotoAttachmentCount</span>
-                                                </span>
-                                            }
-                                            @if (row.HasVideo)
-                                            {
-                                                <span class="badge text-bg-success-subtle text-success activities-attachment-badge" title="Video attachments">
-                                                    <i class="bi bi-camera-video" aria-hidden="true"></i>
-                                                    <span>@row.VideoAttachmentCount</span>
-                                                </span>
-                                            }
-                                        </div>
-                                    </td>
-                                    <td class="text-end">
-                                        <div class="btn-group btn-group-sm" role="group" aria-label="Activity actions">
-                                            <a class="btn btn-outline-secondary" asp-page="./Details" asp-route-id="@row.Id">
-                                                <span class="visually-hidden">View</span>
-                                                <i class="bi bi-eye" aria-hidden="true"></i>
-                                            </a>
-                                            @if (row.CanEdit)
-                                            {
-                                                <a class="btn btn-outline-primary" asp-page="./Edit" asp-route-id="@row.Id">
-                                                    <span class="visually-hidden">Edit</span>
-                                                    <i class="bi bi-pencil" aria-hidden="true"></i>
-                                                </a>
-                                            }
-                                            @if (row.CanDelete)
-                                            {
-                                                var deleteRouteValues = Model.BuildRouteForDeleteRequest(row.Id);
-                                                var deleteFormId = $"delete-form-{row.Id}";
-                                                <form method="post"
-                                                      asp-page="./Index"
-                                                      asp-page-handler="RequestDelete"
-                                                      class="d-inline"
-                                                      id="@deleteFormId"
-                                                      data-activities-delete-form>
-                                                    @Html.AntiForgeryToken()
-                                                    @foreach (var routeValue in deleteRouteValues)
-                                                    {
-                                                        <input type="hidden" name="@routeValue.Key" value="@(routeValue.Value ?? string.Empty)" />
-                                                    }
-                                                </form>
-                                                <button type="submit"
-                                                        class="btn btn-outline-danger js-activities-confirm-delete"
-                                                        form="@deleteFormId"
-                                                        data-confirm="Request deletion of this activity?">
-                                                    <span class="visually-hidden">Request delete</span>
-                                                    <i class="bi bi-trash" aria-hidden="true"></i>
-                                                </button>
-                                            }
-                                        </div>
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
-
-                @if (vm!.TotalPages > 1)
-                {
-                    <nav aria-label="Activity pagination" class="activities-pagination">
-                        <ul class="pagination justify-content-end flex-wrap">
-                            <li class="page-item @(currentPage <= 1 ? "disabled" : null)">
-                                <a class="page-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: Math.Max(1, currentPage - 1))" aria-label="Previous">
-                                    <span aria-hidden="true">&laquo;</span>
-                                </a>
-                            </li>
-                            @for (var p = 1; p <= vm.TotalPages; p++)
-                            {
-                                if (p == currentPage || Math.Abs(p - currentPage) <= 2 || p == 1 || p == vm.TotalPages)
-                                {
-                                    var isActive = p == currentPage;
-                                    <li class="page-item @(isActive ? "active" : null)">
-                                        <a class="page-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: p)">@p</a>
-                                    </li>
-                                }
-                                else if (p == 2 && currentPage > 4)
-                                {
-                                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-                                }
-                                else if (p == vm.TotalPages - 1 && currentPage < vm.TotalPages - 3)
-                                {
-                                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-                                }
-                            }
-                            <li class="page-item @(currentPage >= vm.TotalPages ? "disabled" : null)">
-                                <a class="page-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: Math.Min(vm.TotalPages, currentPage + 1))" aria-label="Next">
-                                    <span aria-hidden="true">&raquo;</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
-                }
+                <section class="activities-month-group" aria-label="@group.Label activities">
+                    <h2>@group.Label</h2>
+                    <div class="activities-month-group__items">
+                        @foreach (var row in group.Items)
+                        {
+                            <partial name="_ActivityCard" model="row" />
+                        }
+                    </div>
+                </section>
             }
         </div>
-    </div>
+    }
+
+    @if (vm is not null && vm.TotalPages > 1)
+    {
+        <!-- SECTION: Pagination -->
+        <nav aria-label="Activity pagination" class="activities-pagination">
+            <ul class="pagination justify-content-end flex-wrap">
+                <li class="page-item @(currentPage <= 1 ? "disabled" : null)"><a class="page-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: Math.Max(1, currentPage - 1))">Previous</a></li>
+                <li class="page-item disabled"><span class="page-link">Page @currentPage of @vm.TotalPages</span></li>
+                <li class="page-item @(currentPage >= vm.TotalPages ? "disabled" : null)"><a class="page-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: Math.Min(vm.TotalPages, currentPage + 1))">Next</a></li>
+            </ul>
+        </nav>
+    }
 </div>
 
 @await Html.PartialAsync("_DeleteConfirmModal")
-
-@functions {
-    private int GetActiveFilterCount()
-    {
-        var count = 0;
-        if (Model.FromDate.HasValue)
-        {
-            count++;
-        }
-        if (Model.ToDate.HasValue)
-        {
-            count++;
-        }
-        if (Model.ActivityTypeId.HasValue)
-        {
-            count++;
-        }
-        if (Model.AttachmentType != ActivityAttachmentTypeFilter.Any)
-        {
-            count++;
-        }
-        return count;
-    }
-}

--- a/Pages/Activities/Index.cshtml.cs
+++ b/Pages/Activities/Index.cshtml.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Routing;
 using ProjectManagement.Contracts.Activities;
 using ProjectManagement.Models;
 using ProjectManagement.Services.Activities;
+using ProjectManagement.Services.Storage;
 using ProjectManagement.ViewModels.Activities;
 
 namespace ProjectManagement.Pages.Activities;
@@ -29,18 +30,21 @@ public sealed class IndexModel : PageModel
     private readonly IActivityExportService _activityExportService;
     private readonly IActivityDeleteRequestService _deleteRequestService;
     private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IProtectedFileUrlBuilder _fileUrlBuilder;
 
     public IndexModel(IActivityService activityService,
                       IActivityTypeService activityTypeService,
                       IActivityExportService activityExportService,
                       IActivityDeleteRequestService deleteRequestService,
-                      UserManager<ApplicationUser> userManager)
+                      UserManager<ApplicationUser> userManager,
+                      IProtectedFileUrlBuilder? fileUrlBuilder = null)
     {
         _activityService = activityService;
         _activityTypeService = activityTypeService;
         _activityExportService = activityExportService;
         _deleteRequestService = deleteRequestService;
         _userManager = userManager;
+        _fileUrlBuilder = fileUrlBuilder ?? new ActivityIndexFallbackUrlBuilder();
     }
 
     [BindProperty(SupportsGet = true)]
@@ -66,6 +70,15 @@ public sealed class IndexModel : PageModel
 
     [BindProperty(SupportsGet = true)]
     public ActivityAttachmentTypeFilter AttachmentType { get; set; } = ActivityAttachmentTypeFilter.Any;
+
+    [BindProperty(SupportsGet = true)]
+    public ActivityMediaFilter MediaFilter { get; set; } = ActivityMediaFilter.Any;
+
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string View { get; set; } = "cards";
 
     public ActivityListViewModel? ViewModel { get; private set; }
 
@@ -98,7 +111,9 @@ public sealed class IndexModel : PageModel
             ToDate,
             ActivityTypeId,
             CreatedByUserId: null,
-            AttachmentType);
+            AttachmentType: AttachmentType,
+            Search: Search,
+            MediaFilter: MediaFilter);
 
         var result = await _activityService.ListAsync(request, cancellationToken);
 
@@ -122,6 +137,7 @@ public sealed class IndexModel : PageModel
                 item.Title,
                 item.ActivityTypeName,
                 item.Location,
+                item.RemarksPreview,
                 item.ScheduledStartUtc,
                 item.ScheduledEndUtc,
                 item.CreatedAtUtc,
@@ -131,6 +147,16 @@ public sealed class IndexModel : PageModel
                 item.PdfAttachmentCount,
                 item.PhotoAttachmentCount,
                 item.VideoAttachmentCount,
+                item.MediaPreviews.Select(media => new ActivityMediaPreviewViewModel(
+                    media.AttachmentId,
+                    media.FileName,
+                    media.ContentType,
+                    media.MediaKind,
+                    string.Equals(media.MediaKind, "Photo", StringComparison.OrdinalIgnoreCase)
+                        ? _fileUrlBuilder.CreateInlineUrl(media.StorageKey, media.FileName, media.ContentType)
+                        : null,
+                    _fileUrlBuilder.CreateDownloadUrl(media.StorageKey, media.FileName, media.ContentType),
+                    media.SizeBytes)).ToList(),
                 item.HasPendingDelete,
                 canManage,
                 canRequestDelete);
@@ -139,6 +165,30 @@ public sealed class IndexModel : PageModel
         var totalPages = result.PageSize <= 0
             ? (result.TotalCount > 0 ? 1 : 0)
             : (int)Math.Ceiling(result.TotalCount / (double)Math.Max(result.PageSize, 1));
+
+        var normalizedView = string.Equals(View, "table", StringComparison.OrdinalIgnoreCase) ? "table" : "cards";
+        View = normalizedView;
+        var groups = rows
+            .GroupBy(row => new { row.ScheduledStartUtc?.Year, row.ScheduledStartUtc?.Month, FallbackYear = row.CreatedAtUtc.Year, FallbackMonth = row.CreatedAtUtc.Month })
+            .Select(group => new
+            {
+                Year = group.Key.Year ?? group.Key.FallbackYear,
+                Month = group.Key.Month ?? group.Key.FallbackMonth,
+                Items = group.ToList()
+            })
+            .OrderByDescending(group => group.Year)
+            .ThenByDescending(group => group.Month)
+            .Select(group => new ActivityMonthGroupViewModel(
+                new DateTime(group.Year, group.Month, 1).ToString("MMM yyyy", CultureInfo.CurrentCulture),
+                group.Items))
+            .ToList();
+
+        var summary = new ActivityReviewSummaryViewModel(
+            result.TotalCount,
+            rows.Count(row => row.HasMedia),
+            rows.Sum(row => row.PhotoAttachmentCount),
+            rows.Sum(row => row.PdfAttachmentCount),
+            rows.Sum(row => row.VideoAttachmentCount));
 
         ViewModel = new ActivityListViewModel(rows,
             result.Page,
@@ -150,7 +200,12 @@ public sealed class IndexModel : PageModel
             AttachmentType,
             FromDate,
             ToDate,
-            ActivityTypeId);
+            ActivityTypeId,
+            normalizedView,
+            Search,
+            MediaFilter,
+            summary,
+            groups);
 
         await BuildFilterOptionsAsync(cancellationToken);
 
@@ -203,7 +258,9 @@ public sealed class IndexModel : PageModel
             ToDate,
             ActivityTypeId,
             CreatedByUserId: null,
-            AttachmentType);
+            AttachmentType: AttachmentType,
+            Search: Search,
+            MediaFilter: MediaFilter);
 
         var export = await _activityExportService.ExportAsync(exportRequest, cancellationToken);
 
@@ -226,7 +283,8 @@ public sealed class IndexModel : PageModel
             ["Page"] = (page ?? Page).ToString(CultureInfo.InvariantCulture),
             ["PageSize"] = (pageSize ?? PageSize).ToString(CultureInfo.InvariantCulture),
             ["SortBy"] = (sort ?? SortBy).ToString(),
-            ["SortDir"] = sortDir ?? SortDirection
+            ["SortDir"] = sortDir ?? SortDirection,
+            ["View"] = View
         };
 
         if (FromDate.HasValue)
@@ -247,6 +305,16 @@ public sealed class IndexModel : PageModel
         if (AttachmentType != ActivityAttachmentTypeFilter.Any)
         {
             values["AttachmentType"] = AttachmentType.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(Search))
+        {
+            values["Search"] = Search;
+        }
+
+        if (MediaFilter != ActivityMediaFilter.Any)
+        {
+            values["MediaFilter"] = MediaFilter.ToString();
         }
 
         return values;
@@ -361,4 +429,17 @@ public sealed class IndexModel : PageModel
         return string.Concat("/Activities/Index", queryString.HasValue ? queryString.ToUriComponent() : string.Empty);
     }
 
+
+    private sealed class ActivityIndexFallbackUrlBuilder : IProtectedFileUrlBuilder
+    {
+        public string CreateDownloadUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
+        {
+            return string.IsNullOrWhiteSpace(storageKey) ? string.Empty : $"/files/{Uri.EscapeDataString(storageKey)}";
+        }
+
+        public string CreateInlineUrl(string storageKey, string? fileName = null, string? contentType = null, TimeSpan? lifetime = null)
+        {
+            return CreateDownloadUrl(storageKey, fileName, contentType, lifetime);
+        }
+    }
 }

--- a/Pages/Activities/_ActivityCard.cshtml
+++ b/Pages/Activities/_ActivityCard.cshtml
@@ -1,0 +1,96 @@
+@model ProjectManagement.ViewModels.Activities.ActivityListRowViewModel
+@using System.Globalization
+@{
+    var eventDate = Model.ScheduledStartUtc?.ToLocalTime();
+    var day = eventDate?.ToString("dd", CultureInfo.CurrentCulture) ?? "—";
+    var monthYear = eventDate?.ToString("MMM yyyy", CultureInfo.CurrentCulture) ?? "Date pending";
+}
+
+<article class="activity-card">
+    <!-- SECTION: Date and location -->
+    <aside class="activity-card__date" aria-label="Activity date">
+        <div class="activity-card__date-day">@day</div>
+        <div class="activity-card__date-month">@monthYear</div>
+        @if (!string.IsNullOrWhiteSpace(Model.Location))
+        {
+            <div class="activity-card__location">
+                <i class="bi bi-geo-alt" aria-hidden="true"></i>
+                <span>@Model.Location</span>
+            </div>
+        }
+    </aside>
+
+    <!-- SECTION: Review content -->
+    <div class="activity-card__body">
+        <div class="activity-card__meta">
+            <span class="activity-card__type">@Model.ActivityType</span>
+        </div>
+        <h2 class="activity-card__title">
+            <a asp-page="./Details" asp-route-id="@Model.Id">@Model.Title</a>
+        </h2>
+
+        <section class="activity-card__remarks" aria-label="Remarks">
+            <div class="activity-card__section-title">Remarks / Brief</div>
+            @if (!string.IsNullOrWhiteSpace(Model.RemarksPreview))
+            {
+                <p>@Model.RemarksPreview</p>
+            }
+            else
+            {
+                <p class="text-muted">No remarks added.</p>
+            }
+        </section>
+
+        <!-- SECTION: Media evidence -->
+        <section class="activity-card__media" aria-label="Media evidence">
+            @if (Model.HasMedia)
+            {
+                <div class="activity-card__media-title">Media (@Model.AttachmentCount)</div>
+                <div class="activity-card__media-strip">
+                    @foreach (var media in Model.MediaPreviews)
+                    {
+                        if (!string.IsNullOrWhiteSpace(media.ThumbnailUrl))
+                        {
+                            <img src="@media.ThumbnailUrl" alt="@media.FileName" class="activity-card__thumb" loading="lazy" />
+                        }
+                        else
+                        {
+                            <a class="activity-card__file-chip" href="@media.DownloadUrl">
+                                <span>@media.MediaKind</span>
+                                <strong>@media.FileName</strong>
+                            </a>
+                        }
+                    }
+                    @if (Model.PhotoAttachmentCount > 0)
+                    {
+                        <span class="activity-card__media-chip"><i class="bi bi-camera" aria-hidden="true"></i> Photos @Model.PhotoAttachmentCount</span>
+                    }
+                    @if (Model.VideoAttachmentCount > 0)
+                    {
+                        <span class="activity-card__media-chip"><i class="bi bi-camera-video" aria-hidden="true"></i> Videos @Model.VideoAttachmentCount</span>
+                    }
+                    @if (Model.PdfAttachmentCount > 0)
+                    {
+                        <span class="activity-card__media-chip"><i class="bi bi-file-earmark-pdf" aria-hidden="true"></i> Documents @Model.PdfAttachmentCount</span>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="activity-card__no-media">
+                    <i class="bi bi-folder" aria-hidden="true"></i>
+                    <span>No media attached</span>
+                </div>
+            }
+        </section>
+
+        <!-- SECTION: Minimal card actions -->
+        <footer class="activity-card__actions">
+            <a asp-page="./Details" asp-route-id="@Model.Id">View details</a>
+            @if (Model.CanEdit)
+            {
+                <a asp-page="./Edit" asp-route-id="@Model.Id"><i class="bi bi-pencil" aria-hidden="true"></i> Edit</a>
+            }
+        </footer>
+    </div>
+</article>

--- a/Services/Activities/ActivityExportService.cs
+++ b/Services/Activities/ActivityExportService.cs
@@ -40,7 +40,9 @@ public sealed class ActivityExportService : IActivityExportService
             request.ToDate,
             request.ActivityTypeId,
             request.CreatedByUserId,
-            request.AttachmentType);
+            request.AttachmentType,
+            request.Search,
+            request.MediaFilter);
 
         var result = await _activityRepository.ListAsync(listRequest, cancellationToken);
 

--- a/Services/Activities/IActivityExportService.cs
+++ b/Services/Activities/IActivityExportService.cs
@@ -19,4 +19,6 @@ public sealed record ActivityExportRequest(
     DateOnly? ToDate = null,
     int? ActivityTypeId = null,
     string? CreatedByUserId = null,
-    ActivityAttachmentTypeFilter AttachmentType = ActivityAttachmentTypeFilter.Any);
+    ActivityAttachmentTypeFilter AttachmentType = ActivityAttachmentTypeFilter.Any,
+    string? Search = null,
+    ActivityMediaFilter MediaFilter = ActivityMediaFilter.Any);

--- a/ViewModels/Activities/ActivityListViewModel.cs
+++ b/ViewModels/Activities/ActivityListViewModel.cs
@@ -15,13 +15,19 @@ public sealed record ActivityListViewModel(
     ActivityAttachmentTypeFilter AttachmentFilter,
     DateOnly? FromDate,
     DateOnly? ToDate,
-    int? ActivityTypeId);
+    int? ActivityTypeId,
+    string ViewMode,
+    string? Search,
+    ActivityMediaFilter MediaFilter,
+    ActivityReviewSummaryViewModel Summary,
+    IReadOnlyList<ActivityMonthGroupViewModel> Groups);
 
 public sealed record ActivityListRowViewModel(
     int Id,
     string Title,
     string ActivityType,
     string? Location,
+    string? RemarksPreview,
     DateTimeOffset? ScheduledStartUtc,
     DateTimeOffset? ScheduledEndUtc,
     DateTimeOffset CreatedAtUtc,
@@ -31,6 +37,7 @@ public sealed record ActivityListRowViewModel(
     int PdfAttachmentCount,
     int PhotoAttachmentCount,
     int VideoAttachmentCount,
+    IReadOnlyList<ActivityMediaPreviewViewModel> MediaPreviews,
     bool HasPendingDelete,
     bool CanEdit,
     bool CanDelete)
@@ -38,4 +45,25 @@ public sealed record ActivityListRowViewModel(
     public bool HasPdf => PdfAttachmentCount > 0;
     public bool HasPhoto => PhotoAttachmentCount > 0;
     public bool HasVideo => VideoAttachmentCount > 0;
+    public bool HasMedia => AttachmentCount > 0;
 }
+
+public sealed record ActivityMediaPreviewViewModel(
+    int AttachmentId,
+    string FileName,
+    string ContentType,
+    string MediaKind,
+    string? ThumbnailUrl,
+    string DownloadUrl,
+    long SizeBytes);
+
+public sealed record ActivityMonthGroupViewModel(
+    string Label,
+    IReadOnlyList<ActivityListRowViewModel> Items);
+
+public sealed record ActivityReviewSummaryViewModel(
+    int All,
+    int WithMedia,
+    int Photos,
+    int Documents,
+    int Videos);

--- a/wwwroot/css/activities/index.css
+++ b/wwwroot/css/activities/index.css
@@ -134,3 +134,270 @@
     width: auto;
   }
 }
+
+/* SECTION: Review-first activity log layout */
+.activities-page-header,
+.activities-actions,
+.activities-filterbar,
+.activities-summary-strip,
+.activities-view-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.activities-page-header {
+  justify-content: space-between;
+}
+
+.activities-actions {
+  justify-content: flex-end;
+}
+
+.activities-filterbar {
+  padding: 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 1rem;
+  background: var(--bs-body-bg);
+  box-shadow: 0 0.5rem 1.5rem rgba(15, 23, 42, 0.06);
+}
+
+.activities-filterbar .form-control,
+.activities-filterbar .form-select {
+  min-height: 2.75rem;
+  width: auto;
+  min-width: 11rem;
+}
+
+.activities-filterbar__search {
+  flex: 1 1 18rem;
+}
+
+.activities-view-toggle {
+  justify-content: flex-end;
+  margin-top: -0.75rem;
+}
+
+.activities-summary-strip {
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(32, 94, 203, 0.14);
+  border-radius: 999px;
+  background: rgba(32, 94, 203, 0.06);
+}
+
+.activities-summary-strip span {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+  color: var(--bs-secondary-color);
+}
+
+.activities-summary-strip strong {
+  color: var(--pm-primary-hover, #174ea6);
+}
+
+/* SECTION: Timeline and cards */
+.activities-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.activities-month-group h2 {
+  margin: 0 0 0.75rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.activities-month-group__items {
+  display: grid;
+  gap: 1rem;
+}
+
+.activity-card {
+  display: grid;
+  grid-template-columns: minmax(6rem, 8rem) 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 1.15rem;
+  background: var(--bs-body-bg);
+  box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.07);
+}
+
+.activity-card__date {
+  padding: 0.9rem;
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(32, 94, 203, 0.12), rgba(32, 94, 203, 0.04));
+  color: var(--pm-primary-hover, #174ea6);
+  text-align: center;
+}
+
+.activity-card__date-day {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.activity-card__date-month {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.activity-card__location {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+  margin-top: 0.75rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.8rem;
+}
+
+.activity-card__body {
+  min-width: 0;
+}
+
+.activity-card__meta {
+  margin-bottom: 0.35rem;
+}
+
+.activity-card__type,
+.activities-type-badge {
+  display: inline-flex;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(32, 94, 203, 0.1);
+  color: var(--pm-primary-hover, #174ea6);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.activity-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.activity-card__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.activity-card__title a:hover,
+.activity-card__title a:focus {
+  color: var(--pm-primary-hover, #174ea6);
+  text-decoration: underline;
+}
+
+.activity-card__section-title,
+.activity-card__media-title {
+  margin-top: 0.9rem;
+  margin-bottom: 0.3rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.activity-card__remarks p {
+  display: -webkit-box;
+  margin-bottom: 0;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--bs-body-color);
+}
+
+.activity-card__media-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.activity-card__thumb {
+  width: 120px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 0.75rem;
+  border: 1px solid var(--bs-border-color);
+}
+
+.activity-card__file-chip,
+.activity-card__media-chip,
+.activity-card__no-media {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.45rem 0.7rem;
+  text-decoration: none;
+}
+
+.activity-card__file-chip {
+  max-width: 16rem;
+  border: 1px solid var(--bs-border-color);
+  color: inherit;
+  background: var(--bs-tertiary-bg);
+}
+
+.activity-card__file-chip strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-card__media-chip {
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+  font-size: 0.85rem;
+}
+
+.activity-card__no-media {
+  margin-top: 0.35rem;
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+}
+
+.activity-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--bs-border-color);
+}
+
+.activity-card__actions a {
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.activities-table__remarks {
+  max-width: 24rem;
+  color: var(--bs-secondary-color);
+}
+
+@media (max-width: 767.98px) {
+  .activity-card {
+    grid-template-columns: 1fr;
+  }
+
+  .activity-card__date {
+    text-align: left;
+  }
+
+  .activity-card__location {
+    justify-content: flex-start;
+  }
+
+  .activities-summary-strip {
+    border-radius: 1rem;
+  }
+}

--- a/wwwroot/js/pages/activities-index.js
+++ b/wwwroot/js/pages/activities-index.js
@@ -7,8 +7,26 @@
   const filterOffcanvas = document.getElementById('activitiesFilterOffcanvas');
   const filterForm = filterOffcanvas
     ? filterOffcanvas.querySelector('form')
-    : moduleRoot.querySelector('.activities-filter, .activities-filter-form');
+    : document.getElementById('activitiesFilterForm') || moduleRoot.querySelector('.activities-filter, .activities-filter-form, .activities-filterbar');
   if (filterForm) {
+    const searchInput = filterForm.querySelector('input[name="Search"]');
+    if (searchInput) {
+      searchInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          const pageInput = filterForm.querySelector('input[name="Page"]');
+          if (pageInput) {
+            pageInput.value = '1';
+          }
+          if (typeof filterForm.requestSubmit === 'function') {
+            filterForm.requestSubmit();
+          } else {
+            filterForm.submit();
+          }
+        }
+      });
+    }
+
     const autoSubmitInputs = filterForm.querySelectorAll('[data-activities-autosubmit]');
     autoSubmitInputs.forEach((input) => {
       input.addEventListener('change', () => {


### PR DESCRIPTION
### Motivation

- Make the Activities list review-first so reviewers immediately see what happened, when it happened, remarks/outcome and any media evidence. 
- Reduce visual weight of administrative metadata (created-by, timestamps, approval state) on the main list and surface only review-relevant fields (date, title, remarks, media, type, optional location). 
- Provide a default card/timeline view for meeting-style review while keeping the compact table as a secondary, export-friendly view.

### Description

- Add list-level search and media filtering by introducing `Search` and `ActivityMediaFilter` to the contracts and export request, and wire them through services and repository queries. 
- Extend repository projection to include `RemarksPreview`, media counts and lightweight `ActivityMediaPreview` (max 3 prioritized previews) so cards can show thumbnails or file chips without loading full files. 
- Replace the index UI with a card-first layout (default `cards` view) plus visible filter bar, review summary chips, a Cards/Table view toggle, month grouping and a new reusable `_ActivityCard` partial focused on date, type badge, title, remarks and media evidence. 
- Update Add/Edit and Details pages to prioritise `Remarks / Brief` and `Media / Documents`, add CSS for card-first styling, and update client JS so dropdowns auto-submit and search submits on Enter; also include search/media filters in exports.

### Testing

- Ran `git diff --check` to validate whitespace/static issues and it passed. 
- Attempted to run a full build (`dotnet build`) but it could not be executed in the environment because the `dotnet` CLI is not installed, so no project build/tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e438c7f808329b43a1dfec77a449c)