### PR TITLE
Use provider-aware case-insensitive activity search

### DIFF
--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -162,7 +162,7 @@ namespace ProjectManagement.Infrastructure.Activities
                 .Where(x => !x.IsDeleted);
         }
 
-        private static IQueryable<Activity> ApplyBaseReviewFilters(IQueryable<Activity> query, ActivityListRequest request)
+        private IQueryable<Activity> ApplyBaseReviewFilters(IQueryable<Activity> query, ActivityListRequest request)
         {
             // SECTION: Base review filters shared by rows and summary
             if (request.ActivityTypeId.HasValue)
@@ -177,12 +177,7 @@ namespace ProjectManagement.Infrastructure.Activities
 
             if (!string.IsNullOrWhiteSpace(request.Search))
             {
-                var term = request.Search.Trim();
-                query = query.Where(x =>
-                    x.Title.Contains(term) ||
-                    (x.Description != null && x.Description.Contains(term)) ||
-                    (x.Location != null && x.Location.Contains(term)) ||
-                    x.ActivityType.Name.Contains(term));
+                query = ApplySearchFilter(query, request.Search);
             }
 
             if (request.FromDate.HasValue)
@@ -206,6 +201,42 @@ namespace ProjectManagement.Infrastructure.Activities
                 ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
                 _ => query
             };
+        }
+
+        private IQueryable<Activity> ApplySearchFilter(IQueryable<Activity> query, string search)
+        {
+            // SECTION: Provider-aware case-insensitive activity search
+            var term = search.Trim();
+            var like = $"%{term}%";
+            var providerName = _dbContext.Database.ProviderName ?? string.Empty;
+
+            if (providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            {
+                return query.Where(x =>
+                    EF.Functions.ILike(x.Title, like) ||
+                    (x.Description != null && EF.Functions.ILike(x.Description, like)) ||
+                    (x.Location != null && EF.Functions.ILike(x.Location, like)) ||
+                    EF.Functions.ILike(x.ActivityType.Name, like));
+            }
+
+            if (providerName.Contains("InMemory", StringComparison.OrdinalIgnoreCase))
+            {
+                var normalizedTerm = term.ToLowerInvariant();
+
+                return query.Where(x =>
+                    x.Title.ToLower().Contains(normalizedTerm) ||
+                    (x.Description != null && x.Description.ToLower().Contains(normalizedTerm)) ||
+                    (x.Location != null && x.Location.ToLower().Contains(normalizedTerm)) ||
+                    x.ActivityType.Name.ToLower().Contains(normalizedTerm));
+            }
+
+            var normalizedLike = like.ToLowerInvariant();
+
+            return query.Where(x =>
+                EF.Functions.Like(x.Title.ToLower(), normalizedLike) ||
+                (x.Description != null && EF.Functions.Like(x.Description.ToLower(), normalizedLike)) ||
+                (x.Location != null && EF.Functions.Like(x.Location.ToLower(), normalizedLike)) ||
+                EF.Functions.Like(x.ActivityType.Name.ToLower(), normalizedLike));
         }
 
         private static IQueryable<Activity> ApplyMediaFilter(IQueryable<Activity> query, ActivityMediaFilter mediaFilter)

--- a/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
@@ -449,4 +449,55 @@ public class ActivityRepositoryTests
         Assert.Equal("14 Jun 2026 IST event", item.Title);
     }
 
+    [Theory]
+    [InlineData("mou", "MoU with IIT Hyderabad")]
+    [InlineData("iit", "MoU with IIT Hyderabad")]
+    public async Task ListAsync_SearchUsesCaseInsensitiveMatching(string search, string expectedTitle)
+    {
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        var type = new ActivityType
+        {
+            Name = "Industry Collaboration",
+            CreatedByUserId = "system"
+        };
+
+        var otherType = new ActivityType
+        {
+            Name = "Operations",
+            CreatedByUserId = "system"
+        };
+
+        context.ActivityTypes.AddRange(type, otherType);
+        await context.SaveChangesAsync();
+
+        // SECTION: Mixed-case search data
+        context.Activities.AddRange(
+            new Activity
+            {
+                Title = "MoU with IIT Hyderabad",
+                Description = "Strategic academic partnership",
+                Location = "Hyderabad",
+                ActivityTypeId = type.Id,
+                CreatedByUserId = "user-1",
+                CreatedAtUtc = DateTimeOffset.UtcNow.AddHours(-1)
+            },
+            new Activity
+            {
+                Title = "Routine status meeting",
+                Description = "No matching institution",
+                Location = "Pune",
+                ActivityTypeId = otherType.Id,
+                CreatedByUserId = "user-1",
+                CreatedAtUtc = DateTimeOffset.UtcNow
+            });
+        await context.SaveChangesAsync();
+
+        var result = await repository.ListAsync(new ActivityListRequest(Search: search, PageSize: 10));
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(expectedTitle, item.Title);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Replace fragile `Contains(term)` usage with a provider-appropriate, case-insensitive search so matches work reliably across PostgreSQL and other providers. 
- Ensure the same wildcard pattern is reused and applied to all searchable columns: `Title`, `Description`, `Location`, and `ActivityType.Name`.
- Avoid EF InMemory translation problems by isolating provider-specific expressions so tests remain stable.

### Description

- Changed `ApplyBaseReviewFilters` from `static` to an instance method so it can access `_dbContext` and route search logic via a new helper `ApplySearchFilter`.
- Added `ApplySearchFilter(IQueryable<Activity>, string)` which builds a single wildcard `like` (e.g. `var like = $"%{term}%"`) and dispatches three branches: use `EF.Functions.ILike(...)` when the provider is Npgsql, an InMemory-safe `ToLower().Contains(...)` branch for the InMemory provider, and a relational fallback using `EF.Functions.Like(...ToLower(), normalizedLike)`.
- Limited the search fields to `x.Title`, `x.Description`, `x.Location`, and `x.ActivityType.Name` as required and guarded nullable fields in the expressions.
- Added unit tests in `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs` asserting that searching for `mou` and `iit` (lowercase) match the mixed-case title `MoU with IIT Hyderabad`.

### Testing

- Added xUnit tests `ListAsync_SearchUsesCaseInsensitiveMatching` in `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs` to cover `mou` and `iit` cases.
- An attempt was made to run the `ActivityRepositoryTests` via `dotnet test`, but the `dotnet` CLI is not available in this environment so automated tests could not be executed here (test run failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e72ad76cc83299fb72277b423f4cc)