### PR TITLE
Use InlineUrl for activity media sources and add rendering tests

### DIFF
--- a/Pages/Activities/Details.cshtml
+++ b/Pages/Activities/Details.cshtml
@@ -176,7 +176,7 @@
                                                 data-bs-toggle="modal"
                                                 data-bs-target="#@modalId"
                                                 aria-label="View photo @photo.FileName">
-                                            <img src="@photo.DownloadUrl" alt="@photo.FileName" class="card-img-top" />
+                                            <img src="@photo.InlineUrl" alt="@photo.FileName" class="card-img-top" />
                                         </button>
                                         <div class="card-body">
                                             <h4 class="card-title h6 mb-1">@photo.FileName</h4>
@@ -204,7 +204,7 @@
                                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                             </div>
                                             <div class="modal-body">
-                                                <img src="@photo.DownloadUrl" alt="@photo.FileName" class="img-fluid" />
+                                                <img src="@photo.InlineUrl" alt="@photo.FileName" class="img-fluid" />
                                             </div>
                                         </div>
                                     </div>
@@ -225,7 +225,7 @@
                                     <div class="card h-100">
                                         <div class="ratio ratio-16x9">
                                             <video controls preload="metadata">
-                                                <source src="@video.DownloadUrl" type="@video.ContentType" />
+                                                <source src="@video.InlineUrl" type="@video.ContentType" />
                                                 Your browser does not support the video tag.
                                             </video>
                                         </div>

--- a/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
@@ -22,6 +22,7 @@ using ProjectManagement.Contracts.Activities;
 using ProjectManagement.Models.Activities;
 using ProjectManagement.Pages.Activities;
 using ProjectManagement.Services.Activities;
+using ProjectManagement.ViewModels.Activities;
 using Xunit;
 
 namespace ProjectManagement.Tests.Activities;
@@ -66,6 +67,80 @@ public sealed class ActivityDetailsPageRenderingTests
         Assert.DoesNotContain("data-bs-target=\"#{modalId}\"", html, StringComparison.Ordinal);
     }
 
+
+
+    [Fact]
+    public async Task DetailsPage_UsesInlineUrlsForMediaSourcesAndDownloadUrlsForLinks()
+    {
+        // SECTION: Arrange media attachments with distinct inline and download URLs.
+        var activity = new Activity
+        {
+            Id = 84,
+            Title = "Media Source Review",
+            Description = "Verify rendering URLs",
+            ActivityType = new ActivityType { Id = 7, Name = "Workshop", CreatedByUserId = "seed" },
+            ActivityTypeId = 7,
+            CreatedByUserId = "owner",
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        var attachments = new[]
+        {
+            new ActivityAttachmentMetadata(12, "photo.jpg", "image/jpeg", 2048, "/download/photo.jpg", "/inline/photo.jpg", "activities/84/photo.jpg", DateTimeOffset.UtcNow, "owner"),
+            new ActivityAttachmentMetadata(13, "clip.mp4", "video/mp4", 4096, "/download/clip.mp4", "/inline/clip.mp4", "activities/84/clip.mp4", DateTimeOffset.UtcNow, "owner")
+        };
+
+        var page = new DetailsModel(
+            new StubActivityService(activity, attachments),
+            new StubActivityAttachmentManager(),
+            NullLogger<DetailsModel>.Instance);
+
+        // SECTION: Act and assert media elements stream inline while actions download files.
+        var html = await RenderDetailsPageAsync(page, activity.Id);
+
+        Assert.Contains("<img src=\"/inline/photo.jpg\"", html, StringComparison.Ordinal);
+        Assert.Contains("<source src=\"/inline/clip.mp4\" type=\"video/mp4\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/download/photo.jpg\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/download/clip.mp4\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<img src=\"/download/photo.jpg\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<source src=\"/download/clip.mp4\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ActivityCard_UsesInlineThumbnailUrlsAndDownloadFileLinks()
+    {
+        // SECTION: Arrange card media with distinct thumbnail and download URLs.
+        var row = new ActivityListRowViewModel(
+            90,
+            "Card Media Review",
+            "Workshop",
+            "Main Hall",
+            "Review card media rendering.",
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddHours(1),
+            DateTimeOffset.UtcNow,
+            "Owner",
+            "owner@example.com",
+            2,
+            1,
+            1,
+            0,
+            new[]
+            {
+                new ActivityMediaPreviewViewModel(1, "thumb.jpg", "image/jpeg", "Photo", "/inline/thumb.jpg", "/download/thumb.jpg", 1024),
+                new ActivityMediaPreviewViewModel(2, "brief.pdf", "application/pdf", "PDF", null, "/download/brief.pdf", 2048)
+            },
+            HasPendingDelete: false,
+            CanEdit: true,
+            CanDelete: true);
+
+        // SECTION: Act and assert card thumbnails and file links use the correct URL intent.
+        var html = await RenderActivityCardAsync(row);
+
+        Assert.Contains("<img src=\"/inline/thumb.jpg\"", html, StringComparison.Ordinal);
+        Assert.Contains("href=\"/download/brief.pdf\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<img src=\"/download/thumb.jpg\"", html, StringComparison.Ordinal);
+    }
 
     [Fact]
     public async Task DetailsPage_LegacyMissingDateRecordStillRenders()
@@ -127,6 +202,34 @@ public sealed class ActivityDetailsPageRenderingTests
             Model = page
         };
         var viewContext = new ViewContext(actionContext, viewResult.View, viewData, page.TempData, writer, new HtmlHelperOptions());
+
+        await viewResult.View.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+
+    private static async Task<string> RenderActivityCardAsync(ActivityListRowViewModel row)
+    {
+        // SECTION: Render the activity card partial with MVC services.
+        using var scope = Services.CreateScope();
+        var provider = scope.ServiceProvider;
+        var httpContext = new DefaultHttpContext { RequestServices = provider };
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        var viewEngine = provider.GetRequiredService<IRazorViewEngine>();
+        var viewResult = viewEngine.GetView(executingFilePath: null, viewPath: "/Pages/Activities/_ActivityCard.cshtml", isMainPage: false);
+        if (!viewResult.Success)
+        {
+            throw new InvalidOperationException("Unable to locate Activities card partial view.");
+        }
+
+        await using var writer = new StringWriter();
+        var tempData = new TempDataDictionary(httpContext, provider.GetRequiredService<ITempDataProvider>());
+        var viewData = new ViewDataDictionary<ActivityListRowViewModel>(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = row
+        };
+        var viewContext = new ViewContext(actionContext, viewResult.View, viewData, tempData, writer, new HtmlHelperOptions());
 
         await viewResult.View.RenderAsync(viewContext);
         return writer.ToString();


### PR DESCRIPTION
### Motivation
- Ensure media intended to be streamed/embedded uses inline URLs so browser elements load content directly while download actions continue to use explicit download URLs.
- Prevent accidental use of download links as media src attributes which can break inline playback or thumbnails.
- Add deterministic rendering tests to guard against regressions in URL intent between inline sources and download links.

### Description
- Updated `Pages/Activities/Details.cshtml` to use `photo.InlineUrl` for card thumbnail `<img src>` and modal `<img src>`, and to use `video.InlineUrl` for `<video><source src>` while keeping download buttons bound to `photo.DownloadUrl` / `video.DownloadUrl`.
- Verified `_ActivityCard.cshtml` continues to use `media.ThumbnailUrl` for thumbnail `<img>` and `media.DownloadUrl` for file links and left it unchanged.
- Added two rendering tests in `ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs`: `DetailsPage_UsesInlineUrlsForMediaSourcesAndDownloadUrlsForLinks` and `ActivityCard_UsesInlineThumbnailUrlsAndDownloadFileLinks`, plus a `RenderActivityCardAsync` helper and the required `using` import for `ViewModels`.
- Committed the template and test changes together and kept download behavior intact for attachment actions.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues and committed the changes successfully.
- Added unit tests under `ProjectManagement.Tests/Activities` but could not execute them here because `dotnet` is not available in the environment.  
- The added tests validate HTML output contains inline source URLs for media elements and download URLs for anchors (not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9cf3dff88329809983d7ba0fb719)