### PR TITLE
Use IST boundaries for activity dates

### DIFF
--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectManagement.Contracts.Activities;
 using ProjectManagement.Data;
+using ProjectManagement.Infrastructure;
 using ProjectManagement.Models.Activities;
 
 namespace ProjectManagement.Infrastructure.Activities
@@ -79,16 +80,16 @@ namespace ProjectManagement.Infrastructure.Activities
                     x.ActivityType.Name.Contains(term));
             }
 
+            // SECTION: IST date-range filters
             if (request.FromDate.HasValue)
             {
-                var from = new DateTimeOffset(request.FromDate.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+                var from = IstClock.StartOfDayIstToUtc(request.FromDate.Value);
                 query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) >= from);
             }
 
             if (request.ToDate.HasValue)
             {
-                var toExclusiveDate = request.ToDate.Value.AddDays(1);
-                var toExclusive = new DateTimeOffset(toExclusiveDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+                var toExclusive = IstClock.ExclusiveEndOfDayIstToUtc(request.ToDate.Value);
                 query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) < toExclusive);
             }
 

--- a/Infrastructure/IstClock.cs
+++ b/Infrastructure/IstClock.cs
@@ -14,5 +14,21 @@ namespace ProjectManagement.Infrastructure
 
         public static DateTime? ToIst(DateTime? utc) =>
             utc.HasValue ? ToIst(utc.Value) : (DateTime?)null;
+
+        // SECTION: Application day-boundary conversion helpers
+        public static DateTimeOffset StartOfDayIstToUtc(DateOnly date)
+        {
+            var istStart = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
+            return new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(istStart, _ist), TimeSpan.Zero);
+        }
+
+        public static DateTimeOffset ExclusiveEndOfDayIstToUtc(DateOnly date) =>
+            StartOfDayIstToUtc(date.AddDays(1));
+
+        public static DateTimeOffset ToIst(DateTimeOffset utc) =>
+            TimeZoneInfo.ConvertTime(utc, _ist);
+
+        public static DateTimeOffset? ToIst(DateTimeOffset? utc) =>
+            utc.HasValue ? ToIst(utc.Value) : (DateTimeOffset?)null;
     }
 }

--- a/Pages/Activities/Approvals.cshtml
+++ b/Pages/Activities/Approvals.cshtml
@@ -1,9 +1,10 @@
 @page
 @model ProjectManagement.Pages.Activities.ApprovalsModel
 @using System.Globalization
+@using ProjectManagement.Infrastructure
 @{
     ViewData["Title"] = "Activity delete approvals";
-    string FormatDate(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture) ?? "—";
+    string FormatDate(DateTimeOffset? value) => value.HasValue ? IstClock.ToIst(value.Value).ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture) : "—";
 }
 
 <div class="container-xxl activities-approvals-page">

--- a/Pages/Activities/Details.cshtml
+++ b/Pages/Activities/Details.cshtml
@@ -1,6 +1,7 @@
 @page "{id:int}"
 @model ProjectManagement.Pages.Activities.DetailsModel
 @using System.Globalization
+@using ProjectManagement.Infrastructure
 @{
     var activity = Model.Activity;
     if (activity is null)
@@ -11,8 +12,8 @@
 
     ViewData["Title"] = activity.Title;
 
-    string FormatEventDate(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy", CultureInfo.CurrentCulture) ?? "—";
-    string FormatTimestamp(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture) ?? "—";
+    string FormatEventDate(DateTimeOffset? value) => value.HasValue ? IstClock.ToIst(value.Value).ToString("dd MMM yyyy", CultureInfo.CurrentCulture) : "—";
+    string FormatTimestamp(DateTimeOffset? value) => value.HasValue ? IstClock.ToIst(value.Value).ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture) : "—";
 
     string FormatUser(string? displayName, string? userId)
     {
@@ -179,7 +180,7 @@
                                         </button>
                                         <div class="card-body">
                                             <h4 class="card-title h6 mb-1">@photo.FileName</h4>
-                                            <p class="card-text text-muted small mb-2">Uploaded @photo.UploadedAtUtc.ToLocalTime().ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture)</p>
+                                            <p class="card-text text-muted small mb-2">Uploaded @IstClock.ToIst(photo.UploadedAtUtc).ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture)</p>
                                             <p class="card-text text-muted small mb-0">@FormatFileSize(photo.FileSize)</p>
                                         </div>
                                         <div class="card-footer bg-transparent border-0 pt-0">
@@ -230,7 +231,7 @@
                                         </div>
                                         <div class="card-body">
                                             <h4 class="card-title h6 mb-1">@video.FileName</h4>
-                                            <p class="card-text text-muted small mb-2">Uploaded @video.UploadedAtUtc.ToLocalTime().ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture)</p>
+                                            <p class="card-text text-muted small mb-2">Uploaded @IstClock.ToIst(video.UploadedAtUtc).ToString("dd MMM yyyy, HH:mm", CultureInfo.CurrentCulture)</p>
                                             <p class="card-text text-muted small mb-0">@FormatFileSize(video.FileSize)</p>
                                         </div>
                                         <div class="card-footer bg-transparent border-0 pt-0">

--- a/Pages/Activities/Edit.cshtml.cs
+++ b/Pages/Activities/Edit.cshtml.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 using ProjectManagement.Contracts.Activities;
+using ProjectManagement.Infrastructure;
 using ProjectManagement.Models.Activities;
 using ProjectManagement.Services.Activities;
 
@@ -399,9 +400,9 @@ public sealed class EditModel : PageModel
             return null;
         }
 
-        var local = value.Value.ToLocalTime();
-        var date = local.Date;
-        return DateTime.SpecifyKind(date, DateTimeKind.Local);
+        var ist = IstClock.ToIst(value.Value);
+        var date = ist.Date;
+        return DateTime.SpecifyKind(date, DateTimeKind.Unspecified);
     }
 
     private static DateTimeOffset? ConvertToUtc(DateTime? value)
@@ -411,9 +412,8 @@ public sealed class EditModel : PageModel
             return null;
         }
 
-        var localDate = value.Value.Date;
-        var local = DateTime.SpecifyKind(localDate, DateTimeKind.Local);
-        return new DateTimeOffset(local).ToUniversalTime();
+        var localDate = DateOnly.FromDateTime(value.Value.Date);
+        return IstClock.StartOfDayIstToUtc(localDate);
     }
 
     public sealed class InputModel

--- a/Pages/Activities/Index.cshtml
+++ b/Pages/Activities/Index.cshtml
@@ -1,13 +1,14 @@
 @page
 @model ProjectManagement.Pages.Activities.IndexModel
 @using ProjectManagement.Contracts.Activities
+@using ProjectManagement.Infrastructure
 @{
     ViewData["Title"] = "Activities";
     var vm = Model.ViewModel;
     var hasRows = vm is not null && vm.Rows.Count > 0;
     var pageSize = vm?.PageSize ?? Model.PageSize;
     var currentPage = vm?.Page ?? Model.Page;
-    string FormatEventDate(DateTimeOffset? value) => value?.ToLocalTime().ToString("dd MMM yyyy", System.Globalization.CultureInfo.CurrentCulture) ?? "—";
+    string FormatEventDate(DateTimeOffset? value) => value.HasValue ? IstClock.ToIst(value.Value).ToString("dd MMM yyyy", System.Globalization.CultureInfo.CurrentCulture) : "—";
 }
 
 @section Styles { <link rel="stylesheet" href="~/css/activities/index.css" asp-append-version="true" /> }

--- a/Pages/Activities/_ActivityCard.cshtml
+++ b/Pages/Activities/_ActivityCard.cshtml
@@ -1,7 +1,8 @@
 @model ProjectManagement.ViewModels.Activities.ActivityListRowViewModel
 @using System.Globalization
+@using ProjectManagement.Infrastructure
 @{
-    var eventDate = Model.ScheduledStartUtc?.ToLocalTime();
+    var eventDate = IstClock.ToIst(Model.ScheduledStartUtc);
     var day = eventDate?.ToString("dd", CultureInfo.CurrentCulture) ?? "—";
     var monthYear = eventDate?.ToString("MMM yyyy", CultureInfo.CurrentCulture) ?? "Date pending";
 }

--- a/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
@@ -390,4 +390,63 @@ public class ActivityRepositoryTests
         var item = Assert.Single(result.Items);
         Assert.True(item.HasPendingDelete);
     }
+
+    [Fact]
+    public async Task ListAsync_FiltersScheduledEventsByIstDayBoundaries()
+    {
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        var type = new ActivityType
+        {
+            Name = "IST Review",
+            CreatedByUserId = "system"
+        };
+
+        context.ActivityTypes.Add(type);
+        await context.SaveChangesAsync();
+
+        // SECTION: Events around the 14 Jun 2026 IST filter window
+        var includedAtIstStart = new Activity
+        {
+            Title = "14 Jun 2026 IST event",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1",
+            ScheduledStartUtc = new DateTimeOffset(2026, 6, 13, 18, 30, 0, TimeSpan.Zero),
+            CreatedAtUtc = new DateTimeOffset(2026, 6, 13, 18, 30, 0, TimeSpan.Zero)
+        };
+
+        var previousIstDay = new Activity
+        {
+            Title = "13 Jun 2026 IST event",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1",
+            ScheduledStartUtc = new DateTimeOffset(2026, 6, 13, 18, 29, 0, TimeSpan.Zero),
+            CreatedAtUtc = new DateTimeOffset(2026, 6, 13, 18, 29, 0, TimeSpan.Zero)
+        };
+
+        var nextIstDay = new Activity
+        {
+            Title = "15 Jun 2026 IST event",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1",
+            ScheduledStartUtc = new DateTimeOffset(2026, 6, 14, 18, 30, 0, TimeSpan.Zero),
+            CreatedAtUtc = new DateTimeOffset(2026, 6, 14, 18, 30, 0, TimeSpan.Zero)
+        };
+
+        context.Activities.AddRange(includedAtIstStart, previousIstDay, nextIstDay);
+        await context.SaveChangesAsync();
+
+        var request = new ActivityListRequest(
+            Page: 1,
+            PageSize: 10,
+            FromDate: new DateOnly(2026, 6, 14),
+            ToDate: new DateOnly(2026, 6, 14));
+
+        var result = await repository.ListAsync(request);
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal("14 Jun 2026 IST event", item.Title);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Ensure date filtering uses India Standard Time day boundaries (Asia/Kolkata) so activities shown for a DateOnly range match the expected local-day semantics rather than UTC-midnight windows. 
- Consolidate timezone conversions into a single helper to avoid scattered `.ToLocalTime()` usage and keep display/round-trip conversions consistent across pages and the repository.

### Description
- Added reusable helpers to `IstClock` (`StartOfDayIstToUtc(DateOnly)`, `ExclusiveEndOfDayIstToUtc(DateOnly)`, and `ToIst(DateTimeOffset)`) for converting IST day boundaries and converting UTC offsets for display. 
- Updated `Infrastructure/Activities/ActivityRepository.cs` to apply IST day-boundary filters (`FromDate` / `ToDate`) using `IstClock.StartOfDayIstToUtc` and `IstClock.ExclusiveEndOfDayIstToUtc` when comparing against stored UTC timestamps. 
- Replaced `.ToLocalTime()` usages in Activities Razor pages and view-model conversions with `IstClock.ToIst(...)`, and switched the Edit page-model date conversions to use the shared IST helpers for round-tripping form dates. 
- Added a unit test `ListAsync_FiltersScheduledEventsByIstDayBoundaries` in `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs` that asserts an event on `14 Jun 2026` IST is returned when filtering `FromDate=2026-06-14` and `ToDate=2026-06-14` while adjacent-day events are excluded. 

### Testing
- Added the automated unit test `ListAsync_FiltersScheduledEventsByIstDayBoundaries` to `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs`. 
- Attempted to run the activity-repository tests with `dotnet test --filter ActivityRepositoryTests`, but test execution could not be performed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6fc7399c8329854250474af7fbda)