### PR TITLE
Refine workspace daily action queue and rail semantics

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -46,11 +46,7 @@
         <div class="workspace-main-grid">
             <main class="workspace-main">
                 @* SECTION: Primary daily action queue *@
-                <span id="other-tasks" class="workspace-anchor"></span>
-                <span id="project-ideas" class="workspace-anchor"></span>
-                <span id="aots" class="workspace-anchor"></span>
-
-                <section id="remarks" class="workspace-card workspace-action-inbox">
+                <section id="action-queue" class="workspace-card workspace-action-inbox">
                     <div class="workspace-card__head">
                         <div>
                             <h2>Action Queue</h2>
@@ -70,12 +66,22 @@
                     else
                     {
                         <div class="workspace-action-queue">
-                            @foreach (var item in Model.Workspace.ActionQueue)
+                            @for (var i = 0; i < Model.Workspace.ActionQueue.Count; i++)
                             {
-                                <article class="workspace-action-row workspace-severity-@item.Severity.ToLowerInvariant()">
-                                    <span class="workspace-chip workspace-chip-@item.Type.ToLowerInvariant()">
-                                        @item.BadgeText
-                                    </span>
+                                var item = Model.Workspace.ActionQueue[i];
+                                var isNext = i == 0;
+
+                                <article class="workspace-action-row workspace-severity-@item.Severity.ToLowerInvariant() @(isNext ? "workspace-action-row-next" : string.Empty)">
+                                    @if (isNext)
+                                    {
+                                        <span class="workspace-next-marker">Next · @item.BadgeText</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="workspace-chip workspace-chip-@item.Type.ToLowerInvariant()">
+                                            @item.BadgeText
+                                        </span>
+                                    }
 
                                     <div class="workspace-action-row__main">
                                         <strong title="@item.Title">@item.Title</strong>
@@ -112,24 +118,144 @@
 
                 @* SECTION: Assigned-project review *@
                 <section id="assigned-projects" class="workspace-card workspace-portfolio-card">
-                    <div class="workspace-card__head"><div><h2>Assigned Projects</h2><p class="workspace-section-subtitle">Project stage, update status and next action</p></div><a href="@Model.Workspace.MyProjectsUrl">View all projects</a></div>
-                    @if (!Model.Workspace.ProjectMatrix.Any()) { <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p> }
-                    else { <div class="workspace-table-wrap"><table class="workspace-table workspace-portfolio-table"><thead><tr><th>Project</th><th>Stage</th><th>Update</th><th>Timeline</th><th>Record</th><th>Next</th></tr></thead><tbody>@foreach (var row in Model.Workspace.ProjectMatrix) { <tr><td><a href="@row.OpenUrl">@row.ProjectName</a></td><td><span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span> @if (row.DaysInCurrentStage.HasValue) { <small>@row.DaysInCurrentStage.Value d</small> }</td><td><span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)</span></td><td><span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()"><span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>@WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)</span></td><td><a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)" title="@($"{row.RecordGapCount} record fixes identified")" href="@row.OpenUrl">@row.RecordHealthPercent% · @row.RecordGapCount</a></td><td><a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">@WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)</a></td></tr> }</tbody></table></div> }
+                    <div class="workspace-card__head">
+                        <div>
+                            <h2>Assigned Projects</h2>
+                            <p class="workspace-section-subtitle">Project stage, update status and next action</p>
+                        </div>
+                        <a href="@Model.Workspace.MyProjectsUrl">View all projects</a>
+                    </div>
+
+                    @if (!Model.Workspace.ProjectMatrix.Any())
+                    {
+                        <p class="workspace-empty workspace-empty-compact">No projects are currently assigned to you.</p>
+                    }
+                    else
+                    {
+                        <div class="workspace-table-wrap">
+                            <table class="workspace-table workspace-portfolio-table">
+                                <thead>
+                                    <tr>
+                                        <th>Project</th>
+                                        <th>Stage</th>
+                                        <th>Update</th>
+                                        <th>Timeline</th>
+                                        <th>Record</th>
+                                        <th>Next</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var row in Model.Workspace.ProjectMatrix)
+                                    {
+                                        <tr>
+                                            <td><a href="@row.OpenUrl">@row.ProjectName</a></td>
+                                            <td>
+                                                <span class="workspace-chip workspace-chip-muted">@row.CurrentStageCode</span>
+                                                @if (row.DaysInCurrentStage.HasValue)
+                                                {
+                                                    <small>@row.DaysInCurrentStage.Value d</small>
+                                                }
+                                            </td>
+                                            <td>
+                                                <span class="workspace-status workspace-status-@row.UpdateStatus.ToLowerInvariant()">
+                                                    <span class="workspace-dot workspace-dot-@row.UpdateStatus.ToLowerInvariant()"></span>
+                                                    @WorkspaceDisplayHelpers.CompactStatusLabel(row.UpdateStatus)
+                                                </span>
+                                            </td>
+                                            <td>
+                                                <span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()">
+                                                    <span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>
+                                                    @WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)
+                                                </span>
+                                            </td>
+                                            <td>
+                                                <a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)"
+                                                   title="@($"{row.RecordHealthPercent}% record health; {row.RecordGapCount} fixes identified")"
+                                                   href="@row.OpenUrl">
+                                                    @WorkspaceDisplayHelpers.HealthBandLabel(row.RecordHealthPercent) · @row.RecordGapCount
+                                                </a>
+                                            </td>
+                                            <td>
+                                                <a class="btn btn-sm btn-outline-primary" href="@row.NextActionUrl">
+                                                    @WorkspaceDisplayHelpers.CompactActionLabel(row.NextActionText)
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
                 </section>
 
                 @* SECTION: Secondary ideas and reminders *@
-                <section class="workspace-card workspace-ideas-reminders">
-                    <div class="workspace-card__head"><div><h2>Ideas &amp; Reminders</h2><p class="workspace-section-subtitle">Early concepts and personal follow-ups</p></div></div>
+                <section id="my-ideas-reminders" class="workspace-card workspace-ideas-reminders">
+                    <div class="workspace-card__head">
+                        <div>
+                            <h2>My Ideas &amp; Reminders</h2>
+                            <p class="workspace-section-subtitle">Early concepts assigned to you and personal follow-ups</p>
+                        </div>
+                    </div>
+
                     <div class="workspace-split-grid">
                         <div>
-                            <div class="workspace-subhead"><h3>Project Ideas</h3><a href="/ProjectIdeas?MyIdeas=true">View ideas</a></div>
-                            @if (!Model.Workspace.Ideas.Any()) { <p class="workspace-inline-clear">No assigned ideas</p> }
-                            else { <div class="workspace-slim-list">@foreach (var idea in Model.Workspace.Ideas.Take(4)) { <article><div><strong>@idea.Title</strong><p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p></div>@if (idea.NeedsUpdate) { <span class="workspace-chip workspace-chip-warning">Needs update</span> }<a href="@idea.OpenUrl">Open</a></article> }</div> }
+                            <div class="workspace-subhead">
+                                <h3>Project Ideas</h3>
+                                <a href="/ProjectIdeas?MyIdeas=true">View ideas</a>
+                            </div>
+
+                            @if (!Model.Workspace.Ideas.Any())
+                            {
+                                <p class="workspace-inline-clear">No assigned ideas</p>
+                            }
+                            else
+                            {
+                                <div class="workspace-slim-list">
+                                    @foreach (var idea in Model.Workspace.Ideas.Take(4))
+                                    {
+                                        <article>
+                                            <div>
+                                                <strong>@idea.Title</strong>
+                                                <p>@idea.Status · @idea.CommentCount comments · @idea.DocumentCount docs</p>
+                                            </div>
+
+                                            @if (idea.NeedsUpdate)
+                                            {
+                                                <span class="workspace-chip workspace-chip-warning">Needs update</span>
+                                            }
+
+                                            <a href="@idea.OpenUrl">Open</a>
+                                        </article>
+                                    }
+                                </div>
+                            }
                         </div>
+
                         <div id="reminders">
-                            <div class="workspace-subhead"><h3>Personal Reminders</h3><a href="/Tasks">Open reminders</a></div>
-                            @if (!Model.Workspace.PersonalReminders.Any()) { <p class="workspace-inline-clear">No reminders</p> }
-                            else { <div class="workspace-slim-list">@foreach (var r in Model.Workspace.PersonalReminders.Take(4)) { <article><div><strong>@r.Title</strong><p>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)@(r.IsPinned ? " · pinned" : string.Empty)</p></div><a href="@r.OpenUrl">Open</a></article> }</div> }
+                            <div class="workspace-subhead">
+                                <h3>Personal Reminders</h3>
+                                <a href="/Tasks">Open reminders</a>
+                            </div>
+
+                            @if (!Model.Workspace.PersonalReminders.Any())
+                            {
+                                <p class="workspace-inline-clear">No reminders</p>
+                            }
+                            else
+                            {
+                                <div class="workspace-slim-list">
+                                    @foreach (var r in Model.Workspace.PersonalReminders.Take(4))
+                                    {
+                                        <article>
+                                            <div>
+                                                <strong>@r.Title</strong>
+                                                <p>@r.Priority · @WorkspaceDisplayHelpers.FormatReminderDate(r.DueAtUtc)@(r.IsPinned ? " · pinned" : string.Empty)</p>
+                                            </div>
+                                            <a href="@r.OpenUrl">Open</a>
+                                        </article>
+                                    }
+                                </div>
+                            }
                         </div>
                     </div>
                 </section>
@@ -139,18 +265,69 @@
                 @* SECTION: Focused next daily action *@
                 <section class="workspace-card workspace-next-fix">
                     <h2>Next Best Action</h2>
-                    @if (Model.Workspace.NextBestAction is null) { <p class="workspace-inline-clear">No immediate action required</p> }
-                    else { <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestAction.Severity.ToLowerInvariant()">@WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestAction)</span><strong>@Model.Workspace.NextBestAction.Title</strong><p>@Model.Workspace.NextBestAction.Detail</p><a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestAction.ActionUrl">@Model.Workspace.NextBestAction.ActionText</a> }
+                    @if (Model.Workspace.NextBestAction is null)
+                    {
+                        <p class="workspace-inline-clear">No immediate action required</p>
+                    }
+                    else
+                    {
+                        <span class="workspace-urgency workspace-urgency-@Model.Workspace.NextBestAction.Severity.ToLowerInvariant()">
+                            @WorkspaceDisplayHelpers.UrgencyLabel(Model.Workspace.NextBestAction)
+                        </span>
+                        <strong>@Model.Workspace.NextBestAction.Title</strong>
+                        <p>@Model.Workspace.NextBestAction.Detail</p>
+                        <a class="btn btn-sm btn-primary" href="@Model.Workspace.NextBestAction.ActionUrl">
+                            @Model.Workspace.NextBestAction.ActionText
+                        </a>
+                    }
                 </section>
 
                 @* SECTION: Durable workspace destinations *@
-                <section class="workspace-card workspace-card-clean"><h2>Quick Actions</h2><div class="workspace-quick-actions">@foreach (var action in Model.Workspace.QuickActions) { <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a> }</div></section>
+                <section class="workspace-card workspace-card-clean">
+                    <h2>Quick Actions</h2>
+                    <div class="workspace-quick-actions">
+                        @foreach (var action in Model.Workspace.QuickActions)
+                        {
+                            <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a>
+                        }
+                    </div>
+                </section>
 
                 @* SECTION: Quiet grouped record cleanup *@
-                <section class="workspace-card workspace-card-clean"><h2>Record Cleanup</h2>@if (!Model.Workspace.ImproveProjects.Any()) { <p class="workspace-inline-clear">No cleanup priority.</p> } else { <div class="workspace-cleanup-list">@foreach (var item in Model.Workspace.ImproveProjects.Take(3)) { <article><div><strong>@item.ProjectName</strong><p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p></div><a href="@item.Url">Open</a></article> }</div> }</section>
+                <section class="workspace-card workspace-card-clean">
+                    <h2>Record Cleanup</h2>
+                    @if (!Model.Workspace.ImproveProjects.Any())
+                    {
+                        <p class="workspace-inline-clear">No cleanup priority.</p>
+                    }
+                    else
+                    {
+                        <div class="workspace-cleanup-list">
+                            @foreach (var item in Model.Workspace.ImproveProjects.Take(3))
+                            {
+                                <article>
+                                    <div>
+                                        <strong>@item.ProjectName</strong>
+                                        <p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p>
+                                    </div>
+                                    <a href="@item.Url">Open</a>
+                                </article>
+                            }
+                        </div>
+                    }
+                </section>
 
                 @* SECTION: ERP engagement remains quiet and factual *@
-                <section class="workspace-card workspace-card-clean"><h2>ERP Engagement</h2><div class="workspace-engagement-grid"><div><span>Active days</span><strong>@Model.Workspace.Engagement.ActiveDaysThisMonth</strong></div><div><span>Actions</span><strong>@Model.Workspace.Engagement.ActionsRecordedThisMonth</strong></div><div><span>Remarks</span><strong>@Model.Workspace.Engagement.RemarksPostedThisMonth</strong></div><div><span>Tasks</span><strong>@Model.Workspace.Engagement.TasksUpdatedThisMonth</strong></div><div><span>Documents</span><strong>@Model.Workspace.Engagement.DocumentsUploadedThisMonth</strong></div></div></section>
+                <section class="workspace-card workspace-card-clean">
+                    <h2>ERP Engagement</h2>
+                    <div class="workspace-engagement-grid">
+                        <div><span>Active days</span><strong>@Model.Workspace.Engagement.ActiveDaysThisMonth</strong></div>
+                        <div><span>Actions</span><strong>@Model.Workspace.Engagement.ActionsRecordedThisMonth</strong></div>
+                        <div><span>Remarks</span><strong>@Model.Workspace.Engagement.RemarksPostedThisMonth</strong></div>
+                        <div><span>Tasks</span><strong>@Model.Workspace.Engagement.TasksUpdatedThisMonth</strong></div>
+                        <div><span>Documents</span><strong>@Model.Workspace.Engagement.DocumentsUploadedThisMonth</strong></div>
+                    </div>
+                </section>
             </aside>
         </div>
     </div>

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -71,7 +71,7 @@ public sealed class ProjectOfficerWorkspaceService
         var aotsDocuments = await LoadUnreadAotsDocumentsAsync(userId, ct);
         var timelineAlerts = _nudges.BuildTimelineAlerts(projects, today).ToList();
         var dailyActionCount = remarksDue.Count + officialTasksDue.Count + ideasNeedingUpdate.Count + aotsUnreadCount;
-        var actionQueue = BuildActionQueue(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments, timelineAlerts);
+        var actionQueue = BuildActionQueue(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments);
 
         var pending = returnedItems
             .Concat(remarksDue)
@@ -140,7 +140,7 @@ public sealed class ProjectOfficerWorkspaceService
             RecordHealth = health.Values.OrderBy(h => h.HealthPercent).Take(5).ToList(),
             ImproveScoreItems = BuildImproveScoreItems(health.Values, maxItems: 4),
             ImproveProjects = BuildImproveProjects(health.Values, maxProjects: 3),
-            NextBestAction = BuildNextBestActionFromQueue(actionQueue),
+            NextBestAction = BuildNextBestAction(actionQueue, timelineAlerts),
             PersonalReminders = reminders,
             QuickActions = BuildQuickActions(userId),
             MyProjectsUrl = myProjectsUrl
@@ -295,8 +295,7 @@ public sealed class ProjectOfficerWorkspaceService
         IReadOnlyList<WorkspaceTaskVm> otherAssignedTasksDue,
         IReadOnlyList<WorkspaceAttentionItemVm> remarksDue,
         IReadOnlyList<WorkspaceIdeaVm> ideasNeedingUpdate,
-        IReadOnlyList<WorkspaceAotsDocumentVm> aotsDocuments,
-        IReadOnlyList<WorkspaceAttentionItemVm> timelineAlerts)
+        IReadOnlyList<WorkspaceAotsDocumentVm> aotsDocuments)
     {
         var items = new List<WorkspaceActionQueueItemVm>();
 
@@ -367,19 +366,6 @@ public sealed class ProjectOfficerWorkspaceService
             SortDateUtc = document.CreatedAtUtc
         }));
 
-        items.AddRange(timelineAlerts.Select(item => new WorkspaceActionQueueItemVm
-        {
-            Type = "Timeline",
-            BadgeText = item.BadgeText,
-            Title = item.Title,
-            Detail = item.Detail,
-            Meta = "Timeline",
-            Severity = item.Severity,
-            ActionText = item.ActionText,
-            ActionUrl = item.ActionUrl,
-            SortDateUtc = item.DueOrEventDateUtc
-        }));
-
         return items
             .OrderBy(GetActionQueuePriority)
             .ThenByDescending(i => i.SortDateUtc)
@@ -387,26 +373,29 @@ public sealed class ProjectOfficerWorkspaceService
             .ToList();
     }
 
-    // SECTION: Next best action mirrors the first row in the unified action queue.
-    private static WorkspaceAttentionItemVm? BuildNextBestActionFromQueue(IReadOnlyList<WorkspaceActionQueueItemVm> queue)
+    // SECTION: Next best action mirrors the daily queue, falling back to timeline follow-up only when daily actions are clear.
+    private static WorkspaceAttentionItemVm? BuildNextBestAction(
+        IReadOnlyList<WorkspaceActionQueueItemVm> actionQueue,
+        IReadOnlyList<WorkspaceAttentionItemVm> timelineAlerts)
     {
-        var first = queue.FirstOrDefault();
-        if (first is null)
+        var first = actionQueue.FirstOrDefault();
+
+        if (first is not null)
         {
-            return null;
+            return new WorkspaceAttentionItemVm
+            {
+                Type = first.Type,
+                Title = first.Title,
+                Detail = first.Detail,
+                Severity = first.Severity,
+                BadgeText = first.BadgeText,
+                ActionText = first.ActionText,
+                ActionUrl = first.ActionUrl,
+                DueOrEventDateUtc = first.SortDateUtc
+            };
         }
 
-        return new WorkspaceAttentionItemVm
-        {
-            Type = first.Type,
-            Title = first.Title,
-            Detail = first.Detail,
-            Severity = first.Severity,
-            BadgeText = first.BadgeText,
-            ActionText = first.ActionText,
-            ActionUrl = first.ActionUrl,
-            DueOrEventDateUtc = first.SortDateUtc
-        };
+        return timelineAlerts.FirstOrDefault();
     }
 
     // SECTION: Queue priority keeps returned corrections and overdue work first.
@@ -420,7 +409,6 @@ public sealed class ProjectOfficerWorkspaceService
             "Idea" => 3,
             "AOTS" => 4,
             "Task" => 5,
-            "Timeline" => 6,
             _ => 9
         };
     }
@@ -738,10 +726,10 @@ public sealed class ProjectOfficerWorkspaceService
         return new[]
         {
             new WorkspaceRailItemVm { Label = "Today", Icon = "bi-calendar-check", Count = vm.DailyActionCount, Anchor = "#today", IsPrimary = true },
-            new WorkspaceRailItemVm { Label = "Remarks Due", Icon = "bi-chat-left-text", Count = vm.RemarksDueCount, Anchor = "#remarks" },
-            new WorkspaceRailItemVm { Label = "Other Assigned Tasks", Icon = "bi-list-check", Count = vm.OfficialTaskCount, Anchor = "#other-tasks" },
-            new WorkspaceRailItemVm { Label = "Project Ideas", Icon = "bi-lightbulb", Count = vm.AssignedIdeaCount, Anchor = "#project-ideas" },
-            new WorkspaceRailItemVm { Label = "AOTS", Icon = "bi-file-earmark-text", Count = vm.AotsUnreadCount, Anchor = "#aots" },
+            new WorkspaceRailItemVm { Label = "Remarks Due", Icon = "bi-chat-left-text", Count = vm.RemarksDueCount, Anchor = "#action-queue" },
+            new WorkspaceRailItemVm { Label = "Other Assigned Tasks", Icon = "bi-list-check", Count = vm.OfficialTaskCount, Anchor = "#action-queue" },
+            new WorkspaceRailItemVm { Label = "My Ideas", Icon = "bi-lightbulb", Count = vm.AssignedIdeaCount, Anchor = "#my-ideas-reminders" },
+            new WorkspaceRailItemVm { Label = "AOTS", Icon = "bi-file-earmark-text", Count = vm.AotsUnreadCount, Anchor = "#action-queue" },
             new WorkspaceRailItemVm { Label = "Assigned Projects", Icon = "bi-kanban", Count = vm.AssignedProjectCount, Anchor = "#assigned-projects" },
             new WorkspaceRailItemVm { Label = "Reminders", Icon = "bi-bell", Count = vm.PersonalReminders.Count, Anchor = "#reminders" }
         };

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -125,6 +125,7 @@ public sealed class WorkspaceAttentionItemVm
 
     public DateTime? DueOrEventDateUtc { get; set; }
 }
+
 public sealed class WorkspaceProjectMatrixRowVm
 {
     public int ProjectId { get; set; }
@@ -167,6 +168,7 @@ public sealed class WorkspaceProjectMatrixRowVm
 
     public string TimelineUrl { get; set; } = string.Empty;
 }
+
 public sealed class WorkspaceTaskVm
 {
     public int TaskId { get; set; }
@@ -187,6 +189,7 @@ public sealed class WorkspaceTaskVm
 
     public string OpenUrl { get; set; } = string.Empty;
 }
+
 public sealed class WorkspaceIdeaVm
 {
     public int IdeaId { get; set; }
@@ -344,6 +347,23 @@ public static class WorkspaceDisplayHelpers
         }
 
         return "danger";
+    }
+
+
+    // SECTION: Record-health labels translate percentages into user-friendly bands.
+    public static string HealthBandLabel(int percent)
+    {
+        if (percent >= 80)
+        {
+            return "Good";
+        }
+
+        if (percent >= 60)
+        {
+            return "Review";
+        }
+
+        return "Needs Work";
     }
 
     // SECTION: Improvement labels turn internal checklist gaps into action wording.

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -17,14 +17,7 @@
 }
 
 
-
-
 /* SECTION: Workspace severity accents */
-
-
-
-
-
 
 
 .workspace-severity-good {
@@ -44,9 +37,6 @@
 }
 
 /* SECTION: Portfolio health visuals */
-
-
-
 
 
 .workspace-urgency {
@@ -95,19 +85,6 @@
 }
 
 /* SECTION: Layout and cards */
-.workspace-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 340px;
-    gap: 1rem;
-}
-
-.workspace-main,
-.workspace-rail {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
 .workspace-card {
     background: #fff;
     border: 1px solid #e8edf5;
@@ -254,63 +231,6 @@
     background: #94a3b8;
 }
 
-/* SECTION: Attention and task lists */
-.workspace-attention-list,
-.workspace-task-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-}
-
-.workspace-attention {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
-    align-items: center;
-    gap: 0.65rem;
-    border: 1px solid #e8edf5;
-    border-radius: 10px;
-    padding: 0.62rem 0.72rem;
-    background: #fff;
-    transition: border-color 0.12s ease, box-shadow 0.12s ease;
-}
-
-.workspace-task-list article,
-.workspace-mini-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto;
-    align-items: center;
-    gap: 0.65rem;
-    border: 1px solid #e8edf5;
-    border-radius: 10px;
-    padding: 0.62rem 0.72rem;
-    background: #fff;
-    transition: border-color 0.12s ease, box-shadow 0.12s ease;
-}
-
-.workspace-attention:hover,
-.workspace-task-list article:hover,
-.workspace-mini-row:hover {
-    border-color: rgba(49, 95, 186, 0.18);
-    box-shadow: 0 4px 12px rgba(20, 32, 55, 0.045);
-    transform: none;
-}
-
-.workspace-attention p,
-.workspace-task-list p {
-    margin: 0;
-    color: #64748b;
-    font-size: 0.8rem;
-}
-
-.workspace-attention strong,
-.workspace-task-list strong,
-.workspace-mini-row strong {
-    font-size: 0.86rem;
-    font-weight: 600;
-    color: #0f172a;
-}
-
-
 /* SECTION: Unified workspace action queue */
 .workspace-action-queue {
     display: grid;
@@ -326,6 +246,24 @@
     border: 1px solid #e8edf5;
     border-radius: 10px;
     background: #fff;
+}
+
+.workspace-action-row-next {
+    border-color: #c9d8f3;
+    background: #fbfdff;
+}
+
+.workspace-next-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.72rem;
+    font-weight: 650;
+    white-space: nowrap;
+    background: #edf4ff;
+    color: #24447c;
 }
 
 .workspace-action-row__main {
@@ -418,6 +356,10 @@
     .workspace-action-row {
         grid-template-columns: 1fr;
         align-items: start;
+    }
+
+    .workspace-action-row__main strong {
+        white-space: normal;
     }
 
     .workspace-action-row small {
@@ -519,41 +461,6 @@
     font-weight: 600;
 }
 
-.workspace-improve-list {
-    display: grid;
-    gap: 0.45rem;
-    margin: 0;
-    padding-left: 1.1rem;
-}
-
-.workspace-improve-list li {
-    list-style-position: outside;
-}
-
-.workspace-improve-list a {
-    display: block;
-    padding: 0.48rem 0.56rem;
-    background: #fffaf0;
-    border: 1px solid #f1ddb0;
-    border-radius: 8px;
-    font-weight: 600;
-    color: #654a12;
-    text-decoration: none;
-}
-
-.workspace-improve-list a:hover {
-    background: #fff4d8;
-    border-color: #e7c979;
-}
-
-.workspace-improve-list small {
-    display: block;
-    margin-top: 0.12rem;
-    color: #8a6d20;
-    font-weight: 500;
-}
-
-.workspace-mini-row small,
 .workspace-engagement span {
     display: block;
     color: #64748b;
@@ -588,26 +495,9 @@
 }
 
 /* SECTION: Responsive behavior */
-@media (max-width: 1100px) {
-    
-    .workspace-grid {
-        grid-template-columns: 1fr;
-    }
-
-    
-    }
-
 @media (max-width: 576px) {
     .workspace-page {
         padding: 0.75rem;
-    }
-
-    
-    .workspace-attention,
-    .workspace-task-list article,
-    .workspace-mini-row {
-        grid-template-columns: 1fr;
-        align-items: flex-start;
     }
 
 }
@@ -634,35 +524,6 @@
 
  
 
-
-
-
-
-
-
-
-.workspace-action-secondary {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-    margin-top: 0.75rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid #edf2f7;
-}
-
-.workspace-action-secondary h3 {
-    margin: 0 0 0.4rem;
-    font-size: 0.8rem;
-    font-weight: 650;
-    color: #334155;
-}
-
-.workspace-action-secondary a {
-    display: block;
-    font-size: 0.76rem;
-    text-decoration: none;
-    margin-bottom: 0.35rem;
-}
 
 .workspace-inline-clear {
     margin: 0;
@@ -792,7 +653,6 @@
 }
 
 @media (max-width: 1100px) {
-    .workspace-action-secondary,
     .workspace-split-grid {
         grid-template-columns: 1fr;
     }
@@ -915,9 +775,6 @@
 }
 
 
-
-
-
 /* SECTION: Workbench content grid */
 .workspace-main-grid {
     display: grid;
@@ -931,7 +788,6 @@
     gap: 0.85rem;
     align-content: start;
 }
-
 
 
 .workspace-section-link {


### PR DESCRIPTION
### Motivation

- Align the visible Action Queue with the command-bar daily count by ensuring the primary queue contains only true daily update actions and not timeline/backfill alerts.
- Keep timeline/backfill visible in project contexts and as a fallback Next Best Action only when no daily action exists.
- Make left-rail labels and anchors clearer (personalise ideas, point category links to meaningful sections) and improve small UI affordances for clarity (first-row Next marker, clearer record-health pill). 
- Remove unused legacy CSS selectors and tidy Razor/ViewModel formatting for maintainability.

### Description

- BuildActionQueue now excludes timeline/backfill items and accepts only returned items, assigned tasks, remarks due, ideas needing update, and unread AOTS documents; queue ordering and priority remain unchanged aside from removing timeline as a primary type. 
- Added `BuildNextBestAction(actionQueue, timelineAlerts)` so the right-rail Next Best Action mirrors the first daily queue item when present and falls back to timeline/backfill only if the daily queue is empty. 
- Updated rail semantics in `BuildRailItems` so `Today` uses `DailyActionCount`, `Project Ideas` was renamed to `My Ideas` and anchors now point to `#action-queue` or `#my-ideas-reminders` as appropriate. 
- Razor updates in `Pages/Workspace/Index.cshtml`: changed Action Queue section id to `action-queue`, updated `assigned-projects` and `my-ideas-reminders` sections and anchors, improved layout readability, and replaced the Action Queue loop to render a subtle `Next · <type>` marker for the first row. 
- Added `HealthBandLabel(int percent)` to `WorkspaceDisplayHelpers` and replaced cryptic `30% · 5` display with `Needs Work · 5` (or corresponding band label) and a title tooltip for Assigned Projects record pill. 
- CSS changes in `wwwroot/css/workspace.css`: removed several unused legacy selectors after reference checks, added subtle styles for `.workspace-action-row-next` and `.workspace-next-marker`, and preserved ellipsis behavior with mobile wrapping. 
- Small ViewModel and Razor formatting fixes (class spacing and multi-line Razor blocks) to improve maintainability.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and found no problems. (passed)
- Performed repository searches with `rg` to verify removed CSS selectors are not referenced and to confirm new identifiers/styles are present (searches matched intended changes). (passed)
- Attempted to run `dotnet build` but `dotnet` is not available in this environment, so a full build could not be executed here. (not run)
- Verified repository status and diffs locally via `git status` / `git diff` to review changes (inspection only). (inspected)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c100dab88329bcb2c874f3928649)