### PR TITLE
Require event date and validate optional end date for Activities; add tests

### DIFF
--- a/Pages/Activities/Edit.cshtml.cs
+++ b/Pages/Activities/Edit.cshtml.cs
@@ -416,7 +416,7 @@ public sealed class EditModel : PageModel
         return IstClock.StartOfDayIstToUtc(localDate);
     }
 
-    public sealed class InputModel
+    public sealed class InputModel : IValidatableObject
     {
         public int? Id { get; set; }
 
@@ -437,6 +437,7 @@ public sealed class EditModel : PageModel
         [Display(Name = "Activity type")]
         public int? ActivityTypeId { get; set; }
 
+        [Required(ErrorMessage = "Event date is required.")]
         [Display(Name = "Event date")]
         public DateTime? ScheduledStart { get; set; }
 
@@ -445,5 +446,16 @@ public sealed class EditModel : PageModel
 
         [Display(Name = "Media / Documents")]
         public IList<IFormFile>? Files { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // SECTION: Optional end date chronology validation
+            if (ScheduledStart.HasValue && ScheduledEnd.HasValue && ScheduledEnd.Value.Date < ScheduledStart.Value.Date)
+            {
+                yield return new ValidationResult(
+                    "End date must be on or after the event date.",
+                    new[] { nameof(ScheduledEnd) });
+            }
+        }
     }
 }

--- a/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
@@ -66,6 +66,36 @@ public sealed class ActivityDetailsPageRenderingTests
         Assert.DoesNotContain("data-bs-target=\"#{modalId}\"", html, StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public async Task DetailsPage_LegacyMissingDateRecordStillRenders()
+    {
+        // SECTION: Arrange a legacy activity without scheduled dates.
+        var activity = new Activity
+        {
+            Id = 77,
+            Title = "Legacy Missing Date",
+            Description = null,
+            ActivityType = new ActivityType { Id = 6, Name = "Misc", CreatedByUserId = "seed" },
+            ActivityTypeId = 6,
+            ScheduledStartUtc = null,
+            ScheduledEndUtc = null,
+            CreatedByUserId = "owner",
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        var page = new DetailsModel(
+            new StubActivityService(activity, Array.Empty<ActivityAttachmentMetadata>()),
+            new StubActivityAttachmentManager(),
+            NullLogger<DetailsModel>.Instance);
+
+        // SECTION: Act and assert the details view renders date placeholders safely.
+        var html = await RenderDetailsPageAsync(page, activity.Id);
+
+        Assert.Contains("Legacy Missing Date", html, StringComparison.Ordinal);
+        Assert.Contains("<dd class=\"col-sm-9\">—</dd>", html, StringComparison.Ordinal);
+    }
+
     private static async Task<string> RenderDetailsPageAsync(DetailsModel page, int activityId)
     {
         // SECTION: Populate the Razor PageModel before rendering the details view.

--- a/ProjectManagement.Tests/Activities/ActivityEditValidationTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityEditValidationTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using ProjectManagement.Pages.Activities;
+using Xunit;
+
+namespace ProjectManagement.Tests.Activities;
+
+public sealed class ActivityEditValidationTests
+{
+    [Fact]
+    public void CreateInput_WithoutEventDate_IsRejected()
+    {
+        // SECTION: Arrange a create payload with the event date omitted.
+        var input = CreateValidInput();
+        input.ScheduledStart = null;
+
+        var errors = Validate(input);
+
+        // SECTION: Assert the required event date error is returned.
+        var error = Assert.Single(errors, error => error.MemberNames.Contains(nameof(EditModel.InputModel.ScheduledStart)));
+        Assert.Equal("Event date is required.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void CreateInput_WithEventDate_Succeeds()
+    {
+        // SECTION: Arrange a complete create payload with an event date.
+        var input = CreateValidInput();
+
+        var errors = Validate(input);
+
+        // SECTION: Assert no validation errors block activity creation.
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void CreateInput_WithEndDateBeforeEventDate_IsRejected()
+    {
+        // SECTION: Arrange a create payload whose optional end date precedes the event date.
+        var input = CreateValidInput();
+        input.ScheduledEnd = input.ScheduledStart!.Value.AddDays(-1);
+
+        var errors = Validate(input);
+
+        // SECTION: Assert the optional end date chronology is enforced.
+        var error = Assert.Single(errors, error => error.MemberNames.Contains(nameof(EditModel.InputModel.ScheduledEnd)));
+        Assert.Equal("End date must be on or after the event date.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void CreateInput_WithEmptyOptionalEndDate_Succeeds()
+    {
+        // SECTION: Arrange a create payload without an optional end date.
+        var input = CreateValidInput();
+        input.ScheduledEnd = null;
+
+        var errors = Validate(input);
+
+        // SECTION: Assert the optional end date can remain empty.
+        Assert.Empty(errors);
+    }
+
+    private static EditModel.InputModel CreateValidInput() => new()
+    {
+        Title = "Project Kickoff",
+        ActivityTypeId = 1,
+        ScheduledStart = new DateTime(2026, 6, 14),
+        ScheduledEnd = new DateTime(2026, 6, 14)
+    };
+
+    private static IReadOnlyList<ValidationResult> Validate(EditModel.InputModel input)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(input, new ValidationContext(input), results, validateAllProperties: true);
+        return results;
+    }
+}

--- a/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
@@ -193,6 +193,60 @@ public sealed class ActivityIndexPageTests
         Assert.False(row.CanDelete);
     }
 
+
+    [Fact]
+    public async Task OnGetAsync_LegacyMissingDateRecordStillBuildsViewModel()
+    {
+        // SECTION: Arrange a legacy activity row without scheduled dates.
+        var now = DateTimeOffset.UtcNow;
+        var result = new ActivityListResult(new List<ActivityListItem>
+        {
+            new ActivityListItem(
+                Id: 9,
+                Title: "Legacy Activity",
+                ActivityTypeName: "Misc",
+                ActivityTypeId: 6,
+                Location: null,
+                RemarksPreview: null,
+                ScheduledStartUtc: null,
+                ScheduledEndUtc: null,
+                CreatedAtUtc: now.AddDays(-5),
+                CreatedByUserId: "legacy-owner",
+                CreatedByDisplayName: "Legacy Owner",
+                CreatedByEmail: "legacy@example.test",
+                AttachmentCount: 0,
+                PdfAttachmentCount: 0,
+                PhotoAttachmentCount: 0,
+                VideoAttachmentCount: 0,
+                MediaPreviews: Array.Empty<ActivityMediaPreview>(),
+                HasPendingDelete: false)
+        }, 1, 1, 25, ActivityListSort.ScheduledStart, true);
+
+        var activityService = new StubActivityService(result);
+        var typeService = new StubActivityTypeService(new List<ActivityType>
+        {
+            new() { Id = 6, Name = "Misc", CreatedByUserId = "seed" }
+        });
+        var exportService = new StubActivityExportService();
+        var deleteRequestService = new StubActivityDeleteRequestService();
+
+        var services = new ServiceCollection().BuildServiceProvider();
+        var user = new ApplicationUser { Id = "legacy-owner", UserName = "legacy" };
+        using var userManager = new StubUserManager(user, services, "Admin");
+
+        var page = new IndexModel(activityService, typeService, exportService, deleteRequestService, userManager);
+        ConfigurePage(page, CreatePrincipal("legacy-owner", new[] { new Claim(ClaimTypes.Role, "Admin") }));
+
+        // SECTION: Act and assert the index can present the legacy row safely.
+        var actionResult = await page.OnGetAsync(CancellationToken.None);
+
+        Assert.IsType<PageResult>(actionResult);
+        var row = Assert.Single(page.ViewModel!.Rows);
+        Assert.Equal("Legacy Activity", row.Title);
+        Assert.Null(row.ScheduledStartUtc);
+        Assert.NotEmpty(page.ViewModel.Groups);
+    }
+
     [Fact]
     public async Task OnPostExportAsync_UsesFiltersAndReturnsFile()
     {


### PR DESCRIPTION
### Motivation
- Ensure Activities created/edited via the UI always have an event date and enforce simple chronology of the optional end date while keeping the UI safe for legacy records that have missing dates.

### Description
- Added `[Required(ErrorMessage = "Event date is required.")]` to `ScheduledStart` on the input model in `Pages/Activities/Edit.cshtml.cs`.
- Implemented `IValidatableObject` on the input model and added a `Validate` method to enforce that `ScheduledEnd` is either empty or on/after `ScheduledStart`.
- Added unit tests: `ProjectManagement.Tests/Activities/ActivityEditValidationTests.cs` to cover create-without-event-date rejection, create-with-event-date success, end-date-before-start rejection, and empty optional end-date success.
- Added legacy-scenario tests to ensure records with `ScheduledStartUtc = null`/`ScheduledEndUtc = null` still render safely in the index and details pages (`ActivityIndexPageTests` and `ActivityDetailsPageRenderingTests`).

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter "FullyQualifiedName~ActivityEditValidationTests|FullyQualifiedName~ActivityIndexPageTests|FullyQualifiedName~ActivityDetailsPageRenderingTests"` but the `dotnet` SDK is not available in this environment so the unit tests were not executed here.
- The change is limited to validation and tests and does not modify persisted schemas or runtime behavior for existing legacy records beyond ensuring UI-level validation and safe rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9c2443e08329a17ce0e47f3bed95)