### PR TITLE
Redesign Project Officer workspace to a daily Action Inbox

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -5,25 +5,36 @@
 @{
     ViewData["Title"] = "My Workspace";
     ViewData["UseFullWidth"] = true;
-    var attentionTitle = Model.Workspace.PendingWithMeCount == 0
-        ? "No urgent items pending today"
-        : $"{Model.Workspace.PendingWithMeCount} item{(Model.Workspace.PendingWithMeCount == 1 ? "" : "s")} need attention today";
+
+    var actionCount =
+        Model.Workspace.RemarksDue.Count +
+        Model.Workspace.OfficialTaskCount +
+        Model.Workspace.IdeasNeedingUpdate.Count +
+        Model.Workspace.ReturnedItems.Count;
+
+    var attentionTitle = actionCount == 0
+        ? "No urgent update pending today"
+        : $"{actionCount} update{(actionCount == 1 ? "" : "s")} need your attention today";
+
+    var attentionSubtitle = actionCount == 0
+        ? "Remarks, tasks and ideas are clear"
+        : "Remarks, tasks and ideas requiring action";
 }
 @section Styles {
     <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }
 
 <div class="workspace-page">
-    @* SECTION: Simplified workboard header *@
+    @* SECTION: Compact daily-action header *@
     <header class="workspace-hero workspace-hero-simple">
         <div>
             <p class="workspace-eyebrow">My Workspace</p>
             <h1>@attentionTitle</h1>
-            <p>Project Officer workboard · Assigned projects, official tasks and ideas</p>
+            <p>@attentionSubtitle</p>
         </div>
     </header>
 
-    @* SECTION: Compact summary strip *@
+    @* SECTION: Compact action summary *@
     <section class="workspace-kpis" aria-label="Workspace KPIs">
         @foreach (var kpi in Model.Workspace.Kpis)
         {
@@ -40,73 +51,133 @@
 
     <div class="workspace-grid">
         <main class="workspace-main">
-            @* SECTION: Primary portfolio workboard *@
-            <section class="workspace-card workspace-portfolio-card">
+            @* SECTION: Primary daily action inbox *@
+            <section class="workspace-card workspace-action-inbox">
                 <div class="workspace-card__head">
                     <div>
-                        <h2>My Project Portfolio</h2>
-                        <p class="workspace-section-subtitle">Assigned projects and next action required</p>
+                        <h2>Action Inbox</h2>
+                        <p class="workspace-section-subtitle">Remarks, tasks and ideas that need your update</p>
                     </div>
-                    <a href="@Model.Workspace.MyProjectsUrl">View all projects</a>
+                    <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
                 </div>
 
+                <div class="workspace-action-tabs">
+                    <section>
+                        <h3>Remarks Due</h3>
+                        @if (!Model.Workspace.RemarksDue.Any())
+                        {
+                            <p class="workspace-inline-clear">Clear</p>
+                        }
+                        else
+                        {
+                            <div class="workspace-action-list">
+                                @foreach (var item in Model.Workspace.RemarksDue.Take(4))
+                                {
+                                    <article>
+                                        <span class="workspace-chip workspace-chip-warning">Remark</span>
+                                        <div><strong>@item.Title</strong><p>@item.Detail</p></div>
+                                        <a href="@item.ActionUrl">Add Remark</a>
+                                    </article>
+                                }
+                            </div>
+                        }
+                    </section>
+
+                    <section>
+                        <h3>Official Tasks</h3>
+                        @if (!Model.Workspace.OfficialTasksDue.Any())
+                        {
+                            <p class="workspace-inline-clear">Clear</p>
+                        }
+                        else
+                        {
+                            <div class="workspace-action-list">
+                                @foreach (var task in Model.Workspace.OfficialTasksDue.Take(4))
+                                {
+                                    <article>
+                                        <span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? "Overdue" : "Task")</span>
+                                        <div><strong>@task.Title</strong><p>@task.Priority · @task.Status</p></div>
+                                        <a href="@task.OpenUrl">Open</a>
+                                    </article>
+                                }
+                            </div>
+                        }
+                    </section>
+
+                    <section>
+                        <h3>Project Ideas</h3>
+                        @if (!Model.Workspace.IdeasNeedingUpdate.Any())
+                        {
+                            <p class="workspace-inline-clear">Clear</p>
+                        }
+                        else
+                        {
+                            <div class="workspace-action-list">
+                                @foreach (var idea in Model.Workspace.IdeasNeedingUpdate.Take(4))
+                                {
+                                    <article>
+                                        <span class="workspace-chip workspace-chip-warning">Idea</span>
+                                        <div><strong>@idea.Title</strong><p>@idea.CommentCount comments · @idea.DocumentCount docs</p></div>
+                                        <a href="@idea.OpenUrl">Open</a>
+                                    </article>
+                                }
+                            </div>
+                        }
+                    </section>
+                </div>
+
+                @if (Model.Workspace.ReturnedItems.Any() || Model.Workspace.WaitingOnOthers.Any())
+                {
+                    <div class="workspace-action-secondary">
+                        @if (Model.Workspace.ReturnedItems.Any())
+                        {
+                            <div>
+                                <h3>Returned</h3>
+                                @foreach (var item in Model.Workspace.ReturnedItems.Take(3))
+                                {
+                                    <a href="@item.ActionUrl">@item.Title — @item.Detail</a>
+                                }
+                            </div>
+                        }
+                        @if (Model.Workspace.WaitingOnOthers.Any())
+                        {
+                            <div>
+                                <h3>Waiting</h3>
+                                @foreach (var item in Model.Workspace.WaitingOnOthers.Take(3))
+                                {
+                                    <a href="@item.ActionUrl">@item.Title — @item.Detail</a>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            </section>
+
+            @* SECTION: Secondary assigned-project review *@
+            <section class="workspace-card workspace-portfolio-card">
+                <div class="workspace-card__head">
+                    <div><h2>Assigned Projects</h2><p class="workspace-section-subtitle">Project stage, update status and next action</p></div>
+                    <a href="@Model.Workspace.MyProjectsUrl">View all projects</a>
+                </div>
                 @if (!Model.Workspace.ProjectMatrix.Any())
                 {
-                    <p class="workspace-empty workspace-empty-compact">
-                        No projects are currently assigned to you.
-                    </p>
+                    <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p>
                 }
                 else
                 {
                     <div class="workspace-table-wrap">
                         <table class="workspace-table workspace-portfolio-table">
-                            <thead>
-                                <tr>
-                                    <th>Project</th>
-                                    <th>Stage</th>
-                                    <th>Update</th>
-                                    <th>Timeline</th>
-                                    <th>Record</th>
-                                    <th>Next</th>
-                                </tr>
-                            </thead>
+                            <thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead>
                             <tbody>
                                 @foreach (var row in Model.Workspace.ProjectMatrix)
                                 {
                                     <tr>
-                                        <td>
-                                            <a href="@row.OpenUrl">@row.ProjectName</a>
-                                        </td>
-                                        <td>
-                                            <span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span>
-                                            @if (row.DaysInCurrentStage.HasValue)
-                                            {
-                                                <small>@row.DaysInCurrentStage.Value d</small>
-                                            }
-                                        </td>
-                                        <td>
-                                            <span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()">
-                                                <span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>
-                                                @WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)
-                                            </span>
-                                        </td>
-                                        <td>
-                                            <span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()">
-                                                <span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>
-                                                @WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)
-                                            </span>
-                                        </td>
-                                        <td>
-                                            <a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)"
-                                               href="@row.OpenUrl">
-                                                @row.RecordHealthPercent% · @row.RecordGapCount
-                                            </a>
-                                        </td>
-                                        <td>
-                                            <a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">
-                                                @WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)
-                                            </a>
-                                        </td>
+                                        <td><a href="@row.OpenUrl">@row.ProjectName</a></td>
+                                        <td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td>
+                                        <td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td>
+                                        <td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td>
+                                        <td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td>
+                                        <td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td>
                                     </tr>
                                 }
                             </tbody>
@@ -115,235 +186,60 @@
                 }
             </section>
 
-            @* SECTION: Merged work inbox *@
-            <section class="workspace-card workspace-inbox-card">
-                <div class="workspace-card__head">
-                    <div>
-                        <h2>Work Inbox</h2>
-                        <p class="workspace-section-subtitle">Pending actions, waiting items and official tasks</p>
-                    </div>
-                    <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
-                </div>
-
-                <div class="workspace-inbox-grid">
-                    <div class="workspace-inbox-pane">
-                        <h3>Pending with me</h3>
-
-                        @if (!Model.Workspace.PendingWithMe.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-inbox-list">
-                                @foreach (var item in Model.Workspace.PendingWithMe.Take(4))
-                                {
-                                    <article class="workspace-inbox-item">
-                                        <span class="workspace-urgency workspace-urgency-@item.Severity.ToLowerInvariant()">
-                                            @WorkspaceDisplayHelpers.UrgencyLabel(item)
-                                        </span>
-                                        <div>
-                                            <strong>@item.Title</strong>
-                                            <p>@item.Detail</p>
-                                        </div>
-                                        <a href="@item.ActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(item.ActionText)</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </div>
-
-                    <div class="workspace-inbox-pane">
-                        <h3>Waiting</h3>
-
-                        @if (!Model.Workspace.WaitingOnOthers.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-inbox-list">
-                                @foreach (var item in Model.Workspace.WaitingOnOthers.Take(3))
-                                {
-                                    <article class="workspace-inbox-item">
-                                        <span class="workspace-chip workspace-chip-muted">@item.BadgeText</span>
-                                        <div>
-                                            <strong>@item.Title</strong>
-                                            <p>@item.Detail</p>
-                                        </div>
-                                        <a href="@item.ActionUrl">@item.ActionText</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </div>
-
-                    <div class="workspace-inbox-pane">
-                        <h3>Official tasks</h3>
-
-                        @if (!Model.Workspace.OfficialTasks.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-inbox-list">
-                                @foreach (var task in Model.Workspace.OfficialTasks.Take(3))
-                                {
-                                    <article class="workspace-inbox-item">
-                                        <span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">
-                                            @(task.IsOverdue ? "Overdue" : "Task")
-                                        </span>
-                                        <div>
-                                            <strong>@task.Title</strong>
-                                            <p>@task.Priority · @task.Status</p>
-                                        </div>
-                                        <a href="@task.OpenUrl">Open</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </div>
-                </div>
-            </section>
-
-            @* SECTION: Combined ideas and reminders *@
+            @* SECTION: Secondary ideas and reminders *@
             <section class="workspace-card workspace-ideas-reminders">
-                <div class="workspace-card__head">
-                    <div>
-                        <h2>Ideas &amp; Reminders</h2>
-                        <p class="workspace-section-subtitle">Early concepts and personal follow-ups</p>
-                    </div>
-                </div>
-
+                <div class="workspace-card__head"><div><h2>Ideas &amp; Reminders</h2><p class="workspace-section-subtitle">Early concepts and personal follow-ups</p></div></div>
                 <div class="workspace-split-grid">
                     <div>
-                        <div class="workspace-subhead">
-                            <h3>Project Ideas</h3>
-                            <a href="/ProjectIdeas?MyIdeas=true">View ideas</a>
-                        </div>
-
-                        @if (!Model.Workspace.Ideas.Any())
-                        {
-                            <p class="workspace-inline-clear">No assigned ideas</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-slim-list">
-                                @foreach (var idea in Model.Workspace.Ideas.Take(4))
-                                {
-                                    <article>
-                                        <div>
-                                            <strong>@idea.Title</strong>
-                                            <p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p>
-                                        </div>
-
-                                        @if (idea.NeedsUpdate)
-                                        {
-                                            <span class="workspace-chip workspace-chip-warning">Needs update</span>
-                                        }
-
-                                        <a href="@idea.OpenUrl">Open</a>
-                                    </article>
-                                }
-                            </div>
-                        }
+                        <div class="workspace-subhead"><h3>Project Ideas</h3><a href="/ProjectIdeas?MyIdeas=true">View ideas</a></div>
+                        @if (!Model.Workspace.Ideas.Any()) { <p class="workspace-inline-clear">No assigned ideas</p> }
+                        else { <div class="workspace-slim-list">@foreach (var idea in Model.Workspace.Ideas.Take(4)) { <article><div><strong>@idea.Title</strong><p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p></div>@if (idea.NeedsUpdate) { <span class="workspace-chip workspace-chip-warning">Needs update</span> }<a href="@idea.OpenUrl">Open</a></article> }</div> }
                     </div>
-
                     <div>
-                        <div class="workspace-subhead">
-                            <h3>Personal Reminders</h3>
-                            <a href="/Tasks">Open reminders</a>
-                        </div>
-
-                        @if (!Model.Workspace.PersonalReminders.Any())
-                        {
-                            <p class="workspace-inline-clear">No reminders</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-slim-list">
-                                @foreach (var r in Model.Workspace.PersonalReminders.Take(4))
-                                {
-                                    <article>
-                                        <div>
-                                            <strong>@r.Title</strong>
-                                            <p>
-                                                @r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)
-                                                @(r.IsPinned ? " · pinned" : string.Empty)
-                                            </p>
-                                        </div>
-                                        <a href="@r.OpenUrl">Open</a>
-                                    </article>
-                                }
-                            </div>
-                        }
+                        <div class="workspace-subhead"><h3>Personal Reminders</h3><a href="/Tasks">Open reminders</a></div>
+                        @if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-inline-clear">No reminders</p> }
+                        else { <div class="workspace-slim-list">@foreach (var r in Model.Workspace.PersonalReminders.Take(4)) { <article><div><strong>@r.Title</strong><p>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)@(r.IsPinned ? " · pinned" : string.Empty)</p></div><a href="@r.OpenUrl">Open</a></article> }</div> }
                     </div>
                 </div>
             </section>
         </main>
 
         <aside class="workspace-rail">
-            @* SECTION: Focused next action *@
+            @* SECTION: Focused next daily action *@
             <section class="workspace-card workspace-next-fix">
-                <h2>Next Best Fix</h2>
-
-                @if (Model.Workspace.NextBestFix is null)
+                <h2>Next Best Action</h2>
+                @if (Model.Workspace.NextBestAction is null)
                 {
-                    <p class="workspace-inline-clear">No immediate fix required</p>
+                    <p class="workspace-inline-clear">No immediate action required</p>
                 }
                 else
                 {
-                    <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestFix.Severity.ToLowerInvariant()">
-                        @WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestFix)
-                    </span>
-
-                    <strong>@Model.Workspace.NextBestFix.Title</strong>
-                    <p>@Model.Workspace.NextBestFix.Detail</p>
-
-                    <a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestFix.ActionUrl">
-                        @Model.Workspace.NextBestFix.ActionText
-                    </a>
+                    <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestAction.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestAction)</span>
+                    <strong>@Model.Workspace.NextBestAction.Title</strong>
+                    <p>@Model.Workspace.NextBestAction.Detail</p>
+                    <a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestAction.ActionUrl">@Model.Workspace.NextBestAction.ActionText</a>
                 }
             </section>
 
             @* SECTION: Durable workspace destinations *@
             <section class="workspace-card workspace-card-clean">
                 <h2>Quick Actions</h2>
-                <div class="workspace-quick-actions">
-                    @foreach (var action in Model.Workspace.QuickActions)
-                    {
-                        <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a>
-                    }
-                </div>
+                <div class="workspace-quick-actions">@foreach (var action in Model.Workspace.QuickActions) { <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a> }</div>
             </section>
 
-            @* SECTION: Grouped record-health improvements *@
+            @* SECTION: Quiet grouped record cleanup *@
             <section class="workspace-card workspace-card-clean">
-                <h2>Improve Record Health</h2>
-
+                <h2>Record Cleanup</h2>
                 @if (!Model.Workspace.ImproveProjects.Any())
                 {
-                    <p class="workspace-inline-clear">
-                        Records are looking good.
-                    </p>
+                    <p class="workspace-inline-clear">No cleanup priority.</p>
                 }
                 else
                 {
-                    <div class="workspace-improve-projects">
-                        @foreach (var item in Model.Workspace.ImproveProjects)
+                    <div class="workspace-cleanup-list">
+                        @foreach (var item in Model.Workspace.ImproveProjects.Take(3))
                         {
-                            <article>
-                                <div>
-                                    <strong>@item.ProjectName</strong>
-                                    <p>
-                                        @item.FixCount fix@(item.FixCount == 1 ? "" : "es") ·
-                                        @string.Join(", ", item.FixLabels)
-                                    </p>
-                                </div>
-
-                                <a href="@item.Url">Open</a>
-                            </article>
+                            <article><div><strong>@item.ProjectName</strong><p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p></div><a href="@item.Url">Open</a></article>
                         }
                     </div>
                 }

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -81,9 +81,25 @@ public sealed class ProjectOfficerWorkspaceService
         var ideaVms = ideas.Select(i => { var last = new[] { i.UpdatedAt }.Concat(i.Comments.Where(c => !c.IsDeleted).Select(c => c.CreatedAt)).Concat(i.Notes.Where(n => !n.IsDeleted).Select(n => n.UpdatedAt)).Concat(i.Documents.Where(d => !d.IsDeleted).Select(d => d.UploadedAt)).DefaultIfEmpty(i.UpdatedAt).Max(); return new WorkspaceIdeaVm { IdeaId = i.Id, Title = i.Title, Status = ProjectIdeaStatuses.ToDisplay(i.Status), LastActivityAtUtc = last, NeedsUpdate = (today.DayNumber - WorkspaceNudgeService.ToIstDate(last).DayNumber) > 15 && (i.Status == ProjectIdeaStatuses.Active || i.Status == ProjectIdeaStatuses.OnHold), CommentCount = i.Comments.Count(c => !c.IsDeleted), DocumentCount = i.Documents.Count(d => !d.IsDeleted), OpenUrl = WorkspaceRouteHelper.ProjectIdea(i.Id) }; }).ToList();
         var reminders = await _db.TodoItems.AsNoTracking().Where(t => t.OwnerId == userId && t.Status != TodoStatus.Done && t.DeletedUtc == null).OrderByDescending(t => t.IsPinned).ThenBy(t => t.DueAtUtc).Take(5).Select(t => new WorkspaceReminderVm { ReminderId = t.Id, Title = t.Title, Priority = t.Priority.ToString(), DueAtUtc = t.DueAtUtc, IsPinned = t.IsPinned, OpenUrl = WorkspaceRouteHelper.PersonalReminders() }).ToListAsync(ct);
         var health = await _health.CalculateForProjectsAsync(projects, userId, ct);
+        var remarksDue = _nudges.BuildRemarksDue(projects, userId, today).ToList();
         var returnedItems = await BuildReturnedItemsAsync(userId, ct);
+        var officialTasksDue = tasks
+            .Where(t => t.IsOverdue || IsDueSoon(t.DueDateUtc, today))
+            .OrderByDescending(t => t.IsOverdue)
+            .ThenBy(t => t.DueDateUtc)
+            .Take(5)
+            .ToList();
+        var ideasNeedingUpdate = ideaVms
+            .Where(i => i.NeedsUpdate)
+            .OrderByDescending(i => i.LastActivityAtUtc)
+            .Take(5)
+            .ToList();
+        var timelineAlerts = _nudges.BuildTimelineAlerts(projects, today).ToList();
         var pending = returnedItems
-            .Concat(_nudges.BuildPendingWithMe(projects, tasks, ideaVms, userId, today))
+            .Concat(remarksDue)
+            .Concat(officialTasksDue.Select(ToAttentionItem))
+            .Concat(ideasNeedingUpdate.Select(ToAttentionItem))
+            .Concat(timelineAlerts)
             .GroupBy(i => $"{i.Type}:{i.Title}")
             .Select(g => g
                 .OrderBy(i => WorkspaceSeverityRank(i.Severity))
@@ -111,10 +127,18 @@ public sealed class ProjectOfficerWorkspaceService
             AssignedProjectCount = projects.Count,
             PendingWithMeCount = pending.Count,
             OverdueTaskCount = tasks.Count(t => t.IsOverdue),
+            RemarksDueCount = remarksDue.Count,
+            OfficialTaskCount = tasks.Count,
+            IdeasNeedingUpdateCount = ideaVms.Count(i => i.NeedsUpdate),
             RecordGapCount = health.Values.Sum(h => h.Gaps.Count),
             AssignedIdeaCount = ideaVms.Count,
             Engagement = engagement,
             PendingWithMe = pending.Take(5).ToList(),
+            RemarksDue = remarksDue.Take(5).ToList(),
+            OfficialTasksDue = officialTasksDue,
+            IdeasNeedingUpdate = ideasNeedingUpdate,
+            ReturnedItems = returnedItems.Take(5).ToList(),
+            TimelineAlerts = timelineAlerts.Take(5).ToList(),
             WaitingOnOthers = waitingOnOthers.Take(5).ToList(),
             ProjectMatrix = matrix,
             OfficialTasks = tasks.Take(5).ToList(),
@@ -127,6 +151,7 @@ public sealed class ProjectOfficerWorkspaceService
             ImproveScoreItems = BuildImproveScoreItems(health.Values, maxItems: 4),
             ImproveProjects = BuildImproveProjects(health.Values, maxProjects: 3),
             NextBestFix = pending.FirstOrDefault(),
+            NextBestAction = BuildNextBestAction(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, timelineAlerts),
             PersonalReminders = reminders,
             QuickActions = BuildQuickActions(userId),
             MyProjectsUrl = myProjectsUrl
@@ -134,6 +159,69 @@ public sealed class ProjectOfficerWorkspaceService
         vm.Kpis = BuildKpis(vm);
         return vm;
     }
+
+    // SECTION: Due-soon detection uses the workspace IST operating date.
+    private static bool IsDueSoon(DateTime? dueDateUtc, DateOnly today)
+    {
+        if (!dueDateUtc.HasValue)
+        {
+            return false;
+        }
+
+        var due = DateOnly.FromDateTime(dueDateUtc.Value);
+        var days = due.DayNumber - today.DayNumber;
+
+        return days >= 0 && days <= 3;
+    }
+
+    // SECTION: Next best action prioritizes daily operations over record cleanup.
+    private static WorkspaceAttentionItemVm? BuildNextBestAction(
+        IReadOnlyList<WorkspaceAttentionItemVm> returnedItems,
+        IReadOnlyList<WorkspaceTaskVm> officialTasksDue,
+        IReadOnlyList<WorkspaceAttentionItemVm> remarksDue,
+        IReadOnlyList<WorkspaceIdeaVm> ideasNeedingUpdate,
+        IReadOnlyList<WorkspaceAttentionItemVm> timelineAlerts)
+    {
+        var returned = returnedItems.FirstOrDefault();
+        if (returned is not null) return returned;
+
+        var overdueTask = officialTasksDue.FirstOrDefault(t => t.IsOverdue);
+        if (overdueTask is not null) return ToAttentionItem(overdueTask);
+
+        var remark = remarksDue.FirstOrDefault();
+        if (remark is not null) return remark;
+
+        var idea = ideasNeedingUpdate.FirstOrDefault();
+        if (idea is not null) return ToAttentionItem(idea);
+
+        return timelineAlerts.FirstOrDefault();
+    }
+
+    private static WorkspaceAttentionItemVm ToAttentionItem(WorkspaceTaskVm task) => new()
+    {
+        Type = "Task",
+        Title = task.Title,
+        Detail = task.IsOverdue
+            ? task.DaysOverdue.HasValue ? $"Official task overdue by {task.DaysOverdue.Value} days" : "Official task overdue"
+            : "Official task due soon",
+        Severity = task.IsOverdue ? "Danger" : "Warning",
+        BadgeText = "Task",
+        ActionText = "Open Task",
+        ActionUrl = task.OpenUrl,
+        DueOrEventDateUtc = task.DueDateUtc
+    };
+
+    private static WorkspaceAttentionItemVm ToAttentionItem(WorkspaceIdeaVm idea) => new()
+    {
+        Type = "Idea",
+        Title = idea.Title,
+        Detail = "Project idea needs update",
+        Severity = "Warning",
+        BadgeText = "Idea",
+        ActionText = "Open Idea",
+        ActionUrl = idea.OpenUrl,
+        DueOrEventDateUtc = idea.LastActivityAtUtc
+    };
 
 
     // SECTION: Waiting-on-others summarizes submissions that are no longer actionable by the PO.
@@ -361,49 +449,15 @@ public sealed class ProjectOfficerWorkspaceService
         };
     }
 
-    // SECTION: Compact KPI strip highlights only essential workspace summary facts.
+    // SECTION: Compact KPI strip highlights daily updates before project health.
     private static IReadOnlyList<WorkspaceKpiVm> BuildKpis(ProjectOfficerWorkspaceVm vm)
     {
         return new[]
         {
-            new WorkspaceKpiVm
-            {
-                Title = "Needs Attention",
-                Value = vm.PendingWithMeCount.ToString(),
-                Caption = vm.PendingWithMeCount == 0
-                    ? "Clear"
-                    : "Highest priority items",
-                Severity = vm.PendingWithMeCount == 0 ? "Good" : "Warning",
-                Icon = "bi-inbox"
-            },
-            new WorkspaceKpiVm
-            {
-                Title = "Assigned Projects",
-                Value = vm.AssignedProjectCount.ToString(),
-                Caption = "Currently with you",
-                Severity = "Info",
-                Icon = "bi-kanban"
-            },
-            new WorkspaceKpiVm
-            {
-                Title = "Official Tasks",
-                Value = vm.OfficialTasks.Count.ToString(),
-                Caption = vm.OverdueTaskCount == 0
-                    ? "No overdue task"
-                    : $"{vm.OverdueTaskCount} overdue",
-                Severity = vm.OverdueTaskCount == 0 ? "Good" : "Danger",
-                Icon = "bi-list-check"
-            },
-            new WorkspaceKpiVm
-            {
-                Title = "Record Health",
-                Value = vm.RecordHealthSummaryLabel,
-                Caption = $"{vm.RecordGapCount} fixes identified",
-                Severity = vm.PortfolioHealthPercent >= 80
-                    ? "Good"
-                    : vm.PortfolioHealthPercent >= 60 ? "Warning" : "Danger",
-                Icon = "bi-folder-check"
-            }
+            new WorkspaceKpiVm { Title = "Remarks Due", Value = vm.RemarksDueCount.ToString(), Caption = "Project updates", Severity = vm.RemarksDueCount == 0 ? "Good" : "Warning", Icon = "bi-chat-left-text" },
+            new WorkspaceKpiVm { Title = "Official Tasks", Value = vm.OfficialTaskCount.ToString(), Caption = vm.OverdueTaskCount == 0 ? "No overdue task" : $"{vm.OverdueTaskCount} overdue", Severity = vm.OverdueTaskCount == 0 ? "Good" : "Danger", Icon = "bi-list-check" },
+            new WorkspaceKpiVm { Title = "Project Ideas", Value = vm.AssignedIdeaCount.ToString(), Caption = vm.IdeasNeedingUpdateCount == 0 ? "No stale idea" : $"{vm.IdeasNeedingUpdateCount} need update", Severity = vm.IdeasNeedingUpdateCount == 0 ? "Good" : "Warning", Icon = "bi-lightbulb" },
+            new WorkspaceKpiVm { Title = "Assigned Projects", Value = vm.AssignedProjectCount.ToString(), Caption = "Currently with you", Severity = "Info", Icon = "bi-kanban" }
         };
     }
 }

--- a/Services/Workspace/WorkspaceNudgeService.cs
+++ b/Services/Workspace/WorkspaceNudgeService.cs
@@ -56,6 +56,112 @@ public sealed class WorkspaceNudgeService
 
     public bool IsCurrentStageOverdue(ProjectStage? stage, DateOnly today) => stage is not null && stage.Status != StageStatus.Completed && stage.PlannedDue is { } due && due < today;
 
+
+    // SECTION: Daily remark nudges are separated from timeline cleanup so remarks stay prominent.
+    public IReadOnlyList<WorkspaceAttentionItemVm> BuildRemarksDue(
+        IReadOnlyList<Project> projects,
+        string userId,
+        DateOnly today)
+    {
+        var items = new List<WorkspaceAttentionItemVm>();
+
+        foreach (var project in projects)
+        {
+            var lastRemark = GetLastPoRemark(project, userId);
+
+            if (!IsRemarkDue(lastRemark, today))
+            {
+                continue;
+            }
+
+            var detail = lastRemark.HasValue
+                ? $"No PO remark in last {today.DayNumber - ToIstDate(lastRemark.Value).DayNumber} days"
+                : "No PO remark has been added yet";
+
+            items.Add(new WorkspaceAttentionItemVm
+            {
+                Type = "Remark",
+                Title = project.Name,
+                Detail = detail,
+                Severity = "Warning",
+                BadgeText = "Remark",
+                ActionText = "Add Remark",
+                ActionUrl = WorkspaceRouteHelper.ProjectRemarks(project.Id),
+                DueOrEventDateUtc = lastRemark
+            });
+        }
+
+        return items
+            .OrderByDescending(i => i.DueOrEventDateUtc is null)
+            .ThenBy(i => i.DueOrEventDateUtc)
+            .ToList();
+    }
+
+    // SECTION: Timeline alerts stay available as secondary record-health guidance.
+    public IReadOnlyList<WorkspaceAttentionItemVm> BuildTimelineAlerts(
+        IReadOnlyList<Project> projects,
+        DateOnly today)
+    {
+        var items = new List<WorkspaceAttentionItemVm>();
+
+        foreach (var project in projects)
+        {
+            var stage = GetCurrentStage(project);
+
+            if (project.ProjectStages.Any(s => s.RequiresBackfill))
+            {
+                items.Add(new WorkspaceAttentionItemVm
+                {
+                    Type = "Timeline",
+                    Title = project.Name,
+                    Detail = "Timeline backfill required",
+                    Severity = "Danger",
+                    BadgeText = "Timeline",
+                    ActionText = "Backfill",
+                    ActionUrl = WorkspaceRouteHelper.ProjectTimeline(project.Id)
+                });
+
+                continue;
+            }
+
+            if (IsCurrentStageOverdue(stage, today))
+            {
+                var overdueDays = stage?.PlannedDue is { } due
+                    ? today.DayNumber - due.DayNumber
+                    : 0;
+
+                items.Add(new WorkspaceAttentionItemVm
+                {
+                    Type = "Timeline",
+                    Title = project.Name,
+                    Detail = $"Current stage overdue by {overdueDays} days",
+                    Severity = "Danger",
+                    BadgeText = "Timeline",
+                    ActionText = "Timeline",
+                    ActionUrl = WorkspaceRouteHelper.ProjectTimeline(project.Id)
+                });
+
+                continue;
+            }
+
+            if (HasCurrentStageTimelineIssue(stage))
+            {
+                items.Add(new WorkspaceAttentionItemVm
+                {
+                    Type = "Timeline",
+                    Title = project.Name,
+                    Detail = GetCurrentStageIssueLabel(stage),
+                    Severity = "Warning",
+                    BadgeText = "Timeline",
+                    ActionText = "Update",
+                    ActionUrl = WorkspaceRouteHelper.ProjectTimeline(project.Id)
+                });
+            }
+        }
+
+        return items;
+    }
+
     public IReadOnlyList<WorkspaceAttentionItemVm> BuildPendingWithMe(IReadOnlyList<Project> projects, IReadOnlyList<WorkspaceTaskVm> tasks, IReadOnlyList<WorkspaceIdeaVm> ideas, string userId, DateOnly today)
     {
         var items = new List<WorkspaceAttentionItemVm>();
@@ -145,6 +251,21 @@ public sealed class WorkspaceNudgeService
             ActionText = action,
             ActionUrl = url
         };
+    private static DateTime? GetLastPoRemark(Project project, string userId) => LastPoRemark(project, userId);
+
+    private static bool IsRemarkDue(DateTime? lastRemarkAtUtc, DateOnly today)
+    {
+        if (!lastRemarkAtUtc.HasValue)
+        {
+            return true;
+        }
+
+        var last = ToIstDate(lastRemarkAtUtc.Value);
+        return today.DayNumber - last.DayNumber > 10;
+    }
+
+    private static string GetCurrentStageIssueLabel(ProjectStage? stage) => StageTimelineDetail(stage);
+
     private static string StageTimelineDetail(ProjectStage? stage) => stage is null ? "Current stage timeline details are incomplete" : stage.Status == StageStatus.InProgress && stage.ActualStart is null ? "Current stage actual start missing" : stage.Status == StageStatus.InProgress && stage.PlannedDue is null ? "Current stage planned due missing" : stage.Status == StageStatus.Completed && stage.CompletedOn is null ? $"{stage.StageCode} stage completion date missing" : "Current stage timeline details are incomplete";
 
     // SECTION: Pending item grouping avoids showing multiple lower-priority nudges for the same project.

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -17,6 +17,14 @@ public sealed class ProjectOfficerWorkspaceVm
     public WorkspaceEngagementVm Engagement { get; set; } = new();
     public IReadOnlyList<WorkspaceKpiVm> Kpis { get; set; } = Array.Empty<WorkspaceKpiVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
+    public IReadOnlyList<WorkspaceAttentionItemVm> RemarksDue { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
+    public IReadOnlyList<WorkspaceTaskVm> OfficialTasksDue { get; set; } = Array.Empty<WorkspaceTaskVm>();
+    public IReadOnlyList<WorkspaceIdeaVm> IdeasNeedingUpdate { get; set; } = Array.Empty<WorkspaceIdeaVm>();
+    public IReadOnlyList<WorkspaceAttentionItemVm> ReturnedItems { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
+    public IReadOnlyList<WorkspaceAttentionItemVm> TimelineAlerts { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
+    public int OfficialTaskCount { get; set; }
+    public int RemarksDueCount { get; set; }
+    public int IdeasNeedingUpdateCount { get; set; }
     public IReadOnlyList<WorkspaceAttentionItemVm> WaitingOnOthers { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceProjectMatrixRowVm> ProjectMatrix { get; set; } = Array.Empty<WorkspaceProjectMatrixRowVm>();
     public IReadOnlyList<WorkspaceTaskVm> OfficialTasks { get; set; } = Array.Empty<WorkspaceTaskVm>();
@@ -25,6 +33,7 @@ public sealed class ProjectOfficerWorkspaceVm
     public IReadOnlyList<WorkspaceImprovementVm> ImproveScoreItems { get; set; } = Array.Empty<WorkspaceImprovementVm>();
     public IReadOnlyList<WorkspaceProjectImprovementVm> ImproveProjects { get; set; } = Array.Empty<WorkspaceProjectImprovementVm>();
     public WorkspaceAttentionItemVm? NextBestFix { get; set; }
+    public WorkspaceAttentionItemVm? NextBestAction { get; set; }
     public IReadOnlyList<WorkspaceQuickActionVm> QuickActions { get; set; } = Array.Empty<WorkspaceQuickActionVm>();
     public IReadOnlyList<WorkspaceReminderVm> PersonalReminders { get; set; } = Array.Empty<WorkspaceReminderVm>();
 }

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -52,7 +52,7 @@
 /* SECTION: KPI strip */
 .workspace-kpis {
     display: grid;
-    grid-template-columns: repeat(5, minmax(145px, 1fr));
+    grid-template-columns: repeat(4, minmax(145px, 1fr));
     gap: 0.7rem;
     margin: 0.75rem 0;
 }
@@ -640,60 +640,84 @@
     font-size: 0.78rem;
 }
 
-.workspace-inbox-grid {
+ .workspace-action-tabs {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 0.75rem;
 }
 
-.workspace-inbox-pane {
+.workspace-action-tabs section {
     border: 1px solid #e8edf5;
     border-radius: 10px;
     padding: 0.7rem;
     background: #fbfcfe;
 }
 
-.workspace-inbox-pane h3 {
-    margin: 0 0 0.5rem;
+.workspace-action-tabs h3 {
+    margin: 0 0 0.55rem;
     font-size: 0.82rem;
     font-weight: 650;
     color: #334155;
 }
 
-.workspace-inbox-list {
+.workspace-action-list {
     display: grid;
     gap: 0.5rem;
 }
 
-.workspace-inbox-item {
+.workspace-action-list article {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
-    gap: 0.5rem;
+    gap: 0.55rem;
     align-items: center;
     padding: 0.45rem 0;
     border-bottom: 1px solid #edf2f7;
 }
 
-.workspace-inbox-item:last-child {
+.workspace-action-list article:last-child {
     border-bottom: 0;
 }
 
-.workspace-inbox-item strong {
+.workspace-action-list strong {
+    display: block;
     font-size: 0.82rem;
     font-weight: 600;
     color: #0f172a;
 }
 
-.workspace-inbox-item p {
-    margin: 0;
-    font-size: 0.76rem;
+.workspace-action-list p {
+    margin: 0.05rem 0 0;
     color: #64748b;
+    font-size: 0.76rem;
 }
 
-.workspace-inbox-item a {
+.workspace-action-list a {
     font-size: 0.76rem;
     font-weight: 550;
     text-decoration: none;
+}
+
+.workspace-action-secondary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #edf2f7;
+}
+
+.workspace-action-secondary h3 {
+    margin: 0 0 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 650;
+    color: #334155;
+}
+
+.workspace-action-secondary a {
+    display: block;
+    font-size: 0.76rem;
+    text-decoration: none;
+    margin-bottom: 0.35rem;
 }
 
 .workspace-inline-clear {
@@ -787,44 +811,45 @@
     font-size: 0.78rem;
 }
 
-.workspace-improve-projects {
+.workspace-cleanup-list {
     display: grid;
     gap: 0.6rem;
 }
 
-.workspace-improve-projects article {
+.workspace-cleanup-list article {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.6rem;
     align-items: center;
-    padding: 0.58rem 0;
+    padding: 0.48rem 0;
     border-bottom: 1px solid #edf2f7;
 }
 
-.workspace-improve-projects article:last-child {
+.workspace-cleanup-list article:last-child {
     border-bottom: 0;
 }
 
-.workspace-improve-projects strong {
-    font-size: 0.84rem;
+.workspace-cleanup-list strong {
+    font-size: 0.82rem;
     font-weight: 600;
     color: #0f172a;
 }
 
-.workspace-improve-projects p {
+.workspace-cleanup-list p {
     margin: 0.1rem 0 0;
     color: #64748b;
     font-size: 0.76rem;
 }
 
-.workspace-improve-projects a {
+.workspace-cleanup-list a {
     font-size: 0.76rem;
     font-weight: 550;
     text-decoration: none;
 }
 
 @media (max-width: 1100px) {
-    .workspace-inbox-grid,
+    .workspace-action-tabs,
+    .workspace-action-secondary,
     .workspace-split-grid {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
### Motivation
- Reorient the Project Officer workspace from a project-health/backfill dashboard to a daily-action workspace that answers "What do I need to update or act on today?".
- Surface the PO's daily priorities (remarks due, official tasks, project ideas, returned/waiting items) and downplay record-health visual dominance.

### Description
- Reworked the page layout in `Pages/Workspace/Index.cshtml` to show a compact header and an `Action Inbox` as the primary card, moved `Assigned Projects` below it, changed the right rail to `Next Best Action`, `Quick Actions`, `Record Cleanup`, and `ERP Engagement`, and removed hero meta noise; header now computes `actionCount` from `RemarksDue`, `OfficialTaskCount`, `IdeasNeedingUpdate`, and `ReturnedItems` and renders `attentionTitle`/`attentionSubtitle` accordingly.
- Extended `ProjectOfficerWorkspaceVm` in `ViewModels/Workspace/WorkspaceViewModels.cs` with grouped action properties: `RemarksDue`, `OfficialTasksDue`, `IdeasNeedingUpdate`, `ReturnedItems`, `TimelineAlerts`, `OfficialTaskCount`, `RemarksDueCount`, `IdeasNeedingUpdateCount`, and `NextBestAction` while keeping existing properties for compatibility.
- Updated `ProjectOfficerWorkspaceService.GetProjectOfficerWorkspaceAsync` to build and compose action groups (`remarksDue`, `officialTasksDue`, `ideasNeedingUpdate`, `returnedItems`, `timelineAlerts`), added `IsDueSoon` helper, `ToAttentionItem` adapters, and `BuildNextBestAction` prioritization (returned items → overdue tasks → remarks → ideas → timeline alerts) and wired the new properties into the VM and KPI builder.
- Split and added nudge builders in `Services/Workspace/WorkspaceNudgeService.cs`: `BuildRemarksDue` (PO remark nudges) and `BuildTimelineAlerts` (backfill/overdue/current-stage alerts) plus remark helpers `GetLastPoRemark`/`IsRemarkDue`/`GetCurrentStageIssueLabel` to ensure remarks stay prominent and timeline/backfill remain secondary.
- Replaced inbox-oriented CSS with new rules in `wwwroot/css/workspace.css` for `.workspace-action-tabs`, `.workspace-action-list`, `.workspace-action-secondary`, and `.workspace-cleanup-list` and adjusted the KPI grid to 4 columns to reflect the new KPI strip (Remarks Due / Official Tasks / Project Ideas / Assigned Projects).

### Testing
- `git diff --check` was executed and passed with no whitespace errors reported.
- `dotnet build` could not be executed in this environment because the `dotnet` CLI is not available, so a compile run was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32155c65348329b1721e5465a49eeb)