### PR TITLE
Polish Project Officer workspace landing, UI and Project Data Gaps logic

### DIFF
--- a/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
 using ProjectManagement.Data;
+using ProjectManagement.Configuration;
 
 namespace ProjectManagement.Areas.Identity.Pages.Account
 {
@@ -20,12 +21,14 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<LoginModel> _logger;
         private readonly ApplicationDbContext _db;
+        private readonly UserManager<ApplicationUser> _userManager;
 
         public LoginModel(SignInManager<ApplicationUser> signInManager, ILogger<LoginModel> logger, ApplicationDbContext db)
         {
             _signInManager = signInManager;
             _logger = logger;
             _db = db;
+            _userManager = signInManager.UserManager;
         }
 
         [BindProperty]
@@ -49,9 +52,19 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
 
         private const string GenericLoginError = "Invalid username or password.";
 
+        // SECTION: Role-aware landing keeps Project Officer daily work front-and-center.
+        private async Task<string> GetDefaultLandingUrlAsync(ApplicationUser user)
+        {
+            if (await _userManager.IsInRoleAsync(user, RoleNames.ProjectOfficer))
+            {
+                return Url.Content("~/Workspace");
+            }
+
+            return Url.Content("~/Dashboard/Index");
+        }
+
         public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
         {
-            returnUrl ??= Url.Content("~/Dashboard/Index");
             if (!ModelState.IsValid) return Page();
 
             var result = await _signInManager.PasswordSignInAsync(Input.UserName, Input.Password, Input.RememberMe, lockoutOnFailure: true);
@@ -81,6 +94,16 @@ namespace ProjectManagement.Areas.Identity.Pages.Account
                     });
                     await _db.SaveChangesAsync();
                 }
+                if (user is not null && (string.IsNullOrWhiteSpace(returnUrl) || !Url.IsLocalUrl(returnUrl)))
+                {
+                    returnUrl = await GetDefaultLandingUrlAsync(user);
+                }
+
+                if (string.IsNullOrWhiteSpace(returnUrl) || !Url.IsLocalUrl(returnUrl))
+                {
+                    returnUrl = Url.Content("~/Dashboard/Index");
+                }
+
                 _logger.LogInformation("User logged in.");
                 return LocalRedirect(returnUrl);
             }

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,14 +1,42 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ProjectManagement.Configuration;
+using ProjectManagement.Models;
 
 namespace ProjectManagement.Pages
 {
     [AllowAnonymous]
     public class IndexModel : PageModel
     {
-        public void OnGet()
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public IndexModel(UserManager<ApplicationUser> userManager)
         {
-            // Landing page does not need server data.
+            _userManager = userManager;
+        }
+
+        // SECTION: Authenticated users skip the public landing page and enter their daily workspace.
+        public async Task<IActionResult> OnGetAsync()
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return Page();
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Page();
+            }
+
+            if (await _userManager.IsInRoleAsync(user, RoleNames.ProjectOfficer))
+            {
+                return RedirectToPage("/Workspace/Index");
+            }
+
+            return RedirectToPage("/Dashboard/Index");
         }
     }
 }

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -300,6 +300,7 @@
                     }
                 </div>
             </div>
+            <span id="media" class="page-anchor"></span>
             <partial name="_ProjectMediaTabs" model="Model" />
         </div>
         <div class="col-lg-4 d-flex flex-column gap-3">

--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -27,19 +27,32 @@
                 </a>
             }
         </nav>
+        <div class="workspace-local-rail__footer">
+            <span>Workspace mode</span>
+            <strong>Project Officer</strong>
+        </div>
     </aside>
 
     <div class="workspace-workarea">
         @* SECTION: Slim command bar for daily actions *@
         <div class="workspace-commandbar" id="today">
-            <div>
-                <p class="workspace-eyebrow">My Workspace</p>
-                <h1>@dailyActionTitle</h1>
-                <p>Project remarks, other assigned tasks, project ideas and AOTS documents.</p>
+            <div class="workspace-commandbar__identity">
+                <div class="workspace-commandbar__icon">
+                    <i class="bi bi-layout-text-window-reverse"></i>
+                </div>
+
+                <div>
+                    <p class="workspace-eyebrow">My Workspace</p>
+                    <h1>@dailyActionTitle</h1>
+                    <p>Daily updates and documents requiring your action.</p>
+                </div>
             </div>
+
             <div class="workspace-refresh">
                 <span>Last refreshed @DateTime.Now.ToString("HH:mm")</span>
-                <a class="btn btn-sm btn-outline-primary" href="/Workspace"><i class="bi bi-arrow-clockwise"></i> Refresh</a>
+                <a class="btn btn-sm btn-outline-primary" href="/Workspace">
+                    <i class="bi bi-arrow-clockwise"></i> Refresh
+                </a>
             </div>
         </div>
 
@@ -100,17 +113,17 @@
                         <div class="workspace-action-clearline">
                             @if (!Model.Workspace.OfficialTasksDue.Any())
                             {
-                                <span>Other assigned tasks: Clear</span>
+                                <span><i class="bi bi-check2"></i> Other assigned tasks clear</span>
                             }
 
                             @if (!Model.Workspace.IdeasNeedingUpdate.Any())
                             {
-                                <span>Project ideas: Clear</span>
+                                <span><i class="bi bi-check2"></i> Project ideas clear</span>
                             }
 
                             @if (!Model.Workspace.AotsDocuments.Any())
                             {
-                                <span>AOTS: All read</span>
+                                <span><i class="bi bi-check2"></i> AOTS all read</span>
                             }
                         </div>
                     }
@@ -163,9 +176,9 @@
                                                 </span>
                                             </td>
                                             <td>
-                                                <span class="workspace-status workspace-status-@row.TimelineStatus.ToLowerInvariant()">
-                                                    <span class="workspace-dot workspace-dot-@row.TimelineStatus.ToLowerInvariant()"></span>
-                                                    @WorkspaceDisplayHelpers.CompactStatusLabel(row.TimelineStatus)
+                                                <span class="workspace-status workspace-status-@WorkspaceDisplayHelpers.TimelineStatusCss(row)">
+                                                    <span class="workspace-dot workspace-dot-@WorkspaceDisplayHelpers.TimelineStatusCss(row)"></span>
+                                                    @WorkspaceDisplayHelpers.TimelineStatusLabel(row)
                                                 </span>
                                             </td>
                                             <td>

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -146,7 +146,6 @@ public sealed class ProjectOfficerWorkspaceService
             MyProjectsUrl = myProjectsUrl
         };
 
-        vm.Kpis = BuildKpis(vm);
         vm.RailItems = BuildRailItems(vm);
         return vm;
     }
@@ -732,19 +731,6 @@ public sealed class ProjectOfficerWorkspaceService
             new WorkspaceQuickActionVm { Text = "Open My Project Ideas", Url = WorkspaceRouteHelper.ProjectIdeasMine(), Icon = "bi-lightbulb" },
             new WorkspaceQuickActionVm { Text = "Open AOTS Inbox", Url = WorkspaceRouteHelper.AotsInbox(), Icon = "bi-file-earmark-text" },
             new WorkspaceQuickActionVm { Text = "Open Personal Reminders", Url = WorkspaceRouteHelper.PersonalReminders(), Icon = "bi-pin-angle" }
-        };
-    }
-
-    // SECTION: Compact KPI strip highlights daily updates before project health.
-    private static IReadOnlyList<WorkspaceKpiVm> BuildKpis(ProjectOfficerWorkspaceVm vm)
-    {
-        return new[]
-        {
-            new WorkspaceKpiVm { Title = "Remarks Due", Value = vm.RemarksDueCount.ToString(), Caption = "Project updates", Severity = vm.RemarksDueCount == 0 ? "Good" : "Warning", Icon = "bi-chat-left-text" },
-            new WorkspaceKpiVm { Title = "Other Assigned Tasks", Value = vm.OfficialTaskCount.ToString(), Caption = vm.OverdueTaskCount == 0 ? "No overdue assigned task" : $"{vm.OverdueTaskCount} overdue", Severity = vm.OverdueTaskCount == 0 ? "Good" : "Danger", Icon = "bi-list-check" },
-            new WorkspaceKpiVm { Title = "Project Ideas", Value = vm.AssignedIdeaCount.ToString(), Caption = vm.IdeasNeedingUpdateCount == 0 ? "No stale idea" : $"{vm.IdeasNeedingUpdateCount} need update", Severity = vm.IdeasNeedingUpdateCount == 0 ? "Good" : "Warning", Icon = "bi-lightbulb" },
-            new WorkspaceKpiVm { Title = "AOTS", Value = vm.AotsUnreadCount.ToString(), Caption = vm.AotsUnreadCount == 0 ? "All read" : "Unread documents", Severity = vm.AotsUnreadCount == 0 ? "Good" : "Warning", Icon = "bi-file-earmark-text" },
-            new WorkspaceKpiVm { Title = "Assigned Projects", Value = vm.AssignedProjectCount.ToString(), Caption = "Currently with you", Severity = "Info", Icon = "bi-kanban" }
         };
     }
 

--- a/Services/Workspace/ProjectRecordHealthService.cs
+++ b/Services/Workspace/ProjectRecordHealthService.cs
@@ -38,7 +38,7 @@ public sealed class ProjectRecordHealthService
     {
         var projectIds = projects.Select(p => p.Id).ToArray();
         var mediaCounts = await LoadMediaCountsAsync(projectIds, ct);
-        var factPresence = await LoadStageFactPresenceAsync(projectIds, ct);
+        var factCompleteness = await LoadStageFactCompletenessAsync(projectIds, ct);
         var today = DateOnly.FromDateTime(IstClock.ToIst(DateTime.UtcNow));
         var results = new Dictionary<int, WorkspaceRecordHealthVm>();
 
@@ -51,9 +51,9 @@ public sealed class ProjectRecordHealthService
             score += ScorePhotos(project.Id, mediaCounts, gaps);
             score += ScoreDocuments(project.Id, mediaCounts, gaps);
             score += ScoreVideo(project.Id, mediaCounts, gaps);
-            score += ScoreBudgetMetrics(project, factPresence, gaps);
+            score += ScoreBudgetMetrics(project, factCompleteness, gaps);
             score += ScoreBackfill(project, gaps);
-            score += ScoreCurrentStageTimeline(project, today, gaps);
+            score += ScoreCurrentStageTimeline(project, gaps);
             score += ScoreRecentPoRemark(project, userId, today, gaps);
 
             results[project.Id] = new WorkspaceRecordHealthVm
@@ -107,19 +107,57 @@ public sealed class ProjectRecordHealthService
                 videoCounts.GetValueOrDefault(id)));
     }
 
-    // SECTION: Stage-specific fact presence supports stage-aware budget completeness.
-    private async Task<StageFactPresence> LoadStageFactPresenceAsync(int[] projectIds, CancellationToken ct)
-        => new(
-            await LoadIdsAsync(_db.ProjectIpaFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectAonFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectBenchmarkFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectCommercialFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectPncFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct),
-            await LoadIdsAsync(_db.ProjectSupplyOrderFacts.Where(x => projectIds.Contains(x.ProjectId)).Select(x => x.ProjectId), ct));
+    // SECTION: Stage-specific fact completeness validates meaningful budget values.
+    private async Task<StageFactCompleteness> LoadStageFactCompletenessAsync(
+        int[] projectIds,
+        CancellationToken ct)
+    {
+        var ipa = await _db.ProjectIpaFacts
+            .AsNoTracking()
+            .Where(f => projectIds.Contains(f.ProjectId) && f.IpaCost > 0)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
 
-    // SECTION: Project ID materialization
-    private static async Task<HashSet<int>> LoadIdsAsync(IQueryable<int> query, CancellationToken ct)
-        => (await query.ToListAsync(ct)).ToHashSet();
+        var aon = await _db.ProjectAonFacts
+            .AsNoTracking()
+            .Where(f => projectIds.Contains(f.ProjectId) && f.AonCost > 0)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
+
+        var benchmark = await _db.ProjectBenchmarkFacts
+            .AsNoTracking()
+            .Where(f => projectIds.Contains(f.ProjectId) && f.BenchmarkCost > 0)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
+
+        var commercial = await _db.ProjectCommercialFacts
+            .AsNoTracking()
+            .Where(f => projectIds.Contains(f.ProjectId) && f.L1Cost > 0)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
+
+        var pnc = await _db.ProjectPncFacts
+            .AsNoTracking()
+            .Where(f => projectIds.Contains(f.ProjectId) && f.PncCost > 0)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
+
+        var supplyOrder = await _db.ProjectSupplyOrderFacts
+            .AsNoTracking()
+            .Where(f =>
+                projectIds.Contains(f.ProjectId) &&
+                f.SupplyOrderDate != default)
+            .Select(f => f.ProjectId)
+            .ToHashSetAsync(ct);
+
+        return new StageFactCompleteness(
+            ipa,
+            aon,
+            benchmark,
+            commercial,
+            pnc,
+            supplyOrder);
+    }
 
     // SECTION: Completeness scoring metrics
     private static int ScoreBriefDescription(Project project, List<string> gaps)
@@ -202,7 +240,7 @@ public sealed class ProjectRecordHealthService
 
     private static int ScoreBudgetMetrics(
         Project project,
-        StageFactPresence facts,
+        StageFactCompleteness facts,
         List<string> gaps)
     {
         var expected = new List<bool>();
@@ -266,7 +304,6 @@ public sealed class ProjectRecordHealthService
 
     private int ScoreCurrentStageTimeline(
         Project project,
-        DateOnly today,
         List<string> gaps)
     {
         var current = WorkspaceNudgeService.GetCurrentStage(project);
@@ -276,8 +313,7 @@ public sealed class ProjectRecordHealthService
             return 10;
         }
 
-        if (_nudges.IsCurrentStageOverdue(current, today) ||
-            _nudges.HasCurrentStageTimelineIssue(current))
+        if (_nudges.HasCurrentStageTimelineIssue(current))
         {
             gaps.Add(GapCurrentStageTimeline);
             return 0;
@@ -323,7 +359,7 @@ public sealed class ProjectRecordHealthService
 
     private sealed record ProjectDataCounts(int PhotoCount, int DocumentCount, int VideoCount);
 
-    private sealed record StageFactPresence(
+    private sealed record StageFactCompleteness(
         HashSet<int> Ipa,
         HashSet<int> Aon,
         HashSet<int> Benchmark,

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -18,7 +18,6 @@ public sealed class ProjectOfficerWorkspaceVm
     public int AotsUnreadCount { get; set; }
     public string AotsUrl { get; set; } = "/DocumentRepository/Documents?scope=aots";
     public WorkspaceEngagementVm Engagement { get; set; } = new();
-    public IReadOnlyList<WorkspaceKpiVm> Kpis { get; set; } = Array.Empty<WorkspaceKpiVm>();
     public IReadOnlyList<WorkspaceRailItemVm> RailItems { get; set; } = Array.Empty<WorkspaceRailItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceActionQueueItemVm> ActionQueue { get; set; } = Array.Empty<WorkspaceActionQueueItemVm>();
@@ -69,21 +68,6 @@ public sealed class WorkspaceAotsDocumentVm
     public DateTime CreatedAtUtc { get; set; }
 
     public string OpenUrl { get; set; } = string.Empty;
-}
-
-public sealed class WorkspaceKpiVm
-{
-    public string Title { get; set; } = string.Empty;
-
-    public string Value { get; set; } = string.Empty;
-
-    public string Caption { get; set; } = string.Empty;
-
-    public string Severity { get; set; } = "Info";
-
-    public string Icon { get; set; } = "bi-circle";
-
-    public string? Url { get; set; }
 }
 
 public sealed class WorkspaceActionQueueItemVm
@@ -321,6 +305,43 @@ public static class WorkspaceDisplayHelpers
         _ => status
     };
 
+
+
+    // SECTION: Timeline matrix labels separate data gaps from overdue performance states.
+    public static string TimelineStatusLabel(WorkspaceProjectMatrixRowVm row)
+    {
+        if (row.HasBackfill)
+        {
+            return "Backfill";
+        }
+
+        if (row.HasOverdueCurrentStage)
+        {
+            return "Overdue";
+        }
+
+        if (row.HasCurrentStageIssue)
+        {
+            return "Update";
+        }
+
+        return "OK";
+    }
+
+    public static string TimelineStatusCss(WorkspaceProjectMatrixRowVm row)
+    {
+        if (row.HasBackfill || row.HasOverdueCurrentStage)
+        {
+            return "danger";
+        }
+
+        if (row.HasCurrentStageIssue)
+        {
+            return "warning";
+        }
+
+        return "good";
+    }
 
     // SECTION: Matrix action labels are shortened for dense enterprise table rows.
     public static string CompactActionLabel(string action) => action switch

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -9138,3 +9138,11 @@ body {
 .pm-desc-editor .toastui-editor-contents {
     font-size: 0.95rem;
 }
+
+/* SECTION: Shared anchor offset for sticky application headers */
+.page-anchor {
+    display: block;
+    position: relative;
+    top: -90px;
+    visibility: hidden;
+}

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -17,6 +17,103 @@
 }
 
 
+
+/* SECTION: Command bar and local workspace rail */
+.workspace-commandbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: #ffffff;
+    border: 1px solid #e8edf5;
+    border-left: 4px solid #315fba;
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    box-shadow: 0 4px 14px rgba(20, 32, 55, 0.035);
+    margin-bottom: 0.75rem;
+}
+
+.workspace-commandbar__identity {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+}
+
+.workspace-commandbar__icon {
+    width: 2.35rem;
+    height: 2.35rem;
+    border-radius: 12px;
+    display: inline-grid;
+    place-items: center;
+    background: #edf4ff;
+    color: #24447c;
+    flex: 0 0 auto;
+}
+
+.workspace-commandbar__icon i {
+    font-size: 1.05rem;
+}
+
+.workspace-commandbar h1 {
+    margin: 0;
+    font-size: 1.12rem;
+    font-weight: 650;
+    color: #0f172a;
+}
+
+.workspace-commandbar p {
+    margin: 0.14rem 0 0;
+    color: #64748b;
+    font-size: 0.84rem;
+}
+
+.workspace-refresh {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #64748b;
+    font-size: 0.78rem;
+    white-space: nowrap;
+}
+
+.workspace-local-rail {
+    position: sticky;
+    top: 72px;
+    align-self: start;
+    min-height: calc(100vh - 92px);
+    background: #ffffff;
+    border-right: 1px solid #e6ebf2;
+    padding: 0.95rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.workspace-local-rail nav {
+    display: grid;
+    gap: 0.28rem;
+}
+
+.workspace-local-rail__footer {
+    margin-top: auto;
+    padding: 0.75rem 0.6rem;
+    border-top: 1px solid #edf2f7;
+    color: #64748b;
+    font-size: 0.74rem;
+}
+
+.workspace-local-rail__footer span,
+.workspace-local-rail__footer strong {
+    display: block;
+}
+
+.workspace-local-rail__footer strong {
+    margin-top: 0.15rem;
+    color: #0f172a;
+    font-size: 0.82rem;
+    font-weight: 650;
+}
+
 /* SECTION: Workspace severity accents */
 
 
@@ -250,7 +347,8 @@
 
 .workspace-action-row-next {
     border-color: #c9d8f3;
-    background: #fbfdff;
+    background: linear-gradient(90deg, #fbfdff 0%, #ffffff 78%);
+    box-shadow: inset 3px 0 0 #315fba;
 }
 
 .workspace-next-marker {
@@ -338,11 +436,17 @@
 .workspace-action-clearline span {
     display: inline-flex;
     align-items: center;
+    gap: 0.25rem;
     min-height: 1.65rem;
     border-radius: 999px;
     padding: 0.18rem 0.55rem;
     background: #f8fafc;
     border: 1px solid #e8edf5;
+    color: #64748b;
+}
+
+.workspace-action-clearline i {
+    color: #15803d;
 }
 
 .workspace-anchor {
@@ -822,4 +926,71 @@
         align-items: flex-start;
         flex-direction: column;
     }
+}
+
+@media (max-width: 1100px) {
+    .workspace-workbench {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-local-rail {
+        position: static;
+        min-height: auto;
+        border-right: 0;
+        border-bottom: 1px solid #e6ebf2;
+    }
+
+    .workspace-main-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .workspace-commandbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .workspace-refresh {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
+/* SECTION: Production polish overrides for compact workspace shell */
+.workspace-commandbar {
+    background: #ffffff;
+    border: 1px solid #e8edf5;
+    border-left: 4px solid #315fba;
+    padding: 0.85rem 1rem;
+}
+
+.workspace-local-rail {
+    display: flex;
+    flex-direction: column;
+}
+
+.workspace-status-good,
+.workspace-dot-good {
+    color: #2f6f46;
+}
+
+.workspace-status-warning {
+    color: #8a6414;
+}
+
+.workspace-status-danger {
+    color: #9f303a;
+}
+
+.workspace-dot-good {
+    background: #4f9d69;
+}
+
+.workspace-dot-warning {
+    background: #d99a22;
+}
+
+.workspace-dot-danger {
+    background: #c94b55;
 }


### PR DESCRIPTION
### Motivation
- Ensure Project Officer users land on the Workspace by default while preserving explicit valid local return URLs.\
- Apply final visual polish to the compact Workspace (command bar, rails, action queue) without reintroducing KPIs or hero banners.\
- Make Project Data Gaps and Assigned Projects timeline semantics accurate by checking meaningful budget values and separating overdue performance from missing-data gaps.

### Description
- Role-aware landing: after successful sign-in, Project Officer role users are redirected to `/Workspace` when no valid local `returnUrl` is provided, while non-PO users continue to the dashboard; the root `/` now redirects authenticated users to their role-specific landing page (`Pages/Index.cshtml.cs`, `Areas/Identity/Pages/Account/Login.cshtml.cs`).\
- Workspace UI polish: compact command bar updated with icon, subtitle changed to `Daily updates and documents requiring your action`, left-rail quiet footer added, clear-state chips replaced with checkmark wording, and first Action Queue row subtly highlighted (`Pages/Workspace/Index.cshtml`, `wwwroot/css/workspace.css`).\
- Assigned Projects timeline clarity: added `TimelineStatusLabel` and `TimelineStatusCss` helpers and replaced vague timeline display with explicit `Backfill`, `Overdue`, `Update`, or `OK` labels and matching dot/severity classes (`ViewModels/Workspace/WorkspaceViewModels.cs`, `Pages/Workspace/Index.cshtml`).\
- Project Data Gaps refinement: replaced presence-only checks with `StageFactCompleteness` and `LoadStageFactCompletenessAsync` that require meaningful budget values (IPA/AON/Benchmark/L1/PNC > 0 and supply order date present), and updated `ScoreBudgetMetrics` to use this completeness map (`Services/Workspace/ProjectRecordHealthService.cs`).\
- Current-stage timeline scoring: changed `ScoreCurrentStageTimeline` so overdue alone does not mark a missing-data gap; only genuine timeline data issues add the gap. (`Services/Workspace/ProjectRecordHealthService.cs`).\
- Media anchor and shared CSS: added a `#media` anchor in Project Overview and a `.page-anchor` offset in shared CSS so `Workspace` routes to media work reliably (`Pages/Projects/Overview.cshtml`, `wwwroot/css/site.css`).\
- Cleanup: removed unused KPI wiring and the `WorkspaceKpiVm` (no KPI cards are rendered) by dropping the `Kpis` property and `BuildKpis` usage to avoid reintroducing KPI UI (`ViewModels/Workspace/WorkspaceViewModels.cs`, `Services/Workspace/ProjectOfficerWorkspaceService.cs`).\
- CSS and responsiveness: added command-bar, local-rail, clear-chip, first-row highlight, timeline dot color rules and small responsive rules to keep the layout compact on narrower viewports (`wwwroot/css/workspace.css`).

### Testing
- Automated style/check: `git diff --check` was run and showed no whitespace/merge-trouble issues.\
- Build: attempted `dotnet build` but it could not be run in this environment because `dotnet` is not installed; no compile/run validation was executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32cc4f9c9c8329a4671c76a515a295)