### PR TITLE
Adjust Activities date filter apply behavior

### DIFF
--- a/Pages/Activities/Index.cshtml
+++ b/Pages/Activities/Index.cshtml
@@ -54,8 +54,8 @@
         <input type="hidden" asp-for="SortDir" />
         <input asp-for="Search" class="form-control activities-filterbar__search" placeholder="Search activity..." autocomplete="off" />
         <select asp-for="ActivityTypeId" class="form-select" asp-items="Model.ActivityTypeOptions" data-activities-autosubmit></select>
-        <input asp-for="FromDate" class="form-control" type="date" data-activities-autosubmit aria-label="From date" />
-        <input asp-for="ToDate" class="form-control" type="date" data-activities-autosubmit aria-label="To date" />
+        <input asp-for="FromDate" class="form-control" type="date" aria-label="From date" />
+        <input asp-for="ToDate" class="form-control" type="date" aria-label="To date" />
         <select asp-for="MediaFilter" class="form-select" data-activities-autosubmit>
             <option value="Any">Any media</option>
             <option value="WithMedia">With media</option>

--- a/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -309,6 +310,35 @@ public sealed class ActivityIndexPageTests
         Assert.Equal("No activities match the selected filters.", page.TempData?["ToastMessage"]);
     }
 
+
+    [Fact]
+    public void FilterMarkup_DoesNotAutoSubmitDateFields()
+    {
+        // SECTION: Arrange
+        var pageMarkup = ReadRepoFile("Pages", "Activities", "Index.cshtml");
+
+        // SECTION: Assert
+        Assert.Contains("asp-for=\"ActivityTypeId\" class=\"form-select\" asp-items=\"Model.ActivityTypeOptions\" data-activities-autosubmit", pageMarkup, StringComparison.Ordinal);
+        Assert.Contains("asp-for=\"MediaFilter\" class=\"form-select\" data-activities-autosubmit", pageMarkup, StringComparison.Ordinal);
+        Assert.Contains("asp-for=\"FromDate\" class=\"form-control\" type=\"date\" aria-label=\"From date\"", pageMarkup, StringComparison.Ordinal);
+        Assert.Contains("asp-for=\"ToDate\" class=\"form-control\" type=\"date\" aria-label=\"To date\"", pageMarkup, StringComparison.Ordinal);
+        Assert.DoesNotContain("asp-for=\"FromDate\" class=\"form-control\" type=\"date\" data-activities-autosubmit", pageMarkup, StringComparison.Ordinal);
+        Assert.DoesNotContain("asp-for=\"ToDate\" class=\"form-control\" type=\"date\" data-activities-autosubmit", pageMarkup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActivitiesScript_BindsAutoSubmitOnlyToExplicitOptInFields()
+    {
+        // SECTION: Arrange
+        var script = ReadRepoFile("wwwroot", "js", "pages", "activities-index.js");
+
+        // SECTION: Assert
+        Assert.Contains("querySelectorAll('[data-activities-autosubmit]')", script, StringComparison.Ordinal);
+        Assert.Contains("input.addEventListener('change', submitFiltersFromFirstPage)", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("input[name=\"FromDate\"]", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("input[name=\"ToDate\"]", script, StringComparison.Ordinal);
+    }
+
     private static ClaimsPrincipal CreatePrincipal(string userId, IEnumerable<Claim>? additionalClaims)
     {
         var identityClaims = new List<Claim>
@@ -335,6 +365,26 @@ public sealed class ActivityIndexPageTests
         };
 
         page.TempData = new TempDataDictionary(httpContext, new DictionaryTempDataProvider());
+    }
+
+
+    private static string ReadRepoFile(params string[] relativePathParts)
+    {
+        // SECTION: Source assertions locate files from either repository-root or test-output working directories.
+        var relativePath = Path.Combine(relativePathParts);
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate repository file {relativePath}.", relativePath);
     }
 
     private sealed class StubActivityService : IActivityService

--- a/wwwroot/js/pages/activities-index.js
+++ b/wwwroot/js/pages/activities-index.js
@@ -27,20 +27,23 @@
       });
     }
 
+    // SECTION: Optional instant-submit filters
+    function submitFiltersFromFirstPage() {
+      const pageInput = filterForm.querySelector('input[name="Page"]');
+      if (pageInput) {
+        pageInput.value = '1';
+      }
+
+      if (typeof filterForm.requestSubmit === 'function') {
+        filterForm.requestSubmit();
+      } else {
+        filterForm.submit();
+      }
+    }
+
     const autoSubmitInputs = filterForm.querySelectorAll('[data-activities-autosubmit]');
     autoSubmitInputs.forEach((input) => {
-      input.addEventListener('change', () => {
-        const pageInput = filterForm.querySelector('input[name="Page"]');
-        if (pageInput) {
-          pageInput.value = '1';
-        }
-
-        if (typeof filterForm.requestSubmit === 'function') {
-          filterForm.requestSubmit();
-        } else {
-          filterForm.submit();
-        }
-      });
+      input.addEventListener('change', submitFiltersFromFirstPage);
     });
   }
 


### PR DESCRIPTION
### Motivation
- Date `FromDate`/`ToDate` fields were triggering immediate filter submits on change which prevented text and date filters from being applied together via the search button.
- The page script also assumed date inputs auto-submitted which made the UX and JS coupling brittle.
- Add regression coverage to ensure date fields do not auto-submit and the JS binds only to explicit opt-in controls.

### Description
- Removed the `data-activities-autosubmit` attribute from `FromDate` and `ToDate` in `Pages/Activities/Index.cshtml` so date filters only apply when the user clicks the existing Search button.
- Refactored `wwwroot/js/pages/activities-index.js` to introduce a single `submitFiltersFromFirstPage()` helper and to bind `change` handlers only to elements matching `[data-activities-autosubmit]`, avoiding any name-based assumptions about date inputs.
- Added two unit tests in `ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs`: `FilterMarkup_DoesNotAutoSubmitDateFields` and `ActivitiesScript_BindsAutoSubmitOnlyToExplicitOptInFields`, plus a `ReadRepoFile` helper and a `using System.IO;` import to support those assertions.

### Testing
- Added unit tests `FilterMarkup_DoesNotAutoSubmitDateFields` and `ActivitiesScript_BindsAutoSubmitOnlyToExplicitOptInFields` to assert the markup and script changes are present.
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter ActivityIndexPageTests` in this environment but `dotnet` is not available here, so CI should run the test suite to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9dac99048329b8555e6c83abc395)