### PR TITLE
Honor EXIF orientation in visit photo dimension guard

### DIFF
--- a/Areas/ProjectOfficeReports/Application/VisitPhotoService.cs
+++ b/Areas/ProjectOfficeReports/Application/VisitPhotoService.cs
@@ -162,7 +162,7 @@ public sealed class VisitPhotoService : IVisitPhotoService
             return VisitPhotoUploadResult.Invalid("Unsupported image format.");
         }
 
-        if (ExceedsDimensionLimits(imageInfo.Width, imageInfo.Height))
+        if (ExceedsPreDecodeDimensionLimits(imageInfo.Width, imageInfo.Height))
         {
             return VisitPhotoUploadResult.Invalid(GetDimensionLimitMessage());
         }
@@ -413,12 +413,29 @@ public sealed class VisitPhotoService : IVisitPhotoService
         }
     }
 
+    // SECTION: Dimension validation helpers
+    private bool ExceedsPreDecodeDimensionLimits(int width, int height)
+    {
+        var megapixels = (long)width * height;
+        return megapixels > (long)_options.MaxMegapixels * 1_000_000 ||
+            !FitsDimensionAxes(width, height);
+    }
+
     private bool ExceedsDimensionLimits(int width, int height)
     {
         var megapixels = (long)width * height;
-        return width > _options.MaxWidthPixels ||
-            height > _options.MaxHeightPixels ||
-            megapixels > (long)_options.MaxMegapixels * 1_000_000;
+        return megapixels > (long)_options.MaxMegapixels * 1_000_000 ||
+            !FitsDimensionLimits(width, height);
+    }
+
+    private bool FitsDimensionAxes(int width, int height)
+    {
+        return FitsDimensionLimits(width, height) || FitsDimensionLimits(height, width);
+    }
+
+    private bool FitsDimensionLimits(int width, int height)
+    {
+        return width <= _options.MaxWidthPixels && height <= _options.MaxHeightPixels;
     }
 
     private string GetDimensionLimitMessage()

--- a/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
+++ b/ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs
@@ -29,6 +29,7 @@ using ProjectManagement.Services.Storage;
 using ProjectManagement.Tests.Fakes;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
@@ -395,6 +396,62 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
         }
     }
 
+
+    [Fact]
+    public async Task UploadingExifRotatedPhotoUsesOrientedDimensionsForLimitChecks()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var db = new ApplicationDbContext(options);
+
+        var now = new DateTimeOffset(2024, 9, 10, 9, 0, 0, TimeSpan.Zero);
+        var visit = await CreateVisitAsync(db, now);
+        var tempRoot = Path.Combine(Path.GetTempPath(), "pm-visit-photos-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var photoOptions = Options.Create(new VisitPhotoOptions
+            {
+                MaxWidthPixels = 5000,
+                MaxHeightPixels = 3000,
+                MaxMegapixels = 12
+            });
+
+            await using var imageStream = await CreateExifRotatedImageStreamAsync(width: 2500, height: 4500);
+            var photoService = new VisitPhotoService(
+                db,
+                new TestClock(now.AddMinutes(5)),
+                new RecordingAudit(),
+                photoOptions,
+                new TestUploadRootProvider(tempRoot),
+                NullLogger<VisitPhotoService>.Instance);
+
+            var result = await photoService.UploadAsync(
+                visit.Id,
+                imageStream,
+                "portrait-rotated.jpg",
+                "image/jpeg",
+                null,
+                "creator",
+                CancellationToken.None);
+
+            Assert.Equal(VisitPhotoUploadOutcome.Success, result.Outcome);
+            var photo = Assert.Single(await db.VisitPhotos.ToListAsync());
+            Assert.Equal(4500, photo.Width);
+            Assert.Equal(2500, photo.Height);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+    }
+
     // SECTION: Visit fixture helpers
     private static async Task<Visit> CreateVisitAsync(ApplicationDbContext db, DateTimeOffset now)
     {
@@ -528,6 +585,21 @@ public class ProjectOfficeReportsVisitPhotoIntegrationTests
             new IdentityErrorDescriber(),
             services,
             NullLogger<UserManager<ApplicationUser>>.Instance);
+    }
+
+    // SECTION: Image fixture helpers
+    private static async Task<MemoryStream> CreateExifRotatedImageStreamAsync(int width, int height)
+    {
+        var stream = new MemoryStream();
+        using var image = new Image<Rgba32>(width, height, new Rgba32(80, 140, 220));
+
+        var exif = new ExifProfile();
+        exif.SetValue(ExifTag.Orientation, (ushort)6);
+        image.Metadata.ExifProfile = exif;
+
+        await image.SaveAsync(stream, new JpegEncoder { Quality = 85 });
+        stream.Position = 0;
+        return stream;
     }
 
     private static async Task<MemoryStream> CreateImageStreamAsync(int width, int height)


### PR DESCRIPTION
### Motivation
- The pre-decode metadata dimension guard rejected images that were EXIF-rotated (portrait stored as landscape), preventing valid images from reaching `AutoOrient()` and the oriented pixel validation stage.
- The intent is to allow EXIF-rotated images to pass the lightweight metadata check and be validated against oriented dimensions after `AutoOrient()`.

### Description
- Change the pre-decode check in `Areas/ProjectOfficeReports/Application/VisitPhotoService.cs` to call a new `ExceedsPreDecodeDimensionLimits` that is axis-insensitive so a width/height swap due to EXIF orientation won't be rejected prematurely.
- Add helper methods `ExceedsPreDecodeDimensionLimits`, `FitsDimensionAxes`, and `FitsDimensionLimits`, and make the existing `ExceedsDimensionLimits` rely on oriented-fit semantics.
- Add an integration test `UploadingExifRotatedPhotoUsesOrientedDimensionsForLimitChecks` to `ProjectManagement.Tests/ProjectOfficeReportsVisitPhotoIntegrationTests.cs` that creates an EXIF-rotated JPEG fixture and verifies the upload succeeds and the persisted dimensions are the oriented values.
- Add an image fixture helper `CreateExifRotatedImageStreamAsync` and import `SixLabors.ImageSharp.Metadata.Profiles.Exif` for the test.

### Testing
- Ran `git diff --check` to validate whitespace and simple diff problems, which passed.
- Attempted to run the integration test with `dotnet test --filter "FullyQualifiedName~ProjectOfficeReportsVisitPhotoIntegrationTests"` but it was not executed because `dotnet` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb995ec0c832987068e1ed03b0f77)