### PR TITLE
Tighten All visits register spacing

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
+++ b/Areas/ProjectOfficeReports/Pages/Visits/All.cshtml
@@ -17,7 +17,8 @@
 }
 
 <div class="visit-shell visit-tracker visit-shell--tight">
-    <div class="visit-register-head d-flex justify-content-between align-items-center mt-1">
+    @* SECTION: Register header and export action *@
+    <div class="visit-register-head d-flex justify-content-between align-items-start">
         <div>
             <nav aria-label="Breadcrumb" class="visit-breadcrumb mb-1">
                 <ol class="breadcrumb mb-0">
@@ -26,10 +27,10 @@
                     <li class="breadcrumb-item active" aria-current="page">All visits to SDD</li>
                 </ol>
             </nav>
-            <h2 class="h3 mb-0">All visits to SDD</h2>
-            <p class="text-muted small mb-0 mt-1">Full historical view of inbound visits to SDD with filtering and export.</p>
+            <h2 class="h3">All visits to SDD</h2>
+            <p class="text-muted small">Full historical view of inbound visits to SDD with filtering and export.</p>
         </div>
-        <div class="d-flex gap-2">
+        <div class="visit-register-export">
             <form method="post" asp-page-handler="Export">
                 <input type="hidden" name="VisitTypeId" value="@Model.VisitTypeId" />
                 <input type="hidden" name="From" value="@(fromValue ?? string.Empty)" />
@@ -108,7 +109,8 @@
     }
     else
     {
-        <div class="card border-0 shadow-sm">
+        @* SECTION: Register results table *@
+        <div class="card border-0 shadow-sm visit-register-table-wrap">
             <div class="table-responsive">
                 <table class="table align-middle mb-0 visit-table visit-register-table">
                     <thead class="table-light">

--- a/wwwroot/css/project-office-reports/visits.css
+++ b/wwwroot/css/project-office-reports/visits.css
@@ -672,15 +672,22 @@
 -------------------------------------------------- */
 
 .visit-register-head {
-    margin-bottom: 0.35rem;
+    margin-bottom: 0.25rem;
 }
 
-.visit-register-head h2 {
+.visit-shell .visit-register-head h2 {
+    margin-bottom: 0.15rem;
     line-height: 1.15;
 }
 
-.visit-register-head p {
-    margin-top: 0.2rem !important;
+.visit-shell .visit-register-head p {
+    margin: 0.15rem 0 0;
+    line-height: 1.3;
+}
+
+.visit-register-export {
+    display: flex;
+    gap: 0.5rem;
 }
 
 .visit-shell .visit-register-filters {
@@ -688,7 +695,7 @@
     grid-template-columns: minmax(12rem, 1.1fr) minmax(9rem, 0.8fr) minmax(9rem, 0.8fr) minmax(16rem, 1.4fr) auto;
     gap: 0.75rem;
     align-items: end;
-    margin: 0.45rem 0 0.55rem;
+    margin: 0.4rem 0 0.45rem;
 }
 
 .visit-shell .visit-register-filters > * {
@@ -719,7 +726,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    margin: 0 0 0.35rem;
+    margin: 0 0 0.3rem;
     color: var(--visit-text-muted, #64748b);
     font-size: 0.86rem;
 }
@@ -746,6 +753,10 @@
     min-width: 4.5rem;
     padding-top: 0.2rem;
     padding-bottom: 0.2rem;
+}
+
+.visit-shell .visit-register-table-wrap {
+    margin-top: 0;
 }
 
 .visit-register-table {


### PR DESCRIPTION
### Motivation
- Reduce excessive vertical whitespace between the page header, filters, toolbar and table on the "All visits to SDD" register by diagnosing and removing the active spacing sources while preserving existing features and behaviour.

### Description
- Update markup in `Areas/ProjectOfficeReports/Pages/Visits/All.cshtml` to remove broad Bootstrap spacing utilities and replace the export wrapper with a page-scoped `visit-register-export` class and section comments for clarity.
- Add a dedicated `visit-register-table-wrap` class to the table card wrapper so table spacing can be controlled without relying on generic `.card` behaviour.
- Tighten scoped CSS in `wwwroot/css/project-office-reports/visits.css` by reducing header/subtitle margins, adjusting `.visit-shell .visit-register-filters` and `.visit-shell .visit-register-toolbar` margins, and adding `.visit-shell .visit-register-table-wrap { margin-top: 0; }` and `.visit-register-export` rules to enforce a compact vertical rhythm.
- Keep filter grid layout, toolbar controls, rows selector, table columns and all functionality unchanged while increasing selector specificity to avoid global regressions.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff checks which passed.
- Verified selector and file updates with `rg` searching for the affected `.visit-register-*` classes to confirm the changes were applied.
- Attempted `dotnet build --no-restore` but it could not be executed in this environment because `dotnet` is not installed, so full build verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301dd90d088329bc3b90eaee223150)