### PR TITLE
Improve Visits to SDD lifecycle and upload limits

### DIFF
--- a/Areas/ProjectOfficeReports/Application/VisitPhotoOptions.cs
+++ b/Areas/ProjectOfficeReports/Application/VisitPhotoOptions.cs
@@ -6,9 +6,19 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Application;
 public sealed class VisitPhotoOptions
 {
     // SECTION: Upload limits
-    public long MaxFileSizeBytes { get; set; } = 10 * 1024 * 1024;
+    public long MaxFileSizeBytes { get; set; } = 20 * 1024 * 1024;
 
     public int MaxFilesPerUpload { get; set; } = 20;
+
+    public long MaxBatchSizeBytes { get; set; } = 100 * 1024 * 1024;
+
+    public int MaxPhotosPerVisit { get; set; } = 50;
+
+    public int MaxWidthPixels { get; set; } = 10000;
+
+    public int MaxHeightPixels { get; set; } = 10000;
+
+    public int MaxMegapixels { get; set; } = 60;
 
     // SECTION: Validation thresholds
     public int MinWidth { get; set; } = 720;

--- a/Areas/ProjectOfficeReports/Application/VisitPhotoService.cs
+++ b/Areas/ProjectOfficeReports/Application/VisitPhotoService.cs
@@ -99,6 +99,11 @@ public sealed class VisitPhotoService : IVisitPhotoService
         _db.Entry(visit).Property(x => x.RowVersion).OriginalValue = visit.RowVersion;
 
         // SECTION: Stream pre-validation
+        if (visit.Photos.Count >= _options.MaxPhotosPerVisit)
+        {
+            return VisitPhotoUploadResult.Invalid($"A visit can have a maximum of {_options.MaxPhotosPerVisit} photos.");
+        }
+
         if (content.CanSeek)
         {
             if (content.Length == 0)
@@ -153,6 +158,16 @@ public sealed class VisitPhotoService : IVisitPhotoService
         buffer.Position = 0;
         using var sourceImage = await Image.LoadAsync<Rgba32>(buffer, cancellationToken);
         sourceImage.Mutate(x => x.AutoOrient());
+
+        // SECTION: Pixel dimension safety
+        var megapixels = (long)sourceImage.Width * sourceImage.Height;
+        if (sourceImage.Width > _options.MaxWidthPixels ||
+            sourceImage.Height > _options.MaxHeightPixels ||
+            megapixels > (long)_options.MaxMegapixels * 1_000_000)
+        {
+            return VisitPhotoUploadResult.Invalid(
+                $"Image dimensions are too large. Please upload an image up to {_options.MaxWidthPixels} × {_options.MaxHeightPixels} pixels and {_options.MaxMegapixels} megapixels.");
+        }
 
         // NOTE: we no longer reject small images.
         // If you still want to know it was small, we log it.

--- a/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.AllModel
 @{
-    ViewData["Title"] = "All visits";
+    ViewData["Title"] = "All visits to SDD";
 
     string? fromValue = Model.From;
     if (!string.IsNullOrWhiteSpace(fromValue) && DateOnly.TryParse(fromValue, out var parsedFrom))
@@ -22,12 +22,12 @@
             <nav aria-label="Breadcrumb" class="visit-breadcrumb mb-1">
                 <ol class="breadcrumb mb-0">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">All visits</li>
+                    <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">All visits to SDD</li>
                 </ol>
             </nav>
-            <h2 class="h3 mb-0">All visits</h2>
-            <p class="text-muted small mb-0 mt-1">Full historical view with filtering and export.</p>
+            <h2 class="h3 mb-0">All visits to SDD</h2>
+            <p class="text-muted small mb-0 mt-1">Full historical view of inbound visits to SDD with filtering and export.</p>
         </div>
         <div class="d-flex gap-2">
             <form method="post" asp-page-handler="Export">

--- a/Areas/ProjectOfficeReports/Pages/Visits/Details.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Details.cshtml
@@ -1,7 +1,7 @@
 @page "{id:guid}"
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.DetailsModel
 @{
-    ViewData["Title"] = "Visit Details";
+    ViewData["Title"] = "Visit to SDD details";
     var toastMessages = new List<VisitToastMessage>();
     if (TempData.TryGetValue("ToastMessage", out var toastMessageValue) && toastMessageValue is string toastMessage && !string.IsNullOrWhiteSpace(toastMessage))
     {
@@ -28,8 +28,8 @@
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Visit details</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Details</li>
             </ol>
         </nav>
         <div class="visit-access-card">
@@ -47,14 +47,14 @@ else
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Visit details</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Details</li>
             </ol>
         </nav>
 
         <section class="visit-hero visit-hero--details">
             <div class="visit-hero__content">
-                <span class="visit-hero__eyebrow">Visit summary</span>
+                <span class="visit-hero__eyebrow">Visit to SDD summary</span>
                 <h1 class="visit-hero__title">@visit?.VisitorName&rsquo;s visit</h1>
                 <p class="visit-hero__subtitle">Recorded on @visit?.DateOfVisit.ToString("dddd, dd MMMM yyyy")</p>
                 <div class="visit-hero__meta">
@@ -65,7 +65,7 @@ else
                 <div class="visit-hero__actions visit-hero__actions--wrap">
                     <a asp-page="Index" class="btn btn-outline-light d-inline-flex align-items-center gap-2">
                         <i class="bi bi-arrow-left" aria-hidden="true"></i>
-                        <span>Back to visits</span>
+                        <span>Back to Visits to SDD</span>
                     </a>
                     @if (Model.CanManage)
                     {
@@ -73,11 +73,11 @@ else
                             <i class="bi bi-pencil-square" aria-hidden="true"></i>
                             <span>Edit</span>
                         </a>
-                        <form method="post" asp-page-handler="Delete" class="visit-hero__delete" data-visits-disable-on-submit data-confirm="Delete this visit?">
+                        <form method="post" asp-page-handler="Delete" class="visit-hero__delete" data-visits-disable-on-submit data-confirm="Delete this visit to SDD? This action will remove the visit record and its uploaded photo evidence. This cannot be undone.">
                             <input type="hidden" name="rowVersion" value="@Model.RowVersion" />
                             <button type="submit" class="btn btn-outline-danger d-inline-flex align-items-center gap-2" data-visits-busy-label="Deleting…">
                                 <i class="bi bi-trash" aria-hidden="true"></i>
-                                <span>Delete</span>
+                                <span>Delete visit</span>
                             </button>
                         </form>
                     }
@@ -185,7 +185,7 @@ else
                 <div class="visit-form-card visit-form-card--gallery">
                     <div class="visit-form-card__header">
                         <h2 class="visit-form-card__title">Photo gallery</h2>
-                        <p class="visit-form-card__subtitle">Photos taken during the visit.</p>
+                        <p class="visit-form-card__subtitle">Uploaded photo evidence for this visit to SDD.</p>
                     </div>
                     <div class="visit-form-card__body">
                         <partial name="_PhotosPartial" model="Model.PhotoGallery" />

--- a/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml
@@ -1,7 +1,7 @@
 @page "{id:guid}"
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.EditModel
 @{
-    ViewData["Title"] = "Edit Visit";
+    ViewData["Title"] = "Edit visit to SDD";
     var toastMessages = new List<VisitToastMessage>();
     if (TempData.TryGetValue("ToastMessage", out var toastMessageValue) && toastMessageValue is string toastMessage && !string.IsNullOrWhiteSpace(toastMessage))
     {
@@ -26,8 +26,8 @@
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Edit visit</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Edit visit to SDD</li>
             </ol>
         </nav>
         <div class="visit-access-card">
@@ -45,8 +45,8 @@ else if (Model.PhotoGallery is null)
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Edit visit</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Edit visit to SDD</li>
             </ol>
         </nav>
         <div class="visit-access-card">
@@ -64,16 +64,16 @@ else
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Edit visit</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Edit visit to SDD</li>
             </ol>
         </nav>
 
         <section class="visit-hero visit-hero--form">
             <div class="visit-hero__content">
                 <span class="visit-hero__eyebrow">Update oversight</span>
-                <h1 class="visit-hero__title">Edit visit record</h1>
-                <p class="visit-hero__subtitle">Refine the narrative, adjust team details, and enrich the media collection for this visit.</p>
+                <h1 class="visit-hero__title">Edit visit to SDD</h1>
+                <p class="visit-hero__subtitle">Safely correct inbound visit details and manage photo evidence for this visit to SDD.</p>
                 <div class="visit-hero__meta">
                     @if (!string.IsNullOrWhiteSpace(visitDateDisplay))
                     {
@@ -95,8 +95,8 @@ else
             <div class="visit-form-layout__primary">
                 <div class="visit-form-card">
                     <div class="visit-form-card__header">
-                        <h2 class="visit-form-card__title">Core information</h2>
-                        <p class="visit-form-card__subtitle">Keep the foundational visit details accurate to maintain reporting fidelity.</p>
+                        <h2 class="visit-form-card__title">Visit details</h2>
+                        <p class="visit-form-card__subtitle">Keep the date, type, visitor, strength, and remarks accurate for reporting fidelity.</p>
                     </div>
                     <form method="post" novalidate class="visit-form" data-visits-disable-on-submit>
                         <input type="hidden" asp-for="RowVersion" />
@@ -169,7 +169,7 @@ else
                 <div class="visit-form-card">
                     <div class="visit-form-card__header">
                         <h2 class="visit-form-card__title">Upload additional photos</h2>
-                        <p class="visit-form-card__subtitle">Drop in multiple images at once. Captions will apply to the entire batch.</p>
+                        <p class="visit-form-card__subtitle">You may upload additional photos. Existing photos will not be removed.</p>
                     </div>
                     <form method="post"
                           enctype="multipart/form-data"
@@ -183,7 +183,7 @@ else
                         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
                         <div class="visit-form-grid visit-form-grid--single">
                             <div class="visit-form-grid__field">
-                                <label class="form-label" for="visit-edit-photo">Photos</label>
+                                <label class="form-label" for="visit-edit-photo">Photo evidence</label>
                                 <input id="visit-edit-photo"
                                        class="form-control"
                                        type="file"
@@ -213,8 +213,8 @@ else
             <div class="visit-media__gallery">
                 <div class="visit-form-card visit-form-card--gallery">
                     <div class="visit-form-card__header">
-                        <h2 class="visit-form-card__title">Photo gallery</h2>
-                        <p class="visit-form-card__subtitle">Manage the visual narrative linked to this visit.</p>
+                        <h2 class="visit-form-card__title">Existing photo evidence</h2>
+                        <p class="visit-form-card__subtitle">@totalPhotos photo@(totalPhotos == 1 ? string.Empty : "s") uploaded. @(Model.CoverPhotoId.HasValue ? "Cover photo is set." : "No cover photo selected.")</p>
                     </div>
                     <div class="visit-form-card__body">
                         <partial name="_PhotosPartial" model="Model.PhotoGallery" />

--- a/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Edit.cshtml.cs
@@ -46,10 +46,14 @@ public class EditModel : PageModel
 
     public int VisitPhotoMaxFiles => _photoOptions.MaxFilesPerUpload;
 
+    public long VisitPhotoMaxBatchBytes => _photoOptions.MaxBatchSizeBytes;
+
+    public int VisitPhotoMaxBatchMb => Math.Max(1, (int)Math.Floor(VisitPhotoMaxBatchBytes / 1024d / 1024d));
+
     public int VisitPhotoMaxMb => Math.Max(1, (int)Math.Floor(VisitPhotoMaxBytes / 1024d / 1024d));
 
     public string VisitPhotoHelpText =>
-        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each. You can select up to {VisitPhotoMaxFiles} files.";
+        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each and {VisitPhotoMaxBatchMb} MB total. You may upload additional photos; existing photos will not be removed.";
 
     [BindProperty]
     public InputModel Input { get; set; } = new();
@@ -176,6 +180,13 @@ public class EditModel : PageModel
         if (uploads.Count > VisitPhotoMaxFiles)
         {
             ModelState.AddModelError(nameof(Uploads), $"You can upload up to {VisitPhotoMaxFiles} photos at a time.");
+            await LoadAsync(visitId, cancellationToken);
+            return Page();
+        }
+
+        if (uploads.Sum(file => file.Length) > VisitPhotoMaxBatchBytes)
+        {
+            ModelState.AddModelError(nameof(Uploads), $"Total upload size cannot exceed {VisitPhotoMaxBatchMb} MB.");
             await LoadAsync(visitId, cancellationToken);
             return Page();
         }
@@ -445,21 +456,25 @@ public class EditModel : PageModel
     public class InputModel
     {
         [Required]
+        [Display(Name = "Visit type")]
         public Guid? VisitTypeId { get; set; }
 
         [Required]
         [DataType(DataType.Date)]
+        [Display(Name = "Date of visit")]
         public DateOnly? DateOfVisit { get; set; }
 
         [Required]
         [StringLength(200)]
-        [Display(Name = "Visitor name")]
+        [Display(Name = "Visitor / course / delegation")]
         public string VisitorName { get; set; } = string.Empty;
 
+        [Display(Name = "Strength")]
         [Range(1, int.MaxValue, ErrorMessage = "Strength must be greater than zero.")]
         public int Strength { get; set; }
 
         [StringLength(2000)]
+        [Display(Name = "Remarks / key observations")]
         public string? Remarks { get; set; }
     }
 

--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -2,7 +2,7 @@
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.IndexModel
 @using System.Linq
 @{
-    ViewData["Title"] = "Visits";
+    ViewData["Title"] = "Visits to SDD";
 
     // normalize incoming dates for inputs
     string? fromValue = Model.From;
@@ -98,14 +98,14 @@
             <nav aria-label="Breadcrumb" class="visit-breadcrumb mb-1">
                 <ol class="breadcrumb mb-0">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">Visit tracker</li>
+                    <li class="breadcrumb-item active" aria-current="page">Visits to SDD</li>
                 </ol>
             </nav>
             <div class="d-flex align-items-center gap-3">
                 <h2 class="h2 mb-1">Visits to SDD</h2>
             </div>
             <p class="text-muted small mb-0 mt-2">
-                Track SDD visits by civilian/military dignitaries and officer courses, with dates, strength and photos.
+                Track inbound visits to SDD by dignitaries, courses and delegations, with strength, remarks and photos.
             </p>
         </div>
         <div class="d-flex flex-wrap gap-2">
@@ -131,7 +131,7 @@
             {
                 <a asp-page="New" class="btn btn-primary d-inline-flex align-items-center gap-1">
                     <i class="bi bi-plus-circle"></i>
-                    <span>Record a visit</span>
+                    <span>Record visit</span>
                 </a>
             }
         </div>
@@ -332,15 +332,6 @@
                                             @if (Model.CanManage)
                                             {
                                                 <a asp-page="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary btn-sm">Edit</a>
-                                                <form method="post" asp-page-handler="Delete" class="d-inline" data-visits-disable-on-submit data-confirm="Delete this visit?">
-                                                    <input type="hidden" name="id" value="@item.Id" />
-                                                    <input type="hidden" name="rowVersion" value="@Convert.ToBase64String(item.RowVersion)" />
-                                                    <input type="hidden" name="VisitTypeId" value="@(Model.VisitTypeId.HasValue? Model.VisitTypeId.ToString() : string.Empty)" />
-                                                    <input type="hidden" name="From" value="@Model.From" />
-                                                    <input type="hidden" name="To" value="@Model.To" />
-                                                    <input type="hidden" name="Q" value="@Model.Q" />
-                                                    <button type="submit" class="btn btn-outline-danger btn-sm" data-visits-busy-label="Deleting…">Delete</button>
-                                                </form>
                                             }
                                         </div>
                                     </td>

--- a/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml
@@ -1,7 +1,7 @@
 @page
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.NewModel
 @{
-    ViewData["Title"] = "New Visit";
+    ViewData["Title"] = "Record visit to SDD";
     var toastMessages = new List<VisitToastMessage>();
     if (TempData.TryGetValue("ToastMessage", out var toastMessageValue) && toastMessageValue is string toastMessage && !string.IsNullOrWhiteSpace(toastMessage))
     {
@@ -22,8 +22,8 @@
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">New visit</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Record visit to SDD</li>
             </ol>
         </nav>
         <div class="visit-access-card">
@@ -41,18 +41,18 @@ else
         <nav aria-label="Breadcrumb" class="visit-breadcrumb">
             <ol class="breadcrumb mb-0">
                 <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                <li class="breadcrumb-item"><a asp-page="Index">Visit tracker</a></li>
-                <li class="breadcrumb-item active" aria-current="page">New visit</li>
+                <li class="breadcrumb-item"><a asp-page="Index">Visits to SDD</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Record visit to SDD</li>
             </ol>
         </nav>
 
         <section class="visit-hero visit-hero--form">
             <div class="visit-hero__content">
-                <h1 class="visit-hero__title">Log a site visit</h1>
+                <h1 class="visit-hero__title">Record visit to SDD</h1>
                 <div class="visit-hero__actions">
                     <a asp-page="Index" class="btn btn-outline-light d-inline-flex align-items-center gap-2">
                         <i class="bi bi-arrow-left" aria-hidden="true"></i>
-                        <span>Back to visits</span>
+                        <span>Back to Visits to SDD</span>
                     </a>
                 </div>
             </div>
@@ -64,19 +64,19 @@ else
                     <div class="visit-form-card">
                         <div class="visit-form-card__header">
                             <h2 class="visit-form-card__title">Visit overview</h2>
-                            <p class="visit-form-card__subtitle">Outline the what, when, and who of your visit. These details power downstream analytics.</p>
+                            <p class="visit-form-card__subtitle">Capture who visited SDD, when they visited, the visit type, strength, and reporting remarks.</p>
                         </div>
                         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
                         <div class="visit-form-grid">
                             <div class="visit-form-grid__field">
-                                <label asp-for="Input.VisitTypeId" class="form-label"></label>
-                                <select asp-for="Input.VisitTypeId" asp-items="Model.VisitTypeOptions" class="form-select"></select>
-                                <span asp-validation-for="Input.VisitTypeId" class="text-danger"></span>
-                            </div>
-                            <div class="visit-form-grid__field">
                                 <label asp-for="Input.DateOfVisit" class="form-label"></label>
                                 <input asp-for="Input.DateOfVisit" class="form-control" type="date" />
                                 <span asp-validation-for="Input.DateOfVisit" class="text-danger"></span>
+                            </div>
+                            <div class="visit-form-grid__field">
+                                <label asp-for="Input.VisitTypeId" class="form-label"></label>
+                                <select asp-for="Input.VisitTypeId" asp-items="Model.VisitTypeOptions" class="form-select"></select>
+                                <span asp-validation-for="Input.VisitTypeId" class="text-danger"></span>
                             </div>
                             <div class="visit-form-grid__field">
                                 <label asp-for="Input.VisitorName" class="form-label"></label>
@@ -108,11 +108,11 @@ else
                     <div class="visit-form-card">
                         <div class="visit-form-card__header">
                             <h2 class="visit-form-card__title">Photo evidence</h2>
-                            <p class="visit-form-card__subtitle">Photos are optional at creation time. You can add or manage photos later from the edit screen.</p>
+                            <p class="visit-form-card__subtitle">Photos are optional at creation time and will be uploaded after the visit is saved.</p>
                         </div>
                         <div class="visit-form-grid visit-form-grid--single">
                             <div class="visit-form-grid__field">
-                                <label class="form-label" for="visit-photo">Photos</label>
+                                <label class="form-label" for="visit-photo">Photo evidence</label>
                                 <input id="visit-photo"
                                        class="form-control"
                                        type="file"
@@ -131,14 +131,15 @@ else
                                 <label asp-for="UploadCaption" class="form-label">Caption for uploaded photos</label>
                                 <input asp-for="UploadCaption" class="form-control" placeholder="What does this photo set show?" />
                                 <span asp-validation-for="UploadCaption" class="text-danger"></span>
-                                <div class="form-text">Applied to every photo in this batch. You can refine captions individually later.</div>
+                                <div class="form-text">Applied to every photo in this batch. You can manage captions and cover photo from the edit screen.</div>
                             </div>
                         </div>
                     </div>
 
                     <div class="visit-form__footer">
                         <a asp-page="Index" class="btn btn-outline-secondary">Cancel</a>
-                        <button type="submit" class="btn btn-primary" data-visits-busy-label="Saving…">Create visit</button>
+                        <button type="submit" name="SaveMode" value="save" class="btn btn-primary" data-visits-busy-label="Saving…">Record visit</button>
+                        <button type="submit" name="SaveMode" value="save-add-another" class="btn btn-outline-primary" data-visits-busy-label="Saving…">Record and add another</button>
                     </div>
                 </form>
             </div>
@@ -154,7 +155,7 @@ else
                 </div>
                 <div class="visit-intel-card">
                     <h2 class="visit-intel-card__title">Photo gallery preview</h2>
-                    <p class="visit-intel-card__subtitle">Your uploaded photos will appear here once the visit is saved.</p>
+                    <p class="visit-intel-card__subtitle">Selected photos will be uploaded after the visit is saved. You can manage captions and cover photo from the edit screen.</p>
                     <div class="visit-intel-card__preview">
                         <partial name="_PhotosPartial" model="Model.EmptyPhotoGallery" />
                     </div>

--- a/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Visits/New.cshtml.cs
@@ -46,10 +46,14 @@ public class NewModel : PageModel
 
     public int VisitPhotoMaxFiles => _photoOptions.MaxFilesPerUpload;
 
+    public long VisitPhotoMaxBatchBytes => _photoOptions.MaxBatchSizeBytes;
+
+    public int VisitPhotoMaxBatchMb => Math.Max(1, (int)Math.Floor(VisitPhotoMaxBatchBytes / 1024d / 1024d));
+
     public int VisitPhotoMaxMb => Math.Max(1, (int)Math.Floor(VisitPhotoMaxBytes / 1024d / 1024d));
 
     public string VisitPhotoHelpText =>
-        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each. You can select up to {VisitPhotoMaxFiles} files, or leave this empty and add photos later.";
+        $"JPEG, PNG or WebP up to {VisitPhotoMaxMb} MB each and {VisitPhotoMaxBatchMb} MB total. Selected photos will be uploaded after the visit is saved.";
 
     [BindProperty]
     public InputModel Input { get; set; } = new();
@@ -60,6 +64,9 @@ public class NewModel : PageModel
 
     [BindProperty]
     public List<IFormFile>? Uploads { get; set; }
+
+    [BindProperty]
+    public string? SaveMode { get; set; }
 
     public IReadOnlyList<SelectListItem> VisitTypeOptions { get; private set; } = Array.Empty<SelectListItem>();
 
@@ -93,6 +100,11 @@ public class NewModel : PageModel
         if (uploads.Count > VisitPhotoMaxFiles)
         {
             ModelState.AddModelError(nameof(Uploads), $"You can upload up to {VisitPhotoMaxFiles} photos at a time.");
+        }
+
+        if (uploads.Sum(file => file.Length) > VisitPhotoMaxBatchBytes)
+        {
+            ModelState.AddModelError(nameof(Uploads), $"Total upload size cannot exceed {VisitPhotoMaxBatchMb} MB.");
         }
 
         if (uploads.Any(file => file.Length == 0))
@@ -175,6 +187,12 @@ public class NewModel : PageModel
             }
 
             TempData["ToastMessage"] = toastMessage;
+            if (string.Equals(SaveMode, "save-add-another", StringComparison.OrdinalIgnoreCase))
+            {
+                TempData["ToastMessage"] = $"{toastMessage} Add another visit to SDD.";
+                return RedirectToPage("New");
+            }
+
             return RedirectToPage("Index");
         }
 
@@ -224,21 +242,25 @@ public class NewModel : PageModel
     public class InputModel
     {
         [Required]
+        [Display(Name = "Visit type")]
         public Guid? VisitTypeId { get; set; }
 
         [Required]
         [DataType(DataType.Date)]
+        [Display(Name = "Date of visit")]
         public DateOnly? DateOfVisit { get; set; }
 
         [Required]
         [StringLength(200)]
-        [Display(Name = "Visitor name")]
+        [Display(Name = "Visitor / course / delegation")]
         public string VisitorName { get; set; } = string.Empty;
 
+        [Display(Name = "Strength")]
         [Range(1, int.MaxValue, ErrorMessage = "Strength must be greater than zero.")]
         public int Strength { get; set; } = 1;
 
         [StringLength(2000)]
+        [Display(Name = "Remarks / key observations")]
         public string? Remarks { get; set; }
     }
 }

--- a/appsettings.Production.json
+++ b/appsettings.Production.json
@@ -89,8 +89,10 @@
   },
   "ProjectOfficeReports": {
     "VisitPhotos": {
-      "MaxFileSizeBytes": 10485760,
+      "MaxFileSizeBytes": 20971520,
       "MaxFilesPerUpload": 20,
+      "MaxBatchSizeBytes": 104857600,
+      "MaxPhotosPerVisit": 50,
       "MinWidth": 720,
       "MinHeight": 540,
       "AllowedContentTypes": [

--- a/appsettings.json
+++ b/appsettings.json
@@ -113,8 +113,10 @@
   },
   "ProjectOfficeReports": {
     "VisitPhotos": {
-      "MaxFileSizeBytes": 10485760,
+      "MaxFileSizeBytes": 20971520,
       "MaxFilesPerUpload": 20,
+      "MaxBatchSizeBytes": 104857600,
+      "MaxPhotosPerVisit": 50,
       "MinWidth": 720,
       "MinHeight": 540,
       "AllowedContentTypes": [


### PR DESCRIPTION
### Motivation

- Ensure the module consistently identifies as "Visits to SDD" and reduce accidental destructive actions. 
- Allow larger, safer photo uploads for visit evidence by increasing per-image limit and introducing batch/quantity guards. 
- Make New/Edit workflows clearer and more efficient (help text, field labels, and a "Record and add another" flow). 
- Add basic pixel-dimension safety guards to avoid extreme memory usage from very large images.

### Description

- Rename user-facing headings, breadcrumbs and buttons to the "Visits to SDD" identity across Index, All, New, Edit and Details pages and de-emphasise delete on list rows while strengthening Details delete confirmation and label text. 
- Increase per-image limit from 10 MB to 20 MB by updating `VisitPhotoOptions.MaxFileSizeBytes` and the appsettings files. 
- Add `MaxBatchSizeBytes`, `MaxPhotosPerVisit`, `MaxWidthPixels`, `MaxHeightPixels`, and `MaxMegapixels` to `VisitPhotoOptions` and wire them into validation. 
- Enforce new guards in `VisitPhotoService.UploadAsync` including max photos-per-visit check and pixel-dimension rejection, and generate derivatives as before. 
- Add batch-size validation and improved helper text in `NewModel` and `EditModel`, add a `SaveMode` property to `NewModel` and UI buttons for "Record visit" and "Record and add another", and improve input labels (`Date of visit`, `Visitor / course / delegation`, `Remarks / key observations`, `Strength`). 
- Update `appsettings.json` and `appsettings.Production.json` to reflect new defaults for visit photo handling.

### Testing

- Validated JSON after appsettings edits using `python3 -m json.tool` to ensure appsettings remain valid. 
- Verified that string updates and UI text changes were found/removed with repository search (`rg`) to reduce remaining hard-coded references. 
- Ran `git diff --check` to confirm no obvious whitespace/conflict markers remained. 
- Attempted to run the automated test suite with `dotnet test --no-restore` but the `dotnet` CLI is not available in this environment so unit/integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f40bf6d148329ac505e5a47e790bc)