### PR TITLE
Update Add/Edit activity form labels and layout

### DIFF
--- a/Pages/Activities/Edit.cshtml
+++ b/Pages/Activities/Edit.cshtml
@@ -11,6 +11,7 @@
 }
 
 <div class="container-xxl">
+    <!-- SECTION: Page header -->
     <nav aria-label="breadcrumb" class="mb-3">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a asp-page="/Activities/Index">Activities</a></li>
@@ -21,10 +22,11 @@
     <h1 class="h3 mb-3">@(isEdit ? "Edit activity" : "Add activity")</h1>
 
     <form method="post" class="needs-validation" novalidate enctype="multipart/form-data">
-        <!-- Section: Activity identity -->
+        <!-- SECTION: Activity identity and validation -->
         <input type="hidden" asp-for="Input.Id" />
         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
+        <!-- SECTION: Basic details -->
         <div class="card mb-3">
             <div class="card-header">Basic details</div>
             <div class="card-body">
@@ -35,38 +37,32 @@
                 </div>
                 <div class="row g-3">
                     <div class="col-md-6">
-                        <label asp-for="Input.ActivityTypeId" class="form-label"></label>
-                        <select asp-for="Input.ActivityTypeId" class="form-select" asp-items="Model.ActivityTypeOptions"></select>
-                        <span asp-validation-for="Input.ActivityTypeId" class="text-danger"></span>
-                    </div>
-                    <div class="col-md-6">
-                        <label asp-for="Input.Location" class="form-label"></label>
-                        <input asp-for="Input.Location" class="form-control" />
-                        <span asp-validation-for="Input.Location" class="text-danger"></span>
-                    </div>
-                </div>
-                <div class="row g-3 mt-0">
-                    <div class="col-md-6">
                         <label asp-for="Input.ScheduledStart" class="form-label"></label>
                         <input asp-for="Input.ScheduledStart" type="date" class="form-control" />
                         <span asp-validation-for="Input.ScheduledStart" class="text-danger"></span>
                     </div>
                     <div class="col-md-6">
-                        <label asp-for="Input.ScheduledEnd" class="form-label"></label>
-                        <input asp-for="Input.ScheduledEnd" type="date" class="form-control" />
-                        <span asp-validation-for="Input.ScheduledEnd" class="text-danger"></span>
+                        <label asp-for="Input.ActivityTypeId" class="form-label"></label>
+                        <select asp-for="Input.ActivityTypeId" class="form-select" asp-items="Model.ActivityTypeOptions"></select>
+                        <span asp-validation-for="Input.ActivityTypeId" class="text-danger"></span>
                     </div>
-                </div>
-                <div class="mt-3">
-                    <label asp-for="Input.Description" class="form-label">Remarks / Brief</label>
-                    <textarea asp-for="Input.Description" class="form-control" rows="6" maxlength="2000" placeholder="Record key points, outcome, decisions, follow-up or brief summary of the activity."></textarea>
-                    <div class="form-text" data-char-count-for="Input_Description">0/2000</div>
-                    <span asp-validation-for="Input.Description" class="text-danger"></span>
                 </div>
             </div>
         </div>
 
-        <div class="card mb-4">
+        <!-- SECTION: Remarks / Brief -->
+        <div class="card mb-3 border-primary-subtle">
+            <div class="card-header bg-primary-subtle text-primary-emphasis">Remarks / Brief</div>
+            <div class="card-body">
+                <label asp-for="Input.Description" class="form-label"></label>
+                <textarea asp-for="Input.Description" class="form-control form-control-lg" rows="10" maxlength="2000" placeholder="Record key points, outcome, decisions, follow-up or brief summary of the activity."></textarea>
+                <div class="form-text" data-char-count-for="Input_Description">0/2000</div>
+                <span asp-validation-for="Input.Description" class="text-danger"></span>
+            </div>
+        </div>
+
+        <!-- SECTION: Media / Documents -->
+        <div class="card mb-3">
             <div class="card-header">Media / Documents</div>
             <div class="card-body">
                 @if (canUpload)
@@ -102,6 +98,26 @@
             </div>
         </div>
 
+        <!-- SECTION: Optional details -->
+        <div class="card mb-4">
+            <div class="card-header">Optional details</div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="Input.Location" class="form-label"></label>
+                        <input asp-for="Input.Location" class="form-control" />
+                        <span asp-validation-for="Input.Location" class="text-danger"></span>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="Input.ScheduledEnd" class="form-label"></label>
+                        <input asp-for="Input.ScheduledEnd" type="date" class="form-control" />
+                        <span asp-validation-for="Input.ScheduledEnd" class="text-danger"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- SECTION: Actions -->
         <div class="d-flex justify-content-between">
             <a asp-page="/Activities/Index" class="btn btn-outline-secondary">Cancel</a>
             <button type="submit" class="btn btn-primary">@(isEdit ? "Save activity" : "Save activity")</button>

--- a/Pages/Activities/Edit.cshtml.cs
+++ b/Pages/Activities/Edit.cshtml.cs
@@ -422,28 +422,28 @@ public sealed class EditModel : PageModel
 
         [Required]
         [StringLength(200)]
-        [Display(Name = "Nomenclature")]
+        [Display(Name = "Activity title")]
         public string? Title { get; set; }
 
         [StringLength(2000)]
-        [Display(Name = "Description")]
+        [Display(Name = "Remarks / Brief")]
         public string? Description { get; set; }
 
         [StringLength(450)]
-        [Display(Name = "Place")]
+        [Display(Name = "Location (optional)")]
         public string? Location { get; set; }
 
         [Required]
         [Display(Name = "Activity type")]
         public int? ActivityTypeId { get; set; }
 
-        [Display(Name = "Start date")]
+        [Display(Name = "Event date")]
         public DateTime? ScheduledStart { get; set; }
 
-        [Display(Name = "End date")]
+        [Display(Name = "End date (optional)")]
         public DateTime? ScheduledEnd { get; set; }
 
-        [Display(Name = "Attachments")]
+        [Display(Name = "Media / Documents")]
         public IList<IFormFile>? Files { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation

- Improve the Add/Edit activity form wording and layout to match the new copy and UX guidance (clearer labels, emphasise remarks, surface optional fields).
- Reorder fields to prioritise basic details and the remarks summary to make the form easier to scan and complete.
- Keep client-side behaviour CSP-compliant by retaining external script references and avoiding inline scripts.

### Description

- Updated display labels in the page model `Pages/Activities/Edit.cshtml.cs` (`InputModel`) to use the new copy: `Activity title`, `Remarks / Brief`, `Location (optional)`, `Event date`, `End date (optional)`, and `Media / Documents`.
- Reordered the Razor view `Pages/Activities/Edit.cshtml` into sections: Basic details (title, event date, activity type), Remarks / Brief (prominent highlighted card with a larger textarea), Media / Documents (file upload), Optional details (location, end date), and Actions, with section comment headers added for readability.
- Made the remarks textarea visually prominent by placing it in a `border-primary-subtle` card with `bg-primary-subtle text-primary-emphasis` header and using `form-control-lg` with `rows="10"`.
- Ensured all JavaScript remains external by keeping existing `<script src="..." defer>` includes (`~/js/widgets/char-count.js` and `~/js/projects/document-requests.js`) and did not add any inline scripts, preserving CSP compliance.

### Testing

- Ran `git diff --check` to validate formatting and found no issues.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter Activity --no-restore` but the `dotnet` CLI is not available in the environment so test execution could not be completed; no automated snapshot updates were applied in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9b3967a8832980ff015fb69d0703)