### PR TITLE
Refine Visits to SDD dashboard vertical density

### DIFF
--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -25,11 +25,11 @@
 
 .visit-shell {
     background: var(--visit-shell-bg);
-    padding: 24px 32px 32px;
+    padding: 16px 32px 28px;
 }
 
     .visit-shell.visit-shell--tight {
-        padding-top: 16px;
+        padding-top: 10px;
     }
 
     /* top spacing helpers */
@@ -44,7 +44,8 @@
 /* breadcrumb */
 
 .visit-breadcrumb .breadcrumb {
-    font-size: 0.875rem;
+    font-size: 0.82rem;
+    line-height: 1.2;
 }
 
 .visit-breadcrumb .breadcrumb-item + .breadcrumb-item::before {
@@ -206,9 +207,9 @@
             font-weight: 600;
             color: var(--visit-text-muted);
             text-transform: uppercase;
-            font-size: 0.75rem;
+            font-size: 0.78rem;
             letter-spacing: 0.04em;
-            padding: 0.75rem 1.25rem;
+            padding: 0.55rem 0.9rem;
         }
 
             /* no vertical lines */
@@ -226,7 +227,7 @@
         }
 
     .visit-table tbody td {
-        padding: 0.8rem 1.25rem;
+        padding: 0.6rem 0.9rem;
         vertical-align: middle;
         color: #111827;
         background-color: #ffffff;
@@ -238,10 +239,15 @@
 
     /* date stacked layout (visits & social both use similar pattern) */
 
+    .visit-table td .fw-semibold {
+        line-height: 1.2;
+    }
+
     .visit-table td .fw-semibold + small,
     .visit-table td small {
         display: block;
-        font-size: 0.75rem;
+        font-size: 0.8rem;
+        line-height: 1.2;
         color: var(--visit-text-muted);
     }
 
@@ -328,20 +334,23 @@
 
 .visit-page-head {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
-    gap: 1.5rem;
-    margin-bottom: 1.25rem;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
 }
 
 .visit-page-head__text h1 {
     margin: 0;
-    font-size: 1.75rem;
+    font-size: 1.55rem;
+    line-height: 1.15;
     font-weight: 700;
 }
 
 .visit-page-head__text p {
-    margin: 0.35rem 0 0;
+    margin: 0.25rem 0 0;
+    font-size: 0.9rem;
+    line-height: 1.35;
     color: var(--bs-secondary-color);
     max-width: 56rem;
 }
@@ -349,17 +358,23 @@
 .visit-page-head__actions {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.45rem;
     flex-wrap: wrap;
     justify-content: flex-end;
+}
+
+.visit-page-head__actions .btn {
+    padding-top: 0.4rem;
+    padding-bottom: 0.4rem;
 }
 
 .visit-page-head .visit-breadcrumb {
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    margin-bottom: 0.75rem;
-    font-size: 0.875rem;
+    margin-bottom: 0.35rem;
+    font-size: 0.82rem;
+    line-height: 1.2;
 }
 
 .visit-kpi-strip {
@@ -368,14 +383,14 @@
     gap: 0;
     background: #ffffff;
     border: 1px solid rgba(148, 163, 184, 0.25);
-    border-radius: 1rem;
-    box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.06);
+    border-radius: 0.75rem;
+    box-shadow: none;
     overflow: hidden;
-    margin-bottom: 1.25rem;
+    margin-bottom: 1rem;
 }
 
 .visit-kpi-strip__item {
-    padding: 0.9rem 1rem;
+    padding: 0.6rem 0.9rem;
     display: flex;
     align-items: baseline;
     justify-content: space-between;
@@ -389,11 +404,12 @@
 
 .visit-kpi-strip__label {
     color: var(--bs-secondary-color);
-    font-size: 0.875rem;
+    font-size: 0.82rem;
 }
 
 .visit-kpi-strip__value {
-    font-size: 1.35rem;
+    font-size: 1.15rem;
+    line-height: 1;
     font-weight: 700;
     color: var(--bs-body-color);
 }
@@ -403,27 +419,35 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
 }
 
 .visit-section-head h2 {
     margin: 0;
     font-size: 1rem;
+    line-height: 1.2;
     font-weight: 700;
 }
 
 .visit-section-head p {
     margin: 0.2rem 0 0;
     color: var(--visit-text-muted);
-    font-size: 0.875rem;
+    font-size: 0.85rem;
+    line-height: 1.3;
+}
+
+.visit-section-head__meta {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
 }
 
 .visit-log-section {
-    margin-bottom: 1.5rem;
+    margin-top: 0;
+    margin-bottom: 1.25rem;
 }
 
 .visit-analytics-section {
-    margin-top: 1.5rem;
+    margin-top: 1.25rem;
 }
 
 .visit-analytics-grid {
@@ -461,9 +485,13 @@
 }
 
 @media (max-width: 768px) {
+    .visit-shell {
+        padding: 14px 16px 24px;
+    }
+
     .visit-page-head {
         flex-direction: column;
-        align-items: stretch;
+        align-items: flex-start;
     }
 
     .visit-page-head__actions {


### PR DESCRIPTION
### Motivation
- Reduce vertical whitespace above the Visit log so the first screen shows more visit rows while keeping content and order unchanged.
- This is a CSS/layout-only refinement to make the header, KPI strip and Visit log more compact without touching business logic, filters, charts or backend.
- Target the Visits dashboard visual hierarchy to improve density and readability on laptop viewports.

### Description
- Updated `wwwroot/css/project-office-reports/visits.css` to reduce top shell padding and tighten the `.visit-shell` and `.visit-shell.visit-shell--tight` paddings.
- Compacted header spacing by adjusting `.visit-page-head`, title/subtitle sizing, breadcrumb sizing, and action button spacing (added `.visit-page-head__actions .btn` padding tweaks).
- Slimmed the KPI strip by reducing border-radius, removing heavy shadow, lowering item padding, and reducing label/value font sizes in `.visit-kpi-strip` and `.visit-kpi-strip__item`.
- Brought the Visit log closer by reducing `.visit-section-head` and `.visit-log-section` margins and densified table rows/headers by lowering `.visit-table` header/body padding and tightening stacked cell line-heights; added a small responsive shell padding rule for narrow viewports.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff issues, which completed without errors.
- Attempted `dotnet test ProjectManagement.sln --no-restore`, but the `dotnet` command is not available in the current environment so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdb864ca08329af026bbe30f21d19)