### PR TITLE
Harden Project Ideas module permissions and document handling

### DIFF
--- a/Pages/ProjectIdeas/Create.cshtml
+++ b/Pages/ProjectIdeas/Create.cshtml
@@ -1,6 +1,37 @@
 @page
 @model ProjectManagement.Pages.ProjectIdeas.CreateModel
-@{ ViewData["Title"] = "Create Idea"; }
+@{
+    ViewData["Title"] = "Create Idea";
+}
 <link rel="stylesheet" href="~/css/project-ideas.css" asp-append-version="true" />
-<div class="pi-page pi-form-page"><a asp-page="Index" class="pi-back">← Back to Ideation Board</a><div class="pi-form-card"><h1><span class="bi bi-lightbulb"></span> Create Idea</h1><p class="pi-muted">Only HoD, Admin, and Comdt roles can create new ideas.</p><form method="post"><div asp-validation-summary="ModelOnly" class="text-danger"></div><label>Idea Title *</label><input asp-for="Input.Title" class="form-control" /><span asp-validation-for="Input.Title" class="text-danger"></span><label>What is the idea? *</label><textarea asp-for="Input.Description" class="form-control" rows="5"></textarea><span asp-validation-for="Input.Description" class="text-danger"></span><label>Assigned Project Officer</label><select asp-for="Input.AssignedProjectOfficerUserId" asp-items="Model.UserOptions" class="form-select"><option value="">Unassigned</option></select><label>Assigned HoD</label><select asp-for="Input.AssignedHodUserId" asp-items="Model.UserOptions" class="form-select"><option value="">Unassigned</option></select><label>Initial Status</label><select asp-for="Input.Status" asp-items="Model.StatusOptions" class="form-select"></select><button class="pi-btn pi-btn-primary" type="submit">Create Idea</button></form></div></div>
+
+<div class="pi-page pi-form-page">
+    <a asp-page="Index" class="pi-back">← Back to Ideation Board</a>
+    <div class="pi-form-card">
+        <h1><span class="bi bi-lightbulb"></span> Create Idea</h1>
+        <p class="pi-muted">Only HoD, Admin, and Comdt roles can create new ideas.</p>
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+        }
+
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <label>Idea Title *</label>
+            <input asp-for="Input.Title" class="form-control" />
+            <span asp-validation-for="Input.Title" class="text-danger"></span>
+            <label>What is the idea? *</label>
+            <textarea asp-for="Input.Description" class="form-control" rows="5"></textarea>
+            <span asp-validation-for="Input.Description" class="text-danger"></span>
+            <label>Assigned Project Officer</label>
+            <select asp-for="Input.AssignedProjectOfficerUserId" asp-items="Model.ProjectOfficerOptions" class="form-select"><option value="">Unassigned</option></select>
+            <label>Assigned HoD</label>
+            <select asp-for="Input.AssignedHodUserId" asp-items="Model.HodOptions" class="form-select"><option value="">Unassigned</option></select>
+            <label>Initial Status</label>
+            <select asp-for="Input.Status" asp-items="Model.EditableStatusOptions" class="form-select"></select>
+            <button class="pi-btn pi-btn-primary" type="submit">Create Idea</button>
+        </form>
+    </div>
+</div>
 @section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Pages/ProjectIdeas/Create.cshtml.cs
+++ b/Pages/ProjectIdeas/Create.cshtml.cs
@@ -5,8 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.EntityFrameworkCore;
-using ProjectManagement.Data;
+using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 using ProjectManagement.Models.ProjectIdeas;
 using ProjectManagement.Services.ProjectIdeas;
@@ -16,13 +15,76 @@ namespace ProjectManagement.Pages.ProjectIdeas;
 [Authorize]
 public class CreateModel : PageModel
 {
-    private readonly UserManager<ApplicationUser> _users; private readonly ProjectIdeaPermissionService _permissions; private readonly ProjectIdeaCommandService _commands;
-    public CreateModel(UserManager<ApplicationUser> users, ProjectIdeaPermissionService permissions, ProjectIdeaCommandService commands) { _users = users; _permissions = permissions; _commands = commands; }
+    private readonly UserManager<ApplicationUser> _users;
+    private readonly ProjectIdeaPermissionService _permissions;
+    private readonly ProjectIdeaCommandService _commands;
+
+    public CreateModel(UserManager<ApplicationUser> users, ProjectIdeaPermissionService permissions, ProjectIdeaCommandService commands)
+    {
+        _users = users;
+        _permissions = permissions;
+        _commands = commands;
+    }
+
+    // SECTION: Bound form state
     [BindProperty] public InputModel Input { get; set; } = new();
-    public SelectList UserOptions { get; private set; } = default!;
-    public SelectList StatusOptions { get; } = new(ProjectIdeaStatuses.All.Select(x => new { Value = x, Text = ProjectIdeaStatuses.ToDisplay(x) }), "Value", "Text");
-    public class InputModel { [Required, MaxLength(200)] public string Title { get; set; } = string.Empty; [Required, MaxLength(2000)] public string Description { get; set; } = string.Empty; public string? AssignedProjectOfficerUserId { get; set; } public string? AssignedHodUserId { get; set; } [Required] public string Status { get; set; } = ProjectIdeaStatuses.Active; }
-    public async Task<IActionResult> OnGetAsync() { if (!_permissions.CanCreateIdea(User)) return Forbid(); await LoadUsersAsync(); return Page(); }
-    public async Task<IActionResult> OnPostAsync() { if (!_permissions.CanCreateIdea(User)) return Forbid(); if (!ProjectIdeaStatuses.All.Contains(Input.Status)) ModelState.AddModelError("Input.Status", "Select a valid status."); if (!ModelState.IsValid) { await LoadUsersAsync(); return Page(); } var idea = await _commands.CreateAsync(new ProjectIdea { Title = Input.Title, Description = Input.Description, Status = Input.Status, AssignedProjectOfficerUserId = Input.AssignedProjectOfficerUserId, AssignedHodUserId = Input.AssignedHodUserId, CreatedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)! }); return RedirectToPage("Details", new { id = idea.Id }); }
-    private async Task LoadUsersAsync() { var list = await _users.Users.OrderBy(u => u.FullName).Select(u => new { u.Id, Name = string.IsNullOrWhiteSpace(u.FullName) ? u.UserName : u.FullName }).ToListAsync(); UserOptions = new SelectList(list, "Id", "Name"); }
+    [TempData] public string? StatusMessage { get; set; }
+    [TempData] public string? ErrorMessage { get; set; }
+
+    // SECTION: Select lists
+    public SelectList ProjectOfficerOptions { get; private set; } = default!;
+    public SelectList HodOptions { get; private set; } = default!;
+    public SelectList EditableStatusOptions { get; } = new(new[] { new { Value = ProjectIdeaStatuses.Active, Text = "Active" }, new { Value = ProjectIdeaStatuses.OnHold, Text = "On Hold" } }, "Value", "Text");
+
+    public class InputModel
+    {
+        [Required, MaxLength(200)] public string Title { get; set; } = string.Empty;
+        [Required, MaxLength(2000)] public string Description { get; set; } = string.Empty;
+        public string? AssignedProjectOfficerUserId { get; set; }
+        public string? AssignedHodUserId { get; set; }
+        [Required] public string Status { get; set; } = ProjectIdeaStatuses.Active;
+    }
+
+    // SECTION: Page handlers
+    public async Task<IActionResult> OnGetAsync()
+    {
+        if (!_permissions.CanCreateIdea(User)) return Forbid();
+        await LoadUsersAsync();
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!_permissions.CanCreateIdea(User)) return Forbid();
+        if (!IsEditableStatus(Input.Status)) ModelState.AddModelError("Input.Status", "Select Active or On Hold.");
+        if (!ModelState.IsValid) { await LoadUsersAsync(); ErrorMessage = "Please correct the highlighted errors."; return Page(); }
+
+        var idea = await _commands.CreateAsync(new ProjectIdea
+        {
+            Title = Input.Title.Trim(),
+            Description = Input.Description.Trim(),
+            Status = Input.Status,
+            AssignedProjectOfficerUserId = Input.AssignedProjectOfficerUserId,
+            AssignedHodUserId = Input.AssignedHodUserId,
+            CreatedByUserId = User.FindFirstValue(ClaimTypes.NameIdentifier)!
+        });
+
+        StatusMessage = "Idea created.";
+        return RedirectToPage("Details", new { id = idea.Id });
+    }
+
+    // SECTION: Lookup loading
+    private async Task LoadUsersAsync()
+    {
+        ProjectOfficerOptions = BuildSelectList(await _users.GetUsersInRoleAsync(RoleNames.ProjectOfficer));
+        HodOptions = BuildSelectList(await _users.GetUsersInRoleAsync(RoleNames.HoD));
+    }
+
+    private static SelectList BuildSelectList(IEnumerable<ApplicationUser> users)
+    {
+        return new SelectList(users.OrderBy(DisplayName).Select(u => new { u.Id, Name = DisplayName(u) }), "Id", "Name");
+    }
+
+    private static string DisplayName(ApplicationUser user) => string.IsNullOrWhiteSpace(user.FullName) ? user.UserName ?? user.Email ?? user.Id : user.FullName;
+    private static bool IsEditableStatus(string status) => status == ProjectIdeaStatuses.Active || status == ProjectIdeaStatuses.OnHold;
 }

--- a/Pages/ProjectIdeas/Details.cshtml
+++ b/Pages/ProjectIdeas/Details.cshtml
@@ -1,7 +1,141 @@
 @page "{id:int}"
 @model ProjectManagement.Pages.ProjectIdeas.DetailsModel
 @using ProjectManagement.Models.ProjectIdeas
-@{ ViewData["Title"] = Model.Idea.Title; }
+@{
+    ViewData["Title"] = Model.Idea.Title;
+}
 <link rel="stylesheet" href="~/css/project-ideas.css" asp-append-version="true" />
-<div class="pi-page"><a asp-page="Index" class="pi-back">← Back to Idea Workspace</a><section class="pi-detail-hero"><div class="pi-icon big"><span class="bi bi-lightbulb"></span></div><div class="pi-detail-title"><h1>@Model.Idea.Title</h1><p>@Model.Idea.Description</p><span class="pi-notice"><span class="bi bi-info-circle"></span> Idea creation is restricted to HoD, Admin, and Comdt roles.</span></div><div class="pi-detail-meta"><span>Status</span><b class="pi-status pi-status-@Model.Idea.Status.ToLowerInvariant()">@ProjectIdeaStatuses.ToDisplay(Model.Idea.Status)</b><span>Assigned PO</span><b>@(Model.Idea.AssignedProjectOfficerUser?.FullName ?? "Unassigned")</b><span>Assigned HoD</span><b>@(Model.Idea.AssignedHodUser?.FullName ?? "Unassigned")</b><span>Created By</span><b>@(Model.Idea.CreatedByUser?.FullName ?? "Unknown")</b><span>Last Updated</span><b>@Model.Idea.UpdatedAt.ToLocalTime().ToString("dd MMM yyyy hh:mm tt")</b></div><div class="pi-actions">@if(Model.CanEdit){<a class="pi-btn" asp-page="Edit" asp-route-id="@Model.Idea.Id"><span class="bi bi-pencil"></span> Edit</a>}@if(Model.CanArchive && Model.Idea.Status != ProjectIdeaStatuses.Archived){<form method="post" asp-page-handler="Archive" asp-route-id="@Model.Idea.Id"><input name="ArchiveReason" placeholder="Closing note / reason" /><button class="pi-btn pi-btn-danger" type="submit"><span class="bi bi-archive"></span> Archive</button></form>}@if(Model.CanArchive && Model.Idea.Status == ProjectIdeaStatuses.Archived){<form method="post" asp-page-handler="Restore" asp-route-id="@Model.Idea.Id"><button class="pi-btn pi-btn-primary" type="submit">Restore</button></form>}</div></section>
-<div class="pi-workspace"><section class="pi-panel"><h2><span class="bi bi-chat-dots"></span> Discussion</h2><div class="pi-feed">@foreach(var c in Model.Idea.Comments.OrderBy(c => c.CreatedAt)){<article class="pi-comment"><div class="pi-avatar">@((c.CreatedByUser?.FullName ?? "U").Substring(0,1))</div><div><b>@(c.CreatedByUser?.FullName ?? "Unknown")</b><time>@c.CreatedAt.ToLocalTime().ToString("dd MMM yyyy, hh:mm tt")</time><p>@c.CommentText</p></div></article>}</div>@if(Model.CanAddComment){<form method="post" asp-page-handler="Comment" asp-route-id="@Model.Idea.Id" class="pi-inline-form"><textarea name="CommentText" placeholder="Write a comment..." maxlength="4000"></textarea><button class="pi-btn pi-btn-primary">Send</button></form>}</section><section class="pi-panel"><h2><span class="bi bi-journal-text"></span> Notes</h2>@foreach(var n in Model.Idea.Notes.OrderByDescending(n => n.IsPinned).ThenByDescending(n => n.UpdatedAt)){<article class="pi-note">@if(n.IsPinned){<span class="pi-featured">Featured</span>}<h3>@n.Title</h3><small>By @(n.CreatedByUser?.FullName ?? "Unknown") · @n.CreatedAt.ToLocalTime().ToString("dd MMM yyyy")</small><p>@n.Body</p></article>}@if(Model.CanAddNote){<form method="post" asp-page-handler="Note" asp-route-id="@Model.Idea.Id" class="pi-inline-form"><input name="NoteTitle" placeholder="Note title" maxlength="200" /><textarea name="NoteBody" placeholder="Add a long-form note..."></textarea><label><input type="checkbox" name="IsPinned" value="true" /> Featured</label><button class="pi-btn">Add Note</button></form>}</section><section class="pi-panel"><h2><span class="bi bi-folder2-open"></span> Documents</h2>@foreach(var d in Model.Idea.Documents.OrderByDescending(d => d.UploadedAt)){<div class="pi-doc"><span class="bi bi-file-earmark"></span><div><b>@d.OriginalFileName</b><small>@(d.ContentType ?? "file") · @(d.FileSizeBytes / 1024) KB · @d.UploadedAt.ToLocalTime().ToString("dd MMM yyyy")</small></div><a asp-page-handler="Download" asp-route-id="@Model.Idea.Id" asp-route-documentId="@d.Id" title="Download"><span class="bi bi-download"></span></a>@if(Model.CanUpload){<form method="post" asp-page-handler="DeleteDocument" asp-route-id="@Model.Idea.Id" asp-route-documentId="@d.Id"><button title="Delete" class="pi-link-button"><span class="bi bi-trash"></span></button></form>}</div>}@if(Model.CanUpload){<form method="post" enctype="multipart/form-data" asp-page-handler="Upload" asp-route-id="@Model.Idea.Id" class="pi-inline-form"><input type="file" name="DocumentUpload" /><button class="pi-btn pi-btn-primary">Upload Document</button></form>}</section></div></div>
+
+<div class="pi-page">
+    <a asp-page="Index" class="pi-back">← Back to Idea Workspace</a>
+
+    @if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @Model.StatusMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            @Model.ErrorMessage
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+
+    <section class="pi-detail-hero">
+        <div class="pi-icon big"><span class="bi bi-lightbulb"></span></div>
+        <div class="pi-detail-title">
+            <h1>@Model.Idea.Title</h1>
+            <p>@Model.Idea.Description</p>
+            <span class="pi-notice"><span class="bi bi-info-circle"></span> Idea creation is restricted to HoD, Admin, and Comdt roles.</span>
+        </div>
+        <div class="pi-detail-meta">
+            <span>Status</span><b class="pi-status pi-status-@Model.Idea.Status.ToLowerInvariant()">@ProjectIdeaStatuses.ToDisplay(Model.Idea.Status)</b>
+            <span>Assigned PO</span><b>@(Model.Idea.AssignedProjectOfficerUser?.FullName ?? "Unassigned")</b>
+            <span>Assigned HoD</span><b>@(Model.Idea.AssignedHodUser?.FullName ?? "Unassigned")</b>
+            <span>Created By</span><b>@(Model.Idea.CreatedByUser?.FullName ?? "Unknown")</b>
+            <span>Last Updated</span><b>@Model.Idea.UpdatedAt.ToLocalTime().ToString("dd MMM yyyy hh:mm tt")</b>
+        </div>
+        <div class="pi-actions">
+            @if (Model.CanEdit)
+            {
+                <a class="pi-btn" asp-page="Edit" asp-route-id="@Model.Idea.Id"><span class="bi bi-pencil"></span> Edit</a>
+            }
+            @if (Model.CanArchive && Model.Idea.Status != ProjectIdeaStatuses.Archived)
+            {
+                <form method="post" asp-page-handler="Archive" asp-route-id="@Model.Idea.Id">
+                    <input name="ArchiveReason" placeholder="Closing note / reason" />
+                    <button class="pi-btn pi-btn-danger" type="submit"><span class="bi bi-archive"></span> Archive</button>
+                </form>
+            }
+            @if (Model.CanRestore && Model.Idea.Status == ProjectIdeaStatuses.Archived)
+            {
+                <form method="post" asp-page-handler="Restore" asp-route-id="@Model.Idea.Id">
+                    <button class="pi-btn pi-btn-primary" type="submit">Restore</button>
+                </form>
+            }
+        </div>
+    </section>
+
+    <div class="pi-workspace">
+        <section class="pi-panel">
+            <h2><span class="bi bi-chat-dots"></span> Discussion</h2>
+            <div class="pi-feed">
+                @foreach (var c in Model.Idea.Comments.OrderBy(c => c.CreatedAt))
+                {
+                    <article class="pi-comment">
+                        <div class="pi-avatar">@DetailsModel.Initials(c.CreatedByUser?.FullName ?? c.CreatedByUser?.UserName)</div>
+                        <div>
+                            <b>@(c.CreatedByUser?.FullName ?? c.CreatedByUser?.UserName ?? "Unknown")</b>
+                            <time>@c.CreatedAt.ToLocalTime().ToString("dd MMM yyyy, hh:mm tt")</time>
+                            <p>@c.CommentText</p>
+                        </div>
+                    </article>
+                }
+            </div>
+            @if (Model.CanAddComment)
+            {
+                <form method="post" asp-page-handler="Comment" asp-route-id="@Model.Idea.Id" class="pi-inline-form">
+                    <textarea name="CommentText" placeholder="Write a comment..." maxlength="4000"></textarea>
+                    <button class="pi-btn pi-btn-primary">Send</button>
+                </form>
+            }
+        </section>
+
+        <section class="pi-panel">
+            <h2><span class="bi bi-journal-text"></span> Notes</h2>
+            @foreach (var n in Model.Idea.Notes.OrderByDescending(n => n.IsPinned).ThenByDescending(n => n.UpdatedAt))
+            {
+                <article class="pi-note">
+                    @if (n.IsPinned)
+                    {
+                        <span class="pi-featured">Featured</span>
+                    }
+                    <h3>@n.Title</h3>
+                    <small>By @(n.CreatedByUser?.FullName ?? n.CreatedByUser?.UserName ?? "Unknown") · @n.CreatedAt.ToLocalTime().ToString("dd MMM yyyy")</small>
+                    <p>@n.Body</p>
+                </article>
+            }
+            @if (Model.CanAddNote)
+            {
+                <form method="post" asp-page-handler="Note" asp-route-id="@Model.Idea.Id" class="pi-inline-form">
+                    <input name="NoteTitle" placeholder="Note title" maxlength="200" />
+                    <textarea name="NoteBody" placeholder="Add a long-form note..."></textarea>
+                    <label><input type="checkbox" name="IsPinned" value="true" /> Featured</label>
+                    <button class="pi-btn">Add Note</button>
+                </form>
+            }
+        </section>
+
+        <section class="pi-panel">
+            <h2><span class="bi bi-folder2-open"></span> Documents</h2>
+            @foreach (var d in Model.Idea.Documents.OrderByDescending(d => d.UploadedAt))
+            {
+                <div class="pi-doc">
+                    <span class="bi bi-file-earmark"></span>
+                    <div>
+                        <b>@d.OriginalFileName</b>
+                        <small>@(d.ContentType ?? "file") · @(d.FileSizeBytes / 1024) KB · @d.UploadedAt.ToLocalTime().ToString("dd MMM yyyy")</small>
+                    </div>
+                    <a asp-page-handler="Download" asp-route-id="@Model.Idea.Id" asp-route-documentId="@d.Id" title="Download"><span class="bi bi-download"></span></a>
+                    @if (Model.CanDeleteDocument(d))
+                    {
+                        <form method="post" asp-page-handler="DeleteDocument" asp-route-id="@Model.Idea.Id" asp-route-documentId="@d.Id">
+                            <button title="Delete" class="pi-link-button"><span class="bi bi-trash"></span></button>
+                        </form>
+                    }
+                </div>
+            }
+            @if (Model.CanUpload)
+            {
+                <form method="post" enctype="multipart/form-data" asp-page-handler="Upload" asp-route-id="@Model.Idea.Id" class="pi-inline-form">
+                    <input type="file" name="DocumentUpload" />
+                    <button class="pi-btn pi-btn-primary">Upload Document</button>
+                </form>
+            }
+        </section>
+    </div>
+</div>

--- a/Pages/ProjectIdeas/Details.cshtml.cs
+++ b/Pages/ProjectIdeas/Details.cshtml.cs
@@ -11,23 +11,151 @@ namespace ProjectManagement.Pages.ProjectIdeas;
 [Authorize]
 public class DetailsModel : PageModel
 {
-    private readonly ProjectIdeaReadService _read; private readonly ProjectIdeaCommandService _commands; private readonly ProjectIdeaPermissionService _permissions; private readonly ProjectIdeaDocumentService _documents;
-    public DetailsModel(ProjectIdeaReadService read, ProjectIdeaCommandService commands, ProjectIdeaPermissionService permissions, ProjectIdeaDocumentService documents) { _read = read; _commands = commands; _permissions = permissions; _documents = documents; }
-    public ProjectIdea Idea { get; private set; } = default!; public bool CanEdit { get; private set; } public bool CanArchive { get; private set; } public bool CanAddComment { get; private set; } public bool CanAddNote { get; private set; } public bool CanUpload { get; private set; }
+    private readonly ProjectIdeaReadService _read;
+    private readonly ProjectIdeaCommandService _commands;
+    private readonly ProjectIdeaPermissionService _permissions;
+    private readonly ProjectIdeaDocumentService _documents;
+
+    public DetailsModel(ProjectIdeaReadService read, ProjectIdeaCommandService commands, ProjectIdeaPermissionService permissions, ProjectIdeaDocumentService documents)
+    {
+        _read = read;
+        _commands = commands;
+        _permissions = permissions;
+        _documents = documents;
+    }
+
+    // SECTION: Page state
+    public ProjectIdea Idea { get; private set; } = default!;
+    public bool CanEdit { get; private set; }
+    public bool CanArchive { get; private set; }
+    public bool CanRestore { get; private set; }
+    public bool CanAddComment { get; private set; }
+    public bool CanAddNote { get; private set; }
+    public bool CanUpload { get; private set; }
+
+    [TempData] public string? StatusMessage { get; set; }
+    [TempData] public string? ErrorMessage { get; set; }
+
+    // SECTION: Bound form state
     [BindProperty, Required, MaxLength(4000)] public string CommentText { get; set; } = string.Empty;
     [BindProperty, Required, MaxLength(200)] public string NoteTitle { get; set; } = string.Empty;
     [BindProperty, Required] public string NoteBody { get; set; } = string.Empty;
     [BindProperty] public bool IsPinned { get; set; }
     [BindProperty, MaxLength(1000)] public string? ArchiveReason { get; set; }
     [BindProperty] public IFormFile? DocumentUpload { get; set; }
-    public async Task<IActionResult> OnGetAsync(int id) => await LoadAsync(id) ? Page() : NotFound();
-    public async Task<IActionResult> OnPostCommentAsync(int id) { if (!await LoadAsync(id)) return NotFound(); if (!CanAddComment) return Forbid(); if (string.IsNullOrWhiteSpace(CommentText)) return RedirectToPage(new { id }); await _commands.AddCommentAsync(Idea, CommentText.Trim(), CurrentUserId()); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnPostNoteAsync(int id) { if (!await LoadAsync(id)) return NotFound(); if (!CanAddNote) return Forbid(); if (string.IsNullOrWhiteSpace(NoteTitle) || string.IsNullOrWhiteSpace(NoteBody)) return RedirectToPage(new { id }); await _commands.AddNoteAsync(Idea, NoteTitle.Trim(), NoteBody.Trim(), IsPinned, CurrentUserId()); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnPostArchiveAsync(int id) { if (!await LoadAsync(id)) return NotFound(); if (!CanArchive) return Forbid(); await _commands.ArchiveAsync(Idea, ArchiveReason); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnPostRestoreAsync(int id) { if (!await LoadAsync(id)) return NotFound(); if (!CanArchive) return Forbid(); await _commands.RestoreAsync(Idea); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnPostUploadAsync(int id) { if (!await LoadAsync(id)) return NotFound(); if (!CanUpload) return Forbid(); if (DocumentUpload is not null) await _documents.UploadAsync(Idea, DocumentUpload, CurrentUserId()); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnPostDeleteDocumentAsync(int id, int documentId) { if (!await LoadAsync(id)) return NotFound(); var doc = Idea.Documents.FirstOrDefault(x => x.Id == documentId); if (doc is null) return NotFound(); if (!_permissions.CanDeleteDocument(User, doc, Idea)) return Forbid(); await _documents.SoftDeleteAsync(doc); return RedirectToPage(new { id }); }
-    public async Task<IActionResult> OnGetDownloadAsync(int id, int documentId) { if (!await LoadAsync(id)) return NotFound(); var doc = await _documents.GetAsync(documentId); if (doc is null || doc.ProjectIdeaId != id) return NotFound(); var path = _documents.GetAbsolutePath(doc); return PhysicalFile(path, doc.ContentType ?? "application/octet-stream", doc.OriginalFileName); }
-    private async Task<bool> LoadAsync(int id) { var idea = await _read.GetDetailsAsync(id); if (idea is null) return false; Idea = idea; CanEdit = _permissions.CanEditIdea(User, idea); CanArchive = _permissions.CanArchiveIdea(User); CanAddComment = _permissions.CanAddComment(User, idea); CanAddNote = _permissions.CanAddNote(User, idea); CanUpload = _permissions.CanUploadDocument(User, idea); return true; }
+
+    // SECTION: Page handlers
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanViewIdea(User, Idea)) return Forbid();
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostCommentAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanAddComment(User, Idea)) return Forbid();
+        if (string.IsNullOrWhiteSpace(CommentText)) { ErrorMessage = "Comment cannot be empty."; return RedirectToPage(new { id }); }
+        await _commands.AddCommentAsync(Idea, CommentText.Trim(), CurrentUserId());
+        StatusMessage = "Comment added.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnPostNoteAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanAddNote(User, Idea)) return Forbid();
+        if (string.IsNullOrWhiteSpace(NoteTitle) || string.IsNullOrWhiteSpace(NoteBody)) { ErrorMessage = "Note title and body are required."; return RedirectToPage(new { id }); }
+        await _commands.AddNoteAsync(Idea, NoteTitle.Trim(), NoteBody.Trim(), IsPinned, CurrentUserId());
+        StatusMessage = "Note added.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnPostArchiveAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanArchiveIdea(User)) return Forbid();
+        await _commands.ArchiveAsync(Idea, ArchiveReason?.Trim());
+        StatusMessage = "Idea archived.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnPostRestoreAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanRestoreIdea(User)) return Forbid();
+        await _commands.RestoreAsync(Idea);
+        StatusMessage = "Idea restored.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnPostUploadAsync(int id)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanUploadDocument(User, Idea)) return Forbid();
+        if (DocumentUpload is null) { ErrorMessage = "Please select a document to upload."; return RedirectToPage(new { id }); }
+        var result = await _documents.UploadAsync(Idea, DocumentUpload, CurrentUserId());
+        if (!result.Success) { ErrorMessage = result.Error ?? "Document upload failed."; return RedirectToPage(new { id }); }
+        StatusMessage = "Document uploaded successfully.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnPostDeleteDocumentAsync(int id, int documentId)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        var doc = await _documents.GetAsync(documentId);
+        if (doc is null || doc.ProjectIdeaId != id || doc.IsDeleted) return NotFound();
+        if (!_permissions.CanDeleteDocument(User, doc, Idea)) return Forbid();
+        await _documents.SoftDeleteAsync(doc);
+        StatusMessage = "Document deleted.";
+        return RedirectToPage(new { id });
+    }
+
+    public async Task<IActionResult> OnGetDownloadAsync(int id, int documentId)
+    {
+        if (!await LoadAsync(id)) return NotFound();
+        if (!_permissions.CanViewIdea(User, Idea)) return Forbid();
+
+        var document = await _documents.GetAsync(documentId);
+        if (document is null || document.ProjectIdeaId != id || document.IsDeleted) return NotFound();
+
+        string absolutePath;
+        try { absolutePath = _documents.GetAbsolutePath(document); }
+        catch (InvalidOperationException) { return NotFound(); }
+
+        if (!System.IO.File.Exists(absolutePath)) return NotFound();
+
+        var contentType = string.IsNullOrWhiteSpace(document.ContentType) ? "application/octet-stream" : document.ContentType;
+        return PhysicalFile(absolutePath, contentType, document.OriginalFileName);
+    }
+
+    // SECTION: View helpers
+    public bool CanDeleteDocument(ProjectIdeaDocument document) => _permissions.CanDeleteDocument(User, document, Idea);
+
+    public static string Initials(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "U";
+        var parts = name.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "U";
+        if (parts.Length == 1) return char.ToUpperInvariant(parts[0][0]).ToString();
+        return string.Concat(parts.Take(2).Select(p => char.ToUpperInvariant(p[0])));
+    }
+
+    // SECTION: Internal loading
+    private async Task<bool> LoadAsync(int id)
+    {
+        var idea = await _read.GetDetailsAsync(id);
+        if (idea is null) return false;
+        Idea = idea;
+        CanEdit = _permissions.CanEditIdeaCore(User, idea);
+        CanArchive = _permissions.CanArchiveIdea(User);
+        CanRestore = _permissions.CanRestoreIdea(User);
+        CanAddComment = _permissions.CanAddComment(User, idea);
+        CanAddNote = _permissions.CanAddNote(User, idea);
+        CanUpload = _permissions.CanUploadDocument(User, idea);
+        return true;
+    }
+
     private string CurrentUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier)!;
 }

--- a/Pages/ProjectIdeas/Edit.cshtml
+++ b/Pages/ProjectIdeas/Edit.cshtml
@@ -1,6 +1,37 @@
 @page "{id:int}"
 @model ProjectManagement.Pages.ProjectIdeas.EditModel
-@{ ViewData["Title"] = "Edit Idea"; }
+@{
+    ViewData["Title"] = "Edit Idea";
+}
 <link rel="stylesheet" href="~/css/project-ideas.css" asp-append-version="true" />
-<div class="pi-page pi-form-page"><a asp-page="Details" asp-route-id="@Model.Input.Id" class="pi-back">← Back to Idea Workspace</a><div class="pi-form-card"><h1>Edit Idea</h1><form method="post"><input type="hidden" asp-for="Input.Id" /><div asp-validation-summary="ModelOnly" class="text-danger"></div><label>Title</label><input asp-for="Input.Title" class="form-control" /><span asp-validation-for="Input.Title" class="text-danger"></span><label>Description</label><textarea asp-for="Input.Description" class="form-control" rows="5"></textarea><span asp-validation-for="Input.Description" class="text-danger"></span><label>Assigned Project Officer</label><select asp-for="Input.AssignedProjectOfficerUserId" asp-items="Model.UserOptions" class="form-select"><option value="">Unassigned</option></select><label>Assigned HoD</label><select asp-for="Input.AssignedHodUserId" asp-items="Model.UserOptions" class="form-select"><option value="">Unassigned</option></select><label>Status</label><select asp-for="Input.Status" asp-items="Model.StatusOptions" class="form-select"></select><button class="pi-btn pi-btn-primary">Save Changes</button></form></div></div>
+
+<div class="pi-page pi-form-page">
+    <a asp-page="Details" asp-route-id="@Model.Input.Id" class="pi-back">← Back to Idea Workspace</a>
+    <div class="pi-form-card">
+        <h1>Edit Idea</h1>
+
+        @if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+        {
+            <div class="alert alert-danger" role="alert">@Model.ErrorMessage</div>
+        }
+
+        <form method="post">
+            <input type="hidden" asp-for="Input.Id" />
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <label>Title</label>
+            <input asp-for="Input.Title" class="form-control" />
+            <span asp-validation-for="Input.Title" class="text-danger"></span>
+            <label>Description</label>
+            <textarea asp-for="Input.Description" class="form-control" rows="5"></textarea>
+            <span asp-validation-for="Input.Description" class="text-danger"></span>
+            <label>Assigned Project Officer</label>
+            <select asp-for="Input.AssignedProjectOfficerUserId" asp-items="Model.ProjectOfficerOptions" class="form-select"><option value="">Unassigned</option></select>
+            <label>Assigned HoD</label>
+            <select asp-for="Input.AssignedHodUserId" asp-items="Model.HodOptions" class="form-select"><option value="">Unassigned</option></select>
+            <label>Status</label>
+            <select asp-for="Input.Status" asp-items="Model.EditableStatusOptions" class="form-select"></select>
+            <button class="pi-btn pi-btn-primary">Save Changes</button>
+        </form>
+    </div>
+</div>
 @section Scripts { <partial name="_ValidationScriptsPartial" /> }

--- a/Pages/ProjectIdeas/Edit.cshtml.cs
+++ b/Pages/ProjectIdeas/Edit.cshtml.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Configuration;
 using ProjectManagement.Models;
 using ProjectManagement.Models.ProjectIdeas;
 using ProjectManagement.Services.ProjectIdeas;
@@ -31,9 +31,13 @@ public class EditModel : PageModel
     [BindProperty]
     public InputModel Input { get; set; } = new();
 
-    public SelectList UserOptions { get; private set; } = default!;
+    public SelectList ProjectOfficerOptions { get; private set; } = default!;
+    public SelectList HodOptions { get; private set; } = default!;
 
-    public SelectList StatusOptions { get; } = new(ProjectIdeaStatuses.All.Select(x => new { Value = x, Text = ProjectIdeaStatuses.ToDisplay(x) }), "Value", "Text");
+    public SelectList EditableStatusOptions { get; } = new(new[] { new { Value = ProjectIdeaStatuses.Active, Text = "Active" }, new { Value = ProjectIdeaStatuses.OnHold, Text = "On Hold" } }, "Value", "Text");
+
+    [TempData] public string? StatusMessage { get; set; }
+    [TempData] public string? ErrorMessage { get; set; }
 
     public class InputModel
     {
@@ -58,7 +62,7 @@ public class EditModel : PageModel
     {
         var idea = await _read.GetDetailsAsync(id);
         if (idea is null) return NotFound();
-        if (!_permissions.CanEditIdea(User, idea)) return Forbid();
+        if (!_permissions.CanEditIdeaCore(User, idea)) return Forbid();
 
         Input = new()
         {
@@ -78,20 +82,12 @@ public class EditModel : PageModel
     {
         var idea = await _read.GetDetailsAsync(Input.Id);
         if (idea is null) return NotFound();
-        if (!_permissions.CanEditIdea(User, idea)) return Forbid();
+        if (!_permissions.CanEditIdeaCore(User, idea)) return Forbid();
 
         var requestedStatus = Input.Status;
-        var statusChanged = !string.Equals(idea.Status, requestedStatus, StringComparison.OrdinalIgnoreCase);
-        var archiveStateChanged = statusChanged && (string.Equals(idea.Status, ProjectIdeaStatuses.Archived, StringComparison.OrdinalIgnoreCase) || string.Equals(requestedStatus, ProjectIdeaStatuses.Archived, StringComparison.OrdinalIgnoreCase));
-
-        if (!ProjectIdeaStatuses.All.Contains(requestedStatus))
+        if (!IsEditableStatus(requestedStatus))
         {
-            ModelState.AddModelError("Input.Status", "Select a valid status.");
-        }
-
-        if (archiveStateChanged && !_permissions.CanArchiveIdea(User))
-        {
-            ModelState.AddModelError("Input.Status", "Only Admin, HoD, or Comdt users can archive or restore project ideas.");
+            ModelState.AddModelError("Input.Status", "Select Active or On Hold. Use the archive action to archive an idea.");
         }
 
         if (!ModelState.IsValid)
@@ -100,30 +96,29 @@ public class EditModel : PageModel
             return Page();
         }
 
-        idea.Title = Input.Title;
-        idea.Description = Input.Description;
+        idea.Title = Input.Title.Trim();
+        idea.Description = Input.Description.Trim();
         idea.AssignedProjectOfficerUserId = Input.AssignedProjectOfficerUserId;
         idea.AssignedHodUserId = Input.AssignedHodUserId;
         idea.Status = requestedStatus;
 
-        if (statusChanged && requestedStatus == ProjectIdeaStatuses.Archived)
-        {
-            idea.ArchivedAt = DateTime.UtcNow;
-        }
-        else if (requestedStatus != ProjectIdeaStatuses.Archived)
-        {
-            idea.ArchivedAt = null;
-            idea.ArchiveReason = null;
-        }
-
         await _commands.UpdateAsync(idea);
+        StatusMessage = "Idea updated.";
         return RedirectToPage("Details", new { id = idea.Id });
     }
 
     // SECTION: Lookup loading
     private async Task LoadUsersAsync()
     {
-        var list = await _users.Users.OrderBy(u => u.FullName).Select(u => new { u.Id, Name = string.IsNullOrWhiteSpace(u.FullName) ? u.UserName : u.FullName }).ToListAsync();
-        UserOptions = new SelectList(list, "Id", "Name");
+        ProjectOfficerOptions = BuildSelectList(await _users.GetUsersInRoleAsync(RoleNames.ProjectOfficer));
+        HodOptions = BuildSelectList(await _users.GetUsersInRoleAsync(RoleNames.HoD));
     }
+
+    private static SelectList BuildSelectList(IEnumerable<ApplicationUser> users)
+    {
+        return new SelectList(users.OrderBy(DisplayName).Select(u => new { u.Id, Name = DisplayName(u) }), "Id", "Name");
+    }
+
+    private static string DisplayName(ApplicationUser user) => string.IsNullOrWhiteSpace(user.FullName) ? user.UserName ?? user.Email ?? user.Id : user.FullName;
+    private static bool IsEditableStatus(string status) => status == ProjectIdeaStatuses.Active || status == ProjectIdeaStatuses.OnHold;
 }

--- a/Services/ProjectIdeas/ProjectIdeaCommandService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaCommandService.cs
@@ -17,6 +17,42 @@ public class ProjectIdeaCommandService
 
     // SECTION: Collaboration commands
     public async Task AddCommentAsync(ProjectIdea idea, string text, string userId) { _db.ProjectIdeaComments.Add(new ProjectIdeaComment { ProjectIdeaId = idea.Id, CommentText = text, CreatedByUserId = userId }); idea.UpdatedAt = DateTime.UtcNow; await _db.SaveChangesAsync(); }
-    public async Task AddNoteAsync(ProjectIdea idea, string title, string body, bool pinned, string userId) { _db.ProjectIdeaNotes.Add(new ProjectIdeaNote { ProjectIdeaId = idea.Id, Title = title, Body = body, IsPinned = pinned, CreatedByUserId = userId }); idea.UpdatedAt = DateTime.UtcNow; await _db.SaveChangesAsync(); }
-    public async Task SoftDeleteNoteAsync(int noteId) { var note = await _db.ProjectIdeaNotes.FirstOrDefaultAsync(x => x.Id == noteId); if (note is not null) { note.IsDeleted = true; await _db.SaveChangesAsync(); } }
+    public async Task AddNoteAsync(ProjectIdea idea, string title, string body, bool pinned, string userId)
+    {
+        if (pinned)
+        {
+            var existingPinnedNotes = await _db.ProjectIdeaNotes
+                .Where(n => n.ProjectIdeaId == idea.Id && !n.IsDeleted && n.IsPinned)
+                .ToListAsync();
+
+            foreach (var note in existingPinnedNotes)
+            {
+                note.IsPinned = false;
+                note.UpdatedAt = DateTime.UtcNow;
+            }
+        }
+
+        _db.ProjectIdeaNotes.Add(new ProjectIdeaNote { ProjectIdeaId = idea.Id, Title = title, Body = body, IsPinned = pinned, CreatedByUserId = userId, UpdatedAt = DateTime.UtcNow });
+        idea.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+    }
+    public async Task SoftDeleteNoteAsync(int noteId)
+    {
+        var note = await _db.ProjectIdeaNotes.FirstOrDefaultAsync(x => x.Id == noteId);
+        if (note is null)
+        {
+            return;
+        }
+
+        note.IsDeleted = true;
+        note.UpdatedAt = DateTime.UtcNow;
+
+        var idea = await _db.ProjectIdeas.FirstOrDefaultAsync(i => i.Id == note.ProjectIdeaId);
+        if (idea is not null)
+        {
+            idea.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync();
+    }
 }

--- a/Services/ProjectIdeas/ProjectIdeaDocumentService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaDocumentService.cs
@@ -7,7 +7,25 @@ namespace ProjectManagement.Services.ProjectIdeas;
 
 public class ProjectIdeaDocumentService
 {
-    private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase) { ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".png", ".jpg", ".jpeg" };
+    // SECTION: Upload validation configuration
+    private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".png", ".jpg", ".jpeg"
+    };
+
+    private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "image/png",
+        "image/jpeg"
+    };
+
     private const long MaxFileSizeBytes = 20 * 1024 * 1024;
     private readonly ApplicationDbContext _db;
     private readonly IUploadRootProvider _uploadRootProvider;
@@ -21,23 +39,100 @@ public class ProjectIdeaDocumentService
     // SECTION: Upload and storage
     public async Task<(bool Success, string? Error)> UploadAsync(ProjectIdea idea, IFormFile file, string userId)
     {
-        if (file.Length <= 0) return (false, "Select a file to upload.");
-        if (file.Length > MaxFileSizeBytes) return (false, "File size must be 20 MB or less.");
+        if (file is null || file.Length == 0)
+        {
+            return (false, "Please select a valid file.");
+        }
+
+        if (file.Length > MaxFileSizeBytes)
+        {
+            return (false, "File size must be 20 MB or less.");
+        }
+
         var extension = Path.GetExtension(file.FileName);
-        if (!AllowedExtensions.Contains(extension)) return (false, "This file type is not allowed.");
+        if (string.IsNullOrWhiteSpace(extension) || !AllowedExtensions.Contains(extension))
+        {
+            return (false, "This file type is not allowed.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(file.ContentType) && !AllowedContentTypes.Contains(file.ContentType))
+        {
+            return (false, "The uploaded file content type is not allowed.");
+        }
+
         var storedFileName = $"{Guid.NewGuid():N}{extension.ToLowerInvariant()}";
         var relativeFolder = Path.Combine("ProjectIdeas", idea.Id.ToString(), "Documents");
         var absoluteFolder = Path.Combine(_uploadRootProvider.RootPath, relativeFolder);
         Directory.CreateDirectory(absoluteFolder);
         var absolutePath = Path.Combine(absoluteFolder, storedFileName);
-        await using (var stream = File.Create(absolutePath)) { await file.CopyToAsync(stream); }
-        _db.ProjectIdeaDocuments.Add(new ProjectIdeaDocument { ProjectIdeaId = idea.Id, OriginalFileName = Path.GetFileName(file.FileName), StoredFileName = storedFileName, FilePath = Path.Combine(relativeFolder, storedFileName).Replace('\\', '/'), ContentType = file.ContentType, FileSizeBytes = file.Length, UploadedByUserId = userId });
+
+        await using (var stream = File.Create(absolutePath))
+        {
+            await file.CopyToAsync(stream);
+        }
+
+        _db.ProjectIdeaDocuments.Add(new ProjectIdeaDocument
+        {
+            ProjectIdeaId = idea.Id,
+            OriginalFileName = Path.GetFileName(file.FileName),
+            StoredFileName = storedFileName,
+            FilePath = Path.Combine(relativeFolder, storedFileName).Replace('\\', '/'),
+            ContentType = file.ContentType,
+            FileSizeBytes = file.Length,
+            UploadedByUserId = userId
+        });
+
         idea.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
         return (true, null);
     }
 
-    public Task<ProjectIdeaDocument?> GetAsync(int id) => _db.ProjectIdeaDocuments.Include(x => x.ProjectIdea).FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted);
-    public async Task SoftDeleteAsync(ProjectIdeaDocument document) { document.IsDeleted = true; await _db.SaveChangesAsync(); }
-    public string GetAbsolutePath(ProjectIdeaDocument document) => Path.Combine(_uploadRootProvider.RootPath, document.FilePath.Replace('/', Path.DirectorySeparatorChar));
+    // SECTION: Document lookup and deletion
+    public Task<ProjectIdeaDocument?> GetAsync(int id)
+    {
+        return _db.ProjectIdeaDocuments.Include(x => x.ProjectIdea).FirstOrDefaultAsync(x => x.Id == id);
+    }
+
+    public async Task SoftDeleteAsync(ProjectIdeaDocument document)
+    {
+        document.IsDeleted = true;
+
+        var idea = await _db.ProjectIdeas.FirstOrDefaultAsync(i => i.Id == document.ProjectIdeaId);
+        if (idea is not null)
+        {
+            idea.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync();
+    }
+
+    // SECTION: Protected path resolution
+    public string GetAbsolutePath(ProjectIdeaDocument document)
+    {
+        if (document is null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath))
+        {
+            throw new InvalidOperationException("Document file path is missing.");
+        }
+
+        var root = Path.GetFullPath(_uploadRootProvider.RootPath);
+        var protectedRoot = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+        var relativePath = document.FilePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(Path.Combine(root, relativePath));
+
+        if (!fullPath.StartsWith(protectedRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Invalid document storage path.");
+        }
+
+        return fullPath;
+    }
 }

--- a/Services/ProjectIdeas/ProjectIdeaPermissionService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaPermissionService.cs
@@ -6,18 +6,64 @@ namespace ProjectManagement.Services.ProjectIdeas;
 
 public class ProjectIdeaPermissionService
 {
-    // SECTION: Privileged role checks
+    // SECTION: Idea-level permissions
     public bool CanCreateIdea(ClaimsPrincipal user) => IsPrivileged(user);
+
+    public bool CanViewIdea(ClaimsPrincipal user, ProjectIdea idea)
+    {
+        if (user?.Identity?.IsAuthenticated != true)
+        {
+            return false;
+        }
+
+        if (IsPrivileged(user))
+        {
+            return true;
+        }
+
+        var userId = GetUserId(user);
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return false;
+        }
+
+        return string.Equals(idea.AssignedProjectOfficerUserId, userId, StringComparison.Ordinal)
+            || string.Equals(idea.AssignedHodUserId, userId, StringComparison.Ordinal)
+            || string.Equals(idea.CreatedByUserId, userId, StringComparison.Ordinal);
+    }
+
+    public bool CanEditIdeaCore(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user);
+    public bool CanEditIdea(ClaimsPrincipal user, ProjectIdea idea) => CanEditIdeaCore(user, idea);
     public bool CanArchiveIdea(ClaimsPrincipal user) => IsPrivileged(user);
-    public bool CanEditIdea(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea);
-    public bool CanAddComment(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssigned(user, idea);
-    public bool CanAddNote(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssigned(user, idea);
-    public bool CanUploadDocument(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssigned(user, idea);
-    public bool CanDeleteDocument(ClaimsPrincipal user, ProjectIdeaDocument document, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea) || string.Equals(GetUserId(user), document.UploadedByUserId, StringComparison.Ordinal);
+    public bool CanRestoreIdea(ClaimsPrincipal user) => IsPrivileged(user);
+
+    // SECTION: Collaboration permissions
+    public bool CanAddComment(ClaimsPrincipal user, ProjectIdea idea) => CanViewIdea(user, idea);
+    public bool CanAddNote(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea);
+    public bool CanUploadDocument(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea);
+
+    public bool CanDeleteDocument(ClaimsPrincipal user, ProjectIdeaDocument document, ProjectIdea idea)
+    {
+        return CanViewIdea(user, idea)
+            && (IsPrivileged(user)
+                || IsAssignedProjectOfficer(user, idea)
+                || string.Equals(GetUserId(user), document.UploadedByUserId, StringComparison.Ordinal));
+    }
 
     // SECTION: Helpers
-    private static bool IsPrivileged(ClaimsPrincipal user) => user.IsInRole(RoleNames.Admin) || user.IsInRole(RoleNames.HoD) || user.IsInRole(RoleNames.Comdt);
-    private static bool IsAssigned(ClaimsPrincipal user, ProjectIdea idea) => IsAssignedProjectOfficer(user, idea) || string.Equals(GetUserId(user), idea.AssignedHodUserId, StringComparison.Ordinal);
-    private static bool IsAssignedProjectOfficer(ClaimsPrincipal user, ProjectIdea idea) => string.Equals(GetUserId(user), idea.AssignedProjectOfficerUserId, StringComparison.Ordinal);
+    private static bool IsPrivileged(ClaimsPrincipal user)
+    {
+        return user?.Identity?.IsAuthenticated == true
+            && (user.IsInRole(RoleNames.Admin)
+                || user.IsInRole(RoleNames.HoD)
+                || user.IsInRole(RoleNames.Comdt));
+    }
+
+    private static bool IsAssignedProjectOfficer(ClaimsPrincipal user, ProjectIdea idea)
+    {
+        return user?.Identity?.IsAuthenticated == true
+            && string.Equals(GetUserId(user), idea.AssignedProjectOfficerUserId, StringComparison.Ordinal);
+    }
+
     private static string? GetUserId(ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.NameIdentifier);
 }


### PR DESCRIPTION
### Motivation
- Strengthen security and permission checks around Project Ideas so downloads and edits cannot be abused. 
- Improve file upload validation and protected storage path handling to prevent path traversal and invalid/unsafe uploads. 
- Make UI actions and POST handlers more robust by adding user feedback and server-side permission validations.

### Description
- Add explicit view and fine-grained permission methods (`CanViewIdea`, `CanEditIdeaCore`, `CanAddNote`, `CanUploadDocument`, `CanDeleteDocument`, `CanArchiveIdea`, `CanRestoreIdea`) and restrict core-edit actions to privileged roles (Admin/HoD/Comdt) while preserving collaboration permissions for assigned Project Officers; changes in `Services/ProjectIdeas/ProjectIdeaPermissionService.cs`.
- Harden document upload and storage in `Services/ProjectIdeas/ProjectIdeaDocumentService.cs` with content-type and extension allowlists, a 20MB size limit, generated GUID storage names, parent-idea `UpdatedAt` updates on soft-delete, and canonicalized absolute path resolution that enforces the file remains under the protected upload root.
- Secure the download handler and other POST handlers in `Pages/ProjectIdeas/Details.cshtml.cs` by verifying idea existence, view permission, document ownership, soft-delete status, physical file existence, and using `GetAbsolutePath` exception handling; also add `TempData` `StatusMessage`/`ErrorMessage` feedback and server-side validation for uploads/notes/comments/archiving.
- Ensure only one pinned/featured note per idea by unpinning existing pinned notes when adding a new pinned note and update parent idea timestamps on soft deletes in `Services/ProjectIdeas/ProjectIdeaCommandService.cs` and related soft-delete logic.
- Restrict Create/Edit status dropdowns to `Active` and `On Hold`, move `Archived` to the archive action flow, and filter assignment dropdowns by role (Project Officer and HoD) with new select lists and helper builders in `Pages/ProjectIdeas/Create.cshtml.cs` and `Pages/ProjectIdeas/Edit.cshtml.cs`.
- Improve UI safety by adding safe avatar initials helper and by showing per-document delete buttons only when `CanDeleteDocument(document)` returns true, and by surfacing upload/operation error and success messages in the Razor pages (`Pages/ProjectIdeas/Details.cshtml`, `Create.cshtml`, `Edit.cshtml`).

### Testing
- Repository checks (`git diff --check`) were run and reported no issues after fixes.  
- Build and EF migrations listing could not be executed in the environment because `dotnet` is not available (`dotnet build` and `dotnet ef migrations list` were not run).  
- Automated code & formatting checks performed during development (line ending/newline checks) were addressed and no remaining check failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ab80933c8329a1503fc3642b4a3f)