### PR TITLE
Simplify activities index media filtering

### DIFF
--- a/Pages/Activities/Index.cshtml
+++ b/Pages/Activities/Index.cshtml
@@ -32,7 +32,6 @@
                 <input type="hidden" name="FromDate" value="@(Model.FromDate?.ToString("yyyy-MM-dd"))" />
                 <input type="hidden" name="ToDate" value="@(Model.ToDate?.ToString("yyyy-MM-dd"))" />
                 <input type="hidden" name="ActivityTypeId" value="@(Model.ActivityTypeId?.ToString())" />
-                <input type="hidden" name="AttachmentType" value="@Model.AttachmentType" />
                 <input type="hidden" name="MediaFilter" value="@Model.MediaFilter" />
                 <input type="hidden" name="SortBy" value="@Model.SortBy" />
                 <input type="hidden" name="SortDir" value="@Model.SortDirection" />

--- a/Pages/Activities/Index.cshtml.cs
+++ b/Pages/Activities/Index.cshtml.cs
@@ -103,6 +103,7 @@ public sealed class IndexModel : PageModel
         Page = Page <= 0 ? 1 : Page;
         PageSize = NormalizePageSize(PageSize);
 
+        // SECTION: User-facing index media filter request
         var request = new ActivityListRequest(Page,
             PageSize,
             SortBy,
@@ -111,7 +112,7 @@ public sealed class IndexModel : PageModel
             ToDate,
             ActivityTypeId,
             CreatedByUserId: null,
-            AttachmentType: AttachmentType,
+            AttachmentType: ActivityAttachmentTypeFilter.Any,
             Search: Search,
             MediaFilter: MediaFilter);
 
@@ -199,7 +200,7 @@ public sealed class IndexModel : PageModel
             totalPages,
             result.Sort,
             result.SortDescending,
-            AttachmentType,
+            ActivityAttachmentTypeFilter.Any,
             FromDate,
             ToDate,
             ActivityTypeId,
@@ -260,7 +261,7 @@ public sealed class IndexModel : PageModel
             ToDate,
             ActivityTypeId,
             CreatedByUserId: null,
-            AttachmentType: AttachmentType,
+            AttachmentType: ActivityAttachmentTypeFilter.Any,
             Search: Search,
             MediaFilter: MediaFilter);
 
@@ -302,11 +303,6 @@ public sealed class IndexModel : PageModel
         if (ActivityTypeId.HasValue)
         {
             values["ActivityTypeId"] = ActivityTypeId.Value.ToString(CultureInfo.InvariantCulture);
-        }
-
-        if (AttachmentType != ActivityAttachmentTypeFilter.Any)
-        {
-            values["AttachmentType"] = AttachmentType.ToString();
         }
 
         if (!string.IsNullOrWhiteSpace(Search))

--- a/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
@@ -249,6 +249,35 @@ public sealed class ActivityIndexPageTests
     }
 
     [Fact]
+    public async Task OnGetAsync_IgnoresStaleAttachmentTypeWhenBuildingMediaFilterRequest()
+    {
+        // SECTION: Arrange a stale legacy AttachmentType query value alongside the redesigned media filter.
+        var activityService = new StubActivityService(new ActivityListResult(Array.Empty<ActivityListItem>(), 0, 1, 25, ActivityListSort.ScheduledStart, true));
+        var typeService = new StubActivityTypeService(Array.Empty<ActivityType>());
+        var exportService = new StubActivityExportService();
+        var deleteRequestService = new StubActivityDeleteRequestService();
+
+        var services = new ServiceCollection().BuildServiceProvider();
+        var user = new ApplicationUser { Id = "viewer", UserName = "viewer" };
+        using var userManager = new StubUserManager(user, services);
+
+        var page = new IndexModel(activityService, typeService, exportService, deleteRequestService, userManager)
+        {
+            AttachmentType = ActivityAttachmentTypeFilter.Photo,
+            MediaFilter = ActivityMediaFilter.WithMedia
+        };
+        ConfigurePage(page, CreatePrincipal("viewer", null));
+
+        // SECTION: Act and assert only ActivityMediaFilter scopes the index request.
+        await page.OnGetAsync(CancellationToken.None);
+
+        Assert.NotNull(activityService.LastListRequest);
+        Assert.Equal(ActivityAttachmentTypeFilter.Any, activityService.LastListRequest!.AttachmentType);
+        Assert.Equal(ActivityMediaFilter.WithMedia, activityService.LastListRequest.MediaFilter);
+        Assert.DoesNotContain("AttachmentType", page.BuildRoute(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task OnPostExportAsync_UsesFiltersAndReturnsFile()
     {
         var activityService = new StubActivityService(new ActivityListResult(Array.Empty<ActivityListItem>(), 0, 1, 25, ActivityListSort.ScheduledStart, true));
@@ -268,7 +297,8 @@ public sealed class ActivityIndexPageTests
             FromDate = new DateOnly(2024, 1, 1),
             ToDate = new DateOnly(2024, 1, 31),
             ActivityTypeId = 7,
-            AttachmentType = ActivityAttachmentTypeFilter.Photo
+            AttachmentType = ActivityAttachmentTypeFilter.Photo,
+            MediaFilter = ActivityMediaFilter.Photos
         };
         ConfigurePage(page, CreatePrincipal("viewer", null));
 
@@ -286,7 +316,8 @@ public sealed class ActivityIndexPageTests
         Assert.Equal(new DateOnly(2024, 1, 1), request.FromDate);
         Assert.Equal(new DateOnly(2024, 1, 31), request.ToDate);
         Assert.Equal(7, request.ActivityTypeId);
-        Assert.Equal(ActivityAttachmentTypeFilter.Photo, request.AttachmentType);
+        Assert.Equal(ActivityAttachmentTypeFilter.Any, request.AttachmentType);
+        Assert.Equal(ActivityMediaFilter.Photos, request.MediaFilter);
     }
 
     [Fact]
@@ -406,7 +437,13 @@ public sealed class ActivityIndexPageTests
 
         public Task<IReadOnlyList<Activity>> ListByTypeAsync(int activityTypeId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-        public Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default) => Task.FromResult(_result);
+        public ActivityListRequest? LastListRequest { get; private set; }
+
+        public Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default)
+        {
+            LastListRequest = request;
+            return Task.FromResult(_result);
+        }
 
         public Task<IReadOnlyList<ActivityAttachmentMetadata>> GetAttachmentMetadataAsync(int activityId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 

--- a/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
@@ -352,6 +352,63 @@ public class ActivityRepositoryTests
         Assert.False(item.HasPendingDelete);
     }
 
+
+    [Fact]
+    public async Task ListAsync_StillHonorsAttachmentTypeForNonIndexWorkflows()
+    {
+        // SECTION: Arrange activities that prove the legacy attachment-type filter still works when used directly.
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        var type = new ActivityType { Name = "Media", CreatedByUserId = "seed" };
+        context.ActivityTypes.Add(type);
+        await context.SaveChangesAsync();
+
+        context.Activities.AddRange(
+            new Activity
+            {
+                Title = "PDF activity",
+                CreatedByUserId = "owner",
+                ActivityTypeId = type.Id,
+                Attachments =
+                {
+                    new ActivityAttachment
+                    {
+                        StorageKey = "files/report.pdf",
+                        OriginalFileName = "report.pdf",
+                        ContentType = "application/pdf",
+                        UploadedByUserId = "owner"
+                    }
+                }
+            },
+            new Activity
+            {
+                Title = "Photo activity",
+                CreatedByUserId = "owner",
+                ActivityTypeId = type.Id,
+                Attachments =
+                {
+                    new ActivityAttachment
+                    {
+                        StorageKey = "files/photo.jpg",
+                        OriginalFileName = "photo.jpg",
+                        ContentType = "image/jpeg",
+                        UploadedByUserId = "owner"
+                    }
+                }
+            });
+        await context.SaveChangesAsync();
+
+        // SECTION: Act
+        var result = await repository.ListAsync(new ActivityListRequest(
+            PageSize: 10,
+            AttachmentType: ActivityAttachmentTypeFilter.Photo));
+
+        // SECTION: Assert
+        var item = Assert.Single(result.Items);
+        Assert.Equal("Photo activity", item.Title);
+    }
+
     [Fact]
     public async Task ListAsync_FlagsPendingDeleteRequests()
     {

--- a/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
@@ -485,6 +485,34 @@ public class ActivityServiceTests : IDisposable
         Assert.Contains("photo.jpg", attachmentsCell.FormulaA1, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    [Fact]
+    public async Task ActivityExportService_IgnoresStaleAttachmentTypeAndUsesMediaFilter()
+    {
+        // SECTION: Arrange an export that should match all media regardless of a stale attachment-type value.
+        var type = await EnsureActivityTypeAsync();
+        await SeedActivityWithAttachmentAsync(type.Id, "PDF Export Activity", "report.pdf", "application/pdf");
+        await SeedActivityWithAttachmentAsync(type.Id, "Photo Export Activity", "photo.jpg", "image/jpeg");
+
+        var exportService = new ActivityExportService(_activityRepository, _attachmentManager);
+
+        // SECTION: Act
+        var export = await exportService.ExportAsync(new ActivityExportRequest(
+            ActivityTypeId: type.Id,
+            AttachmentType: ActivityAttachmentTypeFilter.Photo,
+            MediaFilter: ActivityMediaFilter.WithMedia));
+
+        // SECTION: Assert
+        Assert.NotNull(export);
+        using var stream = new MemoryStream(export!.Content);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheet("Activities");
+
+        Assert.Equal(2, worksheet.LastRowUsed()!.RowNumber() - 1);
+        Assert.Contains("PDF Export Activity", new[] { worksheet.Cell(2, 1).GetString(), worksheet.Cell(3, 1).GetString() });
+        Assert.Contains("Photo Export Activity", new[] { worksheet.Cell(2, 1).GetString(), worksheet.Cell(3, 1).GetString() });
+    }
+
     [Fact]
     public async Task ActivityExportService_ReturnsNullWhenNoResults()
     {

--- a/Services/Activities/ActivityExportService.cs
+++ b/Services/Activities/ActivityExportService.cs
@@ -32,6 +32,7 @@ public sealed class ActivityExportService : IActivityExportService
             throw new ArgumentNullException(nameof(request));
         }
 
+        // SECTION: Export follows the Activities index media-filter behavior
         var listRequest = new ActivityListRequest(1,
             0,
             request.Sort,
@@ -40,7 +41,7 @@ public sealed class ActivityExportService : IActivityExportService
             request.ToDate,
             request.ActivityTypeId,
             request.CreatedByUserId,
-            request.AttachmentType,
+            ActivityAttachmentTypeFilter.Any,
             request.Search,
             request.MediaFilter);
 


### PR DESCRIPTION
### Motivation
- Make `ActivityMediaFilter` the single user-facing media filter for the Activities index and avoid stale legacy `AttachmentType` query params from narrowing index results.
- Keep repository-level `ActivityAttachmentTypeFilter` available for workflows that intentionally use it while removing it from index routing and UI plumbing.
- Ensure exports follow the same index-facing media filter semantics so exported spreadsheets reflect the redesigned UI behaviour.

### Description
- Force index list and export requests to use `ActivityAttachmentTypeFilter.Any` while preserving the `MediaFilter` value by changing `Pages/Activities/Index.cshtml.cs` and `Services/Activities/ActivityExportService.cs` to build requests with `AttachmentType = ActivityAttachmentTypeFilter.Any`.
- Remove the `AttachmentType` hidden input from the export form in `Pages/Activities/Index.cshtml` and stop including `AttachmentType` in `BuildRoute` so stale query params are not preserved in pagination, sorting, redirects, or export URLs.
- Keep `ActivityAttachmentTypeFilter` support in the repository (`ActivityRepository`) so non-index workflows can still use the legacy attachment-type filter.
- Add unit tests covering the redesigned behaviour and backward-compat checks: `OnGetAsync_IgnoresStaleAttachmentTypeWhenBuildingMediaFilterRequest`, `ActivityExportService_IgnoresStaleAttachmentTypeAndUsesMediaFilter`, and `ListAsync_StillHonorsAttachmentTypeForNonIndexWorkflows` to validate index/export ignore stale `AttachmentType` while repository filtering still works.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore --filter "FullyQualifiedName~Activities"` but the command failed because `dotnet` is not available in the execution environment.
- No test failures were observed locally in pre-commit checks; changes were committed after verifying diffs (`git diff --check`) and updating unit tests to assert the new behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9f63d0448329a8fe69d04e3eee5a)