### PR TITLE
Fix activity review grouping, search escaping, and admin visibility

### DIFF
--- a/Infrastructure/Activities/ActivityRepository.cs
+++ b/Infrastructure/Activities/ActivityRepository.cs
@@ -231,16 +231,16 @@ namespace ProjectManagement.Infrastructure.Activities
         {
             // SECTION: Provider-aware case-insensitive activity search
             var term = search.Trim();
-            var like = $"%{term}%";
+            var like = BuildEscapedLikePattern(term);
             var providerName = _dbContext.Database.ProviderName ?? string.Empty;
 
             if (providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
             {
                 return query.Where(x =>
-                    EF.Functions.ILike(x.Title, like) ||
-                    (x.Description != null && EF.Functions.ILike(x.Description, like)) ||
-                    (x.Location != null && EF.Functions.ILike(x.Location, like)) ||
-                    EF.Functions.ILike(x.ActivityType.Name, like));
+                    EF.Functions.ILike(x.Title, like, "\\") ||
+                    (x.Description != null && EF.Functions.ILike(x.Description, like, "\\")) ||
+                    (x.Location != null && EF.Functions.ILike(x.Location, like, "\\")) ||
+                    EF.Functions.ILike(x.ActivityType.Name, like, "\\"));
             }
 
             if (providerName.Contains("InMemory", StringComparison.OrdinalIgnoreCase))
@@ -257,10 +257,16 @@ namespace ProjectManagement.Infrastructure.Activities
             var normalizedLike = like.ToLowerInvariant();
 
             return query.Where(x =>
-                EF.Functions.Like(x.Title.ToLower(), normalizedLike) ||
-                (x.Description != null && EF.Functions.Like(x.Description.ToLower(), normalizedLike)) ||
-                (x.Location != null && EF.Functions.Like(x.Location.ToLower(), normalizedLike)) ||
-                EF.Functions.Like(x.ActivityType.Name.ToLower(), normalizedLike));
+                EF.Functions.Like(x.Title.ToLower(), normalizedLike, "\\") ||
+                (x.Description != null && EF.Functions.Like(x.Description.ToLower(), normalizedLike, "\\")) ||
+                (x.Location != null && EF.Functions.Like(x.Location.ToLower(), normalizedLike, "\\")) ||
+                EF.Functions.Like(x.ActivityType.Name.ToLower(), normalizedLike, "\\"));
+        }
+
+        private static string BuildEscapedLikePattern(string term)
+        {
+            // SECTION: Escape LIKE wildcard characters so search keeps literal contains semantics
+            return $"%{term.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("%", "\\%", StringComparison.Ordinal).Replace("_", "\\_", StringComparison.Ordinal)}%";
         }
 
         private static IQueryable<Activity> ApplyMediaFilter(IQueryable<Activity> query, ActivityMediaFilter mediaFilter)

--- a/Pages/Activities/Details.cshtml
+++ b/Pages/Activities/Details.cshtml
@@ -356,8 +356,10 @@
         </div>
     </section>
 
-    <!-- SECTION: Admin details -->
-    <section class="pm-card pm-shadow mb-4" aria-labelledby="activity-admin-heading">
+    @if (Model.CanManage)
+    {
+        <!-- SECTION: Admin details -->
+        <section class="pm-card pm-shadow mb-4" aria-labelledby="activity-admin-heading">
         <div class="pm-card-header">
             <h2 class="h5 mb-0" id="activity-admin-heading">Admin details</h2>
         </div>
@@ -385,7 +387,8 @@
                 <dd class="col-sm-9">@ResolveDeleteRequestStatus()</dd>
             </dl>
         </div>
-    </section>
+        </section>
+    }
 </div>
 
 @await Html.PartialAsync("_DeleteConfirmModal")

--- a/Pages/Activities/Index.cshtml.cs
+++ b/Pages/Activities/Index.cshtml.cs
@@ -171,7 +171,12 @@ public sealed class IndexModel : PageModel
         var normalizedView = string.Equals(View, "table", StringComparison.OrdinalIgnoreCase) ? "table" : "cards";
         View = normalizedView;
         var groups = rows
-            .GroupBy(row => new { row.ScheduledStartUtc?.Year, row.ScheduledStartUtc?.Month, FallbackYear = row.CreatedAtUtc.Year, FallbackMonth = row.CreatedAtUtc.Month })
+            .GroupBy(row =>
+            {
+                // SECTION: Card month groups use the same IST boundary as displayed card dates
+                var groupDate = IstClock.ToIst(row.ScheduledStartUtc ?? row.CreatedAtUtc);
+                return new { Year = (int?)groupDate.Year, Month = (int?)groupDate.Month, FallbackYear = groupDate.Year, FallbackMonth = groupDate.Month };
+            })
             .Select(group => new
             {
                 Year = group.Key.Year ?? group.Key.FallbackYear,

--- a/ProjectManagement.Tests/Activities/ActivityDeleteRequestServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityDeleteRequestServiceTests.cs
@@ -126,6 +126,9 @@ public sealed class ActivityDeleteRequestServiceTests : IDisposable
         public Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
+        public Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ActivityReviewSummaryResult(0, 0, 0, 0, 0));
+
         public Task<IReadOnlyList<ActivityAttachmentMetadata>> GetAttachmentMetadataAsync(int activityId, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 

--- a/ProjectManagement.Tests/Activities/ActivityExportServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityExportServiceTests.cs
@@ -164,6 +164,9 @@ public sealed class ActivityExportServiceTests
         public Task<ActivityListResult> ListAsync(ActivityListRequest request, CancellationToken cancellationToken = default) =>
             Task.FromResult(_result);
 
+        public Task<bool> ExistsByTypeAndTitleAsync(int activityTypeId, string title, int? excludingActivityId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
         public Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default) =>
             Task.FromResult(new ActivityReviewSummaryResult(0, 0, 0, 0, 0));
 

--- a/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
@@ -445,6 +445,9 @@ public sealed class ActivityIndexPageTests
             return Task.FromResult(_result);
         }
 
+        public Task<ActivityReviewSummaryResult> GetReviewSummaryAsync(ActivityListRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ActivityReviewSummaryResult(_result.TotalCount, 0, 0, 0, 0));
+
         public Task<IReadOnlyList<ActivityAttachmentMetadata>> GetAttachmentMetadataAsync(int activityId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task<ActivityAttachment> AddAttachmentAsync(int activityId, ActivityAttachmentUpload upload, CancellationToken cancellationToken = default) => throw new NotImplementedException();


### PR DESCRIPTION
### Motivation
- Activity cards were sometimes grouped under the wrong month at IST boundaries because grouping used UTC values rather than the displayed IST dates. 
- Search input containing SQL LIKE wildcards could change semantics across providers, causing unexpected matches. 
- Admin-only information (delete-request status) was visible to all users and needed to be restricted to managers, and test stubs needed updates to match new service/repository API members. 

### Description
- Group keys for activity card month grouping were changed to use `IstClock.ToIst(...)` so grouping keys align with displayed IST dates (file: `Pages/Activities/Index.cshtml.cs`).
- Search handling in `ApplySearchFilter` now escapes `%`, `_`, and `\` and uses a new helper `BuildEscapedLikePattern` so provider-specific `LIKE`/`ILIKE` queries preserve literal contains semantics, and `EF.Functions.Like`/`EF.Functions.ILike` calls now include the escape character parameter (file: `Infrastructure/Activities/ActivityRepository.cs`).
- The admin details block on the activity details page is now rendered only when `Model.CanManage` is true to restrict delete-request visibility to managers (file: `Pages/Activities/Details.cshtml`).
- Test stubs were updated to implement newly-required contract members such as `GetReviewSummaryAsync` and `ExistsByTypeAndTitleAsync` so unit tests will compile when run (files: `ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs`, `ActivityDeleteRequestServiceTests.cs`, `ActivityExportServiceTests.cs`).

### Testing
- Ran repository checks with `git diff --check` which reported no whitespace/merge errors. 
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore` but it was not executed in this environment because the `dotnet` SDK is not available, so full unit tests were not run here. 
- Updated test stubs to ensure tests in CI/local environments can execute the added interface members without compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eab7e54dc8329b116d43533528650)