### PR TITLE
Replace unsupported ToHashSetAsync with ToListAsync().ToHashSet() in ProjectRecordHealthService

### DIFF
--- a/Services/Workspace/ProjectRecordHealthService.cs
+++ b/Services/Workspace/ProjectRecordHealthService.cs
@@ -112,43 +112,43 @@ public sealed class ProjectRecordHealthService
         int[] projectIds,
         CancellationToken ct)
     {
-        var ipa = await _db.ProjectIpaFacts
+        var ipa = (await _db.ProjectIpaFacts
             .AsNoTracking()
             .Where(f => projectIds.Contains(f.ProjectId) && f.IpaCost > 0)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
-        var aon = await _db.ProjectAonFacts
+        var aon = (await _db.ProjectAonFacts
             .AsNoTracking()
             .Where(f => projectIds.Contains(f.ProjectId) && f.AonCost > 0)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
-        var benchmark = await _db.ProjectBenchmarkFacts
+        var benchmark = (await _db.ProjectBenchmarkFacts
             .AsNoTracking()
             .Where(f => projectIds.Contains(f.ProjectId) && f.BenchmarkCost > 0)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
-        var commercial = await _db.ProjectCommercialFacts
+        var commercial = (await _db.ProjectCommercialFacts
             .AsNoTracking()
             .Where(f => projectIds.Contains(f.ProjectId) && f.L1Cost > 0)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
-        var pnc = await _db.ProjectPncFacts
+        var pnc = (await _db.ProjectPncFacts
             .AsNoTracking()
             .Where(f => projectIds.Contains(f.ProjectId) && f.PncCost > 0)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
-        var supplyOrder = await _db.ProjectSupplyOrderFacts
+        var supplyOrder = (await _db.ProjectSupplyOrderFacts
             .AsNoTracking()
             .Where(f =>
                 projectIds.Contains(f.ProjectId) &&
                 f.SupplyOrderDate != default)
             .Select(f => f.ProjectId)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct)).ToHashSet();
 
         return new StageFactCompleteness(
             ipa,


### PR DESCRIPTION
### Motivation
- Compiler errors occurred because `IQueryable<int>` does not expose a `ToHashSetAsync` extension, causing `CS1061` in `ProjectRecordHealthService`. 
- The code needs to materialize EF Core query results asynchronously while preserving the existing `HashSet<int>` contract used by health scoring.

### Description
- Replaced all `.ToHashSetAsync(ct)` usages with `(await ... .ToListAsync(ct)).ToHashSet()` in `Services/Workspace/ProjectRecordHealthService.cs` within `LoadStageFactCompletenessAsync` to use supported EF Core async materialization. 
- Kept all queries `AsNoTracking()` and `Select(f => f.ProjectId)` unchanged to maintain query shape and performance characteristics. 
- Preserved the returned `StageFactCompleteness` API which continues to use `HashSet<int>` for downstream scoring logic.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Searched for remaining occurrences with `rg "ToHashSetAsync" -n` and found no matches in the modified files. 
- Attempted `dotnet` commands to run a build but the environment does not have the .NET SDK installed, so a full build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33382c53b0832996342082fb0539c8)