### PR TITLE
Compress Visits to SDD dashboard layout

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -92,25 +92,21 @@
 <partial name="_ToastMessages" model="toastMessages" />
 
 <div class="visit-shell visit-tracker visit-shell--tight">
-    <!-- top bar -->
-    <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3 mt-1">
-        <div>
-            <nav aria-label="Breadcrumb" class="visit-breadcrumb mb-1">
+    <!-- SECTION: Compact page header and actions -->
+    <div class="visit-page-head">
+        <div class="visit-page-head__text">
+            <nav aria-label="Breadcrumb" class="visit-breadcrumb">
                 <ol class="breadcrumb mb-0">
                     <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
                     <li class="breadcrumb-item active" aria-current="page">Visits to SDD</li>
                 </ol>
             </nav>
-            <div class="d-flex align-items-center gap-3">
-                <h2 class="h2 mb-1">Visits to SDD</h2>
-            </div>
-            <p class="text-muted small mb-0 mt-2">
-                Track inbound visits to SDD by dignitaries, courses and delegations, with strength, remarks and photos.
-            </p>
+            <h1>Visits to SDD</h1>
+            <p>Track inbound visits to SDD by dignitaries, courses and delegations.</p>
         </div>
-        <div class="d-flex flex-wrap gap-2">
+        <div class="visit-page-head__actions">
             <button type="button" class="btn btn-outline-secondary d-inline-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#visitsFiltersModal">
-                <i class="bi bi-sliders"></i>
+                <i class="bi bi-sliders" aria-hidden="true"></i>
                 <span>Filters</span>
                 @if (hasFilters)
                 {
@@ -123,113 +119,37 @@
             @if (Model.Items.Count > 0)
             {
                 <button type="button" class="btn btn-outline-secondary d-inline-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#exportVisitsModal">
-                    <i class="bi bi-file-earmark-spreadsheet"></i>
+                    <i class="bi bi-file-earmark-spreadsheet" aria-hidden="true"></i>
                     <span>Export</span>
                 </button>
             }
             @if (Model.CanManage)
             {
                 <a asp-page="New" class="btn btn-primary d-inline-flex align-items-center gap-1">
-                    <i class="bi bi-plus-circle"></i>
+                    <i class="bi bi-plus-circle" aria-hidden="true"></i>
                     <span>Record visit</span>
                 </a>
             }
         </div>
     </div>
 
-    <!-- KPI strip -->
-    <section class="kpi-strip mb-3" aria-label="Key visit metrics">
-        <div class="kpi-card kpi-card--blue">
-            <div class="kpi-card__top">
-                <i class="bi bi-calendar3-week" aria-hidden="true"></i>
-                <span>Visits in last 12 months</span>
-            </div>
-            <div class="kpi-card__value">@Model.VisitsLastYear</div>
-            @if (hasFilters)
-            {
-                <div class="kpi-card__hint">based on filtered set</div>
-            }
+    <!-- SECTION: Compact KPI strip -->
+    <section class="visit-kpi-strip" aria-label="Visit summary">
+        <div class="visit-kpi-strip__item">
+            <span class="visit-kpi-strip__label">Visits / 12 mo</span>
+            <strong class="visit-kpi-strip__value">@Model.VisitsLastYear</strong>
         </div>
-        <div class="kpi-card kpi-card--teal">
-            <div class="kpi-card__top">
-                <i class="bi bi-person-fill-check" aria-hidden="true"></i>
-                <span>People in last 12 months</span>
-            </div>
-            <div class="kpi-card__value">@Model.PeopleLastYear</div>
-            @if (hasFilters)
-            {
-                <div class="kpi-card__hint">sum of strength</div>
-            }
+        <div class="visit-kpi-strip__item">
+            <span class="visit-kpi-strip__label">People / 12 mo</span>
+            <strong class="visit-kpi-strip__value">@Model.PeopleLastYear</strong>
         </div>
-        <div class="kpi-card kpi-card--green">
-            <div class="kpi-card__top">
-                <i class="bi bi-calendar2" aria-hidden="true"></i>
-                <span>Visits in last 30 days</span>
-            </div>
-            <div class="kpi-card__value">@Model.VisitsLast30</div>
+        <div class="visit-kpi-strip__item">
+            <span class="visit-kpi-strip__label">Visits / 30 d</span>
+            <strong class="visit-kpi-strip__value">@Model.VisitsLast30</strong>
         </div>
-        <div class="kpi-card kpi-card--amber">
-            <div class="kpi-card__top">
-                <i class="bi bi-people-fill" aria-hidden="true"></i>
-                <span>People in last 30 days</span>
-            </div>
-            <div class="kpi-card__value">@Model.PeopleLast30</div>
-        </div>
-    </section>
-
-    <!-- charts -->
-    <section class="row g-3 mb-3 align-items-stretch" aria-label="Visit analytics charts">
-        <div class="col-lg-8">
-            <div class="card border-0 shadow-sm h-100">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-center mb-2">
-                        <div>
-                            <h3 class="h6 mb-0" id="visits-monthly-title">Visits &amp; strength – last 12 months</h3>
-                            <p class="text-muted small mb-0">Bars show visits, line shows people (strength).</p>
-                        </div>
-                        <button type="button"
-                                class="btn btn-sm btn-outline-secondary"
-                                data-chart-download="visits-monthly"
-                                aria-label="Download visits and strength chart">
-                            <i class="bi bi-download" aria-hidden="true"></i>
-                        </button>
-                    </div>
-                    <div id="visits-monthly-chart"
-                         data-monthly='@System.Text.Json.JsonSerializer.Serialize(monthlyPoints, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
-                         class="position-relative pm-util-minh-260">
-                        <canvas id="visits-monthly-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-monthly-title"></canvas>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-4">
-            <div class="card border-0 shadow-sm h-100">
-                <div class="card-body d-flex flex-column">
-                    <div class="d-flex justify-content-between align-items-center mb-2">
-                        <div>
-                            <h3 class="h6 mb-0" id="visits-type-title">Visits by type</h3>
-                            <p class="text-muted small mb-0">Distribution of visit categories.</p>
-                        </div>
-                        <div class="d-flex gap-2 align-items-center">
-                            <select id="visits-type-range" class="form-select form-select-sm w-auto" aria-label="Select time range for visits by type chart">
-                                <option value="lastYear" selected>Last 12 months</option>
-                                <option value="all">All time</option>
-                            </select>
-                            <button type="button"
-                                    class="btn btn-sm btn-outline-secondary"
-                                    data-chart-download="visits-type"
-                                    aria-label="Download visits by type chart">
-                                <i class="bi bi-download" aria-hidden="true"></i>
-                            </button>
-                        </div>
-                    </div>
-                    <div id="visits-type-chart"
-                         data-types='@System.Text.Json.JsonSerializer.Serialize(allVisitTypes, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
-                         class="flex-grow-1 pm-util-minh-240">
-                        <canvas id="visits-type-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-type-title"></canvas>
-                    </div>
-                </div>
-            </div>
+        <div class="visit-kpi-strip__item">
+            <span class="visit-kpi-strip__label">People / 30 d</span>
+            <strong class="visit-kpi-strip__value">@Model.PeopleLast30</strong>
         </div>
     </section>
 
@@ -256,26 +176,31 @@
         </div>
     }
 
-    <!-- table -->
-    <section aria-label="Recent visits">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+    <!-- SECTION: Visit log -->
+    <section class="visit-log-section" aria-label="Recent visits">
+        <div class="visit-section-head">
             <div>
                 <h2 class="h6 mb-0">Visit log</h2>
                 <p class="text-muted small mb-0">Chronological list of recent visits.</p>
             </div>
             <div class="d-flex align-items-center gap-2">
-                @if (!hasFilters && Model.TotalItems > ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.IndexModel.DashboardRowLimit)
+                @if (Model.TotalItems > Model.Items.Count)
                 {
                     <span class="text-muted small">
-                        Showing latest @Model.Items.Count of @Model.TotalItems
+                        @(hasFilters ? $"Showing {Model.Items.Count} of {Model.TotalItems}" : $"Showing latest {Model.Items.Count} of {Model.TotalItems}")
                     </span>
-                    <a asp-page="All" class="btn btn-link btn-sm text-decoration-none">
+                    <a asp-page="All"
+                       asp-route-VisitTypeId="@Model.VisitTypeId"
+                       asp-route-From="@fromValue"
+                       asp-route-To="@toValue"
+                       asp-route-Q="@Model.Q"
+                       class="btn btn-link btn-sm text-decoration-none">
                         View all
                     </a>
                 }
                 else if (hasFilters)
                 {
-                    <span class="text-muted small">@Model.Items.Count item@(Model.Items.Count == 1 ? "" : "s")</span>
+                    <span class="text-muted small">Showing @Model.Items.Count item@(Model.Items.Count == 1 ? "" : "s")</span>
                 }
             </div>
         </div>
@@ -343,6 +268,67 @@
             </div>
         }
     </section>
+
+    <!-- SECTION: Analytics charts -->
+    <section class="visit-analytics-section" aria-label="Visit analytics charts">
+        <div class="visit-section-head">
+            <div>
+                <h2>Analytics</h2>
+                <p>Trends and distribution of visits to SDD.</p>
+            </div>
+        </div>
+        <div class="visit-analytics-grid">
+            <div class="card border-0 shadow-sm visit-chart-card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <h3 class="h6 mb-0" id="visits-monthly-title">Visits &amp; strength – last 12 months</h3>
+                            <p class="text-muted small mb-0">Bars show visits, line shows people (strength).</p>
+                        </div>
+                        <button type="button"
+                                class="btn btn-sm btn-outline-secondary"
+                                data-chart-download="visits-monthly"
+                                aria-label="Download visits and strength chart">
+                            <i class="bi bi-download" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <div id="visits-monthly-chart"
+                         data-monthly='@System.Text.Json.JsonSerializer.Serialize(monthlyPoints, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
+                         class="position-relative pm-util-minh-260">
+                        <canvas id="visits-monthly-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-monthly-title"></canvas>
+                    </div>
+                </div>
+            </div>
+            <div class="card border-0 shadow-sm visit-chart-card">
+                <div class="card-body d-flex flex-column">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <h3 class="h6 mb-0" id="visits-type-title">Visits by type</h3>
+                            <p class="text-muted small mb-0">Distribution of visit categories.</p>
+                        </div>
+                        <div class="d-flex gap-2 align-items-center">
+                            <select id="visits-type-range" class="form-select form-select-sm w-auto" aria-label="Select time range for visits by type chart">
+                                <option value="lastYear" selected>Last 12 months</option>
+                                <option value="all">All time</option>
+                            </select>
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-secondary"
+                                    data-chart-download="visits-type"
+                                    aria-label="Download visits by type chart">
+                                <i class="bi bi-download" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div id="visits-type-chart"
+                         data-types='@System.Text.Json.JsonSerializer.Serialize(allVisitTypes, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase })'
+                         class="flex-grow-1 pm-util-minh-240">
+                        <canvas id="visits-type-canvas" class="w-100 h-100" role="img" aria-labelledby="visits-type-title"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
 </div>
 
 <!-- FILTER MODAL -->

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -1,5 +1,5 @@
 /* -------------------------------------------------
-   Project Office Reports – Visits & Social media
+   Project Office Reports â€“ Visits & Social media
    Layout aligned with Analytics page
 -------------------------------------------------- */
 
@@ -20,7 +20,7 @@
 }
 
 /* -------------------------------------------------
-   Shell – follow Analytics page horizontal rhythm
+   Shell â€“ follow Analytics page horizontal rhythm
 -------------------------------------------------- */
 
 .visit-shell {
@@ -52,7 +52,7 @@
 }
 
 /* -------------------------------------------------
-   KPI strip – mirror Analytics card look
+   KPI strip â€“ mirror Analytics card look
 -------------------------------------------------- */
 
 .kpi-strip {
@@ -186,7 +186,7 @@
 }
 
 /* -------------------------------------------------
-   Table – analytics style, horizontal rules only
+   Table â€“ analytics style, horizontal rules only
 -------------------------------------------------- */
 
 .visit-table {
@@ -268,7 +268,7 @@
     }
 
 /* -------------------------------------------------
-   Charts wrappers – force white background
+   Charts wrappers â€“ force white background
 -------------------------------------------------- */
 
 .visit-chart-card {
@@ -283,13 +283,13 @@
         background-color: #ffffff !important;
     }
 
-/* Sometimes charts live directly in .card – normalise */
+/* Sometimes charts live directly in .card â€“ normalise */
 .visit-shell canvas {
     background-color: #ffffff;
 }
 
 /* -------------------------------------------------
-   Modals – keep close to default but slightly softer
+   Modals â€“ keep close to default but slightly softer
 -------------------------------------------------- */
 
 .modal-content {
@@ -320,4 +320,172 @@
 .visit-shell .section-divider {
     margin: 24px 0 16px;
     border-top: 1px solid var(--visit-border-soft);
+}
+
+/* -------------------------------------------------
+   SECTION: Visits dashboard Phase 1 hierarchy
+-------------------------------------------------- */
+
+.visit-page-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.visit-page-head__text h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.visit-page-head__text p {
+    margin: 0.35rem 0 0;
+    color: var(--bs-secondary-color);
+    max-width: 56rem;
+}
+
+.visit-page-head__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.visit-page-head .visit-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.875rem;
+}
+
+.visit-kpi-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0;
+    background: #ffffff;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 1rem;
+    box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.06);
+    overflow: hidden;
+    margin-bottom: 1.25rem;
+}
+
+.visit-kpi-strip__item {
+    padding: 0.9rem 1rem;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-right: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.visit-kpi-strip__item:last-child {
+    border-right: 0;
+}
+
+.visit-kpi-strip__label {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+}
+
+.visit-kpi-strip__value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--bs-body-color);
+}
+
+.visit-section-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.visit-section-head h2 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.visit-section-head p {
+    margin: 0.2rem 0 0;
+    color: var(--visit-text-muted);
+    font-size: 0.875rem;
+}
+
+.visit-log-section {
+    margin-bottom: 1.5rem;
+}
+
+.visit-analytics-section {
+    margin-top: 1.5rem;
+}
+
+.visit-analytics-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(20rem, 1fr);
+    gap: 1rem;
+}
+
+.visit-analytics-grid .visit-chart-card {
+    min-height: 22rem;
+    padding: 0;
+}
+
+.visit-analytics-grid .visit-chart-card canvas {
+    max-height: 18rem;
+}
+
+@media (max-width: 992px) {
+    .visit-kpi-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .visit-kpi-strip__item:nth-child(2) {
+        border-right: 0;
+    }
+
+    .visit-kpi-strip__item:nth-child(1),
+    .visit-kpi-strip__item:nth-child(2) {
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .visit-analytics-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .visit-page-head {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .visit-page-head__actions {
+        justify-content: flex-start;
+    }
+
+    .visit-section-head {
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 576px) {
+    .visit-kpi-strip {
+        grid-template-columns: 1fr;
+    }
+
+    .visit-kpi-strip__item {
+        border-right: 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .visit-kpi-strip__item:last-child {
+        border-bottom: 0;
+    }
 }


### PR DESCRIPTION
### Motivation
- Reduce the vertical space before the visit records so operators reach the Visit log sooner while keeping analytics available below the fold. 
- Keep existing business logic, chart data attributes and filter/export/record actions unchanged (Phase 1: layout only). 
- Improve the header and KPI visual hierarchy for faster operational review.

### Description
- Condensed the page header into a compact semantic block with breadcrumb, `h1` title and right-aligned action buttons (Filters, Export, Record visit) in `Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml`.
- Replaced the large KPI card row with a slim four-metric KPI strip wired to existing PageModel KPI properties (`VisitsLastYear`, `PeopleLastYear`, `VisitsLast30`, `PeopleLast30`).
- Moved the Visit log section above the analytics charts and updated the truncation text to show `Showing X of Y` when appropriate while preserving filter route values on the `View all` link; chart host elements and their `data-*` payloads/IDs were left intact.
- Added responsive and spacing CSS for the compact header, KPI strip, visit log heading and analytics grid in `wwwroot/css/project-office-reports/visits.css` without changing business or data logic.

### Testing
- Ran `git diff --check` to validate whitespace/checks and it reported no issues.
- Attempted `dotnet build --no-restore` to compile, but `dotnet` is not available in the current environment so a build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbab9e5e48329b51cf08064f40c19)