### PR TITLE
Allow Office attachments when browser reports unknown MIME and update validator/tests

### DIFF
--- a/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityServiceTests.cs
@@ -242,13 +242,26 @@ public class ActivityAttachmentValidatorTests
     [Theory]
     [InlineData("notes.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
     [InlineData("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")]
-    public void Validate_RejectsRemovedOfficeDocumentTypes(string fileName, string contentType)
+    [InlineData("slides.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")]
+    public void Validate_AllowsOfficeDocumentTypes(string fileName, string contentType)
     {
         var upload = new ActivityAttachmentUpload(new MemoryStream(new byte[] { 1 }), fileName, contentType, 1);
 
-        var ex = Assert.Throws<ActivityValidationException>(() => _validator.Validate(upload));
+        _validator.Validate(upload);
+    }
 
-        Assert.Contains(nameof(upload.ContentType), ex.Errors.Keys);
+    [Theory]
+    [InlineData("notes.docx", "application/octet-stream")]
+    [InlineData("sheet.xlsx", "application/octet-stream")]
+    [InlineData("slides.pptx", "application/octet-stream")]
+    [InlineData("legacy.doc", "")]
+    [InlineData("legacy.xls", "")]
+    [InlineData("legacy.ppt", "")]
+    public void Validate_AllowsOfficeDocumentsWhenBrowserReportsUnknownContentType(string fileName, string contentType)
+    {
+        var upload = new ActivityAttachmentUpload(new MemoryStream(new byte[] { 1 }), fileName, contentType, 1);
+
+        _validator.Validate(upload);
     }
 
     [Fact]

--- a/Services/Activities/ActivityAttachmentValidator.cs
+++ b/Services/Activities/ActivityAttachmentValidator.cs
@@ -33,6 +33,23 @@ internal sealed class ActivityAttachmentValidator : IActivityAttachmentValidator
 
     private static readonly HashSet<string> AllowedContentTypes = new(AllowedContentTypeList, StringComparer.OrdinalIgnoreCase);
 
+    // SECTION: Browser fallback MIME handling
+    private static readonly HashSet<string> UnknownContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        string.Empty,
+        "application/octet-stream"
+    };
+
+    private static readonly string[] OfficeDocumentExtensions =
+    {
+        ".doc",
+        ".docx",
+        ".xls",
+        ".xlsx",
+        ".ppt",
+        ".pptx"
+    };
+
     private static readonly IReadOnlyDictionary<string, string[]> AllowedExtensionsByContentType =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
@@ -89,18 +106,24 @@ internal sealed class ActivityAttachmentValidator : IActivityAttachmentValidator
             AddError(nameof(upload.FileName), "File name must be 260 characters or fewer.");
         }
 
-        if (string.IsNullOrWhiteSpace(upload.ContentType) || !AllowedContentTypes.Contains(upload.ContentType))
+        // SECTION: File type validation
+        var extension = string.IsNullOrWhiteSpace(upload.FileName)
+            ? string.Empty
+            : Path.GetExtension(upload.FileName);
+        var contentType = NormalizeContentType(upload.ContentType);
+        var hasAllowedContentType = AllowedContentTypes.Contains(contentType);
+        var hasAllowedUnknownOfficeExtension = IsUnknownContentType(contentType) && IsOfficeDocumentExtension(extension);
+
+        if (!hasAllowedContentType && !hasAllowedUnknownOfficeExtension)
         {
             AddError(nameof(upload.ContentType),
                 $"File type is not allowed. Allowed types: {string.Join(", ", AllowedContentTypeList)}.");
         }
 
         if (!string.IsNullOrWhiteSpace(upload.FileName) &&
-            !string.IsNullOrWhiteSpace(upload.ContentType) &&
-            AllowedExtensionsByContentType.TryGetValue(upload.ContentType, out var allowedExtensions))
+            hasAllowedContentType &&
+            AllowedExtensionsByContentType.TryGetValue(contentType, out var allowedExtensions))
         {
-            var extension = Path.GetExtension(upload.FileName);
-
             if (string.IsNullOrWhiteSpace(extension))
             {
                 AddError(nameof(upload.FileName), "File must include an extension.");
@@ -130,6 +153,23 @@ internal sealed class ActivityAttachmentValidator : IActivityAttachmentValidator
         {
             upload.Content.Seek(0, SeekOrigin.Begin);
         }
+    }
+
+    // SECTION: Content type helpers
+    private static string NormalizeContentType(string? contentType)
+    {
+        return string.IsNullOrWhiteSpace(contentType) ? string.Empty : contentType.Trim();
+    }
+
+    private static bool IsUnknownContentType(string contentType)
+    {
+        return UnknownContentTypes.Contains(contentType);
+    }
+
+    private static bool IsOfficeDocumentExtension(string? extension)
+    {
+        return !string.IsNullOrWhiteSpace(extension) &&
+            OfficeDocumentExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase);
     }
 
     public static string SanitizeFileName(string fileName)


### PR DESCRIPTION
### Motivation
- Fix an issue where Office files (`.docx`, `.xlsx`, `.pptx`, etc.) were being rejected incorrectly when the browser reported no MIME or `application/octet-stream` while still enforcing strict validation for known content types.

### Description
- Updated `Services/Activities/ActivityAttachmentValidator.cs` to normalize content types, recognise unknown/browser-fallback MIME values, and allow Office extensions when the reported MIME is empty or `application/octet-stream` while keeping extension-to-MIME checks for known types.
- Added helper arrays/sets (`UnknownContentTypes`, `OfficeDocumentExtensions`) and helper methods (`NormalizeContentType`, `IsUnknownContentType`, `IsOfficeDocumentExtension`) to keep validation logic clear and modular.
- Updated unit tests in `ProjectManagement.Tests/Activities/ActivityServiceTests.cs` to assert that Office MIME types are accepted and that Office files are accepted when the browser reports unknown MIME values.
- Files changed: `Services/Activities/ActivityAttachmentValidator.cs` and `ProjectManagement.Tests/Activities/ActivityServiceTests.cs`.

### Testing
- Attempted to run `dotnet test --filter ActivityAttachmentValidatorTests` but the test run failed in this environment because the `.NET` SDK is not installed (`/bin/bash: line 1: dotnet: command not found`).
- Updated unit tests were added to cover explicit Office MIME acceptance and unknown-MIME Office uploads, but they were not executed here due to the environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb7fdafc4832999d9822ae36bfa16)