### PR TITLE
Visits: compact header with inline KPI metrics

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -95,14 +95,26 @@
     <!-- SECTION: Compact page header and actions -->
     <div class="visit-page-head">
         <div class="visit-page-head__text">
-            <nav aria-label="Breadcrumb" class="visit-breadcrumb">
-                <ol class="breadcrumb mb-0">
-                    <li class="breadcrumb-item"><a asp-area="" asp-page="/Dashboard/Index">Dashboard</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">Visits to SDD</li>
-                </ol>
-            </nav>
             <h1>Visits to SDD</h1>
             <p>Track inbound visits to SDD by dignitaries, courses and delegations.</p>
+            <div class="visit-inline-metrics" aria-label="Visit summary">
+                <span>
+                    <strong>@Model.VisitsLastYear</strong>
+                    visits / 12 mo
+                </span>
+                <span>
+                    <strong>@Model.PeopleLastYear</strong>
+                    people / 12 mo
+                </span>
+                <span>
+                    <strong>@Model.VisitsLast30</strong>
+                    visits / 30 d
+                </span>
+                <span>
+                    <strong>@Model.PeopleLast30</strong>
+                    people / 30 d
+                </span>
+            </div>
         </div>
         <div class="visit-page-head__actions">
             <button type="button" class="btn btn-outline-secondary d-inline-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#visitsFiltersModal">
@@ -133,25 +145,6 @@
         </div>
     </div>
 
-    <!-- SECTION: Compact KPI strip -->
-    <section class="visit-kpi-strip" aria-label="Visit summary">
-        <div class="visit-kpi-strip__item">
-            <span class="visit-kpi-strip__label">Visits / 12 mo</span>
-            <strong class="visit-kpi-strip__value">@Model.VisitsLastYear</strong>
-        </div>
-        <div class="visit-kpi-strip__item">
-            <span class="visit-kpi-strip__label">People / 12 mo</span>
-            <strong class="visit-kpi-strip__value">@Model.PeopleLastYear</strong>
-        </div>
-        <div class="visit-kpi-strip__item">
-            <span class="visit-kpi-strip__label">Visits / 30 d</span>
-            <strong class="visit-kpi-strip__value">@Model.VisitsLast30</strong>
-        </div>
-        <div class="visit-kpi-strip__item">
-            <span class="visit-kpi-strip__label">People / 30 d</span>
-            <strong class="visit-kpi-strip__value">@Model.PeopleLast30</strong>
-        </div>
-    </section>
 
     <!-- active filter chips -->
     @if (hasFilters)

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -329,15 +329,15 @@
 }
 
 /* -------------------------------------------------
-   SECTION: Visits dashboard Phase 1 hierarchy
+   SECTION: Visits dashboard Phase 1B compact header
 -------------------------------------------------- */
 
 .visit-page-head {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.9rem;
 }
 
 .visit-page-head__text h1 {
@@ -348,7 +348,7 @@
 }
 
 .visit-page-head__text p {
-    margin: 0.25rem 0 0;
+    margin: 0.2rem 0 0;
     font-size: 0.9rem;
     line-height: 1.35;
     color: var(--bs-secondary-color);
@@ -368,6 +368,35 @@
     padding-bottom: 0.4rem;
 }
 
+.visit-inline-metrics {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem 1rem;
+    margin-top: 0.45rem;
+    color: var(--bs-secondary-color);
+    font-size: 0.85rem;
+    line-height: 1.3;
+}
+
+.visit-inline-metrics span {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    white-space: nowrap;
+}
+
+.visit-inline-metrics span + span::before {
+    content: "·";
+    margin-right: 0.75rem;
+    color: rgba(100, 116, 139, 0.75);
+}
+
+.visit-inline-metrics strong {
+    color: var(--bs-body-color);
+    font-weight: 700;
+}
+
 .visit-page-head .visit-breadcrumb {
     display: flex;
     align-items: center;
@@ -377,6 +406,7 @@
     line-height: 1.2;
 }
 
+/* Legacy KPI strip retained for possible reuse; dashboard now uses .visit-inline-metrics. */
 .visit-kpi-strip {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -496,6 +526,19 @@
 
     .visit-page-head__actions {
         justify-content: flex-start;
+    }
+
+    .visit-inline-metrics {
+        gap: 0.35rem 0.75rem;
+    }
+
+    .visit-inline-metrics span {
+        white-space: normal;
+    }
+
+    .visit-inline-metrics span + span::before {
+        content: "";
+        margin: 0;
     }
 
     .visit-section-head {


### PR DESCRIPTION
### Motivation
- Reduce vertical space at the top of the Visits dashboard so the Visit log appears higher on the page. 
- Remove the dashboard breadcrumb and separate KPI strip on the dashboard index, while keeping actions and other pages unchanged. 

### Description
- Removed the breadcrumb block and the `<section class="visit-kpi-strip">` from `Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml` and added a compact `visit-inline-metrics` block under the subtitle that uses existing model properties (`VisitsLastYear`, `PeopleLastYear`, `VisitsLast30`, `PeopleLast30`).
- Kept header actions (`Filters`, `Export`, `Record visit`) unchanged and left filter chips, visit log table and analytics sections intact. 
- Added CSS rules to `wwwroot/css/project-office-reports/visits.css` to top-align the header, tighten title/subtitle spacing, introduce `.visit-inline-metrics` styling and responsive wrapping, and added a small note retaining legacy `.visit-kpi-strip` CSS for potential reuse. 

### Testing
- Ran `rg "visit-breadcrumb|visit-kpi-strip|visit-inline-metrics"` against the Visits pages to verify the breadcrumb removal on `Index` and presence on other pages, which succeeded. 
- Ran `git diff --check` to ensure there are no whitespace or diff errors, which returned clean. 
- Attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300ba6a2f883298c36536919aeb85d)