### PR TITLE
Fix visits submit button locking

### DIFF
--- a/wwwroot/js/pages/project-office-reports/visits.js
+++ b/wwwroot/js/pages/project-office-reports/visits.js
@@ -110,10 +110,44 @@ function updateButtonToBusyState(button) {
 }
 
 /**
- * prevent locking the form when client-side validation fails
+ * Submit locking helpers
+ */
+function resolveSubmitter(form, event) {
+    if (event.submitter instanceof HTMLElement) {
+        return event.submitter;
+    }
+
+    if (document.activeElement instanceof HTMLElement && form.contains(document.activeElement)) {
+        const activeElement = document.activeElement;
+        if (activeElement.matches('button[type="submit"], input[type="submit"], input[type="image"]')) {
+            return activeElement;
+        }
+    }
+
+    return form.querySelector('[type="submit"]');
+}
+
+function preserveSubmitterValue(form, submitter) {
+    const name = submitter.getAttribute('name');
+    if (!name) {
+        return;
+    }
+
+    const hidden = document.createElement('input');
+    hidden.type = 'hidden';
+    hidden.name = name;
+    hidden.value = submitter.getAttribute('value') || '';
+    hidden.dataset.visitsSubmitterValue = 'true';
+    form.appendChild(hidden);
+}
+
+/**
+ * Prevent locking the form when client-side validation fails.
  */
 function disableFormOnSubmit(form) {
     form.addEventListener('submit', event => {
+        const submitter = resolveSubmitter(form, event);
+
         setTimeout(() => {
             if (event.defaultPrevented) {
                 return;
@@ -124,11 +158,11 @@ function disableFormOnSubmit(form) {
                 return;
             }
 
-            const submitter = form.querySelector('[type="submit"]');
             if (!submitter || submitter.disabled) {
                 return;
             }
 
+            preserveSubmitterValue(form, submitter);
             submitter.disabled = true;
             updateButtonToBusyState(submitter);
         }, 0);


### PR DESCRIPTION
### Motivation
- Visits forms were disabling the first submit button on submit which caused incorrect behaviour for multi-button forms (for example `Record and add another`) and could drop the intended `name`/`value` of the clicked submit button. 
- The change aims to reliably identify the actual submitter and preserve its posted value before disabling it so form handlers receive the correct save mode.

### Description
- Add `resolveSubmitter(form, event)` to determine the actual submit button using `event.submitter`, focused submit controls, and a fallback selector. 
- Add `preserveSubmitterValue(form, submitter)` which inserts a hidden input carrying the submitter `name`/`value` before the submitter is disabled. 
- Update `disableFormOnSubmit` to use the new helpers so only the resolved clicked submitter is disabled and its value preserved, then call `updateButtonToBusyState`. 
- Keep behaviour unchanged for client-side validation by returning early when `event.defaultPrevented` or `.input-validation-error` are present.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --filter Visits` but it failed because the `dotnet` SDK is not installed in the container, so automated tests could not be executed. 
- No other automated test runs were possible in this environment; changes were verified with local file diffs and manual inspection of the modified `wwwroot/js/pages/project-office-reports/visits.js` file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb515aeac8329b4502147b2c25c35)