### PR TITLE
Fix project idea physical file responses

### DIFF
--- a/Pages/ProjectIdeas/Details.cshtml.cs
+++ b/Pages/ProjectIdeas/Details.cshtml.cs
@@ -142,7 +142,7 @@ public class DetailsModel : PageModel
         var contentType = string.IsNullOrWhiteSpace(document.ContentType) ? GetPreviewContentType(document) : document.ContentType;
         Response.Headers["X-Content-Type-Options"] = "nosniff";
 
-        return PhysicalFile(absolutePath, contentType, enableRangeProcessing: true);
+        return CreatePhysicalFileResult(absolutePath, contentType);
     }
 
     public async Task<IActionResult> OnGetDownloadAsync(int id, int documentId)
@@ -162,7 +162,17 @@ public class DetailsModel : PageModel
         var contentType = string.IsNullOrWhiteSpace(document.ContentType) ? "application/octet-stream" : document.ContentType;
         Response.Headers["X-Content-Type-Options"] = "nosniff";
 
-        return PhysicalFile(absolutePath, contentType, document.OriginalFileName, enableRangeProcessing: true);
+        return CreatePhysicalFileResult(absolutePath, contentType, document.OriginalFileName);
+    }
+
+    // SECTION: File response helpers
+    private static PhysicalFileResult CreatePhysicalFileResult(string absolutePath, string contentType, string? downloadName = null)
+    {
+        return new PhysicalFileResult(absolutePath, contentType)
+        {
+            EnableRangeProcessing = true,
+            FileDownloadName = downloadName
+        };
     }
 
     // SECTION: Attachment view helpers


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by using an unsupported `PhysicalFile(..., enableRangeProcessing: true)` overload while preserving range processing and attachment download filenames.

### Description
- Replace the problematic `PhysicalFile` calls in `Pages/ProjectIdeas/Details.cshtml.cs` with a new `CreatePhysicalFileResult(...)` helper that returns a `PhysicalFileResult` with `EnableRangeProcessing = true` and sets `FileDownloadName` when a download name is provided.

### Testing
- Attempted to run `dotnet build --no-restore` but the `dotnet` CLI is not available in this environment so the build could not be executed and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30c93316708329a12fec94acd4fabc)