### PR TITLE
Add RemarksPreview and redesign dashboard Visit log as seamless record-list

### DIFF
--- a/Areas/ProjectOfficeReports/Application/VisitService.cs
+++ b/Areas/ProjectOfficeReports/Application/VisitService.cs
@@ -34,22 +34,38 @@ public sealed class VisitService
 
         var query = CreateFilteredQuery(options);
 
-        var list = await query
+        // SECTION: Visit log projection
+        var rows = await query
             .OrderByDescending(x => x.DateOfVisit)
             .ThenByDescending(x => x.CreatedAtUtc)
+            .Select(x => new
+            {
+                x.Id,
+                x.DateOfVisit,
+                x.VisitTypeId,
+                VisitTypeName = x.VisitType!.Name,
+                x.VisitorName,
+                x.Remarks,
+                x.Strength,
+                PhotoCount = x.Photos.Count,
+                VisitTypeIsActive = x.VisitType.IsActive,
+                x.RowVersion
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows
             .Select(x => new VisitListItem(
                 x.Id,
                 x.DateOfVisit,
                 x.VisitTypeId,
-                x.VisitType!.Name,
+                x.VisitTypeName,
                 x.VisitorName,
+                BuildRemarksPreview(x.Remarks),
                 x.Strength,
-                x.Photos.Count,
-                x.VisitType.IsActive,
+                x.PhotoCount,
+                x.VisitTypeIsActive,
                 x.RowVersion))
-            .ToListAsync(cancellationToken);
-
-        return list;
+            .ToList();
     }
 
     public async Task<IReadOnlyList<VisitExportRow>> ExportAsync(VisitQueryOptions options, CancellationToken cancellationToken)
@@ -140,6 +156,23 @@ public sealed class VisitService
         }
 
         return query;
+    }
+
+    // SECTION: Visit log preview helpers
+    private static string? BuildRemarksPreview(string? remarks, int maxLength = 180)
+    {
+        if (string.IsNullOrWhiteSpace(remarks))
+        {
+            return null;
+        }
+
+        var normalized = string.Join(
+            " ",
+            remarks.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        return normalized.Length <= maxLength
+            ? normalized
+            : normalized[..maxLength].TrimEnd() + "…";
     }
 
     public async Task<VisitDetails?> GetDetailsAsync(Guid id, CancellationToken cancellationToken)
@@ -313,7 +346,7 @@ public sealed class VisitService
 
 public sealed record VisitQueryOptions(Guid? VisitTypeId, DateOnly? StartDate, DateOnly? EndDate, string? RemarksQuery);
 
-public sealed record VisitListItem(Guid Id, DateOnly DateOfVisit, Guid VisitTypeId, string VisitTypeName, string VisitorName, int Strength, int PhotoCount, bool VisitTypeIsActive, byte[] RowVersion);
+public sealed record VisitListItem(Guid Id, DateOnly DateOfVisit, Guid VisitTypeId, string VisitTypeName, string VisitorName, string? RemarksPreview, int Strength, int PhotoCount, bool VisitTypeIsActive, byte[] RowVersion);
 
 public sealed record VisitExportRow(
     DateOnly DateOfVisit,

--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -212,12 +212,12 @@
         {
             <div class="card border-0 shadow-sm">
                 <div class="table-responsive">
-                    <table class="table align-middle mb-0 visit-table">
+                    <table class="table align-middle mb-0 visit-table visit-log-table">
                         <thead class="table-light">
                             <tr>
                                 <th scope="col">Date</th>
-                                <th scope="col">Visit type</th>
-                                <th scope="col">Visitor</th>
+                                <th scope="col">Type</th>
+                                <th scope="col">Visitor / Remarks</th>
                                 <th scope="col">Strength</th>
                                 <th scope="col">Photos</th>
                                 <th scope="col" class="text-end">Actions</th>
@@ -238,13 +238,33 @@
                                             <span class="badge bg-warning-subtle text-warning-emphasis mt-1">Type inactive</span>
                                         }
                                     </td>
-                                    <td>@item.VisitorName</td>
-                                    <td>
-                                        <div class="fw-semibold">@item.Strength</div>
-                                        <div class="text-muted small">people</div>
+                                    <td class="visit-log-record">
+                                        <div class="visit-log-record__visitor">@item.VisitorName</div>
+                                        @if (!string.IsNullOrWhiteSpace(item.RemarksPreview))
+                                        {
+                                            <div class="visit-log-record__remarks">@item.RemarksPreview</div>
+                                        }
                                     </td>
-                                    <td>@item.PhotoCount</td>
-                                    <td class="text-end">
+                                    <td class="visit-log-strength">
+                                        <strong>@item.Strength</strong>
+                                        <span>@(item.Strength == 1 ? "person" : "people")</span>
+                                    </td>
+                                    <td class="visit-log-photos">
+                                        @if (item.PhotoCount > 0)
+                                        {
+                                            <span class="visit-log-photos__count">
+                                                <i class="bi bi-images" aria-hidden="true"></i>
+                                                <span class="visually-hidden">Photos:</span>
+                                                @item.PhotoCount
+                                                <span>@(item.PhotoCount == 1 ? "photo" : "photos")</span>
+                                            </span>
+                                        }
+                                        else
+                                        {
+                                            <span class="visit-log-photos__empty">No photos</span>
+                                        }
+                                    </td>
+                                    <td class="text-end visit-log-actions">
                                         <div class="btn-group" role="group">
                                             <a asp-page="Details" asp-route-id="@item.Id" class="btn btn-outline-secondary btn-sm">View</a>
                                             @if (Model.CanManage)

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -560,3 +560,101 @@
         border-bottom: 0;
     }
 }
+
+/* -------------------------------------------------
+   Visit log – seamless record list
+-------------------------------------------------- */
+
+.visit-log-table {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+    .visit-log-table thead th {
+        font-weight: 700;
+        background: #f9fafb;
+        border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
+    }
+
+    .visit-log-table tbody td {
+        border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
+    }
+
+    .visit-log-table tbody tr:last-child td {
+        border-bottom: 0;
+    }
+
+    .visit-log-table th:nth-child(1),
+    .visit-log-table td:nth-child(1) {
+        width: 11rem;
+    }
+
+    .visit-log-table th:nth-child(2),
+    .visit-log-table td:nth-child(2) {
+        width: 11rem;
+    }
+
+    .visit-log-table th:nth-child(4),
+    .visit-log-table td:nth-child(4) {
+        width: 8rem;
+    }
+
+    .visit-log-table th:nth-child(5),
+    .visit-log-table td:nth-child(5) {
+        width: 7rem;
+    }
+
+    .visit-log-table th:nth-child(6),
+    .visit-log-table td:nth-child(6) {
+        width: 8rem;
+    }
+
+.visit-log-record {
+    min-width: 16rem;
+}
+
+.visit-log-record__visitor {
+    color: var(--visit-text-heading, #111827);
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+.visit-log-record__remarks {
+    display: -webkit-box;
+    max-width: 42rem;
+    margin-top: 0.18rem;
+    overflow: hidden;
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.84rem;
+    line-height: 1.3;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.visit-log-strength,
+.visit-log-photos,
+.visit-log-actions {
+    white-space: nowrap;
+}
+
+    .visit-log-strength strong {
+        font-weight: 700;
+    }
+
+    .visit-log-strength span {
+        margin-left: 0.2rem;
+        color: var(--visit-text-muted, #64748b);
+        font-size: 0.86rem;
+    }
+
+.visit-log-photos__count {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--visit-text-heading, #111827);
+}
+
+.visit-log-photos__empty {
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.86rem;
+}


### PR DESCRIPTION
### Motivation
- Surface the key contextual field (remarks) in the dashboard Visit log so reviewers can quickly see visitor name plus remarks without losing table alignment. 
- Keep the list compact and scan-dense by using a hybrid record-list (table semantics for alignment, softened visuals for readability).

### Description
- Add `RemarksPreview` to the `VisitListItem` DTO and update the projection in `SearchAsync` so remarks are materialized, normalized and truncated before being returned (see `Areas/ProjectOfficeReports/Application/VisitService.cs` and the new `BuildRemarksPreview` helper).
- Change the dashboard rows in `Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml` to show a `Type` column and a combined `Visitor / Remarks` cell that renders the visitor name prominently and the preview only when present, plus compact `Strength` wording and meaningful `Photos` text (`N photo(s)` / `No photos`).
- Add CSS for the seamless record-list experience in `wwwroot/css/project-office-reports/visits.css`, including light horizontal separators, column width hints, 2-line remark clamping, and styles for visitor/remarks, photos and strength cells.
- Use an EF-safe approach: first select a lightweight anonymous projection (including `Remarks`), materialize with `ToListAsync`, then build `RemarksPreview` on the in-memory results to avoid EF translation issues.

### Testing
- Automated tests were not executed because the `dotnet` CLI is not available in this environment, so `dotnet test` could not be run (no automated test results are available).
- Note: unit tests or fixtures that construct `VisitListItem` will need updating to account for the new `RemarksPreview` positional parameter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300e66f95c83299739eaee1e4f5af9)