### PR TITLE
Harden Project Ideas permissions and document handling

### DIFF
--- a/Pages/ProjectIdeas/Details.cshtml
+++ b/Pages/ProjectIdeas/Details.cshtml
@@ -44,12 +44,12 @@
             {
                 <a class="pi-btn" asp-page="Edit" asp-route-id="@Model.Idea.Id"><span class="bi bi-pencil"></span> Edit</a>
             }
-            @if (Model.CanArchive && Model.Idea.Status != ProjectIdeaStatuses.Archived)
+            @* SECTION: Archive action *@
+            @if (Model.CanArchive && !Model.IsArchived)
             {
-                <form method="post" asp-page-handler="Archive" asp-route-id="@Model.Idea.Id">
-                    <input name="ArchiveReason" placeholder="Closing note / reason" />
-                    <button class="pi-btn pi-btn-danger" type="submit"><span class="bi bi-archive"></span> Archive</button>
-                </form>
+                <button type="button" class="pi-btn pi-btn-danger" data-bs-toggle="modal" data-bs-target="#archiveIdeaModal">
+                    <span class="bi bi-archive"></span> Archive
+                </button>
             }
             @if (Model.CanRestore && Model.Idea.Status == ProjectIdeaStatuses.Archived)
             {
@@ -59,6 +59,23 @@
             }
         </div>
     </section>
+
+
+    @* SECTION: Archived read-only banner *@
+    @if (Model.IsArchived)
+    {
+        <div class="alert alert-secondary d-flex align-items-start gap-2">
+            <i class="bi bi-archive mt-1"></i>
+            <div>
+                <strong>This idea is archived.</strong>
+                <div>It is retained for historical reference. Restore it to make changes.</div>
+                @if (!string.IsNullOrWhiteSpace(Model.Idea.ArchiveReason))
+                {
+                    <div class="mt-2"><strong>Closing note:</strong> @Model.Idea.ArchiveReason</div>
+                }
+            </div>
+        </div>
+    }
 
     <div class="pi-workspace">
         <section class="pi-panel">
@@ -139,3 +156,29 @@
         </section>
     </div>
 </div>
+
+@* SECTION: Archive confirmation modal *@
+@if (Model.CanArchive && !Model.IsArchived)
+{
+    <div class="modal fade" id="archiveIdeaModal" tabindex="-1" aria-labelledby="archiveIdeaModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <form method="post" asp-page-handler="Archive" asp-route-id="@Model.Idea.Id" class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="archiveIdeaModalLabel">Archive Idea</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted mb-3">
+                        Please enter a closing note/reason. This idea will become read-only and retained for historical reference.
+                    </p>
+                    <label class="form-label" for="ArchiveReason">Closing note / reason</label>
+                    <textarea id="ArchiveReason" name="ArchiveReason" class="form-control" required maxlength="1000" rows="4" placeholder="Enter reason for archiving this idea"></textarea>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Archive Idea</button>
+                </div>
+            </form>
+        </div>
+    </div>
+}

--- a/Pages/ProjectIdeas/Details.cshtml.cs
+++ b/Pages/ProjectIdeas/Details.cshtml.cs
@@ -32,6 +32,7 @@ public class DetailsModel : PageModel
     public bool CanAddComment { get; private set; }
     public bool CanAddNote { get; private set; }
     public bool CanUpload { get; private set; }
+    public bool IsArchived => Idea.Status == ProjectIdeaStatuses.Archived;
 
     [TempData] public string? StatusMessage { get; set; }
     [TempData] public string? ErrorMessage { get; set; }
@@ -75,8 +76,14 @@ public class DetailsModel : PageModel
     public async Task<IActionResult> OnPostArchiveAsync(int id)
     {
         if (!await LoadAsync(id)) return NotFound();
-        if (!_permissions.CanArchiveIdea(User)) return Forbid();
-        await _commands.ArchiveAsync(Idea, ArchiveReason?.Trim());
+        if (!_permissions.CanArchiveIdea(User) || IsArchived) return Forbid();
+        if (string.IsNullOrWhiteSpace(ArchiveReason))
+        {
+            ErrorMessage = "Please enter a closing note or reason before archiving the idea.";
+            return RedirectToPage(new { id });
+        }
+
+        await _commands.ArchiveAsync(Idea, ArchiveReason.Trim());
         StatusMessage = "Idea archived.";
         return RedirectToPage(new { id });
     }

--- a/Pages/ProjectIdeas/Index.cshtml.cs
+++ b/Pages/ProjectIdeas/Index.cshtml.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Configuration;
 using ProjectManagement.Models.ProjectIdeas;
 using ProjectManagement.Services.ProjectIdeas;
 
@@ -25,7 +26,9 @@ public class IndexModel : PageModel
     {
         if (!ProjectIdeaStatuses.All.Contains(Status)) Status = ProjectIdeaStatuses.Active;
         CanCreate = _permissions.CanCreateIdea(User);
-        Ideas = await _read.GetBoardIdeasAsync(Status, Query, MyIdeas, User.FindFirstValue(ClaimTypes.NameIdentifier));
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var canViewAll = User.IsInRole(RoleNames.Admin) || User.IsInRole(RoleNames.HoD) || User.IsInRole(RoleNames.Comdt);
+        Ideas = await _read.GetBoardIdeasAsync(Status, Query, MyIdeas, userId, canViewAll);
     }
 
     public static DateTime LastActivity(ProjectIdea idea) => ProjectIdeaReadService.GetLastActivity(idea);

--- a/Services/ProjectIdeas/ProjectIdeaDocumentService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaDocumentService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Application.Security;
 using ProjectManagement.Services.Storage;
 using ProjectManagement.Data;
 using ProjectManagement.Models.ProjectIdeas;
@@ -29,19 +30,26 @@ public class ProjectIdeaDocumentService
     private const long MaxFileSizeBytes = 20 * 1024 * 1024;
     private readonly ApplicationDbContext _db;
     private readonly IUploadRootProvider _uploadRootProvider;
+    private readonly IFileSecurityValidator _fileSecurityValidator;
 
-    public ProjectIdeaDocumentService(ApplicationDbContext db, IUploadRootProvider uploadRootProvider)
+    public ProjectIdeaDocumentService(ApplicationDbContext db, IUploadRootProvider uploadRootProvider, IFileSecurityValidator fileSecurityValidator)
     {
         _db = db;
         _uploadRootProvider = uploadRootProvider;
+        _fileSecurityValidator = fileSecurityValidator;
     }
 
     // SECTION: Upload and storage
     public async Task<(bool Success, string? Error)> UploadAsync(ProjectIdea idea, IFormFile file, string userId)
     {
+        if (idea is null)
+        {
+            return (false, "Idea not found.");
+        }
+
         if (file is null || file.Length == 0)
         {
-            return (false, "Please select a valid file.");
+            return (false, "Please select a valid document.");
         }
 
         if (file.Length > MaxFileSizeBytes)
@@ -49,42 +57,85 @@ public class ProjectIdeaDocumentService
             return (false, "File size must be 20 MB or less.");
         }
 
-        var extension = Path.GetExtension(file.FileName);
+        var originalFileName = Path.GetFileName(file.FileName);
+        if (string.IsNullOrWhiteSpace(originalFileName))
+        {
+            originalFileName = "document";
+        }
+
+        var extension = Path.GetExtension(originalFileName);
         if (string.IsNullOrWhiteSpace(extension) || !AllowedExtensions.Contains(extension))
         {
             return (false, "This file type is not allowed.");
         }
 
-        if (!string.IsNullOrWhiteSpace(file.ContentType) && !AllowedContentTypes.Contains(file.ContentType))
+        var contentType = string.IsNullOrWhiteSpace(file.ContentType) ? "application/octet-stream" : file.ContentType;
+        if (!AllowedContentTypes.Contains(contentType))
         {
             return (false, "The uploaded file content type is not allowed.");
         }
 
         var storedFileName = $"{Guid.NewGuid():N}{extension.ToLowerInvariant()}";
         var relativeFolder = Path.Combine("ProjectIdeas", idea.Id.ToString(), "Documents");
-        var absoluteFolder = Path.Combine(_uploadRootProvider.RootPath, relativeFolder);
-        Directory.CreateDirectory(absoluteFolder);
-        var absolutePath = Path.Combine(absoluteFolder, storedFileName);
-
-        await using (var stream = File.Create(absolutePath))
+        var relativePath = Path.Combine(relativeFolder, storedFileName).Replace('\\', '/');
+        if (relativePath.Length > 500)
         {
-            await file.CopyToAsync(stream);
+            return (false, "Generated storage path is too long.");
         }
 
-        _db.ProjectIdeaDocuments.Add(new ProjectIdeaDocument
+        var root = Path.GetFullPath(_uploadRootProvider.RootPath);
+        var protectedRoot = EnsureTrailingSeparator(root);
+        var absoluteFolder = Path.GetFullPath(Path.Combine(root, relativeFolder));
+        var absolutePath = Path.GetFullPath(Path.Combine(absoluteFolder, storedFileName));
+        if (!absoluteFolder.StartsWith(protectedRoot, StringComparison.OrdinalIgnoreCase)
+            || !absolutePath.StartsWith(protectedRoot, StringComparison.OrdinalIgnoreCase))
         {
-            ProjectIdeaId = idea.Id,
-            OriginalFileName = Path.GetFileName(file.FileName),
-            StoredFileName = storedFileName,
-            FilePath = Path.Combine(relativeFolder, storedFileName).Replace('\\', '/'),
-            ContentType = file.ContentType,
-            FileSizeBytes = file.Length,
-            UploadedByUserId = userId
-        });
+            return (false, "Invalid storage path.");
+        }
 
-        idea.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
-        return (true, null);
+        _fileSecurityValidator.ValidateRelativePath(relativePath);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            await using (var stream = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            if (!await _fileSecurityValidator.IsSafeAsync(tempFile, contentType))
+            {
+                SafeDelete(tempFile);
+                return (false, "File failed security checks.");
+            }
+
+            Directory.CreateDirectory(absoluteFolder);
+            File.Move(tempFile, absolutePath, overwrite: true);
+            tempFile = string.Empty;
+
+            _db.ProjectIdeaDocuments.Add(new ProjectIdeaDocument
+            {
+                ProjectIdeaId = idea.Id,
+                OriginalFileName = Truncate(originalFileName, 255),
+                StoredFileName = Truncate(storedFileName, 255),
+                FilePath = relativePath,
+                ContentType = Truncate(contentType, 100),
+                FileSizeBytes = file.Length,
+                UploadedByUserId = userId,
+                UploadedAt = DateTime.UtcNow,
+                IsDeleted = false
+            });
+
+            idea.UpdatedAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+            return (true, null);
+        }
+        catch
+        {
+            SafeDelete(tempFile);
+            SafeDelete(absolutePath);
+            return (false, "Document upload failed. Please try again.");
+        }
     }
 
     // SECTION: Document lookup and deletion
@@ -120,9 +171,7 @@ public class ProjectIdeaDocumentService
         }
 
         var root = Path.GetFullPath(_uploadRootProvider.RootPath);
-        var protectedRoot = root.EndsWith(Path.DirectorySeparatorChar)
-            ? root
-            : root + Path.DirectorySeparatorChar;
+        var protectedRoot = EnsureTrailingSeparator(root);
         var relativePath = document.FilePath
             .Replace('/', Path.DirectorySeparatorChar)
             .Replace('\\', Path.DirectorySeparatorChar);
@@ -134,5 +183,21 @@ public class ProjectIdeaDocumentService
         }
 
         return fullPath;
+    }
+
+    // SECTION: File helper utilities
+    private static string EnsureTrailingSeparator(string path) => path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+
+    private static void SafeDelete(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return;
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch { /* Suppress cleanup errors deliberately. */ }
+    }
+
+    private static string Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Length <= maxLength ? value : value[..maxLength];
     }
 }

--- a/Services/ProjectIdeas/ProjectIdeaPermissionService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaPermissionService.cs
@@ -32,19 +32,20 @@ public class ProjectIdeaPermissionService
             || string.Equals(idea.CreatedByUserId, userId, StringComparison.Ordinal);
     }
 
-    public bool CanEditIdeaCore(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user);
+    public bool CanEditIdeaCore(ClaimsPrincipal user, ProjectIdea idea) => !IsArchived(idea) && IsPrivileged(user);
     public bool CanEditIdea(ClaimsPrincipal user, ProjectIdea idea) => CanEditIdeaCore(user, idea);
     public bool CanArchiveIdea(ClaimsPrincipal user) => IsPrivileged(user);
     public bool CanRestoreIdea(ClaimsPrincipal user) => IsPrivileged(user);
 
     // SECTION: Collaboration permissions
-    public bool CanAddComment(ClaimsPrincipal user, ProjectIdea idea) => CanViewIdea(user, idea);
-    public bool CanAddNote(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea);
-    public bool CanUploadDocument(ClaimsPrincipal user, ProjectIdea idea) => IsPrivileged(user) || IsAssignedProjectOfficer(user, idea);
+    public bool CanAddComment(ClaimsPrincipal user, ProjectIdea idea) => !IsArchived(idea) && CanViewIdea(user, idea);
+    public bool CanAddNote(ClaimsPrincipal user, ProjectIdea idea) => !IsArchived(idea) && (IsPrivileged(user) || IsAssignedProjectOfficer(user, idea));
+    public bool CanUploadDocument(ClaimsPrincipal user, ProjectIdea idea) => !IsArchived(idea) && (IsPrivileged(user) || IsAssignedProjectOfficer(user, idea));
 
     public bool CanDeleteDocument(ClaimsPrincipal user, ProjectIdeaDocument document, ProjectIdea idea)
     {
-        return CanViewIdea(user, idea)
+        return !IsArchived(idea)
+            && CanViewIdea(user, idea)
             && (IsPrivileged(user)
                 || IsAssignedProjectOfficer(user, idea)
                 || string.Equals(GetUserId(user), document.UploadedByUserId, StringComparison.Ordinal));
@@ -66,4 +67,9 @@ public class ProjectIdeaPermissionService
     }
 
     private static string? GetUserId(ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    private static bool IsArchived(ProjectIdea idea)
+    {
+        return string.Equals(idea.Status, ProjectIdeaStatuses.Archived, StringComparison.Ordinal);
+    }
 }

--- a/Services/ProjectIdeas/ProjectIdeaReadService.cs
+++ b/Services/ProjectIdeas/ProjectIdeaReadService.cs
@@ -10,23 +10,50 @@ public class ProjectIdeaReadService
     public ProjectIdeaReadService(ApplicationDbContext db) => _db = db;
 
     // SECTION: Board queries
-    public async Task<IReadOnlyList<ProjectIdea>> GetBoardIdeasAsync(string status, string? query, bool myIdeas, string? userId)
+    public async Task<IReadOnlyList<ProjectIdea>> GetBoardIdeasAsync(string status, string? query, bool myIdeas, string? userId, bool canViewAll)
     {
+        status = ProjectIdeaStatuses.All.Contains(status) ? status : ProjectIdeaStatuses.Active;
+
         var ideas = _db.ProjectIdeas.AsNoTracking()
             .Include(x => x.AssignedProjectOfficerUser).Include(x => x.AssignedHodUser).Include(x => x.CreatedByUser)
             .Include(x => x.Comments.Where(c => !c.IsDeleted)).Include(x => x.Notes.Where(n => !n.IsDeleted)).Include(x => x.Documents.Where(d => !d.IsDeleted))
             .Where(x => !x.IsDeleted && x.Status == status);
-        if (!string.IsNullOrWhiteSpace(query))
+
+        // SECTION: Board visibility permissions
+        if (!canViewAll)
         {
-            var q = query.Trim().ToLower();
-            ideas = ideas.Where(x => x.Title.ToLower().Contains(q) || x.Description.ToLower().Contains(q)
-                || (x.AssignedProjectOfficerUser != null && x.AssignedProjectOfficerUser.FullName.ToLower().Contains(q))
-                || (x.AssignedHodUser != null && x.AssignedHodUser.FullName.ToLower().Contains(q))
-                || (x.CreatedByUser != null && x.CreatedByUser.FullName.ToLower().Contains(q)));
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return Array.Empty<ProjectIdea>();
+            }
+
+            ideas = ideas.Where(x => x.CreatedByUserId == userId || x.AssignedProjectOfficerUserId == userId || x.AssignedHodUserId == userId);
         }
+
         if (myIdeas && !string.IsNullOrWhiteSpace(userId))
         {
             ideas = ideas.Where(x => x.CreatedByUserId == userId || x.AssignedProjectOfficerUserId == userId || x.AssignedHodUserId == userId);
+        }
+
+        // SECTION: Null-safe PostgreSQL search
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var pattern = $"%{query.Trim()}%";
+            ideas = ideas.Where(x =>
+                EF.Functions.ILike(x.Title, pattern) ||
+                EF.Functions.ILike(x.Description, pattern) ||
+                (x.AssignedProjectOfficerUser != null &&
+                    ((x.AssignedProjectOfficerUser.FullName != null && EF.Functions.ILike(x.AssignedProjectOfficerUser.FullName, pattern)) ||
+                     (x.AssignedProjectOfficerUser.UserName != null && EF.Functions.ILike(x.AssignedProjectOfficerUser.UserName, pattern)) ||
+                     (x.AssignedProjectOfficerUser.Email != null && EF.Functions.ILike(x.AssignedProjectOfficerUser.Email, pattern)))) ||
+                (x.AssignedHodUser != null &&
+                    ((x.AssignedHodUser.FullName != null && EF.Functions.ILike(x.AssignedHodUser.FullName, pattern)) ||
+                     (x.AssignedHodUser.UserName != null && EF.Functions.ILike(x.AssignedHodUser.UserName, pattern)) ||
+                     (x.AssignedHodUser.Email != null && EF.Functions.ILike(x.AssignedHodUser.Email, pattern)))) ||
+                (x.CreatedByUser != null &&
+                    ((x.CreatedByUser.FullName != null && EF.Functions.ILike(x.CreatedByUser.FullName, pattern)) ||
+                     (x.CreatedByUser.UserName != null && EF.Functions.ILike(x.CreatedByUser.UserName, pattern)) ||
+                     (x.CreatedByUser.Email != null && EF.Functions.ILike(x.CreatedByUser.Email, pattern)))));
         }
         var list = await ideas.ToListAsync();
         return list.OrderByDescending(GetLastActivity).ToList();


### PR DESCRIPTION
### Motivation

- Ensure board/list visibility matches the detail view policy so users never see a card they cannot open.  
- Bring Project Ideas file uploads in line with the application's shared file security checks and avoid persisting unsafe or orphan files.  
- Make archived ideas immutable (read-only) and require a closing reason for auditability.  
- Make search null-safe and PostgreSQL-friendly to avoid runtime errors and to improve case-insensitive matching.

### Description

- Updated `ProjectIdeaReadService.GetBoardIdeasAsync` to accept `userId` and `canViewAll` and filter board queries by view permissions, and replaced the previous `.ToLower()` search with a null-safe `EF.Functions.ILike` search over title, description, assigned PO/HoD and creator (keeps results permission-filtered).  
- Modified `Pages/ProjectIdeas/Index.cshtml.cs` to compute `userId` and `canViewAll` (roles `Admin`/`HoD`/`Comdt`) and pass them to `GetBoardIdeasAsync`.  
- Injected the shared `IFileSecurityValidator` into `ProjectIdeaDocumentService` and rewrote the upload flow to: validate presence/size/extension/content-type, save to a temporary file, call `ValidateRelativePath` and `IsSafeAsync`, create protected target folder, move the temp file to the final protected path, add the DB row with truncated/sanitized metadata (`OriginalFileName`, `StoredFileName`, `ContentType`, `FilePath`) and clean up temp/final files on any failure.  
- Added path canonicalization and `EnsureTrailingSeparator` checks in `ProjectIdeaDocumentService.GetAbsolutePath` to keep downloads protected and inside the configured upload root.  
- Hardened permissions in `ProjectIdeaPermissionService` by adding `IsArchived(idea)` and blocking edit/comment/note/upload/document-delete for archived ideas while keeping `CanRestoreIdea` and `CanArchiveIdea` restricted to privileged roles.  
- Reworked `Pages/ProjectIdeas/Details.cshtml.cs` to require an `ArchiveReason` server-side in `OnPostArchiveAsync`, added an `IsArchived` helper property, and updated the page UI (`Details.cshtml`) to show a clear archived banner and a Bootstrap modal that requires an archive reason when archiving.  
- Added internal helpers `SafeDelete`, `Truncate`, and improved various null/length checks to avoid DB constraint violations and orphan files.

### Testing

- Ran `git diff --check` and static grep validations to confirm updated references and that `ProjectIdea` entities remain in the EF model snapshot (search/grep checks passed).  
- Attempted to run `dotnet build` and `dotnet ef migrations list` but the `dotnet` CLI is not available in the execution environment so those automated checks could not be executed here.  
- Verified code-level protections by searching code references for `GetBoardIdeasAsync` and upload/download paths to ensure the new call sites and protections are wired (grep/rg validations passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b47716a48329bb88b8f10dd2ade4)