### PR TITLE
Polish Visits log layout

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml
@@ -216,7 +216,7 @@
                         <thead class="table-light">
                             <tr>
                                 <th scope="col">Date</th>
-                                <th scope="col">Type</th>
+                                <th scope="col">Visit type</th>
                                 <th scope="col">Visitor / Remarks</th>
                                 <th scope="col">Strength</th>
                                 <th scope="col">Photos</th>

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -571,12 +571,14 @@
 }
 
     .visit-log-table thead th {
+        padding: 0.5rem 0.9rem;
         font-weight: 700;
         background: #f9fafb;
         border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
     }
 
     .visit-log-table tbody td {
+        padding: 0.55rem 0.9rem;
         border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
     }
 
@@ -616,17 +618,17 @@
 .visit-log-record__visitor {
     color: var(--visit-text-heading, #111827);
     font-weight: 600;
-    line-height: 1.25;
+    line-height: 1.22;
 }
 
 .visit-log-record__remarks {
     display: -webkit-box;
     max-width: 42rem;
-    margin-top: 0.18rem;
+    margin-top: 0.16rem;
     overflow: hidden;
-    color: var(--visit-text-muted, #64748b);
-    font-size: 0.84rem;
-    line-height: 1.3;
+    color: rgba(100, 116, 139, 0.9);
+    font-size: 0.82rem;
+    line-height: 1.25;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
 }
@@ -652,6 +654,12 @@
     align-items: center;
     gap: 0.3rem;
     color: var(--visit-text-heading, #111827);
+}
+
+.visit-log-photos i,
+.visit-log-photos .bi {
+    color: var(--visit-text-muted, #64748b);
+    opacity: 0.85;
 }
 
 .visit-log-photos__empty {


### PR DESCRIPTION
### Motivation

- Improve density, readability and visual hierarchy of the Visit log without changing backend logic. 
- Ensure visitor name remains primary while remarks remain visible but secondary and limited in height. 
- Make the Photos display visually lighter and keep rows compact for easier scanning.

### Description

- Updated the table header text in `Areas/ProjectOfficeReports/Pages/Visits/Index.cshtml` from `Type` to `Visit type` so the existing uppercase table styling renders as `VISIT TYPE`.
- Adjusted visit log spacing in `wwwroot/css/project-office-reports/visits.css` by reducing header and body cell padding to keep rows compact.
- Refined typography and hierarchy for the visitor and remarks by tightening `line-height`, reducing `margin-top`, muting remarks color, reducing `font-size`, and enforcing a strict 2-line clamp via `-webkit-line-clamp: 2`.
- Muted the photo icon with `.visit-log-photos i, .visit-log-photos .bi { color: var(--visit-text-muted); opacity: 0.85; }` and kept the photo count text prominent while leaving other columns (strength/actions) unchanged.

### Testing

- Attempted to run automated tests with `dotnet test ProjectManagement.sln`, but the `dotnet` CLI is not available in the environment so the test command could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3010c08f748329addb9e0d0059ae60)