### PR TITLE
Add full-result activity review summary and API

### DIFF
--- a/Contracts/Activities/ActivityListModels.cs
+++ b/Contracts/Activities/ActivityListModels.cs
@@ -77,3 +77,15 @@ public sealed record ActivityListResult(
     int PageSize,
     ActivityListSort Sort,
     bool SortDescending);
+
+/// <summary>
+/// Full-result review summary for the activity list. Counts intentionally ignore
+/// <see cref="ActivityListRequest.MediaFilter" /> so media chips can act as
+/// stable navigation buckets while other base filters remain applied.
+/// </summary>
+public sealed record ActivityReviewSummaryResult(
+    int All,
+    int WithMedia,
+    int Photos,
+    int Documents,
+    int Videos);

--- a/Contracts/Activities/IActivityRepository.cs
+++ b/Contracts/Activities/IActivityRepository.cs
@@ -13,6 +13,8 @@ namespace ProjectManagement.Contracts.Activities
 
         Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default);
 
+        Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default);
+
         Task AddAsync(Activity activity, CancellationToken cancellationToken = default);
 
         Task UpdateAsync(Activity activity, CancellationToken cancellationToken = default);

--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -55,69 +55,7 @@ namespace ProjectManagement.Infrastructure.Activities
             var page = request.Page <= 0 ? 1 : request.Page;
             var pageSize = request.PageSize < 0 ? 0 : request.PageSize;
 
-            var query = _dbContext.Activities
-                .AsNoTracking()
-                .Where(x => !x.IsDeleted);
-
-            if (request.ActivityTypeId.HasValue)
-            {
-                query = query.Where(x => x.ActivityTypeId == request.ActivityTypeId.Value);
-            }
-
-            if (!string.IsNullOrWhiteSpace(request.CreatedByUserId))
-            {
-                query = query.Where(x => x.CreatedByUserId == request.CreatedByUserId);
-            }
-
-            // SECTION: Review-first search filters
-            if (!string.IsNullOrWhiteSpace(request.Search))
-            {
-                var term = request.Search.Trim();
-                query = query.Where(x =>
-                    x.Title.Contains(term) ||
-                    (x.Description != null && x.Description.Contains(term)) ||
-                    (x.Location != null && x.Location.Contains(term)) ||
-                    x.ActivityType.Name.Contains(term));
-            }
-
-            // SECTION: IST date-range filters
-            if (request.FromDate.HasValue)
-            {
-                var from = IstClock.StartOfDayIstToUtc(request.FromDate.Value);
-                query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) >= from);
-            }
-
-            if (request.ToDate.HasValue)
-            {
-                var toExclusive = IstClock.ExclusiveEndOfDayIstToUtc(request.ToDate.Value);
-                query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) < toExclusive);
-            }
-
-            query = request.AttachmentType switch
-            {
-                ActivityAttachmentTypeFilter.Pdf => query.Where(x => x.Attachments.Any(a =>
-                    a.ContentType == "application/pdf" ||
-                    a.OriginalFileName.EndsWith(".pdf"))),
-                ActivityAttachmentTypeFilter.Photo => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
-                ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
-                _ => query
-            };
-
-            // SECTION: Media availability filters
-            query = request.MediaFilter switch
-            {
-                ActivityMediaFilter.WithMedia => query.Where(x => x.Attachments.Any()),
-                ActivityMediaFilter.WithoutMedia => query.Where(x => !x.Attachments.Any()),
-                ActivityMediaFilter.Photos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
-                ActivityMediaFilter.Videos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
-                ActivityMediaFilter.Documents => query.Where(x => x.Attachments.Any(a =>
-                    a.ContentType == "application/pdf" ||
-                    a.OriginalFileName.EndsWith(".pdf") ||
-                    a.ContentType.Contains("document") ||
-                    a.ContentType.Contains("spreadsheet") ||
-                    a.ContentType.Contains("presentation"))),
-                _ => query
-            };
+            var query = ApplyMediaFilter(ApplyBaseReviewFilters(CreateBaseQuery(), request), request.MediaFilter);
 
             var total = await query.CountAsync(cancellationToken);
 
@@ -188,6 +126,105 @@ namespace ProjectManagement.Infrastructure.Activities
                 .ToListAsync(cancellationToken);
 
             return new ActivityListResult(items, total, page, pageSize > 0 ? pageSize : total, request.Sort, request.SortDescending);
+        }
+
+        public async Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            // SECTION: Full-result review summary
+            // MediaFilter is intentionally ignored so the summary chips remain stable
+            // navigation buckets while search, activity type, dates, creator, and attachment
+            // type filters continue to scope the aggregate.
+            var query = ApplyBaseReviewFilters(CreateBaseQuery(), request);
+
+            var all = await query.CountAsync(cancellationToken);
+            var withMedia = await query.CountAsync(x => x.Attachments.Any(), cancellationToken);
+            var photos = await query.SelectMany(x => x.Attachments).CountAsync(a => a.ContentType.StartsWith("image/"), cancellationToken);
+            var documents = await query.SelectMany(x => x.Attachments).CountAsync(a =>
+                a.ContentType == "application/pdf" ||
+                a.OriginalFileName.EndsWith(".pdf") ||
+                a.ContentType.Contains("document") ||
+                a.ContentType.Contains("spreadsheet") ||
+                a.ContentType.Contains("presentation"), cancellationToken);
+            var videos = await query.SelectMany(x => x.Attachments).CountAsync(a => a.ContentType.StartsWith("video/"), cancellationToken);
+
+            return new ActivityReviewSummaryResult(all, withMedia, photos, documents, videos);
+        }
+
+        private IQueryable<Activity> CreateBaseQuery()
+        {
+            return _dbContext.Activities
+                .AsNoTracking()
+                .Where(x => !x.IsDeleted);
+        }
+
+        private static IQueryable<Activity> ApplyBaseReviewFilters(IQueryable<Activity> query, ActivityListRequest request)
+        {
+            // SECTION: Base review filters shared by rows and summary
+            if (request.ActivityTypeId.HasValue)
+            {
+                query = query.Where(x => x.ActivityTypeId == request.ActivityTypeId.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.CreatedByUserId))
+            {
+                query = query.Where(x => x.CreatedByUserId == request.CreatedByUserId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Search))
+            {
+                var term = request.Search.Trim();
+                query = query.Where(x =>
+                    x.Title.Contains(term) ||
+                    (x.Description != null && x.Description.Contains(term)) ||
+                    (x.Location != null && x.Location.Contains(term)) ||
+                    x.ActivityType.Name.Contains(term));
+            }
+
+            if (request.FromDate.HasValue)
+            {
+                var from = IstClock.StartOfDayIstToUtc(request.FromDate.Value);
+                query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) >= from);
+            }
+
+            if (request.ToDate.HasValue)
+            {
+                var toExclusive = IstClock.ExclusiveEndOfDayIstToUtc(request.ToDate.Value);
+                query = query.Where(x => (x.ScheduledStartUtc ?? x.CreatedAtUtc) < toExclusive);
+            }
+
+            return request.AttachmentType switch
+            {
+                ActivityAttachmentTypeFilter.Pdf => query.Where(x => x.Attachments.Any(a =>
+                    a.ContentType == "application/pdf" ||
+                    a.OriginalFileName.EndsWith(".pdf"))),
+                ActivityAttachmentTypeFilter.Photo => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
+                ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
+                _ => query
+            };
+        }
+
+        private static IQueryable<Activity> ApplyMediaFilter(IQueryable<Activity> query, ActivityMediaFilter mediaFilter)
+        {
+            // SECTION: Media availability row filters
+            return mediaFilter switch
+            {
+                ActivityMediaFilter.WithMedia => query.Where(x => x.Attachments.Any()),
+                ActivityMediaFilter.WithoutMedia => query.Where(x => !x.Attachments.Any()),
+                ActivityMediaFilter.Photos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
+                ActivityMediaFilter.Videos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
+                ActivityMediaFilter.Documents => query.Where(x => x.Attachments.Any(a =>
+                    a.ContentType == "application/pdf" ||
+                    a.OriginalFileName.EndsWith(".pdf") ||
+                    a.ContentType.Contains("document") ||
+                    a.ContentType.Contains("spreadsheet") ||
+                    a.ContentType.Contains("presentation"))),
+                _ => query
+            };
         }
 
         public async Task AddAsync(Activity activity, CancellationToken cancellationToken = default)

--- a/Pages/Activities/Index.cshtml.cs
+++ b/Pages/Activities/Index.cshtml.cs
@@ -116,6 +116,7 @@ public sealed class IndexModel : PageModel
             MediaFilter: MediaFilter);
 
         var result = await _activityService.ListAsync(request, cancellationToken);
+        var summaryResult = await _activityService.GetReviewSummaryAsync(request, cancellationToken);
 
         var currentUserId = _userManager.GetUserId(User) ?? string.Empty;
         var isManager = IsManager(User);
@@ -183,12 +184,13 @@ public sealed class IndexModel : PageModel
                 group.Items))
             .ToList();
 
+        // SECTION: Full-result review summary
         var summary = new ActivityReviewSummaryViewModel(
-            result.TotalCount,
-            rows.Count(row => row.HasMedia),
-            rows.Sum(row => row.PhotoAttachmentCount),
-            rows.Sum(row => row.PdfAttachmentCount),
-            rows.Sum(row => row.VideoAttachmentCount));
+            summaryResult.All,
+            summaryResult.WithMedia,
+            summaryResult.Photos,
+            summaryResult.Documents,
+            summaryResult.Videos);
 
         ViewModel = new ActivityListViewModel(rows,
             result.Page,

--- a/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
@@ -494,6 +494,42 @@ public class ActivityServiceTests : IDisposable
         Assert.Null(export);
     }
 
+    [Fact]
+    public async Task GetReviewSummaryAsync_DoesNotChangeWhenOnlyPageChanges()
+    {
+        var type = await EnsureActivityTypeAsync();
+        await SeedActivityWithAttachmentAsync(type.Id, "Photo Activity", "photo.jpg", "image/jpeg");
+        await SeedActivityWithAttachmentAsync(type.Id, "Document Activity", "notes.pdf", "application/pdf");
+        await SeedActivityWithAttachmentAsync(type.Id, "Video Activity", "clip.mp4", "video/mp4");
+        await SeedActivityWithoutAttachmentAsync(type.Id, "No Media Activity");
+
+        var firstPageRequest = new ActivityListRequest(Page: 1, PageSize: 2, ActivityTypeId: type.Id);
+        var secondPageRequest = firstPageRequest with { Page = 2 };
+
+        var firstPageSummary = await _service.GetReviewSummaryAsync(firstPageRequest);
+        var secondPageSummary = await _service.GetReviewSummaryAsync(secondPageRequest);
+
+        Assert.Equal(firstPageSummary, secondPageSummary);
+        Assert.Equal(new ActivityReviewSummaryResult(All: 4, WithMedia: 3, Photos: 1, Documents: 1, Videos: 1), firstPageSummary);
+    }
+
+    [Fact]
+    public async Task GetReviewSummaryAsync_IgnoresMediaFilter()
+    {
+        var type = await EnsureActivityTypeAsync();
+        await SeedActivityWithAttachmentAsync(type.Id, "Photo Activity", "photo.jpg", "image/jpeg");
+        await SeedActivityWithoutAttachmentAsync(type.Id, "No Media Activity");
+
+        var unfilteredRequest = new ActivityListRequest(Page: 1, PageSize: 10, ActivityTypeId: type.Id);
+        var mediaFilteredRequest = unfilteredRequest with { MediaFilter = ActivityMediaFilter.Photos };
+
+        var unfilteredSummary = await _service.GetReviewSummaryAsync(unfilteredRequest);
+        var mediaFilteredSummary = await _service.GetReviewSummaryAsync(mediaFilteredRequest);
+
+        Assert.Equal(unfilteredSummary, mediaFilteredSummary);
+        Assert.Equal(2, mediaFilteredSummary.All);
+    }
+
     private ActivityService CreateService(TestUserContext userContext)
     {
         return new ActivityService(_activityRepository,
@@ -514,6 +550,28 @@ public class ActivityServiceTests : IDisposable
         };
         await _activityTypeRepository.AddAsync(type);
         return type;
+    }
+
+    private async Task SeedActivityWithAttachmentAsync(int activityTypeId, string title, string fileName, string contentType)
+    {
+        // SECTION: Activity summary test seed
+        var activity = await _service.CreateAsync(new ActivityInput(title, null, null, activityTypeId, null, null));
+        _context.ActivityAttachments.Add(new ActivityAttachment
+        {
+            ActivityId = activity.Id,
+            OriginalFileName = fileName,
+            ContentType = contentType,
+            StorageKey = $"activities/{activity.Id}/{fileName}",
+            FileSize = 1024,
+            UploadedByUserId = "owner"
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedActivityWithoutAttachmentAsync(int activityTypeId, string title)
+    {
+        // SECTION: Activity summary test seed
+        await _service.CreateAsync(new ActivityInput(title, null, null, activityTypeId, null, null));
     }
 
     public void Dispose()

--- a/Services/Activities/ActivityService.cs
+++ b/Services/Activities/ActivityService.cs
@@ -144,6 +144,17 @@ public sealed class ActivityService : IActivityService
         return _activityRepository.ListAsync(normalized, cancellationToken);
     }
 
+    public Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        // SECTION: Full-result review summary
+        return _activityRepository.GetReviewSummaryAsync(request, cancellationToken);
+    }
+
     public async Task<IReadOnlyList<ActivityAttachmentMetadata>> GetAttachmentMetadataAsync(int activityId,
                                                                                            CancellationToken cancellationToken = default)
     {

--- a/Services/Activities/IActivityService.cs
+++ b/Services/Activities/IActivityService.cs
@@ -22,6 +22,8 @@ public interface IActivityService
 
     Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default);
 
+    Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<ActivityAttachmentMetadata>> GetAttachmentMetadataAsync(int activityId,
                                                                               CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
### Motivation
- Provide a single full-result aggregate for the activity review summary so counts are accurate and stable regardless of pagination and can be used as navigation buckets. 
- Reuse the same base filters for both list rows and the summary to ensure consistent scoping (search, activity type, date range, created-by, attachment type). 
- Intentionally ignore `MediaFilter` for the summary so media chips represent stable buckets rather than a filtered subtotal.

### Description
- Added `ActivityReviewSummaryResult` to `Contracts/Activities/ActivityListModels.cs` with documentation explaining that `MediaFilter` is ignored for summary counts. 
- Added `GetReviewSummaryAsync(ActivityListRequest request, CancellationToken)` to `Contracts/Activities/IActivityRepository.cs` and `Services/Activities/IActivityService.cs`, and implemented service delegation in `Services/Activities/ActivityService.cs`. 
- Implemented the aggregate summary in `Infrastructure/Activities/ActivityRepository.cs` and refactored the repository to share base filters via `CreateBaseQuery`, `ApplyBaseReviewFilters`, and a separate `ApplyMediaFilter` so `ListAsync` and the new summary path reuse identical base scoping. 
- Updated the activities page to use the aggregate summary returned from `GetReviewSummaryAsync` in `Pages/Activities/Index.cshtml.cs` instead of computing counts from the paginated `rows`. 
- Added unit tests to `ProjectManagement.Tests/Activities/ActivityServiceTests.cs` that assert the summary does not change when only `Page` changes and that the summary ignores `MediaFilter`.

### Testing
- Ran `git diff --check` which passed. 
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` but `dotnet` is not available in the environment, so the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e70ea8e8483299ce155e260fcf0e8)