### PR TITLE
Improve activity duplicate title validation

### DIFF
--- a/Contracts/Activities/IActivityRepository.cs
+++ b/Contracts/Activities/IActivityRepository.cs
@@ -11,6 +11,8 @@ namespace ProjectManagement.Contracts.Activities
 
         Task<IReadOnlyList<Activity>> ListByTypeAsync(int activityTypeId, CancellationToken cancellationToken = default);
 
+        Task<bool> ExistsByTypeAndTitleAsync(int activityTypeId, string title, int? excludingActivityId, CancellationToken cancellationToken = default);
+
         Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default);
 
         Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default);

--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -51,6 +51,31 @@ namespace ProjectManagement.Infrastructure.Activities
                 .ToListAsync(cancellationToken);
         }
 
+        public Task<bool> ExistsByTypeAndTitleAsync(int activityTypeId, string title, int? excludingActivityId, CancellationToken cancellationToken = default)
+        {
+            // SECTION: Provider-aware duplicate activity title lookup
+            var normalizedTitle = title.Trim();
+            var query = _dbContext.Activities
+                .AsNoTracking()
+                .Where(x => x.ActivityTypeId == activityTypeId && !x.IsDeleted);
+
+            if (excludingActivityId.HasValue)
+            {
+                query = query.Where(x => x.Id != excludingActivityId.Value);
+            }
+
+            var providerName = _dbContext.Database.ProviderName ?? string.Empty;
+
+            if (providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+            {
+                return query.AnyAsync(x => EF.Functions.ILike(x.Title, normalizedTitle), cancellationToken);
+            }
+
+            var normalizedComparisonTitle = normalizedTitle.ToLower();
+
+            return query.AnyAsync(x => x.Title.ToLower() == normalizedComparisonTitle, cancellationToken);
+        }
+
         public async Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default)
         {
             if (request is null)

--- a/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs
@@ -65,6 +65,78 @@ public class ActivityRepositoryTests
         Assert.Equal("files/plan.pdf", stored.Attachments.First().StorageKey);
     }
 
+
+    [Theory]
+    [InlineData("safety brief", true)]
+    [InlineData("SAFETY BRIEF", true)]
+    [InlineData("Different Brief", false)]
+    public async Task ExistsByTypeAndTitleAsync_UsesCaseInsensitiveDatabaseLookup(string title, bool expected)
+    {
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        // SECTION: Arrange activities for duplicate lookup
+        var type = new ActivityType
+        {
+            Name = "Training",
+            CreatedByUserId = "system"
+        };
+        context.ActivityTypes.Add(type);
+        await context.SaveChangesAsync();
+
+        context.Activities.Add(new Activity
+        {
+            Title = "Safety Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1"
+        });
+        await context.SaveChangesAsync();
+
+        // SECTION: Act and assert
+        var exists = await repository.ExistsByTypeAndTitleAsync(type.Id, title, null);
+
+        Assert.Equal(expected, exists);
+    }
+
+    [Fact]
+    public async Task ExistsByTypeAndTitleAsync_ExcludesRequestedActivityAndDeletedRows()
+    {
+        await using var context = CreateContext();
+        var repository = new ActivityRepository(context);
+
+        // SECTION: Arrange active, edited, and deleted activities
+        var type = new ActivityType
+        {
+            Name = "Workshops",
+            CreatedByUserId = "system"
+        };
+        context.ActivityTypes.Add(type);
+        await context.SaveChangesAsync();
+
+        var editedActivity = new Activity
+        {
+            Title = "Editable Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1"
+        };
+        var deletedActivity = new Activity
+        {
+            Title = "Deleted Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "user-1",
+            IsDeleted = true
+        };
+        context.Activities.AddRange(editedActivity, deletedActivity);
+        await context.SaveChangesAsync();
+
+        // SECTION: Act and assert
+        var selfExists = await repository.ExistsByTypeAndTitleAsync(type.Id, "editable brief", editedActivity.Id);
+        var deletedExists = await repository.ExistsByTypeAndTitleAsync(type.Id, "deleted brief", null);
+
+        Assert.False(selfExists);
+        Assert.False(deletedExists);
+    }
+
     [Fact]
     public async Task ListByTypeAsync_FiltersDeletedAndOrdersBySchedule()
     {

--- a/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
@@ -85,6 +85,95 @@ public class ActivityInputValidatorTests : IDisposable
         Assert.Contains(nameof(input.Title), ex.Errors.Keys);
     }
 
+    [Theory]
+    [InlineData("safety brief")]
+    [InlineData("SAFETY BRIEF")]
+    public async Task ValidateAsync_ThrowsWhenCreateTitleDiffersOnlyByCase(string duplicateTitle)
+    {
+        // SECTION: Arrange an existing activity for create duplicate validation
+        var type = new ActivityType
+        {
+            Name = "Create Case Check",
+            CreatedByUserId = "user",
+            IsActive = true
+        };
+        _context.ActivityTypes.Add(type);
+        await _context.SaveChangesAsync();
+
+        await _activityRepository.AddAsync(new Activity
+        {
+            Title = "Safety Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "owner"
+        });
+
+        // SECTION: Act and assert
+        var input = new ActivityInput(duplicateTitle, null, null, type.Id, null, null);
+        var ex = await Assert.ThrowsAsync<ActivityValidationException>(() => _validator.ValidateAsync(input, null, CancellationToken.None));
+        Assert.Contains(nameof(input.Title), ex.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ThrowsWhenEditTitleDiffersOnlyByCaseFromAnotherActivity()
+    {
+        // SECTION: Arrange two activities in the same type for edit duplicate validation
+        var type = new ActivityType
+        {
+            Name = "Edit Case Check",
+            CreatedByUserId = "user",
+            IsActive = true
+        };
+        _context.ActivityTypes.Add(type);
+        await _context.SaveChangesAsync();
+
+        var existingActivity = new Activity
+        {
+            Title = "Existing Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "owner"
+        };
+        var editedActivity = new Activity
+        {
+            Title = "Editable Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "owner"
+        };
+
+        await _activityRepository.AddAsync(existingActivity);
+        await _activityRepository.AddAsync(editedActivity);
+
+        // SECTION: Act and assert
+        var input = new ActivityInput("existing brief", null, null, type.Id, null, null);
+        var ex = await Assert.ThrowsAsync<ActivityValidationException>(() => _validator.ValidateAsync(input, editedActivity, CancellationToken.None));
+        Assert.Contains(nameof(input.Title), ex.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_AllowsEditWhenTitleDiffersOnlyByCaseFromSameActivity()
+    {
+        // SECTION: Arrange an existing activity being edited
+        var type = new ActivityType
+        {
+            Name = "Self Edit Case Check",
+            CreatedByUserId = "user",
+            IsActive = true
+        };
+        _context.ActivityTypes.Add(type);
+        await _context.SaveChangesAsync();
+
+        var editedActivity = new Activity
+        {
+            Title = "Editable Brief",
+            ActivityTypeId = type.Id,
+            CreatedByUserId = "owner"
+        };
+        await _activityRepository.AddAsync(editedActivity);
+
+        // SECTION: Act and assert
+        var input = new ActivityInput("editable brief", null, null, type.Id, null, null);
+        await _validator.ValidateAsync(input, editedActivity, CancellationToken.None);
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/Services/Activities/ActivityInputValidator.cs
+++ b/Services/Activities/ActivityInputValidator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ProjectManagement.Contracts.Activities;
@@ -96,11 +95,12 @@ internal sealed class ActivityInputValidator : IActivityInputValidator
             throw new ActivityValidationException(errors);
         }
 
-        var existingActivities = await _activityRepository.ListByTypeAsync(input.ActivityTypeId, cancellationToken);
-        var normalizedTitle = input.Title.Trim();
-        var duplicate = existingActivities
-            .Where(x => existing is null || x.Id != existing.Id)
-            .Any(x => string.Equals(x.Title, normalizedTitle, StringComparison.OrdinalIgnoreCase));
+        // SECTION: Duplicate activity title validation
+        var duplicate = await _activityRepository.ExistsByTypeAndTitleAsync(
+            input.ActivityTypeId,
+            input.Title.Trim(),
+            existing?.Id,
+            cancellationToken);
 
         if (duplicate)
         {


### PR DESCRIPTION
### Motivation
- Prevent loading all activities into memory for duplicate-title checks and shift duplicate detection to the database for correctness and performance.
- Ensure case-insensitive duplicate detection across providers, using `EF.Functions.ILike` when running on PostgreSQL and a safe fallback for others.

### Description
- Added `ExistsByTypeAndTitleAsync(int activityTypeId, string title, int? excludingActivityId, CancellationToken cancellationToken)` to the activity repository contract in `Contracts/Activities/IActivityRepository.cs`.
- Implemented the repository method in `Infrastructure/Activities/ActivityRepository.cs` using `AsNoTracking()`, soft-delete filtering, optional `excludingActivityId`, provider-aware case-insensitive matching with `EF.Functions.ILike` for Npgsql, and `AnyAsync` for a database-level existence check.
- Updated `Services/Activities/ActivityInputValidator.cs` to call the new repository method instead of loading all activities for a type and performing in-memory comparisons.
- Added unit tests in `ProjectManagement.Tests/Activities/ActivityServiceTests.cs` and `ProjectManagement.Tests/Activities/ActivityRepositoryTests.cs` to cover create and edit duplicate detection, case-only title differences, exclusion of the edited activity, and soft-deleted rows being ignored.

### Testing
- Ran static checks via `git diff --check` which reported no problems.
- Attempted to run the focused test filter for the modified activity tests with `dotnet test --filter "FullyQualifiedName~ActivityInputValidatorTests|FullyQualifiedName~ActivityRepositoryTests"`, but execution failed because `dotnet` is not available in the environment, so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea21f0e8c8329a6c6cc25b1eeafa2)