### PR TITLE
Respect PNC applicability, route media gaps to media tabs, and add Action Queue “more items” indicator

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -64,7 +64,7 @@
                         <div>
                             <h2>Action Queue</h2>
                             <p class="workspace-section-subtitle">
-                                Remarks, tasks, project ideas and AOTS documents requiring your action
+                                Prioritised items requiring your action.
                             </p>
                         </div>
                         <a href="@WorkspaceRouteHelper.ActionTasksMyWork()">View my work</a>
@@ -126,6 +126,16 @@
                                 <span><i class="bi bi-check2"></i> AOTS all read</span>
                             }
                         </div>
+
+                        @if (Model.Workspace.ActionQueueHiddenCount > 0)
+                        {
+                            <div class="workspace-action-more">
+                                <span>
+                                    @Model.Workspace.ActionQueueHiddenCount more item@(Model.Workspace.ActionQueueHiddenCount == 1 ? "" : "s") not shown
+                                </span>
+                                <span>Complete or review visible items to surface the rest.</span>
+                            </div>
+                        }
                     }
                 </section>
 

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -21,6 +21,11 @@ public sealed class ProjectOfficerWorkspaceService
     private readonly ActionTaskMyWorkQueueBuilder _myWorkQueueBuilder;
     private readonly IActionTrackerClock _clock;
     private readonly IAotsUnreadService _aotsUnreadService;
+
+    private sealed record WorkspaceActionQueueBuildResult(
+        IReadOnlyList<WorkspaceActionQueueItemVm> Items,
+        int TotalCount);
+
     public ProjectOfficerWorkspaceService(
         ApplicationDbContext db,
         UserManager<ApplicationUser> users,
@@ -44,7 +49,17 @@ public sealed class ProjectOfficerWorkspaceService
     {
         var today = DateOnly.FromDateTime(_clock.IstToday);
         var istNow = IstClock.ToIst(_clock.UtcNow);
-        var monthStart = new DateTime(istNow.Year, istNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var istMonthStart = new DateTime(
+            istNow.Year,
+            istNow.Month,
+            1,
+            0,
+            0,
+            0,
+            DateTimeKind.Unspecified);
+        var monthStartUtc = istMonthStart
+            .AddHours(-5)
+            .AddMinutes(-30);
         var user = await _users.FindByIdAsync(userId);
         var myProjectsUrl = WorkspaceRouteHelper.MyProjects(userId);
 
@@ -71,7 +86,13 @@ public sealed class ProjectOfficerWorkspaceService
         var aotsDocuments = await LoadUnreadAotsDocumentsAsync(userId, ct);
         var timelineAlerts = _nudges.BuildTimelineAlerts(projects, today).ToList();
         var dailyActionCount = remarksDue.Count + officialTasksDue.Count + ideasNeedingUpdate.Count + aotsUnreadCount;
-        var actionQueue = BuildActionQueue(returnedItems, officialTasksDue, remarksDue, ideasNeedingUpdate, aotsDocuments);
+        var actionQueueResult = BuildActionQueue(
+            returnedItems,
+            officialTasksDue,
+            remarksDue,
+            ideasNeedingUpdate,
+            aotsDocuments);
+        var actionQueue = actionQueueResult.Items;
 
         var pending = returnedItems
             .Concat(remarksDue)
@@ -98,7 +119,7 @@ public sealed class ProjectOfficerWorkspaceService
         var myWorkQueue = _myWorkQueueBuilder.Build(taskRows, activeSprint: null);
         var waitingOnOthers = await BuildWaitingOnOthersAsync(userId, myWorkQueue.SubmittedAwaitingClosureTasks, ct);
         var matrix = projects.Take(6).Select(p => BuildMatrixRow(p, health[p.Id], userId, today)).ToList();
-        var engagement = await BuildEngagementAsync(userId, user, monthStart, ct);
+        var engagement = await BuildEngagementAsync(userId, user, monthStartUtc, ct);
         var avgHealth = health.Count == 0 ? 100 : (int)Math.Round(health.Values.Average(h => h.HealthPercent));
 
         var vm = new ProjectOfficerWorkspaceVm
@@ -123,6 +144,7 @@ public sealed class ProjectOfficerWorkspaceService
             Engagement = engagement,
             PendingWithMe = pending.Take(5).ToList(),
             ActionQueue = actionQueue,
+            ActionQueueTotalCount = actionQueueResult.TotalCount,
             RemarksDue = remarksDue.Take(5).ToList(),
             OfficialTasksDue = officialTasksDue,
             IdeasNeedingUpdate = ideasNeedingUpdate,
@@ -289,7 +311,7 @@ public sealed class ProjectOfficerWorkspaceService
     }
 
     // SECTION: Unified action queue prioritizes operational work without four competing inbox columns.
-    private static IReadOnlyList<WorkspaceActionQueueItemVm> BuildActionQueue(
+    private static WorkspaceActionQueueBuildResult BuildActionQueue(
         IReadOnlyList<WorkspaceAttentionItemVm> returnedItems,
         IReadOnlyList<WorkspaceTaskVm> otherAssignedTasksDue,
         IReadOnlyList<WorkspaceAttentionItemVm> remarksDue,
@@ -365,11 +387,14 @@ public sealed class ProjectOfficerWorkspaceService
             SortDateUtc = document.CreatedAtUtc
         }));
 
-        return items
+        var orderedItems = items
             .OrderBy(GetActionQueuePriority)
             .ThenByDescending(i => i.SortDateUtc)
-            .Take(8)
             .ToList();
+
+        return new WorkspaceActionQueueBuildResult(
+            orderedItems.Take(8).ToList(),
+            orderedItems.Count);
     }
 
     // SECTION: Next best action mirrors the daily queue, falling back to timeline follow-up only when daily actions are clear.
@@ -673,15 +698,19 @@ public sealed class ProjectOfficerWorkspaceService
             return WorkspaceRouteHelper.ProjectTimeline(projectId);
         }
 
-        if (gap.Contains("document", StringComparison.OrdinalIgnoreCase))
+        if (gap.Contains("photo", StringComparison.OrdinalIgnoreCase))
         {
-            return WorkspaceRouteHelper.ProjectDocumentRequest(projectId);
+            return WorkspaceRouteHelper.ProjectPhotos(projectId);
         }
 
-        if (gap.Contains("photo", StringComparison.OrdinalIgnoreCase) ||
-            gap.Contains("video", StringComparison.OrdinalIgnoreCase))
+        if (gap.Contains("video", StringComparison.OrdinalIgnoreCase))
         {
-            return WorkspaceRouteHelper.ProjectMedia(projectId);
+            return WorkspaceRouteHelper.ProjectVideos(projectId);
+        }
+
+        if (gap.Contains("document", StringComparison.OrdinalIgnoreCase))
+        {
+            return WorkspaceRouteHelper.ProjectDocumentsTab(projectId);
         }
 
         if (gap.Contains("budget", StringComparison.OrdinalIgnoreCase))

--- a/Services/Workspace/ProjectRecordHealthService.cs
+++ b/Services/Workspace/ProjectRecordHealthService.cs
@@ -3,6 +3,7 @@ using ProjectManagement.Infrastructure;
 using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Models.Execution;
+using ProjectManagement.Models.Plans;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.ViewModels.Workspace;
 
@@ -39,6 +40,7 @@ public sealed class ProjectRecordHealthService
         var projectIds = projects.Select(p => p.Id).ToArray();
         var mediaCounts = await LoadMediaCountsAsync(projectIds, ct);
         var factCompleteness = await LoadStageFactCompletenessAsync(projectIds, ct);
+        var pncApplicability = await LoadPncApplicabilityAsync(projectIds, ct);
         var today = DateOnly.FromDateTime(IstClock.ToIst(DateTime.UtcNow));
         var results = new Dictionary<int, WorkspaceRecordHealthVm>();
 
@@ -51,7 +53,7 @@ public sealed class ProjectRecordHealthService
             score += ScorePhotos(project.Id, mediaCounts, gaps);
             score += ScoreDocuments(project.Id, mediaCounts, gaps);
             score += ScoreVideo(project.Id, mediaCounts, gaps);
-            score += ScoreBudgetMetrics(project, factCompleteness, gaps);
+            score += ScoreBudgetMetrics(project, factCompleteness, pncApplicability, gaps);
             score += ScoreBackfill(project, gaps);
             score += ScoreCurrentStageTimeline(project, gaps);
             score += ScoreRecentPoRemark(project, userId, today, gaps);
@@ -68,6 +70,36 @@ public sealed class ProjectRecordHealthService
         }
 
         return results;
+    }
+
+    // SECTION: PNC applicability comes from the latest approved plan and defaults to applicable when unknown.
+    private async Task<IReadOnlyDictionary<int, bool>> LoadPncApplicabilityAsync(
+        int[] projectIds,
+        CancellationToken ct)
+    {
+        var planRows = await _db.PlanVersions
+            .AsNoTracking()
+            .Where(plan =>
+                projectIds.Contains(plan.ProjectId) &&
+                plan.Status == PlanVersionStatus.Approved)
+            .Select(plan => new
+            {
+                plan.ProjectId,
+                plan.PncApplicable,
+                plan.CreatedOn,
+                plan.SubmittedOn,
+                plan.ApprovedOn
+            })
+            .ToListAsync(ct);
+
+        return planRows
+            .GroupBy(plan => plan.ProjectId)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .OrderByDescending(plan => plan.ApprovedOn ?? plan.SubmittedOn ?? plan.CreatedOn)
+                    .First()
+                    .PncApplicable);
     }
 
     // SECTION: Media and document count loading keeps the assigned-project query lightweight.
@@ -241,6 +273,7 @@ public sealed class ProjectRecordHealthService
     private static int ScoreBudgetMetrics(
         Project project,
         StageFactCompleteness facts,
+        IReadOnlyDictionary<int, bool> pncApplicability,
         List<string> gaps)
     {
         var expected = new List<bool>();
@@ -265,7 +298,9 @@ public sealed class ProjectRecordHealthService
             expected.Add(facts.Commercial.Contains(project.Id));
         }
 
-        if (HasReachedStage(project, StageCodes.PNC))
+        var isPncApplicable = !pncApplicability.TryGetValue(project.Id, out var applicable) || applicable;
+
+        if (isPncApplicable && HasReachedStage(project, StageCodes.PNC))
         {
             expected.Add(facts.Pnc.Contains(project.Id));
         }

--- a/Services/Workspace/WorkspaceRouteHelper.cs
+++ b/Services/Workspace/WorkspaceRouteHelper.cs
@@ -11,8 +11,23 @@ internal static class WorkspaceRouteHelper
     public static string ProjectTimeline(int projectId)
         => $"/Projects/Overview/{projectId}#timeline";
 
-    public static string ProjectMedia(int projectId)
-        => $"/Projects/Overview/{projectId}#media";
+    public static string ProjectMedia(int projectId, string mediaTab)
+    {
+        var safeTab = string.IsNullOrWhiteSpace(mediaTab)
+            ? "documents"
+            : mediaTab.Trim().ToLowerInvariant();
+
+        return $"/Projects/Overview/{projectId}?mediaTab={Uri.EscapeDataString(safeTab)}#media";
+    }
+
+    public static string ProjectPhotos(int projectId)
+        => ProjectMedia(projectId, "photos");
+
+    public static string ProjectVideos(int projectId)
+        => ProjectMedia(projectId, "videos");
+
+    public static string ProjectDocumentsTab(int projectId)
+        => ProjectMedia(projectId, "documents");
 
     public static string ProjectRemarks(int projectId)
         => $"/Projects/Remarks/{projectId}";

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ProjectManagement.ViewModels.Workspace;
 
 public sealed class ProjectOfficerWorkspaceVm
@@ -21,6 +23,8 @@ public sealed class ProjectOfficerWorkspaceVm
     public IReadOnlyList<WorkspaceRailItemVm> RailItems { get; set; } = Array.Empty<WorkspaceRailItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceActionQueueItemVm> ActionQueue { get; set; } = Array.Empty<WorkspaceActionQueueItemVm>();
+    public int ActionQueueTotalCount { get; set; }
+    public int ActionQueueHiddenCount => Math.Max(0, ActionQueueTotalCount - ActionQueue.Count);
     public IReadOnlyList<WorkspaceAttentionItemVm> RemarksDue { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceTaskVm> OfficialTasksDue { get; set; } = Array.Empty<WorkspaceTaskVm>();
     public IReadOnlyList<WorkspaceIdeaVm> IdeasNeedingUpdate { get; set; } = Array.Empty<WorkspaceIdeaVm>();

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -449,6 +449,26 @@
     color: #15803d;
 }
 
+.workspace-action-more {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-top: 0.55rem;
+    padding: 0.5rem 0.65rem;
+    border-radius: 9px;
+    background: #f8fafc;
+    border: 1px dashed #d7e0ec;
+    color: #64748b;
+    font-size: 0.76rem;
+}
+
+.workspace-action-more a {
+    font-weight: 550;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
 .workspace-anchor {
     display: block;
     position: relative;


### PR DESCRIPTION
### Motivation

- Prevent false budget gaps and score penalties when a project’s approved plan marks PNC as not applicable. 
- Ensure photo/video/document gaps link users to the correct media tab on the Project Overview to improve fix flow. 
- Surface that the Action Queue is truncated by showing a quiet “more items” footer to reduce user confusion. 
- Apply a small correctness polish to engagement month-start handling and standardise Action Queue wording.

### Description

- Load PNC applicability from the latest approved `PlanVersion` rows and pass a `pncApplicability` map into `ScoreBudgetMetrics`, so PNC is only expected when applicable or unknown; implemented in `Services/Workspace/ProjectRecordHealthService.cs`.
- Add media-tab-aware route helpers (`ProjectMedia(projectId, mediaTab)`, `ProjectPhotos`, `ProjectVideos`, `ProjectDocumentsTab`) to `Services/Workspace/WorkspaceRouteHelper.cs` and update improvement routing so photo/video/document gaps point to the appropriate tab in `Services/Workspace/ProjectOfficerWorkspaceService.cs`.
- Change the unified action-queue builder to return both a preview list and `TotalCount` (`WorkspaceActionQueueBuildResult`), wire `ActionQueueTotalCount` into the workspace VM, compute `ActionQueueHiddenCount`, and keep Next Best Action sourced from the first visible item; changes in `Services/Workspace/ProjectOfficerWorkspaceService.cs` and `ViewModels/Workspace/WorkspaceViewModels.cs`.
- Update the workspace UI: replace the Action Queue subtitle with `Prioritised items requiring your action.` and add a quiet truncated-queue footer in `Pages/Workspace/Index.cshtml`; add styles in `wwwroot/css/workspace.css`.
- Use IST month-start -> convert to UTC boundary for engagement queries (avoid IST-as-UTC bug) in `ProjectOfficerWorkspaceService` and confirm `Pages/Projects/Overview.cshtml` already contains the `#media` anchor so the new routes will scroll + activate media tabs.

### Testing

- Ran `git diff --check` to validate whitespace and trivial diff issues (succeeded). 
- Attempted `dotnet build` but the `dotnet` SDK was not available in the environment so a full compile/test run could not be executed (automated build failed to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334fbfafa48329be4827e1c08d0ca1)