### PR TITLE
Refine Project Officer workspace action queue

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -6,15 +6,9 @@
     ViewData["Title"] = "My Workspace";
     ViewData["UseFullWidth"] = true;
 
-    var dailyActionCount =
-        Model.Workspace.RemarksDueCount +
-        Model.Workspace.OfficialTasksDue.Count +
-        Model.Workspace.IdeasNeedingUpdateCount +
-        Model.Workspace.AotsUnreadCount;
-
-    var dailyActionTitle = dailyActionCount == 0
+    var dailyActionTitle = Model.Workspace.DailyActionCount == 0
         ? "No urgent update pending today"
-        : $"{dailyActionCount} update{(dailyActionCount == 1 ? "" : "s")} need your attention today";
+        : $"{Model.Workspace.DailyActionCount} update{(Model.Workspace.DailyActionCount == 1 ? "" : "s")} need your attention today";
 }
 @section Styles {
     <link rel="stylesheet" href="~/css/workspace.css" asp-append-version="true" />
@@ -49,59 +43,69 @@
             </div>
         </div>
 
-        @* SECTION: Compact action summary pills *@
-        <div class="workspace-count-pills" aria-label="Workspace summary counts">
-            @foreach (var kpi in Model.Workspace.Kpis)
-            {
-                <a href="#today" class="workspace-count-pill workspace-severity-@kpi.Severity.ToLowerInvariant()">
-                    <i class="bi @kpi.Icon"></i><span>@kpi.Value</span><small>@kpi.Title</small>
-                </a>
-            }
-        </div>
-
         <div class="workspace-main-grid">
             <main class="workspace-main">
-                @* SECTION: Primary daily action inbox *@
-                <section class="workspace-card workspace-action-inbox">
+                @* SECTION: Primary daily action queue *@
+                <span id="other-tasks" class="workspace-anchor"></span>
+                <span id="project-ideas" class="workspace-anchor"></span>
+                <span id="aots" class="workspace-anchor"></span>
+
+                <section id="remarks" class="workspace-card workspace-action-inbox">
                     <div class="workspace-card__head">
                         <div>
-                            <h2>Action Inbox</h2>
-                            <p class="workspace-section-subtitle">Items that need your update or review today</p>
+                            <h2>Action Queue</h2>
+                            <p class="workspace-section-subtitle">
+                                Remarks, tasks, project ideas and AOTS documents requiring your action
+                            </p>
                         </div>
                         <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
                     </div>
 
-                    <div class="workspace-action-tabs workspace-action-tabs-four">
-                        <section id="remarks">
-                            <h3>Project Remarks Due</h3>
-                            @if (!Model.Workspace.RemarksDue.Any()) { <p class="workspace-inline-clear">Clear</p> }
-                            else { <div class="workspace-action-list">@foreach (var item in Model.Workspace.RemarksDue.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">Remark</span><div><strong>@item.Title</strong><p>@item.Detail</p></div><a href="@item.ActionUrl">Add Remark</a></article> }</div> }
-                        </section>
-
-                        <section id="other-tasks">
-                            <h3>Other Assigned Tasks</h3>
-                            @if (!Model.Workspace.OfficialTasksDue.Any()) { <p class="workspace-inline-clear">Clear</p> }
-                            else { <div class="workspace-action-list">@foreach (var task in Model.Workspace.OfficialTasksDue.Take(4)) { <article><span class="workspace-chip @(task.IsOverdue ? "workspace-chip-danger" : "workspace-chip-muted")">@(task.IsOverdue ? "Overdue" : "Task")</span><div><strong>@task.Title</strong><p>@task.Priority · @task.Status</p></div><a href="@task.OpenUrl">Open</a></article> }</div> }
-                        </section>
-
-                        <section id="project-ideas">
-                            <h3>Project Ideas</h3>
-                            @if (!Model.Workspace.IdeasNeedingUpdate.Any()) { <p class="workspace-inline-clear">Clear</p> }
-                            else { <div class="workspace-action-list">@foreach (var idea in Model.Workspace.IdeasNeedingUpdate.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">Idea</span><div><strong>@idea.Title</strong><p>@idea.CommentCount comments · @idea.DocumentCount docs</p></div><a href="@idea.OpenUrl">Open</a></article> }</div> }
-                        </section>
-
-                        <section id="aots">
-                            <h3>AOTS Documents</h3>
-                            @if (!Model.Workspace.AotsDocuments.Any()) { <p class="workspace-inline-clear">All read</p> }
-                            else { <div class="workspace-action-list">@foreach (var doc in Model.Workspace.AotsDocuments.Take(4)) { <article><span class="workspace-chip workspace-chip-warning">AOTS</span><div><strong>@doc.Subject</strong><p>@doc.Office · @doc.Category</p></div><a href="@doc.OpenUrl">Review</a></article> }</div><a class="workspace-section-link" href="@Model.Workspace.AotsUrl">Open AOTS inbox</a> }
-                        </section>
-                    </div>
-
-                    @if (Model.Workspace.ReturnedItems.Any() || Model.Workspace.WaitingOnOthers.Any())
+                    @if (!Model.Workspace.ActionQueue.Any())
                     {
-                        <div class="workspace-action-secondary">
-                            @if (Model.Workspace.ReturnedItems.Any()) { <div><h3>Returned</h3>@foreach (var item in Model.Workspace.ReturnedItems.Take(3)) { <a href="@item.ActionUrl">@item.Title — @item.Detail</a> }</div> }
-                            @if (Model.Workspace.WaitingOnOthers.Any()) { <div><h3>Waiting</h3>@foreach (var item in Model.Workspace.WaitingOnOthers.Take(3)) { <a href="@item.ActionUrl">@item.Title — @item.Detail</a> }</div> }
+                        <p class="workspace-inline-clear">
+                            No daily action is pending.
+                        </p>
+                    }
+                    else
+                    {
+                        <div class="workspace-action-queue">
+                            @foreach (var item in Model.Workspace.ActionQueue)
+                            {
+                                <article class="workspace-action-row workspace-severity-@item.Severity.ToLowerInvariant()">
+                                    <span class="workspace-chip workspace-chip-@item.Type.ToLowerInvariant()">
+                                        @item.BadgeText
+                                    </span>
+
+                                    <div class="workspace-action-row__main">
+                                        <strong title="@item.Title">@item.Title</strong>
+                                        <p>@item.Detail</p>
+                                    </div>
+
+                                    <small>@item.Meta</small>
+
+                                    <a href="@item.ActionUrl">
+                                        @item.ActionText
+                                    </a>
+                                </article>
+                            }
+                        </div>
+
+                        <div class="workspace-action-clearline">
+                            @if (!Model.Workspace.OfficialTasksDue.Any())
+                            {
+                                <span>Other assigned tasks: Clear</span>
+                            }
+
+                            @if (!Model.Workspace.IdeasNeedingUpdate.Any())
+                            {
+                                <span>Project ideas: Clear</span>
+                            }
+
+                            @if (!Model.Workspace.AotsDocuments.Any())
+                            {
+                                <span>AOTS: All read</span>
+                            }
                         </div>
                     }
                 </section>
@@ -110,7 +114,7 @@
                 <section id="assigned-projects" class="workspace-card workspace-portfolio-card">
                     <div class="workspace-card__head"><div><h2>Assigned Projects</h2><p class="workspace-section-subtitle">Project stage, update status and next action</p></div><a href="@Model.Workspace.MyProjectsUrl">View all projects</a></div>
                     @if (!Model.Workspace.ProjectMatrix.Any()) { <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p> }
-                    else { <div class="workspace-table-wrap"><table class="workspace-table workspace-portfolio-table"><thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td><td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td></tr> }</tbody></table></div> }
+                    else { <div class="workspace-table-wrap"><table class="workspace-table workspace-portfolio-table"><thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td><td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" title="@($"{row.RecordGapCount} record fixes identified")" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td></tr> }</tbody></table></div> }
                 </section>
 
                 @* SECTION: Secondary ideas and reminders *@

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -47,50 +47,19 @@ public sealed class ProjectOfficerWorkspaceService
         var monthStart = new DateTime(istNow.Year, istNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
         var user = await _users.FindByIdAsync(userId);
         var myProjectsUrl = WorkspaceRouteHelper.MyProjects(userId);
-        var projects = await _db.Projects
-            .AsNoTracking()
-            .Include(p => p.ProjectStages)
-            .Include(p => p.Remarks)
-            .Include(p => p.Documents)
-            .Where(p =>
-                p.LeadPoUserId == userId &&
-                !p.IsDeleted &&
-                p.LifecycleStatus != ProjectLifecycleStatus.Completed)
-            .OrderBy(p => p.Name)
-            .Take(50)
-            .ToListAsync(ct);
-        var taskRows = await _db.ActionTasks.AsNoTracking()
-            .Where(t => !t.IsDeleted && t.AssignedToUserId == userId && t.Status != ActionTaskStatuses.Closed && t.Status != ActionTaskStatuses.Backlog)
-            .OrderBy(t => t.DueDate)
-            .Take(50)
-            .ToListAsync(ct);
-        var myWorkQueue = _myWorkQueueBuilder.Build(taskRows, activeSprint: null);
-        var orderedTaskRows = myWorkQueue.ActionRequiredTasks
-            .Concat(myWorkQueue.CurrentWorkTasks)
-            .Concat(myWorkQueue.SubmittedAwaitingClosureTasks)
-            .Concat(myWorkQueue.AllMyTasks)
-            .GroupBy(t => t.Id)
-            .Select(g => g.First())
-            .Take(8)
-            .ToList();
-        var overdueTaskIds = myWorkQueue.OverdueTasks.Select(t => t.Id).ToHashSet();
-        var tasks = orderedTaskRows.Select(t =>
-        {
-            // SECTION: Date-only action task dates are normalized after materialization because Npgsql cannot translate SpecifyKind for date columns.
-            var dueDateUtc = DateTime.SpecifyKind(t.DueDate.Date, DateTimeKind.Utc);
-            var daysOverdue = overdueTaskIds.Contains(t.Id) ? (_clock.IstToday - t.DueDate.Date).Days : (int?)null;
-            return new WorkspaceTaskVm { TaskId = t.Id, Title = t.Title, Priority = t.Priority, Status = t.Status, DueDateUtc = dueDateUtc, IsOverdue = daysOverdue.HasValue, DaysOverdue = daysOverdue, OpenUrl = WorkspaceRouteHelper.ActionTask(t.Id) };
-        }).ToList();
-        var ideas = await _db.ProjectIdeas.AsNoTracking().Include(i => i.Comments).Include(i => i.Notes).Include(i => i.Documents).Where(i => !i.IsDeleted && (i.AssignedProjectOfficerUserId == userId || i.CreatedByUserId == userId) && i.Status != ProjectIdeaStatuses.Archived).OrderByDescending(i => i.UpdatedAt).Take(6).ToListAsync(ct);
-        var ideaVms = ideas.Select(i => { var last = new[] { i.UpdatedAt }.Concat(i.Comments.Where(c => !c.IsDeleted).Select(c => c.CreatedAt)).Concat(i.Notes.Where(n => !n.IsDeleted).Select(n => n.UpdatedAt)).Concat(i.Documents.Where(d => !d.IsDeleted).Select(d => d.UploadedAt)).DefaultIfEmpty(i.UpdatedAt).Max(); return new WorkspaceIdeaVm { IdeaId = i.Id, Title = i.Title, Status = ProjectIdeaStatuses.ToDisplay(i.Status), LastActivityAtUtc = last, NeedsUpdate = (today.DayNumber - WorkspaceNudgeService.ToIstDate(last).DayNumber) > 15 && (i.Status == ProjectIdeaStatuses.Active || i.Status == ProjectIdeaStatuses.OnHold), CommentCount = i.Comments.Count(c => !c.IsDeleted), DocumentCount = i.Documents.Count(d => !d.IsDeleted), OpenUrl = WorkspaceRouteHelper.ProjectIdea(i.Id) }; }).ToList();
-        var reminders = await _db.TodoItems.AsNoTracking().Where(t => t.OwnerId == userId && t.Status != TodoStatus.Done && t.DeletedUtc == null).OrderByDescending(t => t.IsPinned).ThenBy(t => t.DueAtUtc).Take(5).Select(t => new WorkspaceReminderVm { ReminderId = t.Id, Title = t.Title, Priority = t.Priority.ToString(), DueAtUtc = t.DueAtUtc, IsPinned = t.IsPinned, OpenUrl = WorkspaceRouteHelper.PersonalReminders() }).ToListAsync(ct);
+
+        var projects = await LoadAssignedProjectsAsync(userId, ct);
+        var tasks = await LoadOtherAssignedTasksAsync(userId, today, ct);
+        var ideaVms = await LoadProjectIdeasAsync(userId, today, ct);
+        var reminders = await LoadPersonalRemindersAsync(userId, ct);
         var health = await _health.CalculateForProjectsAsync(projects, userId, ct);
+
         var remarksDue = _nudges.BuildRemarksDue(projects, userId, today).ToList();
         var returnedItems = await BuildReturnedItemsAsync(userId, ct);
         var officialTasksDue = tasks
             .Where(t => t.IsOverdue || IsDueSoon(t.DueDateUtc, today))
             .OrderByDescending(t => t.IsOverdue)
-            .ThenBy(t => t.DueDateUtc)
+            .ThenBy(t => t.DueDateUtc ?? DateTime.MaxValue)
             .Take(5)
             .ToList();
         var ideasNeedingUpdate = ideaVms
@@ -101,6 +70,9 @@ public sealed class ProjectOfficerWorkspaceService
         var aotsUnreadCount = await _aotsUnreadService.GetUnreadCountAsync(userId, ct);
         var aotsDocuments = await LoadUnreadAotsDocumentsAsync(userId, ct);
         var timelineAlerts = _nudges.BuildTimelineAlerts(projects, today).ToList();
+        var dailyActionCount = remarksDue.Count + officialTasksDue.Count + ideasNeedingUpdate.Count + aotsUnreadCount;
+        var actionQueue = BuildActionQueue(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments, timelineAlerts);
+
         var pending = returnedItems
             .Concat(remarksDue)
             .Concat(officialTasksDue.Select(ToAttentionItem))
@@ -117,10 +89,18 @@ public sealed class ProjectOfficerWorkspaceService
             .ThenBy(i => WorkspacePendingPriority(i.Detail))
             .ThenByDescending(i => i.DueOrEventDateUtc)
             .ToList();
+
+        var taskRows = await _db.ActionTasks
+            .AsNoTracking()
+            .Where(t => !t.IsDeleted && t.AssignedToUserId == userId && t.Status != ActionTaskStatuses.Closed && t.Status != ActionTaskStatuses.Backlog)
+            .OrderBy(t => t.DueDate)
+            .ToListAsync(ct);
+        var myWorkQueue = _myWorkQueueBuilder.Build(taskRows, activeSprint: null);
         var waitingOnOthers = await BuildWaitingOnOthersAsync(userId, myWorkQueue.SubmittedAwaitingClosureTasks, ct);
         var matrix = projects.Take(6).Select(p => BuildMatrixRow(p, health[p.Id], userId, today)).ToList();
         var engagement = await BuildEngagementAsync(userId, user, monthStart, ct);
         var avgHealth = health.Count == 0 ? 100 : (int)Math.Round(health.Values.Average(h => h.HealthPercent));
+
         var vm = new ProjectOfficerWorkspaceVm
         {
             UserDisplayName = string.IsNullOrWhiteSpace(user?.FullName)
@@ -128,11 +108,10 @@ public sealed class ProjectOfficerWorkspaceService
                 : user.FullName,
             PortfolioHealthPercent = avgHealth,
             PortfolioHealthLabel = avgHealth >= 80 ? "Good" : avgHealth >= 60 ? "Attention" : "Needs Work",
-            RecordHealthSummaryLabel = avgHealth >= 80
-                ? "Good"
-                : avgHealth >= 60 ? "Attention" : "Needs Work",
+            RecordHealthSummaryLabel = avgHealth >= 80 ? "Good" : avgHealth >= 60 ? "Attention" : "Needs Work",
             AssignedProjectCount = projects.Count,
             PendingWithMeCount = pending.Count,
+            DailyActionCount = dailyActionCount,
             OverdueTaskCount = tasks.Count(t => t.IsOverdue),
             RemarksDueCount = remarksDue.Count,
             OfficialTaskCount = tasks.Count,
@@ -143,6 +122,7 @@ public sealed class ProjectOfficerWorkspaceService
             AssignedIdeaCount = ideaVms.Count,
             Engagement = engagement,
             PendingWithMe = pending.Take(5).ToList(),
+            ActionQueue = actionQueue,
             RemarksDue = remarksDue.Take(5).ToList(),
             OfficialTasksDue = officialTasksDue,
             IdeasNeedingUpdate = ideasNeedingUpdate,
@@ -160,14 +140,139 @@ public sealed class ProjectOfficerWorkspaceService
             RecordHealth = health.Values.OrderBy(h => h.HealthPercent).Take(5).ToList(),
             ImproveScoreItems = BuildImproveScoreItems(health.Values, maxItems: 4),
             ImproveProjects = BuildImproveProjects(health.Values, maxProjects: 3),
-            NextBestAction = BuildNextBestAction(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments, timelineAlerts),
+            NextBestAction = BuildNextBestActionFromQueue(actionQueue),
             PersonalReminders = reminders,
             QuickActions = BuildQuickActions(userId),
             MyProjectsUrl = myProjectsUrl
         };
+
         vm.Kpis = BuildKpis(vm);
         vm.RailItems = BuildRailItems(vm);
         return vm;
+    }
+
+    // SECTION: Assigned projects include current-stage context for the workspace matrix.
+    private async Task<IReadOnlyList<Project>> LoadAssignedProjectsAsync(string userId, CancellationToken ct)
+    {
+        return await _db.Projects
+            .AsNoTracking()
+            .Include(p => p.ProjectStages)
+            .Include(p => p.Remarks)
+            .Include(p => p.Documents)
+            .Where(p =>
+                p.LeadPoUserId == userId &&
+                !p.IsDeleted &&
+                p.LifecycleStatus != ProjectLifecycleStatus.Completed)
+            .OrderBy(p => p.Name)
+            .Take(50)
+            .ToListAsync(ct);
+    }
+
+    // SECTION: Other assigned tasks are loaded in full before previews are trimmed.
+    private async Task<IReadOnlyList<WorkspaceTaskVm>> LoadOtherAssignedTasksAsync(string userId, DateOnly today, CancellationToken ct)
+    {
+        var taskRows = await _db.ActionTasks
+            .AsNoTracking()
+            .Where(t =>
+                !t.IsDeleted &&
+                t.AssignedToUserId == userId &&
+                t.Status != ActionTaskStatuses.Closed &&
+                t.Status != ActionTaskStatuses.Backlog)
+            .OrderBy(t => t.DueDate)
+            .ToListAsync(ct);
+        var myWorkQueue = _myWorkQueueBuilder.Build(taskRows, activeSprint: null);
+        var overdueTaskIds = myWorkQueue.OverdueTasks.Select(t => t.Id).ToHashSet();
+
+        return myWorkQueue.ActionRequiredTasks
+            .Concat(myWorkQueue.CurrentWorkTasks)
+            .Concat(myWorkQueue.SubmittedAwaitingClosureTasks)
+            .Concat(myWorkQueue.AllMyTasks)
+            .GroupBy(t => t.Id)
+            .Select(g => BuildWorkspaceTaskVm(g.First(), overdueTaskIds, today))
+            .ToList();
+    }
+
+    // SECTION: Project ideas are loaded before preview trimming so stale and assigned counts remain accurate.
+    private async Task<IReadOnlyList<WorkspaceIdeaVm>> LoadProjectIdeasAsync(string userId, DateOnly today, CancellationToken ct)
+    {
+        var ideas = await _db.ProjectIdeas
+            .AsNoTracking()
+            .Include(i => i.Comments)
+            .Include(i => i.Notes)
+            .Include(i => i.Documents)
+            .Where(i =>
+                !i.IsDeleted &&
+                (i.AssignedProjectOfficerUserId == userId || i.CreatedByUserId == userId) &&
+                i.Status != ProjectIdeaStatuses.Archived)
+            .OrderByDescending(i => i.UpdatedAt)
+            .ToListAsync(ct);
+
+        return ideas.Select(i => BuildWorkspaceIdeaVm(i, today)).ToList();
+    }
+
+    // SECTION: Personal reminders stay separate from the operational action queue.
+    private async Task<IReadOnlyList<WorkspaceReminderVm>> LoadPersonalRemindersAsync(string userId, CancellationToken ct)
+    {
+        return await _db.TodoItems
+            .AsNoTracking()
+            .Where(t => t.OwnerId == userId && t.Status != TodoStatus.Done && t.DeletedUtc == null)
+            .OrderByDescending(t => t.IsPinned)
+            .ThenBy(t => t.DueAtUtc)
+            .Take(5)
+            .Select(t => new WorkspaceReminderVm
+            {
+                ReminderId = t.Id,
+                Title = t.Title,
+                Priority = t.Priority.ToString(),
+                DueAtUtc = t.DueAtUtc,
+                IsPinned = t.IsPinned,
+                OpenUrl = WorkspaceRouteHelper.PersonalReminders()
+            })
+            .ToListAsync(ct);
+    }
+
+    // SECTION: Task rows are converted once so counts and previews share one model.
+    private static WorkspaceTaskVm BuildWorkspaceTaskVm(ActionTaskItem row, HashSet<int> overdueTaskIds, DateOnly today)
+    {
+        var dueDateUtc = DateTime.SpecifyKind(row.DueDate.Date, DateTimeKind.Utc);
+        var daysOverdue = overdueTaskIds.Contains(row.Id) ? today.DayNumber - DateOnly.FromDateTime(row.DueDate.Date).DayNumber : (int?)null;
+
+        return new WorkspaceTaskVm
+        {
+            TaskId = row.Id,
+            Title = row.Title,
+            ContextLabel = "Other assigned task",
+            Priority = row.Priority,
+            Status = row.Status,
+            DueDateUtc = dueDateUtc,
+            IsOverdue = daysOverdue.HasValue,
+            DaysOverdue = daysOverdue,
+            OpenUrl = WorkspaceRouteHelper.ActionTask(row.Id)
+        };
+    }
+
+    // SECTION: Idea activity is centralized so preview and stale counts use identical rules.
+    private static WorkspaceIdeaVm BuildWorkspaceIdeaVm(ProjectIdea idea, DateOnly today)
+    {
+        var last = new[] { idea.UpdatedAt }
+            .Concat(idea.Comments.Where(c => !c.IsDeleted).Select(c => c.CreatedAt))
+            .Concat(idea.Notes.Where(n => !n.IsDeleted).Select(n => n.UpdatedAt))
+            .Concat(idea.Documents.Where(d => !d.IsDeleted).Select(d => d.UploadedAt))
+            .DefaultIfEmpty(idea.UpdatedAt)
+            .Max();
+
+        return new WorkspaceIdeaVm
+        {
+            IdeaId = idea.Id,
+            Title = idea.Title,
+            Status = ProjectIdeaStatuses.ToDisplay(idea.Status),
+            LastActivityAtUtc = last,
+            NeedsUpdate = (today.DayNumber - WorkspaceNudgeService.ToIstDate(last).DayNumber) > 15 &&
+                (idea.Status == ProjectIdeaStatuses.Active || idea.Status == ProjectIdeaStatuses.OnHold),
+            CommentCount = idea.Comments.Count(c => !c.IsDeleted),
+            DocumentCount = idea.Documents.Count(d => !d.IsDeleted),
+            OpenUrl = WorkspaceRouteHelper.ProjectIdea(idea.Id)
+        };
     }
 
     // SECTION: Due-soon detection uses the workspace IST operating date.
@@ -184,31 +289,140 @@ public sealed class ProjectOfficerWorkspaceService
         return days >= 0 && days <= 3;
     }
 
-    // SECTION: Next best action prioritizes daily operations over record cleanup.
-    private static WorkspaceAttentionItemVm? BuildNextBestAction(
+    // SECTION: Unified action queue prioritizes operational work without four competing inbox columns.
+    private static IReadOnlyList<WorkspaceActionQueueItemVm> BuildActionQueue(
         IReadOnlyList<WorkspaceAttentionItemVm> returnedItems,
-        IReadOnlyList<WorkspaceTaskVm> officialTasksDue,
+        IReadOnlyList<WorkspaceTaskVm> otherAssignedTasksDue,
         IReadOnlyList<WorkspaceAttentionItemVm> remarksDue,
         IReadOnlyList<WorkspaceIdeaVm> ideasNeedingUpdate,
         IReadOnlyList<WorkspaceAotsDocumentVm> aotsDocuments,
         IReadOnlyList<WorkspaceAttentionItemVm> timelineAlerts)
     {
-        var returned = returnedItems.FirstOrDefault();
-        if (returned is not null) return returned;
+        var items = new List<WorkspaceActionQueueItemVm>();
 
-        var overdueTask = officialTasksDue.FirstOrDefault(t => t.IsOverdue);
-        if (overdueTask is not null) return ToAttentionItem(overdueTask);
+        items.AddRange(returnedItems.Select(item => new WorkspaceActionQueueItemVm
+        {
+            Type = "Returned",
+            BadgeText = item.BadgeText,
+            Title = item.Title,
+            Detail = item.Detail,
+            Meta = "Returned item",
+            Severity = item.Severity,
+            ActionText = item.ActionText,
+            ActionUrl = item.ActionUrl,
+            SortDateUtc = item.DueOrEventDateUtc
+        }));
 
-        var remark = remarksDue.FirstOrDefault();
-        if (remark is not null) return remark;
+        items.AddRange(otherAssignedTasksDue.Select(task => new WorkspaceActionQueueItemVm
+        {
+            Type = "Task",
+            BadgeText = task.IsOverdue ? "Overdue" : "Task",
+            Title = task.Title,
+            Detail = task.IsOverdue && task.DaysOverdue.HasValue
+                ? $"Overdue by {task.DaysOverdue.Value} days"
+                : task.DueDateUtc.HasValue ? $"Due {task.DueDateUtc.Value:dd MMM}" : "Assigned task",
+            Meta = $"{task.Priority} · {task.Status}",
+            Severity = task.IsOverdue ? "Danger" : "Warning",
+            ActionText = "Open",
+            ActionUrl = task.OpenUrl,
+            SortDateUtc = task.DueDateUtc
+        }));
 
-        var idea = ideasNeedingUpdate.FirstOrDefault();
-        if (idea is not null) return ToAttentionItem(idea);
+        items.AddRange(remarksDue.Select(item => new WorkspaceActionQueueItemVm
+        {
+            Type = "Remark",
+            BadgeText = "Remark",
+            Title = item.Title,
+            Detail = item.Detail,
+            Meta = "Project update",
+            Severity = item.Severity,
+            ActionText = "Add Remark",
+            ActionUrl = item.ActionUrl,
+            SortDateUtc = item.DueOrEventDateUtc
+        }));
 
-        var aots = aotsDocuments.FirstOrDefault();
-        if (aots is not null) return ToAttentionItem(aots);
+        items.AddRange(ideasNeedingUpdate.Select(idea => new WorkspaceActionQueueItemVm
+        {
+            Type = "Idea",
+            BadgeText = "Idea",
+            Title = idea.Title,
+            Detail = "Project idea needs update",
+            Meta = $"{idea.CommentCount} comments · {idea.DocumentCount} docs",
+            Severity = "Warning",
+            ActionText = "Open",
+            ActionUrl = idea.OpenUrl,
+            SortDateUtc = idea.LastActivityAtUtc
+        }));
 
-        return timelineAlerts.FirstOrDefault();
+        items.AddRange(aotsDocuments.Select(document => new WorkspaceActionQueueItemVm
+        {
+            Type = "AOTS",
+            BadgeText = "AOTS",
+            Title = document.Subject,
+            Detail = "Unread AOTS document",
+            Meta = $"{document.Office} · {document.Category}",
+            Severity = "Warning",
+            ActionText = "Review",
+            ActionUrl = document.OpenUrl,
+            SortDateUtc = document.CreatedAtUtc
+        }));
+
+        items.AddRange(timelineAlerts.Select(item => new WorkspaceActionQueueItemVm
+        {
+            Type = "Timeline",
+            BadgeText = item.BadgeText,
+            Title = item.Title,
+            Detail = item.Detail,
+            Meta = "Timeline",
+            Severity = item.Severity,
+            ActionText = item.ActionText,
+            ActionUrl = item.ActionUrl,
+            SortDateUtc = item.DueOrEventDateUtc
+        }));
+
+        return items
+            .OrderBy(GetActionQueuePriority)
+            .ThenByDescending(i => i.SortDateUtc)
+            .Take(8)
+            .ToList();
+    }
+
+    // SECTION: Next best action mirrors the first row in the unified action queue.
+    private static WorkspaceAttentionItemVm? BuildNextBestActionFromQueue(IReadOnlyList<WorkspaceActionQueueItemVm> queue)
+    {
+        var first = queue.FirstOrDefault();
+        if (first is null)
+        {
+            return null;
+        }
+
+        return new WorkspaceAttentionItemVm
+        {
+            Type = first.Type,
+            Title = first.Title,
+            Detail = first.Detail,
+            Severity = first.Severity,
+            BadgeText = first.BadgeText,
+            ActionText = first.ActionText,
+            ActionUrl = first.ActionUrl,
+            DueOrEventDateUtc = first.SortDateUtc
+        };
+    }
+
+    // SECTION: Queue priority keeps returned corrections and overdue work first.
+    private static int GetActionQueuePriority(WorkspaceActionQueueItemVm item)
+    {
+        return item.Type switch
+        {
+            "Returned" => 0,
+            "Task" when item.Severity == "Danger" => 1,
+            "Remark" => 2,
+            "Idea" => 3,
+            "AOTS" => 4,
+            "Task" => 5,
+            "Timeline" => 6,
+            _ => 9
+        };
     }
 
     private static WorkspaceAttentionItemVm ToAttentionItem(WorkspaceTaskVm task) => new()
@@ -523,7 +737,7 @@ public sealed class ProjectOfficerWorkspaceService
     {
         return new[]
         {
-            new WorkspaceRailItemVm { Label = "Today", Icon = "bi-calendar-check", Count = vm.PendingWithMeCount, Anchor = "#today", IsPrimary = true },
+            new WorkspaceRailItemVm { Label = "Today", Icon = "bi-calendar-check", Count = vm.DailyActionCount, Anchor = "#today", IsPrimary = true },
             new WorkspaceRailItemVm { Label = "Remarks Due", Icon = "bi-chat-left-text", Count = vm.RemarksDueCount, Anchor = "#remarks" },
             new WorkspaceRailItemVm { Label = "Other Assigned Tasks", Icon = "bi-list-check", Count = vm.OfficialTaskCount, Anchor = "#other-tasks" },
             new WorkspaceRailItemVm { Label = "Project Ideas", Icon = "bi-lightbulb", Count = vm.AssignedIdeaCount, Anchor = "#project-ideas" },

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -11,6 +11,7 @@ public sealed class ProjectOfficerWorkspaceVm
     public string RecordHealthSummaryLabel { get; set; } = "Good";
     public int AssignedProjectCount { get; set; }
     public int PendingWithMeCount { get; set; }
+    public int DailyActionCount { get; set; }
     public int OverdueTaskCount { get; set; }
     public int RecordGapCount { get; set; }
     public int AssignedIdeaCount { get; set; }
@@ -20,6 +21,7 @@ public sealed class ProjectOfficerWorkspaceVm
     public IReadOnlyList<WorkspaceKpiVm> Kpis { get; set; } = Array.Empty<WorkspaceKpiVm>();
     public IReadOnlyList<WorkspaceRailItemVm> RailItems { get; set; } = Array.Empty<WorkspaceRailItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
+    public IReadOnlyList<WorkspaceActionQueueItemVm> ActionQueue { get; set; } = Array.Empty<WorkspaceActionQueueItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> RemarksDue { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceTaskVm> OfficialTasksDue { get; set; } = Array.Empty<WorkspaceTaskVm>();
     public IReadOnlyList<WorkspaceIdeaVm> IdeasNeedingUpdate { get; set; } = Array.Empty<WorkspaceIdeaVm>();
@@ -83,6 +85,28 @@ public sealed class WorkspaceKpiVm
 
     public string? Url { get; set; }
 }
+
+public sealed class WorkspaceActionQueueItemVm
+{
+    public string Type { get; set; } = string.Empty;
+
+    public string BadgeText { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Detail { get; set; } = string.Empty;
+
+    public string Meta { get; set; } = string.Empty;
+
+    public string Severity { get; set; } = "Info";
+
+    public string ActionText { get; set; } = string.Empty;
+
+    public string ActionUrl { get; set; } = string.Empty;
+
+    public DateTime? SortDateUtc { get; set; }
+}
+
 public sealed class WorkspaceAttentionItemVm
 {
     public string Type { get; set; } = string.Empty;

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -1,4 +1,4 @@
-/* SECTION: Workspace shell and hero */
+/* SECTION: Workspace shell */
 .workspace-page {
     background: #f6f8fb;
     border-radius: 0;
@@ -6,17 +6,6 @@
     color: #1f2937;
 }
 
-.workspace-hero {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    align-items: center;
-    background: linear-gradient(135deg, #17366f, #24447c);
-    color: #fff;
-    border-radius: 12px;
-    padding: 0.72rem 0.95rem;
-    box-shadow: 0 8px 20px rgba(19, 47, 94, 0.12);
-}
 
 .workspace-eyebrow {
     margin: 0 0 0.12rem;
@@ -27,83 +16,16 @@
     opacity: 0.75;
 }
 
-.workspace-hero h1 {
-    margin: 0;
-    font-size: clamp(1.05rem, 1.35vw, 1.28rem);
-    font-weight: 650;
-    letter-spacing: -0.015em;
-}
 
-.workspace-hero p {
-    margin: 0.14rem 0 0;
-    font-size: 0.86rem;
-    opacity: 0.86;
-}
 
-.workspace-hero__meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.18rem;
-    text-align: right;
-    font-size: 0.76rem;
-    opacity: 0.78;
-}
 
-/* SECTION: KPI strip */
-.workspace-kpis {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(145px, 1fr));
-    gap: 0.7rem;
-    margin: 0.75rem 0;
-}
+/* SECTION: Workspace severity accents */
 
-.workspace-kpi {
-    display: flex;
-    gap: 0.65rem;
-    align-items: center;
-    background: #fff;
-    border-radius: 12px;
-    padding: 0.72rem 0.78rem;
-    box-shadow: 0 4px 14px rgba(20, 32, 55, 0.045);
-    border: 1px solid #e8edf5;
-    border-left: 3px solid #94a3b8;
-}
 
-.workspace-kpi i {
-    width: 32px;
-    height: 32px;
-    display: grid;
-    place-items: center;
-    border-radius: 999px;
-    background: #f1f5f9;
-    color: #24447c;
-    font-size: 0.98rem;
-}
 
-.workspace-kpi span,
-.workspace-kpi small {
-    display: block;
-}
 
-.workspace-kpi span {
-    font-size: 0.72rem;
-    font-weight: 600;
-    color: #64748b;
-}
 
-.workspace-kpi strong {
-    display: block;
-    margin-top: 0.06rem;
-    font-size: 1.18rem;
-    line-height: 1.05;
-    font-weight: 650;
-    color: #0f172a;
-}
 
-.workspace-kpi small {
-    font-size: 0.74rem;
-    color: #64748b;
-}
 
 .workspace-severity-good {
     border-left-color: #4f9d69;
@@ -122,39 +44,10 @@
 }
 
 /* SECTION: Portfolio health visuals */
-.workspace-health-ring {
-    width: 38px;
-    height: 38px;
-    flex: 0 0 38px;
-    border-radius: 999px;
-    display: grid;
-    place-items: center;
-    background: conic-gradient(#4f9d69 calc(var(--health) * 1%), #e9eef6 0);
-}
 
-.workspace-health-ring span {
-    width: 28px;
-    height: 28px;
-    border-radius: 999px;
-    background: #fff;
-    display: grid;
-    place-items: center;
-    font-size: 0.64rem;
-    font-weight: 650;
-    color: #1f2937;
-}
 
-.workspace-health-ring-good {
-    background: conic-gradient(#4f9d69 calc(var(--health) * 1%), #e9eef6 0);
-}
 
-.workspace-health-ring-attention {
-    background: conic-gradient(#d99a22 calc(var(--health) * 1%), #e9eef6 0);
-}
 
-.workspace-health-ring-danger {
-    background: conic-gradient(#c94b55 calc(var(--health) * 1%), #e9eef6 0);
-}
 
 .workspace-urgency {
     font-size: 0.66rem;
@@ -417,6 +310,125 @@
     color: #0f172a;
 }
 
+
+/* SECTION: Unified workspace action queue */
+.workspace-action-queue {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.workspace-action-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(120px, 180px) auto;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.62rem 0.72rem;
+    border: 1px solid #e8edf5;
+    border-radius: 10px;
+    background: #fff;
+}
+
+.workspace-action-row__main {
+    min-width: 0;
+}
+
+.workspace-action-row__main strong {
+    display: block;
+    max-width: 100%;
+    color: #0f172a;
+    font-size: 0.86rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.workspace-action-row__main p {
+    margin: 0.08rem 0 0;
+    color: #64748b;
+    font-size: 0.76rem;
+}
+
+.workspace-action-row small {
+    color: #64748b;
+    font-size: 0.74rem;
+    line-height: 1.25;
+}
+
+.workspace-action-row > a {
+    font-size: 0.78rem;
+    font-weight: 550;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.workspace-chip-remark {
+    background: #fff4dc;
+    color: #8a6414;
+}
+
+.workspace-chip-task {
+    background: #eef3fb;
+    color: #315176;
+}
+
+.workspace-chip-idea {
+    background: #eff6ff;
+    color: #1d4ed8;
+}
+
+.workspace-chip-aots {
+    background: #fff4dc;
+    color: #8a6414;
+}
+
+.workspace-chip-timeline,
+.workspace-chip-returned {
+    background: #fbeaec;
+    color: #9f303a;
+}
+
+.workspace-action-clearline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.6rem;
+    color: #64748b;
+    font-size: 0.76rem;
+}
+
+.workspace-action-clearline span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.65rem;
+    border-radius: 999px;
+    padding: 0.18rem 0.55rem;
+    background: #f8fafc;
+    border: 1px solid #e8edf5;
+}
+
+.workspace-anchor {
+    display: block;
+    position: relative;
+    top: -90px;
+    visibility: hidden;
+}
+
+@media (max-width: 900px) {
+    .workspace-action-row {
+        grid-template-columns: 1fr;
+        align-items: start;
+    }
+
+    .workspace-action-row small {
+        display: block;
+    }
+
+    .workspace-action-row > a {
+        justify-self: start;
+    }
+}
+
 /* SECTION: Project matrix */
 .workspace-table-wrap {
     overflow-x: auto;
@@ -577,33 +589,20 @@
 
 /* SECTION: Responsive behavior */
 @media (max-width: 1100px) {
-    .workspace-kpis {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
+    
     .workspace-grid {
         grid-template-columns: 1fr;
     }
 
-    .workspace-hero {
-        align-items: flex-start;
-        flex-direction: column;
+    
     }
-
-    .workspace-hero__meta {
-        text-align: left;
-    }
-}
 
 @media (max-width: 576px) {
     .workspace-page {
         padding: 0.75rem;
     }
 
-    .workspace-kpis {
-        grid-template-columns: 1fr;
-    }
-
+    
     .workspace-attention,
     .workspace-task-list article,
     .workspace-mini-row {
@@ -611,9 +610,6 @@
         align-items: flex-start;
     }
 
-    .workspace-hero {
-        border-radius: 12px;
-    }
 }
 
 /* SECTION: Record health bands */
@@ -630,72 +626,20 @@
 }
 
 /* SECTION: Redesigned workspace information architecture */
-.workspace-hero-simple {
-    justify-content: flex-start;
-}
-
 .workspace-section-subtitle {
     margin: 0.12rem 0 0;
     color: #64748b;
     font-size: 0.78rem;
 }
 
- .workspace-action-tabs {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.75rem;
-}
+ 
 
-.workspace-action-tabs section {
-    border: 1px solid #e8edf5;
-    border-radius: 10px;
-    padding: 0.7rem;
-    background: #fbfcfe;
-}
 
-.workspace-action-tabs h3 {
-    margin: 0 0 0.55rem;
-    font-size: 0.82rem;
-    font-weight: 650;
-    color: #334155;
-}
 
-.workspace-action-list {
-    display: grid;
-    gap: 0.5rem;
-}
 
-.workspace-action-list article {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    gap: 0.55rem;
-    align-items: center;
-    padding: 0.45rem 0;
-    border-bottom: 1px solid #edf2f7;
-}
 
-.workspace-action-list article:last-child {
-    border-bottom: 0;
-}
 
-.workspace-action-list strong {
-    display: block;
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #0f172a;
-}
 
-.workspace-action-list p {
-    margin: 0.05rem 0 0;
-    color: #64748b;
-    font-size: 0.76rem;
-}
-
-.workspace-action-list a {
-    font-size: 0.76rem;
-    font-weight: 550;
-    text-decoration: none;
-}
 
 .workspace-action-secondary {
     display: grid;
@@ -848,7 +792,6 @@
 }
 
 @media (max-width: 1100px) {
-    .workspace-action-tabs,
     .workspace-action-secondary,
     .workspace-split-grid {
         grid-template-columns: 1fr;
@@ -971,35 +914,9 @@
     white-space: nowrap;
 }
 
-.workspace-count-pills {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: 0.55rem;
-    margin-bottom: 0.75rem;
-}
 
-.workspace-count-pill {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-height: 2.45rem;
-    padding: 0.45rem 0.55rem;
-    border: 1px solid #e8edf5;
-    border-radius: 9px;
-    background: #fff;
-    color: #334155;
-    text-decoration: none;
-}
 
-.workspace-count-pill span {
-    font-weight: 650;
-    color: #0f172a;
-}
 
-.workspace-count-pill small {
-    color: #64748b;
-    font-size: 0.74rem;
-}
 
 /* SECTION: Workbench content grid */
 .workspace-main-grid {
@@ -1015,15 +932,7 @@
     align-content: start;
 }
 
-.workspace-action-tabs {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.75rem;
-}
 
-.workspace-action-tabs-four {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-}
 
 .workspace-section-link {
     display: inline-block;
@@ -1031,16 +940,6 @@
     font-size: 0.76rem;
     font-weight: 550;
     text-decoration: none;
-}
-
-@media (max-width: 1280px) {
-    .workspace-action-tabs-four {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .workspace-count-pills {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
 }
 
 @media (max-width: 1100px) {
@@ -1060,12 +959,6 @@
     }
 
     .workspace-main-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .workspace-action-tabs,
-    .workspace-action-tabs-four,
-    .workspace-count-pills {
         grid-template-columns: 1fr;
     }
 


### PR DESCRIPTION
### Motivation
- Unify the authoritative daily-action count so the command bar, left rail and action summary all show the same number. 
- Prevent underreporting by deriving Other Assigned Tasks and Project Ideas counts from full user-specific queries instead of truncated preview lists. 
- Replace the four-column action inbox with a single prioritized Action Queue to avoid narrow columns, excessive wrapping and duplicated count pills, and improve readability for long AOTS titles.

### Description
- Added `DailyActionCount` and `ActionQueue` to `ProjectOfficerWorkspaceVm` and introduced `WorkspaceActionQueueItemVm` to model unified queue rows. (modified `ViewModels/Workspace/WorkspaceViewModels.cs`).
- Refactored `ProjectOfficerWorkspaceService.GetProjectOfficerWorkspaceAsync` to load full task and idea sets via new helper methods (`LoadAssignedProjectsAsync`, `LoadOtherAssignedTasksAsync`, `LoadProjectIdeasAsync`, `LoadPersonalRemindersAsync`), compute `DailyActionCount`, build a prioritized `ActionQueue`, and derive `NextBestAction` from the first queue item. (modified `Services/Workspace/ProjectOfficerWorkspaceService.cs`).
- Reworked Razor UI in `Pages/Workspace/Index.cshtml` to use `DailyActionCount` for the command bar title, remove the horizontal KPI/count-pill row, and replace the four-column inbox with the unified Action Queue markup and hidden anchors for existing rail links.
- Added dedicated action-queue CSS and removed/disabled legacy four-column/count-pill/hero-related styles in `wwwroot/css/workspace.css`, and added a title attribute for compact record-health display in the Assigned Projects table.
- Kept other workspace routing, database schema and project-stage/workflow rules unchanged while centralising conversion helpers for task and idea view models.

### Testing
- Performed repository searches for obsolete selectors and references (e.g. action-tab/count-pills/KPI/hero selectors) and found no remaining usage of the removed layout patterns.
- Verified there are no workspace links pointing to `/Projects/Timeline/EditActuals/{id}` and confirmed `MyProjects` and `MyIdeas` routing patterns remain consistent via grep checks.
- Attempted to run `dotnet build` but the environment does not have the `dotnet` CLI installed, so a full build/test run could not be executed; manual code and grep inspections were used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325b84852c8329b5598bdc6fa08ed8)