### PR TITLE
Fix activity test compile errors

### DIFF
--- a/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityDetailsPageRenderingTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;

--- a/ProjectManagement.Tests/Activities/ActivityExportServiceTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityExportServiceTests.cs
@@ -161,7 +161,7 @@ public sealed class ActivityExportServiceTests
         public Dictionary<int, Activity> ActivityById { get; } = new();
 
         public Task<Activity?> GetByIdAsync(int id, CancellationToken cancellationToken = default) =>
-            Task.FromResult(ActivityById.TryGetValue(id, out var activity) ? activity : new Activity { Id = id, Title = "Readiness Review", CreatedByUserId = "user-1" });
+            Task.FromResult<Activity?>(ActivityById.TryGetValue(id, out var activity) ? activity : new Activity { Id = id, Title = "Readiness Review", CreatedByUserId = "user-1" });
 
         public Task<IReadOnlyList<Activity>> ListByTypeAsync(int activityTypeId, CancellationToken cancellationToken = default) =>
             Task.FromResult<IReadOnlyList<Activity>>(Array.Empty<Activity>());

--- a/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
+++ b/ProjectManagement.Tests/Activities/ActivityIndexPageTests.cs
@@ -278,7 +278,7 @@ public sealed class ActivityIndexPageTests
         Assert.NotNull(activityService.LastListRequest);
         Assert.Equal(ActivityAttachmentTypeFilter.Any, activityService.LastListRequest!.AttachmentType);
         Assert.Equal(ActivityMediaFilter.WithMedia, activityService.LastListRequest.MediaFilter);
-        Assert.DoesNotContain("AttachmentType", page.BuildRoute(), StringComparer.OrdinalIgnoreCase);
+        Assert.False(page.BuildRoute().ContainsKey("AttachmentType"));
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Resolve compile-time errors in the Activity unit tests caused by a missing Razor Pages namespace, an incorrect assertion overload usage, and a nullable task return mismatch.

### Description
- Add `using Microsoft.AspNetCore.Mvc.RazorPages;` to the activity details rendering tests so `PageContext` and `PageResult` resolve.
- Replace the invalid `Assert.DoesNotContain(..., StringComparer.OrdinalIgnoreCase)` usage with `Assert.False(page.BuildRoute().ContainsKey("AttachmentType"))` to check the presence of the route key directly.
- Make the stub repository explicit about nullable returns by returning `Task.FromResult<Activity?>(...)` to match the `Task<Activity?>` contract.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore`, but the `dotnet` CLI is not available in this environment so the test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3161047abc8329818dd96178c2d326)