### PR TITLE
Fix activity details rendering test Activity type ambiguity

### DIFF
--- a/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
@@ -24,6 +24,7 @@ using ProjectManagement.Pages.Activities;
 using ProjectManagement.Services.Activities;
 using ProjectManagement.ViewModels.Activities;
 using Xunit;
+using Activity = ProjectManagement.Models.Activities.Activity;
 
 namespace ProjectManagement.Tests.Activities;
 


### PR DESCRIPTION
### Motivation
- Tests in `ActivityDetailsPageRenderingTests` were failing to implement `IActivityService`/`IActivityAttachmentManager` members and produced ambiguous `Activity` references because `System.Diagnostics.Activity` conflicted with the project model type, causing signature/return-type mismatches during compilation.

### Description
- Add an explicit alias `using Activity = ProjectManagement.Models.Activities.Activity;` to `ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs` so the test stubs reference the project `Activity` model unambiguously.

### Testing
- Attempted to run `dotnet test` but the `dotnet` CLI is not available in the environment so automated test execution could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a5c0642c83298e941ca431b00bfc)