### PR TITLE
Polish Project Officer Workspace UI

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -4,6 +4,10 @@
 @{
     ViewData["Title"] = "My Workspace";
     ViewData["UseFullWidth"] = true;
+    var postureText =
+        $"{Model.Workspace.PendingWithMeCount} action items · " +
+        $"{Model.Workspace.RecordGapCount} record gaps · " +
+        $"{Model.Workspace.OverdueTaskCount} overdue tasks";
 }
 @section Styles { <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" /> }
 <div class="workspace-page">
@@ -11,7 +15,7 @@
         <div>
             <p class="workspace-eyebrow">My Workspace</p>
             <h1>Good morning, @Model.Workspace.UserDisplayName</h1>
-            <p>@Model.Workspace.RoleTitle · Focus on the highest-impact corrections first.</p>
+            <p>@Model.Workspace.RoleTitle · @postureText</p>
         </div>
         <div class="workspace-hero__meta">
             <span>Generated @Model.Workspace.GeneratedAtUtc.ToString("dd MMM yyyy HH:mm") UTC</span>
@@ -22,8 +26,19 @@
     <section class="workspace-kpis" aria-label="Workspace KPIs">
         @foreach (var kpi in Model.Workspace.Kpis)
         {
+            var isPortfolioHealth = string.Equals(kpi.Title, "Portfolio Health", StringComparison.OrdinalIgnoreCase);
+
             <article class="workspace-kpi workspace-severity-@kpi.Severity.ToLowerInvariant()">
-                <i class="bi @kpi.Icon"></i>
+                @if (isPortfolioHealth)
+                {
+                    <div class="workspace-health-ring workspace-health-ring-@WorkspaceDisplayHelpers.HealthCss(Model.Workspace.PortfolioHealthPercent)" style="--health:@Model.Workspace.PortfolioHealthPercent">
+                        <span>@Model.Workspace.PortfolioHealthPercent%</span>
+                    </div>
+                }
+                else
+                {
+                    <i class="bi @kpi.Icon"></i>
+                }
                 <div><span>@kpi.Title</span><strong>@kpi.Value</strong><small>@kpi.Caption</small></div>
             </article>
         }
@@ -32,25 +47,29 @@
     <div class="workspace-grid">
         <main class="workspace-main">
             <section class="workspace-card"><div class="workspace-card__head"><h2>Pending With Me</h2><a href="@Model.Workspace.MyProjectsUrl">View projects</a></div>
-                @if (!Model.Workspace.PendingWithMe.Any()) { <p class="workspace-empty">All clear. No urgent action is pending with you.</p> } else { <div class="workspace-attention-list">@foreach (var item in Model.Workspace.PendingWithMe) { <article class="workspace-attention workspace-severity-@item.Severity.ToLowerInvariant()"><span class="workspace-chip">@item.BadgeText</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><a class="btn btn-sm btn-primary" href="@item.ActionUrl">@item.ActionText</a></article> }</div> }
+                @if (!Model.Workspace.PendingWithMe.Any()) { <p class="workspace-empty workspace-empty-compact">All clear. No urgent action is pending with you.</p> } else { <div class="workspace-attention-list">@foreach (var item in Model.Workspace.PendingWithMe) { <article class="workspace-attention workspace-severity-@item.Severity.ToLowerInvariant()"><span class="workspace-chip">@item.BadgeText</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><span class="workspace-urgency workspace-urgency-@item.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(item)</span><a class="btn btn-sm btn-primary" href="@item.ActionUrl">@item.ActionText</a></article> }</div> }
             </section>
             <section class="workspace-card"><div class="workspace-card__head"><h2>Waiting On Others</h2><a href="/ActionTasks?viewMode=MyWork">View my work</a></div>
-                @if (!Model.Workspace.WaitingOnOthers.Any()) { <p class="workspace-empty">Nothing is currently waiting on another desk.</p> } else { <div class="workspace-attention-list">@foreach (var item in Model.Workspace.WaitingOnOthers) { <article class="workspace-attention workspace-severity-@item.Severity.ToLowerInvariant()"><span class="workspace-chip">@item.BadgeText</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><a class="btn btn-sm btn-outline-primary" href="@item.ActionUrl">@item.ActionText</a></article> }</div> }
+                @if (!Model.Workspace.WaitingOnOthers.Any()) { <p class="workspace-empty workspace-empty-compact">Nothing is currently waiting on another desk.</p> } else { <div class="workspace-attention-list">@foreach (var item in Model.Workspace.WaitingOnOthers) { <article class="workspace-attention workspace-severity-@item.Severity.ToLowerInvariant()"><span class="workspace-chip">@item.BadgeText</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><span class="workspace-urgency workspace-urgency-@item.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(item)</span><a class="btn btn-sm btn-outline-primary" href="@item.ActionUrl">@item.ActionText</a></article> }</div> }
             </section>
             <section class="workspace-card"><div class="workspace-card__head"><h2>Project Portfolio Matrix</h2><a href="@Model.Workspace.MyProjectsUrl">View all projects</a></div>
-                @if (!Model.Workspace.ProjectMatrix.Any()) { <p class="workspace-empty">No projects are currently assigned to you.</p> } else { <div class="workspace-table-wrap"><table class="workspace-table"><thead><tr><th>Project</th><th>Current stage age</th><th>PO update</th><th>Timeline status</th><th>Record health</th><th>Next best action</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage days</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.StatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.StatusLabel(row.TimelineStatus)</span></td><td><strong>@row.RecordHealthPercent%</strong> <small>@row.RecordGapCount gaps</small></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@row.NextActionText</a></td></tr> }</tbody></table></div> }
+                @if (!Model.Workspace.ProjectMatrix.Any()) { <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p> } else { <div class="workspace-table-wrap"><table class="workspace-table"><thead><tr><th>Project</th><th>Current stage age</th><th>PO update</th><th>Timeline status</th><th>Record health</th><th>Next best action</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage days</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.StatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.StatusLabel(row.TimelineStatus)</span></td><td><span class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)">@row.RecordHealthPercent% · @row.RecordGapCount gaps</span></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@row.NextActionText</a></td></tr> }</tbody></table></div> }
             </section>
             <section class="workspace-card"><div class="workspace-card__head"><h2>My Official Tasks</h2><a href="/ActionTasks?viewMode=MyWork">View all tasks</a></div>
-                @if (!Model.Workspace.OfficialTasks.Any()) { <p class="workspace-empty">No official tasks are pending.</p> } else { <div class="workspace-task-list">@foreach (var task in Model.Workspace.OfficialTasks) { <article><div><strong>@task.Title</strong><p>@task.ContextLabel · @task.Priority · @task.Status</p></div><span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? $"Overdue {task.DaysOverdue}d" : task.DueDateUtc?.ToString("dd MMM") ?? "No due date")</span><a class="btn btn-sm btn-outline-primary" href="@task.OpenUrl">Open</a></article> }</div> }
+                @if (!Model.Workspace.OfficialTasks.Any()) { <p class="workspace-empty workspace-empty-compact">No official tasks are pending.</p> } else { <div class="workspace-task-list">@foreach (var task in Model.Workspace.OfficialTasks) { <article><div><strong>@task.Title</strong><p>@task.ContextLabel · @task.Priority · @task.Status</p></div><span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? $"Overdue {task.DaysOverdue}d" : task.DueDateUtc?.ToString("dd MMM") ?? "No due date")</span><a class="btn btn-sm btn-outline-primary" href="@task.OpenUrl">Open</a></article> }</div> }
+            </section>
+            <section class="workspace-card"><div class="workspace-card__head"><h2>My Project Ideas</h2><a href="/ProjectIdeas">View ideas</a></div>
+                @if (!Model.Workspace.Ideas.Any()) { <p class="workspace-empty workspace-empty-compact">No project ideas are currently assigned to you.</p> } else { foreach (var idea in Model.Workspace.Ideas) { <article class="workspace-mini-row"><div><strong>@idea.Title</strong><small>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</small></div>@if (idea.NeedsUpdate) { <span class="workspace-chip workspace-chip-warning">Needs update</span> }<a href="@idea.OpenUrl">Open</a></article> } }
+            </section>
+            <section class="workspace-card"><h2>Personal Reminders</h2>
+                @if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-empty workspace-empty-compact">No personal reminders.</p> } else { foreach (var r in Model.Workspace.PersonalReminders) { <article class="workspace-mini-row"><div><strong>@r.Title</strong><small>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc) @(r.IsPinned ? " · pinned" : string.Empty)</small></div><a href="@r.OpenUrl">Open</a></article> } }
             </section>
         </main>
         <aside class="workspace-rail">
             <section class="workspace-card workspace-card-clean"><h2>Quick Actions</h2><div class="workspace-quick-actions">@foreach (var action in Model.Workspace.QuickActions) { <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a> }</div></section>
-            <section class="workspace-card workspace-card-clean"><h2>Improve score by…</h2>@if (!Model.Workspace.ImproveScoreItems.Any()) { <p class="workspace-empty">Record health is looking good. Keep remarks and documents current.</p> } else { <ol class="workspace-improve-list">@foreach (var item in Model.Workspace.ImproveScoreItems) { <li><a href="@item.Url">@item.Label</a><small>@item.ProjectName</small></li> }</ol> }</section>
+            <section class="workspace-card workspace-card-clean"><h2>Improve score by…</h2>@if (!Model.Workspace.ImproveScoreItems.Any()) { <p class="workspace-empty workspace-empty-compact">Record health is looking good. Keep remarks and documents current.</p> } else { <ol class="workspace-improve-list">@foreach (var item in Model.Workspace.ImproveScoreItems) { <li><a href="@item.Url"><span>@item.Label</span><small>@item.ProjectName</small></a></li> }</ol> }</section>
             <section class="workspace-card workspace-card-clean"><h2>Project Record Health</h2>@foreach (var h in Model.Workspace.RecordHealth) { <article class="workspace-health workspace-health-@WorkspaceDisplayHelpers.HealthCss(h.HealthPercent)"><strong>@h.ProjectName</strong><span>@h.HealthPercent%</span><small>@string.Join("; ", h.Gaps.Take(2).Select(WorkspaceDisplayHelpers.ImprovementLabel))</small></article> }</section>
-            <section class="workspace-card workspace-card-clean"><h2>My Project Ideas</h2>@if (!Model.Workspace.Ideas.Any()) { <p class="workspace-empty">No project ideas are currently assigned to you.</p> } else { foreach (var idea in Model.Workspace.Ideas) { <article class="workspace-mini-row"><div><strong>@idea.Title</strong><small>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</small></div><a href="@idea.OpenUrl">Open</a></article> } }</section>
-            <section class="workspace-card workspace-card-clean"><h2>Personal Reminders</h2>@if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-empty">No personal reminders.</p> } else { foreach (var r in Model.Workspace.PersonalReminders) { <article class="workspace-mini-row"><div><strong>@r.Title</strong><small>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc) @(r.IsPinned ? "· pinned" : string.Empty)</small></div><a href="@r.OpenUrl">Open</a></article> } }</section>
-            <section class="workspace-card workspace-card-clean"><h2>ERP Engagement</h2><p class="workspace-engagement"><strong>@Model.Workspace.Engagement.EngagementLabel · @Model.Workspace.Engagement.ActiveDaysThisMonth active days</strong><span>@Model.Workspace.Engagement.ActionsRecordedThisMonth actions recorded</span><span>@Model.Workspace.Engagement.RemarksPostedThisMonth remarks posted</span><span>@Model.Workspace.Engagement.TasksUpdatedThisMonth tasks updated</span><span>@Model.Workspace.Engagement.DocumentsUploadedThisMonth documents uploaded</span></p></section>
+            <section class="workspace-card workspace-card-clean"><h2>ERP Engagement</h2><div class="workspace-engagement-grid"><div><span>Active days</span><strong>@Model.Workspace.Engagement.ActiveDaysThisMonth</strong></div><div><span>Actions</span><strong>@Model.Workspace.Engagement.ActionsRecordedThisMonth</strong></div><div><span>Remarks</span><strong>@Model.Workspace.Engagement.RemarksPostedThisMonth</strong></div><div><span>Tasks</span><strong>@Model.Workspace.Engagement.TasksUpdatedThisMonth</strong></div><div><span>Documents</span><strong>@Model.Workspace.Engagement.DocumentsUploadedThisMonth</strong></div></div></section>
         </aside>
     </div>
 </div>

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -13,8 +13,8 @@
     align-items: center;
     background: linear-gradient(135deg, #113b83, #2452a4);
     color: #fff;
-    border-radius: 20px;
-    padding: 1.05rem 1.25rem;
+    border-radius: 18px;
+    padding: 0.8rem 1.05rem;
     box-shadow: 0 16px 38px rgba(19, 47, 94, 0.18);
 }
 
@@ -28,7 +28,7 @@
 
 .workspace-hero h1 {
     margin: 0;
-    font-size: clamp(1.25rem, 2vw, 1.65rem);
+    font-size: clamp(1.15rem, 1.6vw, 1.45rem);
     font-weight: 850;
     letter-spacing: -0.02em;
 }
@@ -102,6 +102,60 @@
 .workspace-severity-warning { border-left-color: #f59f00; }
 .workspace-severity-danger { border-left-color: #dc3545; }
 
+
+/* SECTION: Portfolio health visuals */
+.workspace-health-ring {
+    width: 46px;
+    height: 46px;
+    flex: 0 0 46px;
+    border-radius: 999px;
+    display: grid;
+    place-items: center;
+    background: conic-gradient(#198754 calc(var(--health) * 1%), #e9eef6 0);
+}
+
+.workspace-health-ring span {
+    width: 34px;
+    height: 34px;
+    border-radius: 999px;
+    background: #fff;
+    display: grid;
+    place-items: center;
+    font-size: 0.72rem;
+    font-weight: 850;
+    color: #172033;
+}
+
+.workspace-health-ring-good { background: conic-gradient(#198754 calc(var(--health) * 1%), #e9eef6 0); }
+.workspace-health-ring-attention { background: conic-gradient(#f59f00 calc(var(--health) * 1%), #e9eef6 0); }
+.workspace-health-ring-danger { background: conic-gradient(#dc3545 calc(var(--health) * 1%), #e9eef6 0); }
+
+.workspace-urgency {
+    font-size: 0.72rem;
+    font-weight: 850;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+}
+
+.workspace-urgency-danger { color: #dc3545; }
+.workspace-urgency-warning { color: #f59f00; }
+.workspace-urgency-info { color: #0d6efd; }
+
+.workspace-health-pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 0.28rem 0.58rem;
+    font-size: 0.76rem;
+    font-weight: 850;
+    white-space: nowrap;
+}
+
+.workspace-health-pill-good { background: #e9f8ef; color: #146c43; }
+.workspace-health-pill-attention { background: #fff4d8; color: #8a5a00; }
+.workspace-health-pill-danger { background: #fff1f1; color: #c1121f; }
+
 /* SECTION: Layout and cards */
 .workspace-grid {
     display: grid;
@@ -158,6 +212,10 @@
     margin: 0;
 }
 
+.workspace-empty-compact {
+    padding: 0.65rem 0.8rem;
+}
+
 /* SECTION: Chips and status labels */
 .workspace-chip,
 .workspace-status {
@@ -174,6 +232,7 @@
 .workspace-chip { background: #eef4ff; color: #24447c; }
 .workspace-chip-muted { background: #eef1f6; color: #667085; }
 .workspace-chip-danger { background: #fff1f1; color: #c1121f; }
+.workspace-chip-warning { background: #fff4d8; color: #8a5a00; }
 .workspace-status { background: #f8fafc; color: #344054; }
 .workspace-dot { display: inline-block; width: 0.55rem; height: 0.55rem; border-radius: 50%; background: #adb5bd; }
 .workspace-dot-ok { background: #198754; }
@@ -189,11 +248,22 @@
     gap: 0.65rem;
 }
 
-.workspace-attention,
+.workspace-attention {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.8rem;
+    border: 1px solid #eef1f6;
+    border-radius: 15px;
+    padding: 0.78rem 0.85rem;
+    background: #fff;
+    transition: border-color 0.14s ease, box-shadow 0.14s ease, transform 0.14s ease;
+}
+
 .workspace-task-list article,
 .workspace-mini-row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     align-items: center;
     gap: 0.8rem;
     border: 1px solid #eef1f6;
@@ -306,12 +376,30 @@
 }
 
 .workspace-improve-list li {
-    padding: 0.45rem 0.55rem;
+    list-style-position: outside;
+}
+
+.workspace-improve-list a {
+    display: block;
+    padding: 0.52rem 0.62rem;
     background: #fff8e6;
     border: 1px solid #ffe3a3;
     border-radius: 10px;
-    font-weight: 700;
+    font-weight: 750;
     color: #694700;
+    text-decoration: none;
+}
+
+.workspace-improve-list a:hover {
+    background: #fff1c2;
+    border-color: #ffd166;
+}
+
+.workspace-improve-list small {
+    display: block;
+    margin-top: 0.15rem;
+    color: #8a6d20;
+    font-weight: 600;
 }
 
 .workspace-mini-row small,
@@ -320,10 +408,31 @@
     color: #667085;
 }
 
-.workspace-engagement {
+.workspace-engagement-grid {
     display: grid;
-    gap: 0.35rem;
-    margin: 0;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem;
+}
+
+.workspace-engagement-grid div {
+    background: #f8fafc;
+    border: 1px solid #eef1f6;
+    border-radius: 12px;
+    padding: 0.6rem;
+}
+
+.workspace-engagement-grid span {
+    display: block;
+    color: #667085;
+    font-size: 0.76rem;
+    font-weight: 650;
+}
+
+.workspace-engagement-grid strong {
+    display: block;
+    margin-top: 0.12rem;
+    font-size: 1.05rem;
+    color: #172033;
 }
 
 /* SECTION: Responsive behavior */


### PR DESCRIPTION
### Motivation
- Make the Workspace page feel like a premium Project Officer workboard with improved visual hierarchy and reduced hero height. 
- Surface key posture counts (action items, record gaps, overdue tasks) in the hero to improve at-a-glance situational awareness. 
- Rebalance main and rail columns so primary work (pending items, ideas, reminders) appears in the main column while keeping the rail lightweight and actionable.

### Description
- Reduced hero height and typography and replaced the hero subtext with a computed `postureText` showing PendingWithMe, RecordGap and Overdue counts in `Pages/Workspace/Index.cshtml` and updated `.workspace-hero` styles in `wwwroot/css/workspace.css`. 
- Replaced the Portfolio Health KPI icon with a health ring component that uses CSS `conic-gradient` and a `--health` custom property, and added matching health-band classes. 
- Added urgency labels to Pending/Waiting rows and updated attention list CSS grid to a four-column layout so each row renders as `Badge | Title/detail | urgency | button`. 
- Converted matrix record health to a compact health pill, made the Improve-score items clickable cards, added a compact ERP engagement stats grid, and introduced a small "Needs update" chip for stale project ideas. 
- Moved "My Project Ideas" and "Personal Reminders" from the right rail into the main column and improved empty-state spacing with a `.workspace-empty-compact` utility. 
- All changes are limited to view markup and CSS; no backend logic, permissions, database, or service behavior was altered.

### Testing
- `git diff --check` was run and reported no whitespace issues or simple diffs. 
- `dotnet build` could not be executed in this environment because the `dotnet` CLI is not available (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31eabddcf88329b046173c44488f3c)