### PR TITLE
Fix record health fact ID query

### DIFF
--- a/Services/Workspace/ProjectRecordHealthService.cs
+++ b/Services/Workspace/ProjectRecordHealthService.cs
@@ -50,8 +50,9 @@ public sealed class ProjectRecordHealthService
             await LoadIdsAsync(_db.ProjectPncFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
             await LoadIdsAsync(_db.ProjectSupplyOrderFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct));
 
+    // SECTION: Project ID materialization
     private static async Task<HashSet<int>> LoadIdsAsync(IQueryable<int> query, CancellationToken ct)
-        => (await query.AsNoTracking().ToListAsync(ct)).ToHashSet();
+        => (await query.ToListAsync(ct)).ToHashSet();
 
     private static bool HasRequiredFacts(Project project, StageFactPresence facts, ProjectStage? current)
     {


### PR DESCRIPTION
### Motivation
- Resolve compiler error `CS0452` caused by calling `AsNoTracking<TEntity>()` on a projected `IQueryable<int>` since EF Core requires a reference type for `TEntity`.

### Description
- Remove `AsNoTracking()` from the ID projection helper `LoadIdsAsync` in `Services/Workspace/ProjectRecordHealthService.cs` and add a section comment; the helper now materializes IDs with `ToListAsync(ct)` and converts to a `HashSet<int>`.

### Testing
- Attempted to run `dotnet build ProjectManagement.sln --no-restore` but it could not be executed because the `dotnet` CLI is not available in the environment, so no automated build/tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316bf7b1548329bbf89fd55ddef6d8)