### PR TITLE
Refine Workspace Project Data Gaps scoring and UI wording

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -170,7 +170,7 @@
                                             </td>
                                             <td>
                                                 <a class="workspace-health-pill workspace-health-pill-@WorkspaceDisplayHelpers.HealthCss(row.RecordHealthPercent)"
-                                                   title="@($"{row.RecordHealthPercent}% record health; {row.RecordGapCount} fixes identified")"
+                                                   title="@($"{row.RecordHealthPercent}% project data completeness; {row.RecordGapCount} details pending")"
                                                    href="@row.OpenUrl">
                                                     @WorkspaceDisplayHelpers.HealthBandLabel(row.RecordHealthPercent) · @row.RecordGapCount
                                                 </a>
@@ -293,12 +293,12 @@
                     </div>
                 </section>
 
-                @* SECTION: Quiet grouped record cleanup *@
+                @* SECTION: Quiet grouped project data gaps *@
                 <section class="workspace-card workspace-card-clean">
-                    <h2>Record Cleanup</h2>
+                    <h2>Project Data Gaps</h2>
                     @if (!Model.Workspace.ImproveProjects.Any())
                     {
-                        <p class="workspace-inline-clear">No cleanup priority.</p>
+                        <p class="workspace-inline-clear">Project data looks complete.</p>
                     }
                     else
                     {
@@ -308,7 +308,7 @@
                                 <article>
                                     <div>
                                         <strong>@item.ProjectName</strong>
-                                        <p>@item.FixCount fix@(item.FixCount == 1 ? "" : "es") identified</p>
+                                        <p>@item.FixCount detail@(item.FixCount == 1 ? "" : "s") pending</p>
                                     </div>
                                     <a href="@item.Url">Open</a>
                                 </article>

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -663,10 +663,38 @@ public sealed class ProjectOfficerWorkspaceService
     // SECTION: Improvement routing points each gap to the most relevant correction workflow.
     private static string ResolveImprovementUrl(int projectId, string gap)
     {
-        if (gap.Contains("remark", StringComparison.OrdinalIgnoreCase)) return WorkspaceRouteHelper.ProjectRemarks(projectId);
-        if (gap.Contains("backfill", StringComparison.OrdinalIgnoreCase) || gap.Contains("current stage", StringComparison.OrdinalIgnoreCase) || gap.Contains("completion date", StringComparison.OrdinalIgnoreCase)) return WorkspaceRouteHelper.ProjectTimeline(projectId);
-        if (gap.Contains("classification", StringComparison.OrdinalIgnoreCase) || gap.Contains("metadata", StringComparison.OrdinalIgnoreCase)) return WorkspaceRouteHelper.ProjectMetaRequest(projectId);
-        if (gap.Contains("document", StringComparison.OrdinalIgnoreCase)) return WorkspaceRouteHelper.ProjectDocumentRequest(projectId);
+        if (gap.Contains("remark", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectRemarks(projectId);
+        }
+
+        if (gap.Contains("backfill", StringComparison.OrdinalIgnoreCase) ||
+            gap.Contains("current stage timeline", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectTimeline(projectId);
+        }
+
+        if (gap.Contains("document", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectDocumentRequest(projectId);
+        }
+
+        if (gap.Contains("photo", StringComparison.OrdinalIgnoreCase) ||
+            gap.Contains("video", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectMedia(projectId);
+        }
+
+        if (gap.Contains("budget", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectOverview(projectId);
+        }
+
+        if (gap.Contains("description", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectMetaRequest(projectId);
+        }
+
         return WorkspaceRouteHelper.ProjectOverview(projectId);
     }
 

--- a/Services/Workspace/ProjectRecordHealthService.cs
+++ b/Services/Workspace/ProjectRecordHealthService.cs
@@ -3,7 +3,6 @@ using ProjectManagement.Infrastructure;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
-using ProjectManagement.Models.Remarks;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.ViewModels.Workspace;
 
@@ -11,31 +10,52 @@ namespace ProjectManagement.Services.Workspace;
 
 public sealed class ProjectRecordHealthService
 {
+    private const string GapBriefDescription = "Brief description pending";
+    private const string GapPhotos = "Add at least 3 project photos";
+    private const string GapDocuments = "Upload at least 3 project documents";
+    private const string GapVideo = "Add at least 1 project video";
+    private const string GapBudget = "Update applicable budget details";
+    private const string GapBackfill = "Clear timeline backfill";
+    private const string GapCurrentStageTimeline = "Update current stage timeline";
+    private const string GapRecentRemark = "Add recent project remark";
+
     private readonly ApplicationDbContext _db;
     private readonly WorkspaceNudgeService _nudges;
-    public ProjectRecordHealthService(ApplicationDbContext db, WorkspaceNudgeService nudges) { _db = db; _nudges = nudges; }
 
-    // SECTION: Batch record-health calculation
-    public async Task<IReadOnlyDictionary<int, WorkspaceRecordHealthVm>> CalculateForProjectsAsync(IReadOnlyList<Project> projects, string userId, CancellationToken ct)
+    public ProjectRecordHealthService(
+        ApplicationDbContext db,
+        WorkspaceNudgeService nudges)
     {
-        var ids = projects.Select(p => p.Id).ToArray();
-        var factPresence = await LoadStageFactPresenceAsync(ids, ct);
+        _db = db;
+        _nudges = nudges;
+    }
+
+    // SECTION: Batch project-data completeness calculation
+    public async Task<IReadOnlyDictionary<int, WorkspaceRecordHealthVm>> CalculateForProjectsAsync(
+        IReadOnlyList<Project> projects,
+        string userId,
+        CancellationToken ct)
+    {
+        var projectIds = projects.Select(p => p.Id).ToArray();
+        var mediaCounts = await LoadMediaCountsAsync(projectIds, ct);
+        var factPresence = await LoadStageFactPresenceAsync(projectIds, ct);
         var today = DateOnly.FromDateTime(IstClock.ToIst(DateTime.UtcNow));
         var results = new Dictionary<int, WorkspaceRecordHealthVm>();
+
         foreach (var project in projects)
         {
             var gaps = new List<string>();
             var score = 0;
-            if (!string.IsNullOrWhiteSpace(project.Description) && !string.IsNullOrWhiteSpace(project.HodUserId) && !string.IsNullOrWhiteSpace(project.LeadPoUserId)) score += 15; else gaps.Add("Basic metadata incomplete");
-            if (project.CategoryId.HasValue && project.TechnicalCategoryId.HasValue && project.ProjectTypeId.HasValue) score += 15; else gaps.Add("Category / technical category / project type incomplete");
-            var current = WorkspaceNudgeService.GetCurrentStage(project);
-            var currentStageGaps = GetCurrentStageGaps(current, today);
-            if (currentStageGaps.Count == 0) score += 15; else gaps.AddRange(currentStageGaps);
-            if (!project.ProjectStages.Any(s => s.RequiresBackfill)) score += 15; else gaps.Add("Timeline backfill required");
-            if (HasRequiredFacts(project, factPresence, current)) score += 15; else gaps.Add("Required current/past stage facts missing");
-            var lastRemark = WorkspaceNudgeService.LastPoRemark(project, userId);
-            if (lastRemark.HasValue && (today.DayNumber - WorkspaceNudgeService.ToIstDate(lastRemark.Value).DayNumber) <= 10) score += 15; else gaps.Add(lastRemark.HasValue ? "No PO remark in last 10 days" : "No PO remark has been added yet");
-            if (project.Documents.Any(d => d.Status == ProjectDocumentStatus.Published)) score += 10; else gaps.Add("No project document uploaded");
+
+            score += ScoreBriefDescription(project, gaps);
+            score += ScorePhotos(project.Id, mediaCounts, gaps);
+            score += ScoreDocuments(project.Id, mediaCounts, gaps);
+            score += ScoreVideo(project.Id, mediaCounts, gaps);
+            score += ScoreBudgetMetrics(project, factPresence, gaps);
+            score += ScoreBackfill(project, gaps);
+            score += ScoreCurrentStageTimeline(project, today, gaps);
+            score += ScoreRecentPoRemark(project, userId, today, gaps);
+
             results[project.Id] = new WorkspaceRecordHealthVm
             {
                 ProjectId = project.Id,
@@ -46,14 +66,51 @@ public sealed class ProjectRecordHealthService
                 OpenUrl = WorkspaceRouteHelper.ProjectOverview(project.Id)
             };
         }
+
         return results;
     }
 
-    // SECTION: Stage-specific fact presence prevents one stage fact from satisfying all stage checks.
+    // SECTION: Media and document count loading keeps the assigned-project query lightweight.
+    private async Task<IReadOnlyDictionary<int, ProjectDataCounts>> LoadMediaCountsAsync(
+        int[] projectIds,
+        CancellationToken ct)
+    {
+        var photoCounts = await _db.ProjectPhotos
+            .AsNoTracking()
+            .Where(p => projectIds.Contains(p.ProjectId))
+            .GroupBy(p => p.ProjectId)
+            .Select(g => new { ProjectId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.ProjectId, x => x.Count, ct);
+
+        var documentCounts = await _db.ProjectDocuments
+            .AsNoTracking()
+            .Where(d =>
+                projectIds.Contains(d.ProjectId) &&
+                d.Status == ProjectDocumentStatus.Published &&
+                !d.IsArchived)
+            .GroupBy(d => d.ProjectId)
+            .Select(g => new { ProjectId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.ProjectId, x => x.Count, ct);
+
+        var videoCounts = await _db.ProjectVideos
+            .AsNoTracking()
+            .Where(v => projectIds.Contains(v.ProjectId))
+            .GroupBy(v => v.ProjectId)
+            .Select(g => new { ProjectId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.ProjectId, x => x.Count, ct);
+
+        return projectIds.ToDictionary(
+            id => id,
+            id => new ProjectDataCounts(
+                photoCounts.GetValueOrDefault(id),
+                documentCounts.GetValueOrDefault(id),
+                videoCounts.GetValueOrDefault(id)));
+    }
+
+    // SECTION: Stage-specific fact presence supports stage-aware budget completeness.
     private async Task<StageFactPresence> LoadStageFactPresenceAsync(int[] projectIds, CancellationToken ct)
         => new(
             await LoadIdsAsync(_db.ProjectIpaFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectSowFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
             await LoadIdsAsync(_db.ProjectAonFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
             await LoadIdsAsync(_db.ProjectBenchmarkFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
             await LoadIdsAsync(_db.ProjectCommercialFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
@@ -64,41 +121,213 @@ public sealed class ProjectRecordHealthService
     private static async Task<HashSet<int>> LoadIdsAsync(IQueryable<int> query, CancellationToken ct)
         => (await query.ToListAsync(ct)).ToHashSet();
 
-    // SECTION: Current-stage gap wording separates overdue and missing-date fixes.
-    private IReadOnlyList<string> GetCurrentStageGaps(ProjectStage? stage, DateOnly today)
+    // SECTION: Completeness scoring metrics
+    private static int ScoreBriefDescription(Project project, List<string> gaps)
     {
-        var gaps = new List<string>();
-        if (_nudges.IsCurrentStageOverdue(stage, today)) gaps.Add("Current stage overdue");
-        if (stage is null) return gaps;
-        if (stage.Status == StageStatus.InProgress && stage.ActualStart is null) gaps.Add("Current stage actual start missing");
-        if (stage.Status == StageStatus.InProgress && stage.PlannedDue is null) gaps.Add("Current stage planned due missing");
-        if (stage.Status == StageStatus.Completed && stage.CompletedOn is null) gaps.Add($"{stage.StageCode} stage completion date missing");
-        return gaps;
-    }
-
-    private static bool HasRequiredFacts(Project project, StageFactPresence facts, ProjectStage? current)
-    {
-        if (current is null) return true;
-
-        return project.ProjectStages
-            .Where(s => s.Status == StageStatus.Completed || s.Id == current.Id)
-            .All(s => HasFactForStage(project.Id, s.StageCode, facts));
-    }
-
-    private static bool HasFactForStage(int projectId, string stageCode, StageFactPresence facts)
-        => stageCode.ToUpperInvariant() switch
+        if (!string.IsNullOrWhiteSpace(project.Description) &&
+            project.Description.Trim().Length >= 30)
         {
-            StageCodes.IPA => facts.Ipa.Contains(projectId),
-            StageCodes.SOW => facts.Sow.Contains(projectId),
-            StageCodes.AON => facts.Aon.Contains(projectId),
-            StageCodes.BM => facts.Benchmark.Contains(projectId),
-            StageCodes.COB => facts.Commercial.Contains(projectId),
-            StageCodes.PNC => facts.Pnc.Contains(projectId),
-            StageCodes.SO => facts.SupplyOrder.Contains(projectId),
-            _ => true
+            return 15;
+        }
+
+        gaps.Add(GapBriefDescription);
+        return 0;
+    }
+
+    private static int ScorePhotos(
+        int projectId,
+        IReadOnlyDictionary<int, ProjectDataCounts> counts,
+        List<string> gaps)
+    {
+        var photoCount = counts.TryGetValue(projectId, out var value)
+            ? value.PhotoCount
+            : 0;
+
+        if (photoCount >= 3)
+        {
+            return 10;
+        }
+
+        gaps.Add(GapPhotos);
+
+        return photoCount switch
+        {
+            2 => 7,
+            1 => 4,
+            _ => 0
         };
+    }
+
+    private static int ScoreDocuments(
+        int projectId,
+        IReadOnlyDictionary<int, ProjectDataCounts> counts,
+        List<string> gaps)
+    {
+        var documentCount = counts.TryGetValue(projectId, out var value)
+            ? value.DocumentCount
+            : 0;
+
+        if (documentCount >= 3)
+        {
+            return 15;
+        }
+
+        gaps.Add(GapDocuments);
+
+        return documentCount switch
+        {
+            2 => 10,
+            1 => 5,
+            _ => 0
+        };
+    }
+
+    private static int ScoreVideo(
+        int projectId,
+        IReadOnlyDictionary<int, ProjectDataCounts> counts,
+        List<string> gaps)
+    {
+        var videoCount = counts.TryGetValue(projectId, out var value)
+            ? value.VideoCount
+            : 0;
+
+        if (videoCount >= 1)
+        {
+            return 10;
+        }
+
+        gaps.Add(GapVideo);
+        return 0;
+    }
+
+    private static int ScoreBudgetMetrics(
+        Project project,
+        StageFactPresence facts,
+        List<string> gaps)
+    {
+        var expected = new List<bool>();
+
+        if (HasReachedStage(project, StageCodes.IPA))
+        {
+            expected.Add(facts.Ipa.Contains(project.Id));
+        }
+
+        if (HasReachedStage(project, StageCodes.AON))
+        {
+            expected.Add(facts.Aon.Contains(project.Id));
+        }
+
+        if (HasReachedStage(project, StageCodes.BM))
+        {
+            expected.Add(facts.Benchmark.Contains(project.Id));
+        }
+
+        if (HasReachedStage(project, StageCodes.COB))
+        {
+            expected.Add(facts.Commercial.Contains(project.Id));
+        }
+
+        if (HasReachedStage(project, StageCodes.PNC))
+        {
+            expected.Add(facts.Pnc.Contains(project.Id));
+        }
+
+        if (HasReachedStage(project, StageCodes.SO))
+        {
+            expected.Add(facts.SupplyOrder.Contains(project.Id));
+        }
+
+        if (expected.Count == 0)
+        {
+            return 15;
+        }
+
+        var completed = expected.Count(x => x);
+
+        if (completed == expected.Count)
+        {
+            return 15;
+        }
+
+        gaps.Add(GapBudget);
+        return (int)Math.Round(15m * completed / expected.Count);
+    }
+
+    private static int ScoreBackfill(Project project, List<string> gaps)
+    {
+        if (!project.ProjectStages.Any(s => s.RequiresBackfill))
+        {
+            return 15;
+        }
+
+        gaps.Add(GapBackfill);
+        return 0;
+    }
+
+    private int ScoreCurrentStageTimeline(
+        Project project,
+        DateOnly today,
+        List<string> gaps)
+    {
+        var current = WorkspaceNudgeService.GetCurrentStage(project);
+
+        if (current is null)
+        {
+            return 10;
+        }
+
+        if (_nudges.IsCurrentStageOverdue(current, today) ||
+            _nudges.HasCurrentStageTimelineIssue(current))
+        {
+            gaps.Add(GapCurrentStageTimeline);
+            return 0;
+        }
+
+        return 10;
+    }
+
+    private static int ScoreRecentPoRemark(
+        Project project,
+        string userId,
+        DateOnly today,
+        List<string> gaps)
+    {
+        var lastRemark = WorkspaceNudgeService.LastPoRemark(project, userId);
+
+        if (lastRemark.HasValue &&
+            today.DayNumber - WorkspaceNudgeService.ToIstDate(lastRemark.Value).DayNumber <= 10)
+        {
+            return 10;
+        }
+
+        gaps.Add(GapRecentRemark);
+        return 0;
+    }
+
+    // SECTION: Stage applicability helpers
+    private static bool HasReachedStage(Project project, string stageCode)
+    {
+        var targetOrder = ProcurementWorkflow.OrderOf(project.WorkflowVersion, stageCode);
+
+        if (targetOrder == int.MaxValue)
+        {
+            return false;
+        }
+
+        return project.ProjectStages.Any(stage =>
+            ProcurementWorkflow.OrderOf(project.WorkflowVersion, stage.StageCode) >= targetOrder &&
+            stage.Status != StageStatus.NotStarted);
+    }
 
     private static string Label(int score) => score >= 80 ? "Good" : score >= 60 ? "Attention" : "Needs Work";
 
-    private sealed record StageFactPresence(HashSet<int> Ipa, HashSet<int> Sow, HashSet<int> Aon, HashSet<int> Benchmark, HashSet<int> Commercial, HashSet<int> Pnc, HashSet<int> SupplyOrder);
+    private sealed record ProjectDataCounts(int PhotoCount, int DocumentCount, int VideoCount);
+
+    private sealed record StageFactPresence(
+        HashSet<int> Ipa,
+        HashSet<int> Aon,
+        HashSet<int> Benchmark,
+        HashSet<int> Commercial,
+        HashSet<int> Pnc,
+        HashSet<int> SupplyOrder);
 }

--- a/Services/Workspace/WorkspaceRouteHelper.cs
+++ b/Services/Workspace/WorkspaceRouteHelper.cs
@@ -11,6 +11,9 @@ internal static class WorkspaceRouteHelper
     public static string ProjectTimeline(int projectId)
         => $"/Projects/Overview/{projectId}#timeline";
 
+    public static string ProjectMedia(int projectId)
+        => $"/Projects/Overview/{projectId}#media";
+
     public static string ProjectRemarks(int projectId)
         => $"/Projects/Remarks/{projectId}";
 

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -369,6 +369,14 @@ public static class WorkspaceDisplayHelpers
     // SECTION: Improvement labels turn internal checklist gaps into action wording.
     public static string ImprovementLabel(string gap) => gap switch
     {
+        "Brief description pending" => "Add brief description",
+        "Add at least 3 project photos" => "Add project photos",
+        "Upload at least 3 project documents" => "Upload project documents",
+        "Add at least 1 project video" => "Add project video",
+        "Update applicable budget details" => "Update budget details",
+        "Clear timeline backfill" => "Clear timeline backfill",
+        "Update current stage timeline" => "Update current stage timeline",
+        "Add recent project remark" => "Add recent project remark",
         "Basic metadata incomplete" => "Complete basic project details",
         "Category / technical category / project type incomplete" => "Complete project classification",
         "Timeline backfill required" => "Clear timeline backfill",


### PR DESCRIPTION
### Motivation

- Replace the legacy "Record Cleanup" experience with a clearer, user-friendly "Project Data Gaps" system and wording so Project Officers see guidance rather than punitive wording.
- Evaluate project data completeness using the final eight metrics (brief description, photos, documents, video, stage-aware budget facts, backfill, current-stage timeline, recent PO remark) and store the result in `WorkspaceRecordHealthVm.HealthPercent` and `Gaps`.

### Description

- Rewrote `Services/Workspace/ProjectRecordHealthService.cs` to compute a 100-point completeness score using the specified weights and to emit the exact new gap labels (`"Brief description pending"`, `"Add at least 3 project photos"`, `"Upload at least 3 project documents"`, `"Add at least 1 project video"`, `"Update applicable budget details"`, `"Clear timeline backfill"`, `"Update current stage timeline"`, `"Add recent project remark"`).
- Added lightweight media/document counting via `LoadMediaCountsAsync` and a `ProjectDataCounts` record to avoid heavy `Include` usage when calculating photo/document/video counts.
- Implemented metric helpers: `ScoreBriefDescription`, `ScorePhotos`, `ScoreDocuments`, `ScoreVideo`, `ScoreBudgetMetrics` (stage-aware using `ProcurementWorkflow.OrderOf`), `ScoreBackfill`, `ScoreCurrentStageTimeline`, and `ScoreRecentPoRemark` and a `HasReachedStage` helper to respect workflow version.
- Updated workspace routing and improvement helpers: added `WorkspaceRouteHelper.ProjectMedia`, updated `ProjectOfficerWorkspaceService.ResolveImprovementUrl` to route photos/videos to media, documents to upload request, remarks to remarks, timeline/backfill to timeline, budget to overview, and description to meta request, and extended `WorkspaceDisplayHelpers.ImprovementLabel` with mappings for the new gap labels.
- Updated UI text in `Pages/Workspace/Index.cshtml` to show `Project Data Gaps` heading, row text using `details pending`, and empty state `Project data looks complete.`, and updated the Assigned Projects tooltip to say `project data completeness` and `details pending`.

### Testing

- Ran a local repository build attempt (`dotnet build`), but the .NET SDK was not available in the container so automated build could not be executed: `/bin/bash: line 1: dotnet: command not found`.
- Verified repository-level changes via static inspection and grep/diff to ensure all required wording, routing, and new scoring methods were added and old gap emission points removed.
- Committed the changes on the current branch (commit message: "Refine workspace project data gaps scoring").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c7cdf1508329889a23eb08aff1a5)