### PR TITLE
Tighten All visits register vertical rhythm

### DIFF
--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -672,7 +672,15 @@
 -------------------------------------------------- */
 
 .visit-register-head {
-    margin-bottom: 1rem;
+    margin-bottom: 0.35rem;
+}
+
+.visit-register-head h2 {
+    line-height: 1.15;
+}
+
+.visit-register-head p {
+    margin-top: 0.2rem !important;
 }
 
 .visit-shell .visit-register-filters {
@@ -680,7 +688,7 @@
     grid-template-columns: minmax(12rem, 1.1fr) minmax(9rem, 0.8fr) minmax(9rem, 0.8fr) minmax(16rem, 1.4fr) auto;
     gap: 0.75rem;
     align-items: end;
-    margin: 0.75rem 0 0.85rem;
+    margin: 0.45rem 0 0.55rem;
 }
 
 .visit-shell .visit-register-filters > * {
@@ -711,7 +719,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    margin: 0 0 0.55rem;
+    margin: 0 0 0.35rem;
     color: var(--visit-text-muted, #64748b);
     font-size: 0.86rem;
 }


### PR DESCRIPTION
### Motivation

- Reduce the excessive vertical spacing between the page header/subtitle, the filter row, the Showing count / Rows toolbar, and the table so the All visits register reads as a compact historical register.
- Make the spacing adjustments purely CSS-focused while preserving existing filter, toolbar and table layouts and behavior.

### Description

- Updated `wwwroot/css/project-office-reports/visits.css` to tighten vertical rhythm by reducing header bottom margin and adding compact title/subtitle rules for `.visit-register-head`.
- Added `.visit-register-head h2 { line-height: 1.15; }` and `.visit-register-head p { margin-top: 0.2rem !important; }` to keep the title/subtitle visually tight.
- Reduced the filter row margins via `.visit-shell .visit-register-filters { margin: 0.45rem 0 0.55rem; }` to bring filters closer to the header and toolbar.
- Reduced the toolbar bottom margin via `.visit-shell .visit-register-toolbar { margin: 0 0 0.35rem; }` so the Showing count / Rows selector sits closer to the table.

### Testing

- Ran `git diff --check` to validate there are no obvious whitespace or diff errors and it completed successfully.
- Attempted `dotnet build ProjectManagement.sln` but the `dotnet` SDK is not available in the environment so a full build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301ba1ff388329aa7a91b2a5726f75)