### PR TITLE
Project Officer workspace: AOTS, left-rail workbench, PO remark logic and UI text updates

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -6,256 +6,148 @@
     ViewData["Title"] = "My Workspace";
     ViewData["UseFullWidth"] = true;
 
-    var actionCount =
-        Model.Workspace.RemarksDue.Count +
-        Model.Workspace.OfficialTaskCount +
-        Model.Workspace.IdeasNeedingUpdate.Count +
-        Model.Workspace.ReturnedItems.Count;
+    var dailyActionCount =
+        Model.Workspace.RemarksDueCount +
+        Model.Workspace.OfficialTasksDue.Count +
+        Model.Workspace.IdeasNeedingUpdateCount +
+        Model.Workspace.AotsUnreadCount;
 
-    var attentionTitle = actionCount == 0
+    var dailyActionTitle = dailyActionCount == 0
         ? "No urgent update pending today"
-        : $"{actionCount} update{(actionCount == 1 ? "" : "s")} need your attention today";
-
-    var attentionSubtitle = actionCount == 0
-        ? "Remarks, tasks and ideas are clear"
-        : "Remarks, tasks and ideas requiring action";
+        : $"{dailyActionCount} update{(dailyActionCount == 1 ? "" : "s")} need your attention today";
 }
 @section Styles {
     <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
 }
 
-<div class="workspace-page">
-    @* SECTION: Compact daily-action header *@
-    <header class="workspace-hero workspace-hero-simple">
-        <div>
-            <p class="workspace-eyebrow">My Workspace</p>
-            <h1>@attentionTitle</h1>
-            <p>@attentionSubtitle</p>
+<div class="workspace-page workspace-workbench">
+    @* SECTION: Workspace local navigation rail *@
+    <aside class="workspace-local-rail">
+        <div class="workspace-local-rail__title">Workspace</div>
+        <nav aria-label="Workspace sections">
+            @foreach (var item in Model.Workspace.RailItems)
+            {
+                <a href="@item.Anchor" class="@(item.IsPrimary ? "active" : string.Empty)">
+                    <span><i class="bi @item.Icon"></i>@item.Label</span>
+                    <em>@item.Count</em>
+                </a>
+            }
+        </nav>
+    </aside>
+
+    <div class="workspace-workarea">
+        @* SECTION: Slim command bar for daily actions *@
+        <div class="workspace-commandbar" id="today">
+            <div>
+                <p class="workspace-eyebrow">My Workspace</p>
+                <h1>@dailyActionTitle</h1>
+                <p>Project remarks, other assigned tasks, project ideas and AOTS documents.</p>
+            </div>
+            <div class="workspace-refresh">
+                <span>Last refreshed @DateTime.Now.ToString("HH:mm")</span>
+                <a class="btn btn-sm btn-outline-primary" href="/Workspace"><i class="bi bi-arrow-clockwise"></i> Refresh</a>
+            </div>
         </div>
-    </header>
 
-    @* SECTION: Compact action summary *@
-    <section class="workspace-kpis" aria-label="Workspace KPIs">
-        @foreach (var kpi in Model.Workspace.Kpis)
-        {
-            <article class="workspace-kpi workspace-severity-@kpi.Severity.ToLowerInvariant()">
-                <i class="bi @kpi.Icon"></i>
-                <div>
-                    <span>@kpi.Title</span>
-                    <strong>@kpi.Value</strong>
-                    <small>@kpi.Caption</small>
-                </div>
-            </article>
-        }
-    </section>
+        @* SECTION: Compact action summary pills *@
+        <div class="workspace-count-pills" aria-label="Workspace summary counts">
+            @foreach (var kpi in Model.Workspace.Kpis)
+            {
+                <a href="#today" class="workspace-count-pill workspace-severity-@kpi.Severity.ToLowerInvariant()">
+                    <i class="bi @kpi.Icon"></i><span>@kpi.Value</span><small>@kpi.Title</small>
+                </a>
+            }
+        </div>
 
-    <div class="workspace-grid">
-        <main class="workspace-main">
-            @* SECTION: Primary daily action inbox *@
-            <section class="workspace-card workspace-action-inbox">
-                <div class="workspace-card__head">
-                    <div>
-                        <h2>Action Inbox</h2>
-                        <p class="workspace-section-subtitle">Remarks, tasks and ideas that need your update</p>
+        <div class="workspace-main-grid">
+            <main class="workspace-main">
+                @* SECTION: Primary daily action inbox *@
+                <section class="workspace-card workspace-action-inbox">
+                    <div class="workspace-card__head">
+                        <div>
+                            <h2>Action Inbox</h2>
+                            <p class="workspace-section-subtitle">Items that need your update or review today</p>
+                        </div>
+                        <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
                     </div>
-                    <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
-                </div>
 
-                <div class="workspace-action-tabs">
-                    <section>
-                        <h3>Remarks Due</h3>
-                        @if (!Model.Workspace.RemarksDue.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-action-list">
-                                @foreach (var item in Model.Workspace.RemarksDue.Take(4))
-                                {
-                                    <article>
-                                        <span class="workspace-chip workspace-chip-warning">Remark</span>
-                                        <div><strong>@item.Title</strong><p>@item.Detail</p></div>
-                                        <a href="@item.ActionUrl">Add Remark</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </section>
+                    <div class="workspace-action-tabs workspace-action-tabs-four">
+                        <section id="remarks">
+                            <h3>Project Remarks Due</h3>
+                            @if (!Model.Workspace.RemarksDue.Any()) { <p class="workspace-inline-clear">Clear</p> }
+                            else { <div class="workspace-action-list">@foreach (var item in Model.Workspace.RemarksDue.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">Remark</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><a href="@item.ActionUrl">Add Remark</a></article> }</div> }
+                        </section>
 
-                    <section>
-                        <h3>Official Tasks</h3>
-                        @if (!Model.Workspace.OfficialTasksDue.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-action-list">
-                                @foreach (var task in Model.Workspace.OfficialTasksDue.Take(4))
-                                {
-                                    <article>
-                                        <span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? "Overdue" : "Task")</span>
-                                        <div><strong>@task.Title</strong><p>@task.Priority · @task.Status</p></div>
-                                        <a href="@task.OpenUrl">Open</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </section>
+                        <section id="other-tasks">
+                            <h3>Other Assigned Tasks</h3>
+                            @if (!Model.Workspace.OfficialTasksDue.Any()) { <p class="workspace-inline-clear">Clear</p> }
+                            else { <div class="workspace-action-list">@foreach (var task in Model.Workspace.OfficialTasksDue.Take(4)) { <article><span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? "Overdue" : "Task")</span><div><strong>@task.Title</strong><p>@task.Priority · @task.Status</p></div><a href="@task.OpenUrl">Open</a></article> }</div> }
+                        </section>
 
-                    <section>
-                        <h3>Project Ideas</h3>
-                        @if (!Model.Workspace.IdeasNeedingUpdate.Any())
-                        {
-                            <p class="workspace-inline-clear">Clear</p>
-                        }
-                        else
-                        {
-                            <div class="workspace-action-list">
-                                @foreach (var idea in Model.Workspace.IdeasNeedingUpdate.Take(4))
-                                {
-                                    <article>
-                                        <span class="workspace-chip workspace-chip-warning">Idea</span>
-                                        <div><strong>@idea.Title</strong><p>@idea.CommentCount comments · @idea.DocumentCount docs</p></div>
-                                        <a href="@idea.OpenUrl">Open</a>
-                                    </article>
-                                }
-                            </div>
-                        }
-                    </section>
-                </div>
+                        <section id="project-ideas">
+                            <h3>Project Ideas</h3>
+                            @if (!Model.Workspace.IdeasNeedingUpdate.Any()) { <p class="workspace-inline-clear">Clear</p> }
+                            else { <div class="workspace-action-list">@foreach (var idea in Model.Workspace.IdeasNeedingUpdate.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">Idea</span><div><strong>@idea.Title</strong><p>@idea.CommentCount comments · @idea.DocumentCount docs</p></div><a href="@idea.OpenUrl">Open</a></article> }</div> }
+                        </section>
 
-                @if (Model.Workspace.ReturnedItems.Any() || Model.Workspace.WaitingOnOthers.Any())
-                {
-                    <div class="workspace-action-secondary">
-                        @if (Model.Workspace.ReturnedItems.Any())
-                        {
-                            <div>
-                                <h3>Returned</h3>
-                                @foreach (var item in Model.Workspace.ReturnedItems.Take(3))
-                                {
-                                    <a href="@item.ActionUrl">@item.Title — @item.Detail</a>
-                                }
-                            </div>
-                        }
-                        @if (Model.Workspace.WaitingOnOthers.Any())
-                        {
-                            <div>
-                                <h3>Waiting</h3>
-                                @foreach (var item in Model.Workspace.WaitingOnOthers.Take(3))
-                                {
-                                    <a href="@item.ActionUrl">@item.Title — @item.Detail</a>
-                                }
-                            </div>
-                        }
+                        <section id="aots">
+                            <h3>AOTS Documents</h3>
+                            @if (!Model.Workspace.AotsDocuments.Any()) { <p class="workspace-inline-clear">All read</p> }
+                            else { <div class="workspace-action-list">@foreach (var doc in Model.Workspace.AotsDocuments.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">AOTS</span><div><strong>@doc.Subject</strong><p>@doc.Office · @doc.Category</p></div><a href="@doc.OpenUrl">Review</a></article> }</div><a class="workspace-section-link" href="@Model.Workspace.AotsUrl">Open AOTS inbox</a> }
+                        </section>
                     </div>
-                }
-            </section>
 
-            @* SECTION: Secondary assigned-project review *@
-            <section class="workspace-card workspace-portfolio-card">
-                <div class="workspace-card__head">
-                    <div><h2>Assigned Projects</h2><p class="workspace-section-subtitle">Project stage, update status and next action</p></div>
-                    <a href="@Model.Workspace.MyProjectsUrl">View all projects</a>
-                </div>
-                @if (!Model.Workspace.ProjectMatrix.Any())
-                {
-                    <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p>
-                }
-                else
-                {
-                    <div class="workspace-table-wrap">
-                        <table class="workspace-table workspace-portfolio-table">
-                            <thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead>
-                            <tbody>
-                                @foreach (var row in Model.Workspace.ProjectMatrix)
-                                {
-                                    <tr>
-                                        <td><a href="@row.OpenUrl">@row.ProjectName</a></td>
-                                        <td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td>
-                                        <td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td>
-                                        <td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td>
-                                        <td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td>
-                                        <td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
+                    @if (Model.Workspace.ReturnedItems.Any() || Model.Workspace.WaitingOnOthers.Any())
+                    {
+                        <div class="workspace-action-secondary">
+                            @if (Model.Workspace.ReturnedItems.Any()) { <div><h3>Returned</h3>@foreach (var item in Model.Workspace.ReturnedItems.Take(3)) { <a href="@item.ActionUrl">@item.Title — @item.Detail</a> }</div> }
+                            @if (Model.Workspace.WaitingOnOthers.Any()) { <div><h3>Waiting</h3>@foreach (var item in Model.Workspace.WaitingOnOthers.Take(3)) { <a href="@item.ActionUrl">@item.Title — @item.Detail</a> }</div> }
+                        </div>
+                    }
+                </section>
+
+                @* SECTION: Assigned-project review *@
+                <section id="assigned-projects" class="workspace-card workspace-portfolio-card">
+                    <div class="workspace-card__head"><div><h2>Assigned Projects</h2><p class="workspace-section-subtitle">Project stage, update status and next action</p></div><a href="@Model.Workspace.MyProjectsUrl">View all projects</a></div>
+                    @if (!Model.Workspace.ProjectMatrix.Any()) { <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p> }
+                    else { <div class="workspace-table-wrap"><table class="workspace-table workspace-portfolio-table"><thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td><td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td></tr> }</tbody></table></div> }
+                </section>
+
+                @* SECTION: Secondary ideas and reminders *@
+                <section class="workspace-card workspace-ideas-reminders">
+                    <div class="workspace-card__head"><div><h2>Ideas &amp; Reminders</h2><p class="workspace-section-subtitle">Early concepts and personal follow-ups</p></div></div>
+                    <div class="workspace-split-grid">
+                        <div>
+                            <div class="workspace-subhead"><h3>Project Ideas</h3><a href="/ProjectIdeas?MyIdeas=true">View ideas</a></div>
+                            @if (!Model.Workspace.Ideas.Any()) { <p class="workspace-inline-clear">No assigned ideas</p> }
+                            else { <div class="workspace-slim-list">@foreach (var idea in Model.Workspace.Ideas.Take(4)) { <article><div><strong>@idea.Title</strong><p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p></div>@if (idea.NeedsUpdate) { <span class="workspace-chip workspace-chip-warning">Needs update</span> }<a href="@idea.OpenUrl">Open</a></article> }</div> }
+                        </div>
+                        <div id="reminders">
+                            <div class="workspace-subhead"><h3>Personal Reminders</h3><a href="/Tasks">Open reminders</a></div>
+                            @if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-inline-clear">No reminders</p> }
+                            else { <div class="workspace-slim-list">@foreach (var r in Model.Workspace.PersonalReminders.Take(4)) { <article><div><strong>@r.Title</strong><p>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)@(r.IsPinned ? " · pinned" : string.Empty)</p></div><a href="@r.OpenUrl">Open</a></article> }</div> }
+                        </div>
                     </div>
-                }
-            </section>
+                </section>
+            </main>
 
-            @* SECTION: Secondary ideas and reminders *@
-            <section class="workspace-card workspace-ideas-reminders">
-                <div class="workspace-card__head"><div><h2>Ideas &amp; Reminders</h2><p class="workspace-section-subtitle">Early concepts and personal follow-ups</p></div></div>
-                <div class="workspace-split-grid">
-                    <div>
-                        <div class="workspace-subhead"><h3>Project Ideas</h3><a href="/ProjectIdeas?MyIdeas=true">View ideas</a></div>
-                        @if (!Model.Workspace.Ideas.Any()) { <p class="workspace-inline-clear">No assigned ideas</p> }
-                        else { <div class="workspace-slim-list">@foreach (var idea in Model.Workspace.Ideas.Take(4)) { <article><div><strong>@idea.Title</strong><p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p></div>@if (idea.NeedsUpdate) { <span class="workspace-chip workspace-chip-warning">Needs update</span> }<a href="@idea.OpenUrl">Open</a></article> }</div> }
-                    </div>
-                    <div>
-                        <div class="workspace-subhead"><h3>Personal Reminders</h3><a href="/Tasks">Open reminders</a></div>
-                        @if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-inline-clear">No reminders</p> }
-                        else { <div class="workspace-slim-list">@foreach (var r in Model.Workspace.PersonalReminders.Take(4)) { <article><div><strong>@r.Title</strong><p>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)@(r.IsPinned ? " · pinned" : string.Empty)</p></div><a href="@r.OpenUrl">Open</a></article> }</div> }
-                    </div>
-                </div>
-            </section>
-        </main>
+            <aside class="workspace-rail">
+                @* SECTION: Focused next daily action *@
+                <section class="workspace-card workspace-next-fix">
+                    <h2>Next Best Action</h2>
+                    @if (Model.Workspace.NextBestAction is null) { <p class="workspace-inline-clear">No immediate action required</p> }
+                    else { <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestAction.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestAction)</span><strong>@Model.Workspace.NextBestAction.Title</strong><p>@Model.Workspace.NextBestAction.Detail</p><a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestAction.ActionUrl">@Model.Workspace.NextBestAction.ActionText</a> }
+                </section>
 
-        <aside class="workspace-rail">
-            @* SECTION: Focused next daily action *@
-            <section class="workspace-card workspace-next-fix">
-                <h2>Next Best Action</h2>
-                @if (Model.Workspace.NextBestAction is null)
-                {
-                    <p class="workspace-inline-clear">No immediate action required</p>
-                }
-                else
-                {
-                    <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestAction.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestAction)</span>
-                    <strong>@Model.Workspace.NextBestAction.Title</strong>
-                    <p>@Model.Workspace.NextBestAction.Detail</p>
-                    <a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestAction.ActionUrl">@Model.Workspace.NextBestAction.ActionText</a>
-                }
-            </section>
+                @* SECTION: Durable workspace destinations *@
+                <section class="workspace-card workspace-card-clean"><h2>Quick Actions</h2><div class="workspace-quick-actions">@foreach (var action in Model.Workspace.QuickActions) { <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a> }</div></section>
 
-            @* SECTION: Durable workspace destinations *@
-            <section class="workspace-card workspace-card-clean">
-                <h2>Quick Actions</h2>
-                <div class="workspace-quick-actions">@foreach (var action in Model.Workspace.QuickActions) { <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a> }</div>
-            </section>
+                @* SECTION: Quiet grouped record cleanup *@
+                <section class="workspace-card workspace-card-clean"><h2>Record Cleanup</h2>@if (!Model.Workspace.ImproveProjects.Any()) { <p class="workspace-inline-clear">No cleanup priority.</p> } else { <div class="workspace-cleanup-list">@foreach (var item in Model.Workspace.ImproveProjects.Take(3)) { <article><div><strong>@item.ProjectName</strong><p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p></div><a href="@item.Url">Open</a></article> }</div> }</section>
 
-            @* SECTION: Quiet grouped record cleanup *@
-            <section class="workspace-card workspace-card-clean">
-                <h2>Record Cleanup</h2>
-                @if (!Model.Workspace.ImproveProjects.Any())
-                {
-                    <p class="workspace-inline-clear">No cleanup priority.</p>
-                }
-                else
-                {
-                    <div class="workspace-cleanup-list">
-                        @foreach (var item in Model.Workspace.ImproveProjects.Take(3))
-                        {
-                            <article><div><strong>@item.ProjectName</strong><p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p></div><a href="@item.Url">Open</a></article>
-                        }
-                    </div>
-                }
-            </section>
-
-            @* SECTION: ERP engagement remains quiet and factual *@
-            <section class="workspace-card workspace-card-clean">
-                <h2>ERP Engagement</h2>
-                <div class="workspace-engagement-grid">
-                    <div><span>Active days</span><strong>@Model.Workspace.Engagement.ActiveDaysThisMonth</strong></div>
-                    <div><span>Actions</span><strong>@Model.Workspace.Engagement.ActionsRecordedThisMonth</strong></div>
-                    <div><span>Remarks</span><strong>@Model.Workspace.Engagement.RemarksPostedThisMonth</strong></div>
-                    <div><span>Tasks</span><strong>@Model.Workspace.Engagement.TasksUpdatedThisMonth</strong></div>
-                    <div><span>Documents</span><strong>@Model.Workspace.Engagement.DocumentsUploadedThisMonth</strong></div>
-                </div>
-            </section>
-        </aside>
+                @* SECTION: ERP engagement remains quiet and factual *@
+                <section class="workspace-card workspace-card-clean"><h2>ERP Engagement</h2><div class="workspace-engagement-grid"><div><span>Active days</span><strong>@Model.Workspace.Engagement.ActiveDaysThisMonth</strong></div><div><span>Actions</span><strong>@Model.Workspace.Engagement.ActionsRecordedThisMonth</strong></div><div><span>Remarks</span><strong>@Model.Workspace.Engagement.RemarksPostedThisMonth</strong></div><div><span>Tasks</span><strong>@Model.Workspace.Engagement.TasksUpdatedThisMonth</strong></div><div><span>Documents</span><strong>@Model.Workspace.Engagement.DocumentsUploadedThisMonth</strong></div></div></section>
+            </aside>
+        </div>
     </div>
 </div>

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -7,6 +7,7 @@ using ProjectManagement.Models.ProjectIdeas;
 using ProjectManagement.Models.Plans;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Services.ActionTasks;
+using ProjectManagement.Services.DocRepo;
 using ProjectManagement.ViewModels.Workspace;
 
 namespace ProjectManagement.Services.Workspace;
@@ -19,13 +20,15 @@ public sealed class ProjectOfficerWorkspaceService
     private readonly WorkspaceNudgeService _nudges;
     private readonly ActionTaskMyWorkQueueBuilder _myWorkQueueBuilder;
     private readonly IActionTrackerClock _clock;
+    private readonly IAotsUnreadService _aotsUnreadService;
     public ProjectOfficerWorkspaceService(
         ApplicationDbContext db,
         UserManager<ApplicationUser> users,
         ProjectRecordHealthService health,
         WorkspaceNudgeService nudges,
         ActionTaskMyWorkQueueBuilder myWorkQueueBuilder,
-        IActionTrackerClock clock)
+        IActionTrackerClock clock,
+        IAotsUnreadService aotsUnreadService)
     {
         _db = db;
         _users = users;
@@ -33,6 +36,7 @@ public sealed class ProjectOfficerWorkspaceService
         _nudges = nudges;
         _myWorkQueueBuilder = myWorkQueueBuilder;
         _clock = clock;
+        _aotsUnreadService = aotsUnreadService;
     }
 
     // SECTION: Workspace composition
@@ -94,11 +98,14 @@ public sealed class ProjectOfficerWorkspaceService
             .OrderByDescending(i => i.LastActivityAtUtc)
             .Take(5)
             .ToList();
+        var aotsUnreadCount = await _aotsUnreadService.GetUnreadCountAsync(userId, ct);
+        var aotsDocuments = await LoadUnreadAotsDocumentsAsync(userId, ct);
         var timelineAlerts = _nudges.BuildTimelineAlerts(projects, today).ToList();
         var pending = returnedItems
             .Concat(remarksDue)
             .Concat(officialTasksDue.Select(ToAttentionItem))
             .Concat(ideasNeedingUpdate.Select(ToAttentionItem))
+            .Concat(aotsDocuments.Select(ToAttentionItem))
             .Concat(timelineAlerts)
             .GroupBy(i => $"{i.Type}:{i.Title}")
             .Select(g => g
@@ -130,6 +137,8 @@ public sealed class ProjectOfficerWorkspaceService
             RemarksDueCount = remarksDue.Count,
             OfficialTaskCount = tasks.Count,
             IdeasNeedingUpdateCount = ideaVms.Count(i => i.NeedsUpdate),
+            AotsUnreadCount = aotsUnreadCount,
+            AotsUrl = WorkspaceRouteHelper.AotsInbox(),
             RecordGapCount = health.Values.Sum(h => h.Gaps.Count),
             AssignedIdeaCount = ideaVms.Count,
             Engagement = engagement,
@@ -137,6 +146,7 @@ public sealed class ProjectOfficerWorkspaceService
             RemarksDue = remarksDue.Take(5).ToList(),
             OfficialTasksDue = officialTasksDue,
             IdeasNeedingUpdate = ideasNeedingUpdate,
+            AotsDocuments = aotsDocuments,
             ReturnedItems = returnedItems.Take(5).ToList(),
             TimelineAlerts = timelineAlerts.Take(5).ToList(),
             WaitingOnOthers = waitingOnOthers.Take(5).ToList(),
@@ -150,13 +160,13 @@ public sealed class ProjectOfficerWorkspaceService
             RecordHealth = health.Values.OrderBy(h => h.HealthPercent).Take(5).ToList(),
             ImproveScoreItems = BuildImproveScoreItems(health.Values, maxItems: 4),
             ImproveProjects = BuildImproveProjects(health.Values, maxProjects: 3),
-            NextBestFix = pending.FirstOrDefault(),
-            NextBestAction = BuildNextBestAction(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, timelineAlerts),
+            NextBestAction = BuildNextBestAction(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments, timelineAlerts),
             PersonalReminders = reminders,
             QuickActions = BuildQuickActions(userId),
             MyProjectsUrl = myProjectsUrl
         };
         vm.Kpis = BuildKpis(vm);
+        vm.RailItems = BuildRailItems(vm);
         return vm;
     }
 
@@ -180,6 +190,7 @@ public sealed class ProjectOfficerWorkspaceService
         IReadOnlyList<WorkspaceTaskVm> officialTasksDue,
         IReadOnlyList<WorkspaceAttentionItemVm> remarksDue,
         IReadOnlyList<WorkspaceIdeaVm> ideasNeedingUpdate,
+        IReadOnlyList<WorkspaceAotsDocumentVm> aotsDocuments,
         IReadOnlyList<WorkspaceAttentionItemVm> timelineAlerts)
     {
         var returned = returnedItems.FirstOrDefault();
@@ -194,6 +205,9 @@ public sealed class ProjectOfficerWorkspaceService
         var idea = ideasNeedingUpdate.FirstOrDefault();
         if (idea is not null) return ToAttentionItem(idea);
 
+        var aots = aotsDocuments.FirstOrDefault();
+        if (aots is not null) return ToAttentionItem(aots);
+
         return timelineAlerts.FirstOrDefault();
     }
 
@@ -202,13 +216,25 @@ public sealed class ProjectOfficerWorkspaceService
         Type = "Task",
         Title = task.Title,
         Detail = task.IsOverdue
-            ? task.DaysOverdue.HasValue ? $"Official task overdue by {task.DaysOverdue.Value} days" : "Official task overdue"
-            : "Official task due soon",
+            ? task.DaysOverdue.HasValue ? $"Assigned task overdue by {task.DaysOverdue.Value} days" : "Assigned task overdue"
+            : "Assigned task due soon",
         Severity = task.IsOverdue ? "Danger" : "Warning",
         BadgeText = "Task",
         ActionText = "Open Task",
         ActionUrl = task.OpenUrl,
         DueOrEventDateUtc = task.DueDateUtc
+    };
+
+    private static WorkspaceAttentionItemVm ToAttentionItem(WorkspaceAotsDocumentVm document) => new()
+    {
+        Type = "AOTS",
+        Title = document.Subject,
+        Detail = "Unread AOTS document",
+        Severity = "Warning",
+        BadgeText = "AOTS",
+        ActionText = "Review",
+        ActionUrl = document.OpenUrl,
+        DueOrEventDateUtc = document.CreatedAtUtc
     };
 
     private static WorkspaceAttentionItemVm ToAttentionItem(WorkspaceIdeaVm idea) => new()
@@ -222,6 +248,35 @@ public sealed class ProjectOfficerWorkspaceService
         ActionUrl = idea.OpenUrl,
         DueOrEventDateUtc = idea.LastActivityAtUtc
     };
+
+    // SECTION: AOTS documents reuse the repository unread-view rule for daily review.
+    private async Task<IReadOnlyList<WorkspaceAotsDocumentVm>> LoadUnreadAotsDocumentsAsync(
+        string userId,
+        CancellationToken ct)
+    {
+        return await _db.Documents
+            .AsNoTracking()
+            .Where(document =>
+                document.IsAots &&
+                !document.IsDeleted &&
+                !document.IsExternal &&
+                document.IsActive &&
+                !_db.DocRepoAotsViews.Any(view =>
+                    view.DocumentId == document.Id &&
+                    view.UserId == userId))
+            .OrderByDescending(document => document.CreatedAtUtc)
+            .Take(5)
+            .Select(document => new WorkspaceAotsDocumentVm
+            {
+                DocumentId = document.Id,
+                Subject = document.Subject,
+                Category = document.DocumentCategory.Name,
+                Office = document.OfficeCategory.Name,
+                CreatedAtUtc = document.CreatedAtUtc,
+                OpenUrl = WorkspaceRouteHelper.AotsReader(document.Id)
+            })
+            .ToListAsync(ct);
+    }
 
 
     // SECTION: Waiting-on-others summarizes submissions that are no longer actionable by the PO.
@@ -443,8 +498,9 @@ public sealed class ProjectOfficerWorkspaceService
         return new[]
         {
             new WorkspaceQuickActionVm { Text = "Open My Projects", Url = WorkspaceRouteHelper.MyProjects(userId), Icon = "bi-kanban" },
-            new WorkspaceQuickActionVm { Text = "View My Official Tasks", Url = WorkspaceRouteHelper.ActionTasksMyWork(), Icon = "bi-list-check" },
+            new WorkspaceQuickActionVm { Text = "View Other Assigned Tasks", Url = WorkspaceRouteHelper.ActionTasksMyWork(), Icon = "bi-list-check" },
             new WorkspaceQuickActionVm { Text = "Open My Project Ideas", Url = WorkspaceRouteHelper.ProjectIdeasMine(), Icon = "bi-lightbulb" },
+            new WorkspaceQuickActionVm { Text = "Open AOTS Inbox", Url = WorkspaceRouteHelper.AotsInbox(), Icon = "bi-file-earmark-text" },
             new WorkspaceQuickActionVm { Text = "Open Personal Reminders", Url = WorkspaceRouteHelper.PersonalReminders(), Icon = "bi-pin-angle" }
         };
     }
@@ -455,9 +511,25 @@ public sealed class ProjectOfficerWorkspaceService
         return new[]
         {
             new WorkspaceKpiVm { Title = "Remarks Due", Value = vm.RemarksDueCount.ToString(), Caption = "Project updates", Severity = vm.RemarksDueCount == 0 ? "Good" : "Warning", Icon = "bi-chat-left-text" },
-            new WorkspaceKpiVm { Title = "Official Tasks", Value = vm.OfficialTaskCount.ToString(), Caption = vm.OverdueTaskCount == 0 ? "No overdue task" : $"{vm.OverdueTaskCount} overdue", Severity = vm.OverdueTaskCount == 0 ? "Good" : "Danger", Icon = "bi-list-check" },
+            new WorkspaceKpiVm { Title = "Other Assigned Tasks", Value = vm.OfficialTaskCount.ToString(), Caption = vm.OverdueTaskCount == 0 ? "No overdue assigned task" : $"{vm.OverdueTaskCount} overdue", Severity = vm.OverdueTaskCount == 0 ? "Good" : "Danger", Icon = "bi-list-check" },
             new WorkspaceKpiVm { Title = "Project Ideas", Value = vm.AssignedIdeaCount.ToString(), Caption = vm.IdeasNeedingUpdateCount == 0 ? "No stale idea" : $"{vm.IdeasNeedingUpdateCount} need update", Severity = vm.IdeasNeedingUpdateCount == 0 ? "Good" : "Warning", Icon = "bi-lightbulb" },
+            new WorkspaceKpiVm { Title = "AOTS", Value = vm.AotsUnreadCount.ToString(), Caption = vm.AotsUnreadCount == 0 ? "All read" : "Unread documents", Severity = vm.AotsUnreadCount == 0 ? "Good" : "Warning", Icon = "bi-file-earmark-text" },
             new WorkspaceKpiVm { Title = "Assigned Projects", Value = vm.AssignedProjectCount.ToString(), Caption = "Currently with you", Severity = "Info", Icon = "bi-kanban" }
+        };
+    }
+
+    // SECTION: Local workspace rail anchors daily-action sections without changing global navigation.
+    private static IReadOnlyList<WorkspaceRailItemVm> BuildRailItems(ProjectOfficerWorkspaceVm vm)
+    {
+        return new[]
+        {
+            new WorkspaceRailItemVm { Label = "Today", Icon = "bi-calendar-check", Count = vm.PendingWithMeCount, Anchor = "#today", IsPrimary = true },
+            new WorkspaceRailItemVm { Label = "Remarks Due", Icon = "bi-chat-left-text", Count = vm.RemarksDueCount, Anchor = "#remarks" },
+            new WorkspaceRailItemVm { Label = "Other Assigned Tasks", Icon = "bi-list-check", Count = vm.OfficialTaskCount, Anchor = "#other-tasks" },
+            new WorkspaceRailItemVm { Label = "Project Ideas", Icon = "bi-lightbulb", Count = vm.AssignedIdeaCount, Anchor = "#project-ideas" },
+            new WorkspaceRailItemVm { Label = "AOTS", Icon = "bi-file-earmark-text", Count = vm.AotsUnreadCount, Anchor = "#aots" },
+            new WorkspaceRailItemVm { Label = "Assigned Projects", Icon = "bi-kanban", Count = vm.AssignedProjectCount, Anchor = "#assigned-projects" },
+            new WorkspaceRailItemVm { Label = "Reminders", Icon = "bi-bell", Count = vm.PersonalReminders.Count, Anchor = "#reminders" }
         };
     }
 }

--- a/Services/Workspace/WorkspaceNudgeService.cs
+++ b/Services/Workspace/WorkspaceNudgeService.cs
@@ -33,8 +33,13 @@ public sealed class WorkspaceNudgeService
             : null;
     }
 
+    // SECTION: Workspace project update remark
+    // Any remark by the assigned Project Officer user counts as a project update,
+    // even if the user posted it under another role such as HoD.
     public static DateTime? LastPoRemark(Project project, string userId) => project.Remarks
-        .Where(r => !r.IsDeleted && r.AuthorUserId == userId && r.AuthorRole == RemarkActorRole.ProjectOfficer)
+        .Where(r =>
+            !r.IsDeleted &&
+            r.AuthorUserId == userId)
         .OrderByDescending(r => r.CreatedAtUtc)
         .Select(r => (DateTime?)r.CreatedAtUtc)
         .FirstOrDefault();

--- a/Services/Workspace/WorkspaceRouteHelper.cs
+++ b/Services/Workspace/WorkspaceRouteHelper.cs
@@ -38,4 +38,10 @@ internal static class WorkspaceRouteHelper
 
     public static string PersonalReminders()
         => "/Tasks";
+
+    public static string AotsInbox()
+        => "/DocumentRepository/Documents?scope=aots";
+
+    public static string AotsReader(Guid documentId)
+        => $"/DocumentRepository/Documents/Reader/{documentId}?returnUrl={Uri.EscapeDataString(AotsInbox())}";
 }

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -14,12 +14,16 @@ public sealed class ProjectOfficerWorkspaceVm
     public int OverdueTaskCount { get; set; }
     public int RecordGapCount { get; set; }
     public int AssignedIdeaCount { get; set; }
+    public int AotsUnreadCount { get; set; }
+    public string AotsUrl { get; set; } = "/DocumentRepository/Documents?scope=aots";
     public WorkspaceEngagementVm Engagement { get; set; } = new();
     public IReadOnlyList<WorkspaceKpiVm> Kpis { get; set; } = Array.Empty<WorkspaceKpiVm>();
+    public IReadOnlyList<WorkspaceRailItemVm> RailItems { get; set; } = Array.Empty<WorkspaceRailItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> RemarksDue { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceTaskVm> OfficialTasksDue { get; set; } = Array.Empty<WorkspaceTaskVm>();
     public IReadOnlyList<WorkspaceIdeaVm> IdeasNeedingUpdate { get; set; } = Array.Empty<WorkspaceIdeaVm>();
+    public IReadOnlyList<WorkspaceAotsDocumentVm> AotsDocuments { get; set; } = Array.Empty<WorkspaceAotsDocumentVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> ReturnedItems { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> TimelineAlerts { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public int OfficialTaskCount { get; set; }
@@ -32,10 +36,37 @@ public sealed class ProjectOfficerWorkspaceVm
     public IReadOnlyList<WorkspaceRecordHealthVm> RecordHealth { get; set; } = Array.Empty<WorkspaceRecordHealthVm>();
     public IReadOnlyList<WorkspaceImprovementVm> ImproveScoreItems { get; set; } = Array.Empty<WorkspaceImprovementVm>();
     public IReadOnlyList<WorkspaceProjectImprovementVm> ImproveProjects { get; set; } = Array.Empty<WorkspaceProjectImprovementVm>();
-    public WorkspaceAttentionItemVm? NextBestFix { get; set; }
     public WorkspaceAttentionItemVm? NextBestAction { get; set; }
     public IReadOnlyList<WorkspaceQuickActionVm> QuickActions { get; set; } = Array.Empty<WorkspaceQuickActionVm>();
     public IReadOnlyList<WorkspaceReminderVm> PersonalReminders { get; set; } = Array.Empty<WorkspaceReminderVm>();
+}
+
+public sealed class WorkspaceRailItemVm
+{
+    public string Label { get; set; } = string.Empty;
+
+    public string Icon { get; set; } = "bi-circle";
+
+    public int Count { get; set; }
+
+    public string Anchor { get; set; } = "#";
+
+    public bool IsPrimary { get; set; }
+}
+
+public sealed class WorkspaceAotsDocumentVm
+{
+    public Guid DocumentId { get; set; }
+
+    public string Subject { get; set; } = string.Empty;
+
+    public string Category { get; set; } = string.Empty;
+
+    public string Office { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public string OpenUrl { get; set; } = string.Empty;
 }
 
 public sealed class WorkspaceKpiVm

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -854,3 +854,223 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* SECTION: Workbench shell with local left rail */
+.workspace-workbench {
+    display: grid;
+    grid-template-columns: 230px minmax(0, 1fr);
+    gap: 0;
+    padding: 0;
+    background: #f6f8fb;
+}
+
+.workspace-local-rail {
+    position: sticky;
+    top: 72px;
+    align-self: start;
+    min-height: calc(100vh - 92px);
+    background: #ffffff;
+    border-right: 1px solid #e6ebf2;
+    padding: 0.95rem 0.75rem;
+}
+
+.workspace-local-rail__title {
+    font-size: 0.9rem;
+    font-weight: 650;
+    color: #0f172a;
+    margin: 0 0 0.75rem;
+}
+
+.workspace-local-rail nav {
+    display: grid;
+    gap: 0.28rem;
+}
+
+.workspace-local-rail a {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    padding: 0.55rem 0.6rem;
+    border-radius: 9px;
+    color: #334155;
+    text-decoration: none;
+    font-size: 0.84rem;
+    font-weight: 520;
+}
+
+.workspace-local-rail a span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.workspace-local-rail a i {
+    color: #476083;
+    font-size: 0.95rem;
+}
+
+.workspace-local-rail a em {
+    min-width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    display: inline-grid;
+    place-items: center;
+    background: #f1f5f9;
+    color: #475569;
+    font-style: normal;
+    font-size: 0.74rem;
+    font-weight: 600;
+}
+
+.workspace-local-rail a.active,
+.workspace-local-rail a:hover {
+    background: #edf4ff;
+    color: #17366f;
+}
+
+.workspace-workarea {
+    padding: 0.85rem;
+    min-width: 0;
+}
+
+/* SECTION: Workbench command bar and compact counts */
+.workspace-commandbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: #fff;
+    border: 1px solid #e8edf5;
+    border-radius: 12px;
+    padding: 0.8rem 0.95rem;
+    box-shadow: 0 4px 14px rgba(20, 32, 55, 0.035);
+    margin-bottom: 0.75rem;
+}
+
+.workspace-commandbar h1 {
+    margin: 0;
+    font-size: 1.12rem;
+    font-weight: 650;
+    color: #0f172a;
+}
+
+.workspace-commandbar p {
+    margin: 0.14rem 0 0;
+    color: #64748b;
+    font-size: 0.84rem;
+}
+
+.workspace-refresh {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #64748b;
+    font-size: 0.78rem;
+    white-space: nowrap;
+}
+
+.workspace-count-pills {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin-bottom: 0.75rem;
+}
+
+.workspace-count-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 2.45rem;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid #e8edf5;
+    border-radius: 9px;
+    background: #fff;
+    color: #334155;
+    text-decoration: none;
+}
+
+.workspace-count-pill span {
+    font-weight: 650;
+    color: #0f172a;
+}
+
+.workspace-count-pill small {
+    color: #64748b;
+    font-size: 0.74rem;
+}
+
+/* SECTION: Workbench content grid */
+.workspace-main-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 0.85rem;
+}
+
+.workspace-main,
+.workspace-rail {
+    display: grid;
+    gap: 0.85rem;
+    align-content: start;
+}
+
+.workspace-action-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.workspace-action-tabs-four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.workspace-section-link {
+    display: inline-block;
+    margin-top: 0.55rem;
+    font-size: 0.76rem;
+    font-weight: 550;
+    text-decoration: none;
+}
+
+@media (max-width: 1280px) {
+    .workspace-action-tabs-four {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .workspace-count-pills {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 1100px) {
+    .workspace-workbench {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-local-rail {
+        position: static;
+        min-height: auto;
+        border-right: 0;
+        border-bottom: 1px solid #e6ebf2;
+    }
+
+    .workspace-local-rail nav {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .workspace-main-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-action-tabs,
+    .workspace-action-tabs-four,
+    .workspace-count-pills {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-commandbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the Project Officer workspace is a daily-action workbench focused on remarks, other assigned tasks, ideas and unread AOTS documents. 
- Treat any non-deleted remark by the assigned PO user as a project update regardless of the selected remark role to avoid false “no PO remark” nudges.
- Replace the large hero/KPI feel with a local left navigation rail and compact command bar while surfacing AOTS and quick links.

### Description
- Update remark logic in `WorkspaceNudgeService.LastPoRemark` to count any non-deleted remark by the PO user and add a clarifying comment about the rule. (`Services/Workspace/WorkspaceNudgeService.cs`)
- Add AOTS support: route helpers (`WorkspaceRouteHelper.AotsInbox` / `AotsReader`), DI of `IAotsUnreadService`, unread-count load and `LoadUnreadAotsDocumentsAsync`, AOTS view models, AOTS-to-pending conversion and Next Best Action priority insertion. (`Services/Workspace/WorkspaceRouteHelper.cs`, `Services/Workspace/ProjectOfficerWorkspaceService.cs`, `ViewModels/Workspace/WorkspaceViewModels.cs`)
- Rename user-facing “Official Tasks” strings to “Other Assigned Tasks” and update KPI/quick-action texts while preserving internal property names. (`Services/Workspace/ProjectOfficerWorkspaceService.cs`, `Pages/Workspace/Index.cshtml`)
- Workbench UI: replace hero + large KPI cards with a left rail, slim command bar, compact KPI pills, four-column Action Inbox including AOTS, and right support rail; add corresponding CSS in `wwwroot/css/workspace.css`. (`Pages/Workspace/Index.cshtml`, `wwwroot/css/workspace.css`)
- Fix potential initializer issue by ensuring only a single `ActionText = "Backfill"` appears in timeline alert items (compile-risk fix). (Workspace nudge code)
- Remove `NextBestFix` usage from the view model (now using only `NextBestAction`) and add `RailItems` and `AotsDocuments` to the workspace VM for UI binding. (`ViewModels/Workspace/WorkspaceViewModels.cs`)

### Testing
- Ran `git diff --check` and verified there are no whitespace/merge warnings; check succeeded.
- Verified text and label replacements with `rg 'NextBestFix|Official Tasks|Official tasks|View My Official Tasks|No overdue task|Generated UTC|/Projects/Timeline/EditActuals'` across changed files; checks passed.
- Confirmed the duplicate `ActionText = "Backfill"` initializer was addressed by searching `rg 'ActionText = "Backfill"'` and observing only the intended single assignment remains.
- Attempted `dotnet build` but could not run in this environment because the `dotnet` CLI is not installed, so compilation was not executed here (manual/CI build recommended before deployment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32541665588329b633fbaa5247fbe2)