### PR TITLE
All visits: add pagination, Visitor/Remarks column, photo labels and compact register UI

### DIFF
--- a/Areas/ProjectOfficeReports/Application/VisitService.cs
+++ b/Areas/ProjectOfficeReports/Application/VisitService.cs
@@ -68,6 +68,58 @@ public sealed class VisitService
             .ToList();
     }
 
+
+    // SECTION: Paged visit register search
+    public async Task<VisitPagedResult> SearchPagedAsync(VisitQueryOptions options, int pageNumber, int pageSize, CancellationToken cancellationToken)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        pageNumber = Math.Max(1, pageNumber);
+        pageSize = pageSize is 25 or 50 or 100 ? pageSize : 25;
+
+        var query = CreateFilteredQuery(options);
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var rows = await query
+            .OrderByDescending(x => x.DateOfVisit)
+            .ThenByDescending(x => x.CreatedAtUtc)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .Select(x => new
+            {
+                x.Id,
+                x.DateOfVisit,
+                x.VisitTypeId,
+                VisitTypeName = x.VisitType!.Name,
+                x.VisitorName,
+                x.Remarks,
+                x.Strength,
+                PhotoCount = x.Photos.Count,
+                VisitTypeIsActive = x.VisitType.IsActive,
+                x.RowVersion
+            })
+            .ToListAsync(cancellationToken);
+
+        var items = rows
+            .Select(x => new VisitListItem(
+                x.Id,
+                x.DateOfVisit,
+                x.VisitTypeId,
+                x.VisitTypeName,
+                x.VisitorName,
+                BuildRemarksPreview(x.Remarks),
+                x.Strength,
+                x.PhotoCount,
+                x.VisitTypeIsActive,
+                x.RowVersion))
+            .ToList();
+
+        return new VisitPagedResult(items, totalCount);
+    }
+
     public async Task<IReadOnlyList<VisitExportRow>> ExportAsync(VisitQueryOptions options, CancellationToken cancellationToken)
     {
         if (options is null)
@@ -345,6 +397,8 @@ public sealed class VisitService
 }
 
 public sealed record VisitQueryOptions(Guid? VisitTypeId, DateOnly? StartDate, DateOnly? EndDate, string? RemarksQuery);
+
+public sealed record VisitPagedResult(IReadOnlyList<VisitListItem> Items, int TotalCount);
 
 public sealed record VisitListItem(Guid Id, DateOnly DateOfVisit, Guid VisitTypeId, string VisitTypeName, string VisitorName, string? RemarksPreview, int Strength, int PhotoCount, bool VisitTypeIsActive, byte[] RowVersion);
 

--- a/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits.AllModel
 @{
     ViewData["Title"] = "All visits to SDD";
@@ -17,7 +17,7 @@
 }
 
 <div class="visit-shell visit-tracker visit-shell--tight">
-    <div class="d-flex justify-content-between align-items-center mb-3 mt-1">
+    <div class="visit-register-head d-flex justify-content-between align-items-center mt-1">
         <div>
             <nav aria-label="Breadcrumb" class="visit-breadcrumb mb-1">
                 <ol class="breadcrumb mb-0">
@@ -31,6 +31,10 @@
         </div>
         <div class="d-flex gap-2">
             <form method="post" asp-page-handler="Export">
+                <input type="hidden" name="VisitTypeId" value="@Model.VisitTypeId" />
+                <input type="hidden" name="From" value="@(fromValue ?? string.Empty)" />
+                <input type="hidden" name="To" value="@(toValue ?? string.Empty)" />
+                <input type="hidden" name="Q" value="@Model.Q" />
                 <button type="submit" class="btn btn-outline-secondary d-inline-flex align-items-center gap-1">
                     <i class="bi bi-file-earmark-spreadsheet"></i>
                     <span>Export</span>
@@ -39,47 +43,72 @@
         </div>
     </div>
 
-    <form method="get" class="row g-3 mb-3">
-        <div class="col-md-3">
+    <form method="get" class="visit-register-filters">
+        <input type="hidden" name="PageNumber" value="1" />
+        <input type="hidden" name="PageSize" value="@Model.PageSize" />
+        <div>
             <label asp-for="VisitTypeId" class="form-label">Visit type</label>
             <select asp-for="VisitTypeId" asp-items="Model.VisitTypeOptions" class="form-select"></select>
         </div>
-        <div class="col-md-2">
+        <div>
             <label class="form-label" for="from-date">From</label>
             <input id="from-date" name="From" type="date" value="@(fromValue ?? string.Empty)" class="form-control" />
         </div>
-        <div class="col-md-2">
+        <div>
             <label class="form-label" for="to-date">To</label>
             <input id="to-date" name="To" type="date" value="@(toValue ?? string.Empty)" class="form-control" />
         </div>
-        <div class="col-md-3">
+        <div>
             <label class="form-label" for="search-filter">Visitor or remarks</label>
             <input id="search-filter" name="Q" value="@Model.Q" class="form-control" placeholder="Search visitor or remarks" />
         </div>
-        <div class="col-md-2 d-flex align-items-end gap-2">
+        <div class="visit-register-filters__actions">
             <button type="submit" class="btn btn-primary">Apply</button>
-            <a asp-page="All" class="btn btn-outline-secondary">Reset</a>
+            <a asp-page="All" class="btn btn-outline-secondary">Clear</a>
         </div>
     </form>
+
+    @* SECTION: Register count and page size controls *@
+    <div class="visit-register-toolbar">
+        <div class="visit-register-toolbar__count">
+            Showing @Model.ShowingFrom–@Model.ShowingTo of @Model.TotalItems
+        </div>
+
+        <form method="get" class="visit-register-toolbar__page-size">
+            <input type="hidden" name="VisitTypeId" value="@Model.VisitTypeId" />
+            <input type="hidden" name="From" value="@(fromValue ?? string.Empty)" />
+            <input type="hidden" name="To" value="@(toValue ?? string.Empty)" />
+            <input type="hidden" name="Q" value="@Model.Q" />
+            <input type="hidden" name="PageNumber" value="1" />
+
+            <label for="PageSize">Rows</label>
+            <select id="PageSize" name="PageSize" class="form-select form-select-sm">
+                <option value="25" selected="@(Model.PageSize == 25)">25</option>
+                <option value="50" selected="@(Model.PageSize == 50)">50</option>
+                <option value="100" selected="@(Model.PageSize == 100)">100</option>
+            </select>
+            <button type="submit" class="btn btn-outline-secondary btn-sm">Apply</button>
+        </form>
+    </div>
 
     @if (Model.Items.Count == 0)
     {
         <div class="visit-empty visit-empty--subtle text-center py-5">
             <div class="visit-empty__icon" aria-hidden="true"><i class="bi bi-clipboard2-minus"></i></div>
             <h2 class="visit-empty__title">No visits found</h2>
-            <p class="visit-empty__subtitle">Try adjusting your filters.</p>
+            <p class="visit-empty__subtitle">Try changing filters or clearing the search.</p>
         </div>
     }
     else
     {
         <div class="card border-0 shadow-sm">
             <div class="table-responsive">
-                <table class="table align-middle mb-0 visit-table">
+                <table class="table align-middle mb-0 visit-table visit-register-table">
                     <thead class="table-light">
                         <tr>
                             <th scope="col">Date</th>
                             <th scope="col">Visit type</th>
-                            <th scope="col">Visitor</th>
+                            <th scope="col">Visitor / Remarks</th>
                             <th scope="col">Strength</th>
                             <th scope="col">Photos</th>
                             <th scope="col" class="text-end">Actions</th>
@@ -100,9 +129,24 @@
                                         <span class="badge bg-warning-subtle text-warning-emphasis mt-1">Type inactive</span>
                                     }
                                 </td>
-                                <td>@item.VisitorName</td>
+                                <td class="visit-register-record">
+                                    <div class="visit-register-record__visitor">@item.VisitorName</div>
+                                    @if (!string.IsNullOrWhiteSpace(item.RemarksPreview))
+                                    {
+                                        <div class="visit-register-record__remarks">@item.RemarksPreview</div>
+                                    }
+                                </td>
                                 <td>@item.Strength</td>
-                                <td>@item.PhotoCount</td>
+                                <td class="visit-register-photos">
+                                    @if (item.PhotoCount > 0)
+                                    {
+                                        <span>@item.PhotoCount photo@(item.PhotoCount == 1 ? "" : "s")</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="visit-register-photos__empty">No photos</span>
+                                    }
+                                </td>
                                 <td class="text-end">
                                     <a asp-page="Details" asp-route-id="@item.Id" class="btn btn-outline-secondary btn-sm">View</a>
                                     @if (Model.CanManage)
@@ -116,5 +160,32 @@
                 </table>
             </div>
         </div>
+        @* SECTION: Register pagination controls *@
+        @if (Model.TotalPages > 1)
+        {
+            <nav class="visit-pagination" aria-label="All visits pagination">
+                <a class="btn btn-outline-secondary btn-sm @(Model.PageNumber <= 1 ? "disabled" : null)"
+                   asp-page="./All"
+                   asp-route-PageNumber="@(Model.PageNumber - 1)"
+                   asp-route-PageSize="@Model.PageSize"
+                   asp-route-VisitTypeId="@Model.VisitTypeId"
+                   asp-route-From="@(fromValue ?? string.Empty)"
+                   asp-route-To="@(toValue ?? string.Empty)"
+                   asp-route-Q="@Model.Q"
+                   aria-disabled="@(Model.PageNumber <= 1)">Previous</a>
+
+                <span class="visit-pagination__status">Page @Model.PageNumber of @Model.TotalPages</span>
+
+                <a class="btn btn-outline-secondary btn-sm @(Model.PageNumber >= Model.TotalPages ? "disabled" : null)"
+                   asp-page="./All"
+                   asp-route-PageNumber="@(Model.PageNumber + 1)"
+                   asp-route-PageSize="@Model.PageSize"
+                   asp-route-VisitTypeId="@Model.VisitTypeId"
+                   asp-route-From="@(fromValue ?? string.Empty)"
+                   asp-route-To="@(toValue ?? string.Empty)"
+                   asp-route-Q="@Model.Q"
+                   aria-disabled="@(Model.PageNumber >= Model.TotalPages)">Next</a>
+            </nav>
+        }
     }
 </div>

--- a/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml.cs
@@ -17,6 +17,8 @@ namespace ProjectManagement.Areas.ProjectOfficeReports.Pages.Visits;
 [Authorize]
 public class AllModel : PageModel
 {
+    private static readonly int[] AllowedPageSizes = [25, 50, 100];
+
     private readonly VisitService _visitService;
     private readonly VisitTypeService _visitTypeService;
     private readonly IVisitExportService _visitExportService;
@@ -46,6 +48,24 @@ public class AllModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Q { get; set; }
 
+    [BindProperty(SupportsGet = true)]
+    public int PageNumber { get; set; } = 1;
+
+    [BindProperty(SupportsGet = true)]
+    public int PageSize { get; set; } = 25;
+
+    public int TotalItems { get; private set; }
+
+    public int TotalPages => PageSize <= 0
+        ? 1
+        : Math.Max(1, (int)Math.Ceiling((double)TotalItems / PageSize));
+
+    public int ShowingFrom => TotalItems == 0
+        ? 0
+        : ((PageNumber - 1) * PageSize) + 1;
+
+    public int ShowingTo => Math.Min(PageNumber * PageSize, TotalItems);
+
     public IReadOnlyList<VisitListItem> Items { get; private set; } = Array.Empty<VisitListItem>();
 
     public IReadOnlyList<SelectListItem> VisitTypeOptions { get; private set; } = Array.Empty<SelectListItem>();
@@ -55,14 +75,20 @@ public class AllModel : PageModel
     public async Task OnGetAsync(CancellationToken cancellationToken)
     {
         CanManage = IsManager();
+        NormalizePaging();
         await PopulateVisitTypesAsync(cancellationToken);
-        var all = await _visitService.SearchAsync(BuildQuery(), cancellationToken);
 
-        // for the "all" view we show everything, sorted
-        Items = all
-            .OrderByDescending(v => v.DateOfVisit)
-            .ThenByDescending(v => v.PhotoCount)
-            .ToList();
+        // SECTION: Historical register pagination
+        var result = await _visitService.SearchPagedAsync(BuildQuery(), PageNumber, PageSize, cancellationToken);
+        TotalItems = result.TotalCount;
+        ClampPageNumber();
+
+        if (PageNumber != 1 && result.TotalCount > 0 && result.Items.Count == 0)
+        {
+            result = await _visitService.SearchPagedAsync(BuildQuery(), PageNumber, PageSize, cancellationToken);
+        }
+
+        Items = result.Items;
     }
 
     public async Task<IActionResult> OnPostExportAsync(CancellationToken cancellationToken)
@@ -101,6 +127,28 @@ public class AllModel : PageModel
     private VisitQueryOptions BuildQuery()
     {
         return new VisitQueryOptions(VisitTypeId, ParseDate(From), ParseDate(To), Q);
+    }
+
+    // SECTION: Paging normalization
+    private void NormalizePaging()
+    {
+        if (!AllowedPageSizes.Contains(PageSize))
+        {
+            PageSize = 25;
+        }
+
+        if (PageNumber < 1)
+        {
+            PageNumber = 1;
+        }
+    }
+
+    private void ClampPageNumber()
+    {
+        if (TotalPages > 0 && PageNumber > TotalPages)
+        {
+            PageNumber = TotalPages;
+        }
     }
 
     private async Task PopulateVisitTypesAsync(CancellationToken cancellationToken)

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -666,3 +666,162 @@
     color: var(--visit-text-muted, #64748b);
     font-size: 0.86rem;
 }
+
+/* -------------------------------------------------
+   SECTION: All visits historical register
+-------------------------------------------------- */
+
+.visit-register-head {
+    margin-bottom: 1rem;
+}
+
+.visit-register-filters {
+    display: grid;
+    grid-template-columns: minmax(12rem, 1.2fr) minmax(9rem, 0.8fr) minmax(9rem, 0.8fr) minmax(16rem, 1.4fr) auto;
+    gap: 0.75rem;
+    align-items: end;
+    margin-top: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.visit-register-filters__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    white-space: nowrap;
+}
+
+.visit-register-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.6rem;
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.86rem;
+}
+
+.visit-register-toolbar__page-size {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.visit-register-toolbar__page-size select {
+    min-width: 4.5rem;
+}
+
+.visit-register-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: #fff;
+}
+
+.visit-register-table thead th {
+    padding: 0.55rem 0.9rem;
+    font-size: 0.76rem;
+    font-weight: 700;
+    color: var(--visit-text-muted, #64748b);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: #f9fafb;
+    border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
+}
+
+.visit-register-table tbody td {
+    padding: 0.58rem 0.9rem;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--visit-border-subtle, #e5e7eb);
+    background: #fff;
+}
+
+.visit-register-table tbody tr:hover td {
+    background: var(--visit-row-hover, #f5f7ff);
+}
+
+.visit-register-table th:nth-child(1),
+.visit-register-table td:nth-child(1) {
+    width: 10rem;
+}
+
+.visit-register-table th:nth-child(2),
+.visit-register-table td:nth-child(2) {
+    width: 10rem;
+}
+
+.visit-register-table th:nth-child(4),
+.visit-register-table td:nth-child(4) {
+    width: 7rem;
+}
+
+.visit-register-table th:nth-child(5),
+.visit-register-table td:nth-child(5) {
+    width: 8rem;
+}
+
+.visit-register-table th:nth-child(6),
+.visit-register-table td:nth-child(6) {
+    width: 8rem;
+}
+
+.visit-register-record {
+    min-width: 16rem;
+}
+
+.visit-register-record__visitor {
+    font-weight: 500;
+    color: var(--visit-text-heading, #111827);
+    line-height: 1.2;
+}
+
+.visit-register-record__remarks {
+    display: -webkit-box;
+    margin-top: 0.15rem;
+    overflow: hidden;
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.82rem;
+    line-height: 1.25;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+}
+
+.visit-register-photos {
+    white-space: nowrap;
+}
+
+.visit-register-photos__empty {
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.86rem;
+}
+
+.visit-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 0.9rem;
+}
+
+.visit-pagination__status {
+    color: var(--visit-text-muted, #64748b);
+    font-size: 0.86rem;
+}
+
+@media (max-width: 992px) {
+    .visit-register-filters {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 576px) {
+    .visit-register-head,
+    .visit-register-toolbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .visit-register-filters {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
### Motivation
- Turn the unpaginated long list into a dense historical register that scales and remains usable.
- Surface visitor remarks inline while keeping the page compact (1-line clamp) and preserve existing export behaviour.
- Improve photos display from raw counts to human-friendly labels and tighten header/filter spacing for a cleaner register.
- Preserve existing filters during paging and exporting to avoid changing current workflows.

### Description
- Add server-side paging support: `PageNumber`, `PageSize`, `TotalItems`, `TotalPages`, `ShowingFrom`, `ShowingTo`, plus `NormalizePaging()` and `ClampPageNumber()` to the All page model (`All.cshtml.cs`) and wire the page to use a new paged search result.
- Add `VisitService.SearchPagedAsync(...)` and `VisitPagedResult` to return a page of `VisitListItem` with a `TotalCount`, leaving existing `SearchAsync`/`ExportAsync` behaviour unchanged so export still returns all filtered rows.
- Update the Razor view (`All.cshtml`) to add a compact filter row, a register toolbar with `Showing X–Y of Z` and a page-size selector (25/50/100), a combined `Visitor / Remarks` column with a one-line clamped remarks preview, improved photo labels (`1 photo` / `7 photos` / `No photos`), and pagination controls that preserve filters and page size.
- Add register-specific CSS (`wwwroot/css/project-office-reports/visits.css`) for tightened header/filters, dense table styling, one-line remark clamp, photo label styling, toolbar and pagination responsive behaviour.

### Testing
- Ran `git diff --check` to validate whitespace and simple diff checks and it completed without reported problems.
- Verified presence of new symbols/strings with `rg -n "SearchPagedAsync|VisitPagedResult|PageNumber|PageSize|Visitor / Remarks|No photos|visit-register-toolbar|visit-pagination"` to confirm the changes are present in code and styles (search succeeded).
- Attempted to run `dotnet format` but it could not be executed in this environment because `dotnet` is not installed, so code-format verification was not performed here.
- No unit/integration tests were executed in this environment; recommend running the project test suite and a local build/format step in CI to ensure compile and style checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3013a0133c83298e8c5646f1b2a587)