### PR TITLE
Fix LastActivity static helper reference in ProjectIdeas index

### DIFF
--- a/Pages/ProjectIdeas/Index.cshtml
+++ b/Pages/ProjectIdeas/Index.cshtml
@@ -104,7 +104,7 @@
                     <div class="pi-meta">
                         <div class="pi-meta-row"><span>Assigned PO</span><b>@Model.DisplayUser(idea.AssignedProjectOfficerUser)</b></div>
                         <div class="pi-meta-row"><span>Assigned HoD</span><b>@Model.DisplayUser(idea.AssignedHodUser)</b></div>
-                        <div class="pi-meta-row"><span>Last activity</span><b>@Model.DisplayDateTime(Model.LastActivity(idea))</b></div>
+                        <div class="pi-meta-row"><span>Last activity</span><b>@Model.DisplayDateTime(IndexModel.LastActivity(idea))</b></div>
                     </div>
 
                     <div class="pi-card-footer">


### PR DESCRIPTION
### Motivation
- Resolve the CS0176 error caused by calling the static `LastActivity` helper via the `Model` instance in the Project Ideas index Razor page.

### Description
- Replace `@Model.DisplayDateTime(Model.LastActivity(idea))` with `@Model.DisplayDateTime(IndexModel.LastActivity(idea))` in `Pages/ProjectIdeas/Index.cshtml` so the static method is invoked via the type name.

### Testing
- Attempted to run `dotnet build`, but it could not be executed in this environment because the `dotnet` CLI is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30c3bde1a08329bd741ec183f7145c)