### PR TITLE
Centralize activity attachment classification

### DIFF
--- a/Contracts/Activities/ActivityAttachmentClassifier.cs
+++ b/Contracts/Activities/ActivityAttachmentClassifier.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Linq.Expressions;
+using ProjectManagement.Models.Activities;
+
+namespace ProjectManagement.Contracts.Activities;
+
+public enum ActivityAttachmentKind
+{
+    Other,
+    Photo,
+    Video,
+    Pdf,
+    Document
+}
+
+public static class ActivityAttachmentClassifier
+{
+    public const string PhotoLabel = "Photo";
+    public const string VideoLabel = "Video";
+    public const string PdfLabel = "PDF";
+    public const string DocumentLabel = "Document";
+    public const string OtherLabel = "Other";
+
+    // SECTION: EF-translatable normalized classification expressions
+    public static readonly Expression<Func<ActivityAttachment, bool>> IsPhotoExpression = attachment =>
+        attachment.ContentType != null && attachment.ContentType.ToLower().StartsWith("image/");
+
+    public static readonly Expression<Func<ActivityAttachment, bool>> IsVideoExpression = attachment =>
+        attachment.ContentType != null && attachment.ContentType.ToLower().StartsWith("video/");
+
+    public static readonly Expression<Func<ActivityAttachment, bool>> IsPdfExpression = attachment =>
+        (attachment.ContentType != null && attachment.ContentType.ToLower() == "application/pdf") ||
+        (attachment.OriginalFileName != null && attachment.OriginalFileName.ToLower().EndsWith(".pdf"));
+
+    public static readonly Expression<Func<ActivityAttachment, bool>> IsDocumentExpression = attachment =>
+        (attachment.ContentType != null && attachment.ContentType.ToLower() == "application/pdf") ||
+        (attachment.OriginalFileName != null && attachment.OriginalFileName.ToLower().EndsWith(".pdf")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("document")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("spreadsheet")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("presentation")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("wordprocessingml")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("spreadsheetml")) ||
+        (attachment.ContentType != null && attachment.ContentType.ToLower().Contains("presentationml"));
+
+    // SECTION: In-memory classification helpers
+    public static ActivityAttachmentKind Classify(string? fileName, string? contentType)
+    {
+        if (IsPhoto(fileName, contentType))
+        {
+            return ActivityAttachmentKind.Photo;
+        }
+
+        if (IsVideo(fileName, contentType))
+        {
+            return ActivityAttachmentKind.Video;
+        }
+
+        if (IsPdf(fileName, contentType))
+        {
+            return ActivityAttachmentKind.Pdf;
+        }
+
+        if (IsDocument(fileName, contentType))
+        {
+            return ActivityAttachmentKind.Document;
+        }
+
+        return ActivityAttachmentKind.Other;
+    }
+
+    public static bool IsPhoto(string? fileName, string? contentType) =>
+        StartsWithNormalized(contentType, "image/");
+
+    public static bool IsVideo(string? fileName, string? contentType) =>
+        StartsWithNormalized(contentType, "video/");
+
+    public static bool IsPdf(string? fileName, string? contentType) =>
+        EqualsNormalized(contentType, "application/pdf") || EndsWithNormalized(fileName, ".pdf");
+
+    public static bool IsDocument(string? fileName, string? contentType) =>
+        IsPdf(fileName, contentType) ||
+        ContainsNormalized(contentType, "document") ||
+        ContainsNormalized(contentType, "spreadsheet") ||
+        ContainsNormalized(contentType, "presentation") ||
+        ContainsNormalized(contentType, "wordprocessingml") ||
+        ContainsNormalized(contentType, "spreadsheetml") ||
+        ContainsNormalized(contentType, "presentationml");
+
+    public static string GetDisplayLabel(string? fileName, string? contentType) => Classify(fileName, contentType) switch
+    {
+        ActivityAttachmentKind.Photo => PhotoLabel,
+        ActivityAttachmentKind.Video => VideoLabel,
+        ActivityAttachmentKind.Pdf => PdfLabel,
+        ActivityAttachmentKind.Document => DocumentLabel,
+        _ => OtherLabel
+    };
+
+    private static bool EqualsNormalized(string? value, string expected) =>
+        string.Equals(value?.Trim(), expected, StringComparison.OrdinalIgnoreCase);
+
+    private static bool StartsWithNormalized(string? value, string expected) =>
+        value?.Trim().StartsWith(expected, StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool EndsWithNormalized(string? value, string expected) =>
+        value?.Trim().EndsWith(expected, StringComparison.OrdinalIgnoreCase) == true;
+
+    private static bool ContainsNormalized(string? value, string expected) =>
+        value?.Trim().IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0;
+}

--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -105,20 +105,20 @@ namespace ProjectManagement.Infrastructure.Activities
                     x.CreatedByUser != null ? x.CreatedByUser.FullName : null,
                     x.CreatedByUser != null ? x.CreatedByUser.Email : null,
                     x.Attachments.Count,
-                    x.Attachments.Count(a => a.ContentType == "application/pdf" || a.OriginalFileName.EndsWith(".pdf")),
-                    x.Attachments.Count(a => a.ContentType.StartsWith("image/")),
-                    x.Attachments.Count(a => a.ContentType.StartsWith("video/")),
+                    x.Attachments.AsQueryable().Count(ActivityAttachmentClassifier.IsPdfExpression),
+                    x.Attachments.AsQueryable().Count(ActivityAttachmentClassifier.IsPhotoExpression),
+                    x.Attachments.AsQueryable().Count(ActivityAttachmentClassifier.IsVideoExpression),
                     x.Attachments
-                        .OrderByDescending(a => a.ContentType.StartsWith("image/"))
-                        .ThenByDescending(a => a.ContentType.StartsWith("video/"))
-                        .ThenByDescending(a => a.ContentType == "application/pdf" || a.OriginalFileName.EndsWith(".pdf"))
+                        .OrderByDescending(a => a.ContentType != null && a.ContentType.ToLower().StartsWith("image/"))
+                        .ThenByDescending(a => a.ContentType != null && a.ContentType.ToLower().StartsWith("video/"))
+                        .ThenByDescending(a => (a.ContentType != null && a.ContentType.ToLower() == "application/pdf") || (a.OriginalFileName != null && a.OriginalFileName.ToLower().EndsWith(".pdf")))
                         .ThenByDescending(a => a.UploadedAtUtc)
                         .Take(3)
                         .Select(a => new ActivityMediaPreview(
                             a.Id,
                             a.OriginalFileName,
                             a.ContentType,
-                            a.ContentType.StartsWith("image/") ? "Photo" : a.ContentType.StartsWith("video/") ? "Video" : "Document",
+                            a.ContentType != null && a.ContentType.ToLower().StartsWith("image/") ? ActivityAttachmentClassifier.PhotoLabel : a.ContentType != null && a.ContentType.ToLower().StartsWith("video/") ? ActivityAttachmentClassifier.VideoLabel : ((a.ContentType != null && a.ContentType.ToLower() == "application/pdf") || (a.OriginalFileName != null && a.OriginalFileName.ToLower().EndsWith(".pdf"))) ? ActivityAttachmentClassifier.PdfLabel : ActivityAttachmentClassifier.DocumentLabel,
                             a.StorageKey,
                             a.FileSize))
                         .ToList(),
@@ -143,14 +143,9 @@ namespace ProjectManagement.Infrastructure.Activities
 
             var all = await query.CountAsync(cancellationToken);
             var withMedia = await query.CountAsync(x => x.Attachments.Any(), cancellationToken);
-            var photos = await query.SelectMany(x => x.Attachments).CountAsync(a => a.ContentType.StartsWith("image/"), cancellationToken);
-            var documents = await query.SelectMany(x => x.Attachments).CountAsync(a =>
-                a.ContentType == "application/pdf" ||
-                a.OriginalFileName.EndsWith(".pdf") ||
-                a.ContentType.Contains("document") ||
-                a.ContentType.Contains("spreadsheet") ||
-                a.ContentType.Contains("presentation"), cancellationToken);
-            var videos = await query.SelectMany(x => x.Attachments).CountAsync(a => a.ContentType.StartsWith("video/"), cancellationToken);
+            var photos = await query.SelectMany(x => x.Attachments).CountAsync(ActivityAttachmentClassifier.IsPhotoExpression, cancellationToken);
+            var documents = await query.SelectMany(x => x.Attachments).CountAsync(ActivityAttachmentClassifier.IsDocumentExpression, cancellationToken);
+            var videos = await query.SelectMany(x => x.Attachments).CountAsync(ActivityAttachmentClassifier.IsVideoExpression, cancellationToken);
 
             return new ActivityReviewSummaryResult(all, withMedia, photos, documents, videos);
         }
@@ -194,11 +189,9 @@ namespace ProjectManagement.Infrastructure.Activities
 
             return request.AttachmentType switch
             {
-                ActivityAttachmentTypeFilter.Pdf => query.Where(x => x.Attachments.Any(a =>
-                    a.ContentType == "application/pdf" ||
-                    a.OriginalFileName.EndsWith(".pdf"))),
-                ActivityAttachmentTypeFilter.Photo => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
-                ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
+                ActivityAttachmentTypeFilter.Pdf => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsPdfExpression)),
+                ActivityAttachmentTypeFilter.Photo => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsPhotoExpression)),
+                ActivityAttachmentTypeFilter.Video => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsVideoExpression)),
                 _ => query
             };
         }
@@ -246,14 +239,9 @@ namespace ProjectManagement.Infrastructure.Activities
             {
                 ActivityMediaFilter.WithMedia => query.Where(x => x.Attachments.Any()),
                 ActivityMediaFilter.WithoutMedia => query.Where(x => !x.Attachments.Any()),
-                ActivityMediaFilter.Photos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("image/"))),
-                ActivityMediaFilter.Videos => query.Where(x => x.Attachments.Any(a => a.ContentType.StartsWith("video/"))),
-                ActivityMediaFilter.Documents => query.Where(x => x.Attachments.Any(a =>
-                    a.ContentType == "application/pdf" ||
-                    a.OriginalFileName.EndsWith(".pdf") ||
-                    a.ContentType.Contains("document") ||
-                    a.ContentType.Contains("spreadsheet") ||
-                    a.ContentType.Contains("presentation"))),
+                ActivityMediaFilter.Photos => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsPhotoExpression)),
+                ActivityMediaFilter.Videos => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsVideoExpression)),
+                ActivityMediaFilter.Documents => query.Where(x => x.Attachments.AsQueryable().Any(ActivityAttachmentClassifier.IsDocumentExpression)),
                 _ => query
             };
         }

--- a/Pages/Activities/Details.cshtml.cs
+++ b/Pages/Activities/Details.cshtml.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using ProjectManagement.Contracts.Activities;
 using ProjectManagement.Infrastructure.Ui;
 using ProjectManagement.Models.Activities;
 using ProjectManagement.Services.Activities;
@@ -197,28 +198,18 @@ public sealed class DetailsModel : PageModel
 
         var attachments = await _activityService.GetAttachmentMetadataAsync(activity.Id, cancellationToken);
         Attachments = attachments;
-        PhotoAttachments = attachments.Where(IsPhoto).ToList();
-        VideoAttachments = attachments.Where(IsVideo).ToList();
-        PdfAttachments = attachments.Where(IsPdf).ToList();
-        OtherAttachments = attachments.Except(PhotoAttachments.Concat(VideoAttachments).Concat(PdfAttachments)).ToList();
+        PhotoAttachments = attachments.Where(a => ActivityAttachmentClassifier.Classify(a.FileName, a.ContentType) == ActivityAttachmentKind.Photo).ToList();
+        VideoAttachments = attachments.Where(a => ActivityAttachmentClassifier.Classify(a.FileName, a.ContentType) == ActivityAttachmentKind.Video).ToList();
+        PdfAttachments = attachments.Where(a => ActivityAttachmentClassifier.Classify(a.FileName, a.ContentType) == ActivityAttachmentKind.Pdf).ToList();
+        OtherAttachments = attachments
+            .Where(a =>
+            {
+                var kind = ActivityAttachmentClassifier.Classify(a.FileName, a.ContentType);
+                return kind is ActivityAttachmentKind.Document or ActivityAttachmentKind.Other;
+            })
+            .ToList();
 
         RemainingAttachmentSlots = Math.Max(0, ActivityAttachmentManager.MaxAttachmentsPerActivity - attachments.Count);
-    }
-
-    private static bool IsPhoto(ActivityAttachmentMetadata attachment)
-    {
-        return attachment.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsVideo(ActivityAttachmentMetadata attachment)
-    {
-        return attachment.ContentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsPdf(ActivityAttachmentMetadata attachment)
-    {
-        return string.Equals(attachment.ContentType, "application/pdf", StringComparison.OrdinalIgnoreCase) ||
-               attachment.FileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsManager(ClaimsPrincipal user)

--- a/ProjectManagement.Tests/Activities/ActivityAttachmentClassifierTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityAttachmentClassifierTests.cs
@@ -1,0 +1,52 @@
+using ProjectManagement.Contracts.Activities;
+using Xunit;
+
+namespace ProjectManagement.Tests.Activities;
+
+public class ActivityAttachmentClassifierTests
+{
+    // SECTION: PDF extension classification
+    [Theory]
+    [InlineData("brief.pdf")]
+    [InlineData("brief.PDF")]
+    [InlineData("brief.Pdf")]
+    public void Classify_DetectsPdfExtensionsCaseInsensitively(string fileName)
+    {
+        var kind = ActivityAttachmentClassifier.Classify(fileName, "application/octet-stream");
+
+        Assert.Equal(ActivityAttachmentKind.Pdf, kind);
+    }
+
+    // SECTION: Mixed-case content type classification
+    [Theory]
+    [InlineData("photo.JPG", "Image/JPEG", ActivityAttachmentKind.Photo)]
+    [InlineData("clip.mov", "Video/QuickTime", ActivityAttachmentKind.Video)]
+    [InlineData("report.bin", "Application/PDF", ActivityAttachmentKind.Pdf)]
+    public void Classify_DetectsMixedCaseContentTypes(string fileName, string contentType, ActivityAttachmentKind expected)
+    {
+        var kind = ActivityAttachmentClassifier.Classify(fileName, contentType);
+
+        Assert.Equal(expected, kind);
+    }
+
+    // SECTION: Office document MIME classification
+    [Theory]
+    [InlineData("memo.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")]
+    [InlineData("slides.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")]
+    public void Classify_DetectsOfficeDocumentMimeTypes(string fileName, string contentType)
+    {
+        var kind = ActivityAttachmentClassifier.Classify(fileName, contentType);
+
+        Assert.Equal(ActivityAttachmentKind.Document, kind);
+    }
+
+    // SECTION: Fallback classification
+    [Fact]
+    public void Classify_ReturnsOtherForUnknownAttachments()
+    {
+        var kind = ActivityAttachmentClassifier.Classify("archive.zip", "application/zip");
+
+        Assert.Equal(ActivityAttachmentKind.Other, kind);
+    }
+}

--- a/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
@@ -500,4 +500,77 @@ public class ActivityRepositoryTests
         Assert.Equal(expectedTitle, item.Title);
     }
 
+    [Fact]
+    public async Task ListAsync_ClassifiesAttachmentsWithCaseInsensitiveNormalizedRules()
+    {
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        var type = new ActivityType
+        {
+            Name = "Attachments",
+            CreatedByUserId = "system"
+        };
+        context.ActivityTypes.Add(type);
+        await context.SaveChangesAsync();
+
+        // SECTION: Mixed-case attachment data used by filters, counts, and previews
+        var activity = new Activity
+        {
+            Title = "Attachment classification",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1",
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            Attachments =
+            {
+                new ActivityAttachment
+                {
+                    StorageKey = "files/upper-pdf",
+                    OriginalFileName = "brief.PDF",
+                    ContentType = "application/octet-stream",
+                    UploadedByUserId = "user-1",
+                    UploadedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-3)
+                },
+                new ActivityAttachment
+                {
+                    StorageKey = "files/photo",
+                    OriginalFileName = "photo.jpg",
+                    ContentType = "Image/JPEG",
+                    UploadedByUserId = "user-1",
+                    UploadedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-2)
+                },
+                new ActivityAttachment
+                {
+                    StorageKey = "files/video",
+                    OriginalFileName = "clip.mp4",
+                    ContentType = "Video/MP4",
+                    UploadedByUserId = "user-1",
+                    UploadedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-1)
+                },
+                new ActivityAttachment
+                {
+                    StorageKey = "files/office",
+                    OriginalFileName = "memo.docx",
+                    ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    UploadedByUserId = "user-1",
+                    UploadedAtUtc = DateTimeOffset.UtcNow
+                }
+            }
+        };
+
+        context.Activities.Add(activity);
+        await context.SaveChangesAsync();
+
+        var result = await repository.ListAsync(new ActivityListRequest(PageSize: 10, MediaFilter: ActivityMediaFilter.Documents));
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(4, item.AttachmentCount);
+        Assert.Equal(1, item.PdfAttachmentCount);
+        Assert.Equal(1, item.PhotoAttachmentCount);
+        Assert.Equal(1, item.VideoAttachmentCount);
+        Assert.Contains(item.MediaPreviews, preview => preview.MediaKind == ActivityAttachmentClassifier.PhotoLabel);
+        Assert.Contains(item.MediaPreviews, preview => preview.MediaKind == ActivityAttachmentClassifier.VideoLabel);
+        Assert.Contains(item.MediaPreviews, preview => preview.MediaKind == ActivityAttachmentClassifier.PdfLabel);
+    }
+
 }

--- a/Services/Activities/ActivityAttachmentManager.cs
+++ b/Services/Activities/ActivityAttachmentManager.cs
@@ -76,7 +76,7 @@ public sealed class ActivityAttachmentManager : IActivityAttachmentManager
         await _activityRepository.AddAttachmentAsync(attachment, cancellationToken);
         activity.Attachments.Add(attachment);
 
-        if (string.Equals(upload.ContentType, "application/pdf", StringComparison.OrdinalIgnoreCase))
+        if (ActivityAttachmentClassifier.Classify(storageResult.FileName, upload.ContentType) == ActivityAttachmentKind.Pdf)
         {
             try
             {


### PR DESCRIPTION
### Motivation
- Provide a single, consistent way to classify attachments (photo, video, PDF, document, other) both in-memory and in EF queries to avoid divergent logic across the codebase.
- Replace uses of `StringComparison` overloads and ad-hoc case checks that are not EF-translatable with normalized, translatable expressions.
- Ensure mixed-case content types and file extensions (e.g. `.PDF`, `Image/JPEG`) are handled consistently for filters, counts, previews, details grouping, and ingestion.

### Description
- Added a shared classifier at `Contracts/Activities/ActivityAttachmentClassifier.cs` containing `ActivityAttachmentKind`, EF-translatable expressions (`IsPhotoExpression`, `IsVideoExpression`, `IsPdfExpression`, `IsDocumentExpression`), and in-memory helpers (`Classify`, `IsPhoto`, `IsVideo`, `IsPdf`, `IsDocument`, `GetDisplayLabel`).
- Updated `Infrastructure/Activities/ActivityRepository.cs` to use the classifier expressions and normalized checks for projection counts, attachment-type filters, media filters, and media preview labels, using `AsQueryable()` where needed so EF can translate the expressions.
- Updated `Pages/Activities/Details.cshtml.cs` to use the shared classifier for grouping attachments into photos, videos, PDFs and other/document buckets instead of page-local `StringComparison` checks.
- Updated `Services/Activities/ActivityAttachmentManager.cs` to use the classifier when deciding to ingest PDFs (so files identified as PDF by extension or content type are treated uniformly).
- Added unit tests: `ProjectManagement.Tests/Activities/ActivityAttachmentClassifierTests.cs` covering `.pdf`/`.PDF`/`.Pdf`, mixed-case content types, image/video, and Office MIME detection, and extended `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs` with `ListAsync_ClassifiesAttachmentsWithCaseInsensitiveNormalizedRules` to exercise list filters, counts and previews.

### Testing
- Ran `git diff --check` to verify workspace changes and there were no diff-check errors.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActivityAttachmentClassifierTests|FullyQualifiedName~ActivityRepositoryTests"` but the `dotnet` CLI is not available in this environment so the tests could not be executed here.
- New unit tests were added to the test project but remain unexecuted in this environment and should be run in CI or a developer machine with the .NET SDK installed using `dotnet test` to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9a1504a88329b19011225e65dac4)