### PR TITLE
Restore activity table sort links

### DIFF
--- a/Pages/Activities/Index.cshtml
+++ b/Pages/Activities/Index.cshtml
@@ -97,7 +97,31 @@
         <div class="pm-card pm-shadow activities-table-card">
             <div class="pm-card-body table-responsive">
                 <table class="table table-hover align-middle activities-table">
-                    <thead><tr><th>Activity</th><th>Type</th><th>Event date</th><th>Remarks</th><th>Media</th><th class="text-end">Actions</th></tr></thead>
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.Title, sortDir: Model.GetSortDirectionFor(ActivityListSort.Title))">
+                                    <span>Activity</span>
+                                    <i class="@Model.GetSortIconClass(ActivityListSort.Title)" aria-hidden="true"></i>
+                                </a>
+                            </th>
+                            <th scope="col">
+                                <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.ActivityType, sortDir: Model.GetSortDirectionFor(ActivityListSort.ActivityType))">
+                                    <span>Type</span>
+                                    <i class="@Model.GetSortIconClass(ActivityListSort.ActivityType)" aria-hidden="true"></i>
+                                </a>
+                            </th>
+                            <th scope="col">
+                                <a class="activities-sort-link" asp-page="./Index" asp-all-route-data="Model.BuildRoute(page: 1, sort: ActivityListSort.ScheduledStart, sortDir: Model.GetSortDirectionFor(ActivityListSort.ScheduledStart))">
+                                    <span>Event date</span>
+                                    <i class="@Model.GetSortIconClass(ActivityListSort.ScheduledStart)" aria-hidden="true"></i>
+                                </a>
+                            </th>
+                            <th scope="col">Remarks</th>
+                            <th scope="col">Media</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
                     <tbody>
                     @foreach (var row in vm!.Rows)
                     {


### PR DESCRIPTION
### Motivation
- Restore table sorting in the Activities table view so users can sort by Activity title, Type and Event date from the UI. 
- Reuse existing sorting helpers so the UI reflects the current sort state and toggles consistently. 
- Preserve active filters and the selected `View=table` when a sort link is used so navigation is stable.

### Description
- Replaced the static table header row in `Pages/Activities/Index.cshtml` with clickable sort links for the `Activity`, `Type`, and `Event date` columns. 
- Each header link uses `Model.BuildRoute(page: 1, sort: ActivityListSort.<X>, sortDir: Model.GetSortDirectionFor(ActivityListSort.<X>))` so active filters, `PageSize` and `View=table` are preserved. 
- The current sort state is rendered with `Model.GetSortIconClass(ActivityListSort.<X>)` and `Model.GetSortDirectionFor(ActivityListSort.<X>)` so icons and directions match the model. 
- No changes were made to `Pages/Activities/Index.cshtml.cs`; existing helper methods are reused rather than removed.

### Testing
- Attempted to run automated tests with `dotnet test` but the `dotnet` CLI is not available in the environment, so no test run was executed. 
- No automated tests in the repository were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9ebddc688329918c210d307665b7)