### PR TITLE
Make Workspace Project Data Gaps actionable with per-gap actions and summaries

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -316,24 +316,69 @@
                     </div>
                 </section>
 
-                @* SECTION: Quiet grouped project data gaps *@
-                <section class="workspace-card workspace-card-clean">
-                    <h2>Project Data Gaps</h2>
+                @* SECTION: Actionable project data gaps with direct correction routes *@
+                <section class="workspace-card workspace-project-gaps">
+                    <div class="workspace-card__head">
+                        <div>
+                            <h2>Project Data Gaps</h2>
+                            <p class="workspace-section-subtitle">
+                                Missing details that reduce project data completeness.
+                            </p>
+                        </div>
+                    </div>
+
                     @if (!Model.Workspace.ImproveProjects.Any())
                     {
                         <p class="workspace-inline-clear">Project data looks complete.</p>
                     }
                     else
                     {
-                        <div class="workspace-cleanup-list">
+                        <div class="workspace-gap-list">
                             @foreach (var item in Model.Workspace.ImproveProjects.Take(3))
                             {
-                                <article>
-                                    <div>
-                                        <strong>@item.ProjectName</strong>
-                                        <p>@item.FixCount detail@(item.FixCount == 1 ? "" : "s") pending</p>
+                                <article class="workspace-gap-card">
+                                    <div class="workspace-gap-card__top">
+                                        <div>
+                                            <strong title="@item.ProjectName">@item.ProjectName</strong>
+                                            <p>@item.FixCount detail@(item.FixCount == 1 ? "" : "s") pending</p>
+                                        </div>
+
+                                        <a href="@item.Url">Open</a>
                                     </div>
-                                    <a href="@item.Url">Open</a>
+
+                                    @if (item.PreviewGapDetails.Any())
+                                    {
+                                        <div class="workspace-gap-summary">
+                                            <span>Missing:</span>
+                                            <strong>@string.Join(", ", item.PreviewGapDetails.Select(g => WorkspaceDisplayHelpers.ShortGapLabel(g.Label)))</strong>
+
+                                            @if (item.HiddenGapCount > 0)
+                                            {
+                                                <em>+@item.HiddenGapCount more</em>
+                                            }
+                                        </div>
+                                    }
+
+                                    <details class="workspace-gap-details-native">
+                                        <summary>Show details</summary>
+
+                                        <div class="workspace-gap-details">
+                                            @foreach (var gap in item.GapDetails)
+                                            {
+                                                <div class="workspace-gap-detail-row">
+                                                    <span class="workspace-gap-detail-icon workspace-gap-detail-@gap.Severity.ToLowerInvariant()">
+                                                        <i class="bi @gap.Icon"></i>
+                                                    </span>
+
+                                                    <div>
+                                                        <strong>@gap.Label</strong>
+                                                    </div>
+
+                                                    <a href="@gap.ActionUrl">@gap.ActionText</a>
+                                                </div>
+                                            }
+                                        </div>
+                                    </details>
                                 </article>
                             }
                         </div>

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -734,20 +734,138 @@ public sealed class ProjectOfficerWorkspaceService
         return healthRows
             .Where(h => h.Gaps.Any())
             .OrderBy(h => h.HealthPercent)
+            .ThenByDescending(h => h.Gaps.Count)
             .Take(maxProjects)
-            .Select(h => new WorkspaceProjectImprovementVm
+            .Select(h =>
             {
-                ProjectId = h.ProjectId,
-                ProjectName = h.ProjectName,
-                FixCount = h.Gaps.Count,
-                FixLabels = h.Gaps
-                    .Take(3)
-                    .Select(WorkspaceDisplayHelpers.ImprovementLabel)
-                    .ToList(),
-                Url = WorkspaceRouteHelper.ProjectOverview(h.ProjectId),
-                Severity = h.HealthPercent < 60 ? "Danger" : "Warning"
+                var gapDetails = h.Gaps
+                    .Select(gap => BuildGapDetail(h.ProjectId, gap))
+                    .ToList();
+
+                return new WorkspaceProjectImprovementVm
+                {
+                    ProjectId = h.ProjectId,
+                    ProjectName = h.ProjectName,
+                    FixCount = h.Gaps.Count,
+                    FixLabels = gapDetails
+                        .Take(3)
+                        .Select(detail => detail.Label)
+                        .ToList(),
+                    GapDetails = gapDetails,
+                    Url = WorkspaceRouteHelper.ProjectOverview(h.ProjectId),
+                    Severity = h.HealthPercent < 60 ? "Danger" : "Warning"
+                };
             })
             .ToList();
+    }
+
+    // SECTION: Gap details map record-health service output to direct workspace correction actions.
+    private static WorkspaceProjectGapDetailVm BuildGapDetail(int projectId, string gap)
+    {
+        if (gap.Contains("description", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Brief description pending",
+                ActionText = "Edit details",
+                ActionUrl = WorkspaceRouteHelper.ProjectMetaRequest(projectId),
+                Icon = "bi-card-text",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("photo", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Add at least 3 project photos",
+                ActionText = "Add photos",
+                ActionUrl = WorkspaceRouteHelper.ProjectPhotos(projectId),
+                Icon = "bi-images",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("document", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Upload at least 3 project documents",
+                ActionText = "Upload",
+                ActionUrl = WorkspaceRouteHelper.ProjectDocumentsTab(projectId),
+                Icon = "bi-file-earmark-text",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("video", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Add at least 1 project video",
+                ActionText = "Add video",
+                ActionUrl = WorkspaceRouteHelper.ProjectVideos(projectId),
+                Icon = "bi-camera-video",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("budget", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Update applicable budget details",
+                ActionText = "Update",
+                ActionUrl = WorkspaceRouteHelper.ProjectOverview(projectId),
+                Icon = "bi-currency-rupee",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("backfill", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Clear timeline backfill",
+                ActionText = "Backfill",
+                ActionUrl = WorkspaceRouteHelper.ProjectTimeline(projectId),
+                Icon = "bi-clock-history",
+                Severity = "Danger"
+            };
+        }
+
+        if (gap.Contains("current stage timeline", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Update current stage timeline",
+                ActionText = "Timeline",
+                ActionUrl = WorkspaceRouteHelper.ProjectTimeline(projectId),
+                Icon = "bi-calendar-check",
+                Severity = "Warning"
+            };
+        }
+
+        if (gap.Contains("remark", StringComparison.OrdinalIgnoreCase))
+        {
+            return new WorkspaceProjectGapDetailVm
+            {
+                Label = "Add recent project remark",
+                ActionText = "Add remark",
+                ActionUrl = WorkspaceRouteHelper.ProjectRemarks(projectId),
+                Icon = "bi-chat-left-text",
+                Severity = "Warning"
+            };
+        }
+
+        return new WorkspaceProjectGapDetailVm
+        {
+            Label = gap,
+            ActionText = "Open",
+            ActionUrl = WorkspaceRouteHelper.ProjectOverview(projectId),
+            Icon = "bi-exclamation-circle",
+            Severity = "Warning"
+        };
     }
 
     // SECTION: Quick actions keep only durable workspace destinations.

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace ProjectManagement.ViewModels.Workspace;
 
@@ -212,6 +213,19 @@ public sealed class WorkspaceImprovementVm
     public string Severity { get; set; } = "Warning";
 }
 
+public sealed class WorkspaceProjectGapDetailVm
+{
+    public string Label { get; set; } = string.Empty;
+
+    public string ActionText { get; set; } = string.Empty;
+
+    public string ActionUrl { get; set; } = string.Empty;
+
+    public string Icon { get; set; } = "bi-dot";
+
+    public string Severity { get; set; } = "Warning";
+}
+
 public sealed class WorkspaceProjectImprovementVm
 {
     public int ProjectId { get; set; }
@@ -221,6 +235,12 @@ public sealed class WorkspaceProjectImprovementVm
     public int FixCount { get; set; }
 
     public IReadOnlyList<string> FixLabels { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<WorkspaceProjectGapDetailVm> GapDetails { get; set; } = Array.Empty<WorkspaceProjectGapDetailVm>();
+
+    public IReadOnlyList<WorkspaceProjectGapDetailVm> PreviewGapDetails => GapDetails.Take(3).ToList();
+
+    public int HiddenGapCount => Math.Max(0, GapDetails.Count - PreviewGapDetails.Count);
 
     public string Url { get; set; } = string.Empty;
 
@@ -413,6 +433,20 @@ public static class WorkspaceDisplayHelpers
         "Current stage actual start missing" => "Update current stage actual start",
         "Current stage planned due missing" => "Update current stage planned due date",
         _ when gap.Contains("completion date missing", StringComparison.OrdinalIgnoreCase) => "Update current stage completion date",
+        _ => gap
+    };
+
+    // SECTION: Short gap labels keep right-rail project data summaries scannable.
+    public static string ShortGapLabel(string gap) => gap switch
+    {
+        "Brief description pending" => "Description",
+        "Add at least 3 project photos" => "Photos",
+        "Upload at least 3 project documents" => "Documents",
+        "Add at least 1 project video" => "Video",
+        "Update applicable budget details" => "Budget",
+        "Clear timeline backfill" => "Backfill",
+        "Update current stage timeline" => "Timeline",
+        "Add recent project remark" => "Recent remark",
         _ => gap
     };
 

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -1014,3 +1014,145 @@
 .workspace-dot-danger {
     background: #c94b55;
 }
+
+/* SECTION: Actionable project data gaps right-rail card */
+.workspace-project-gaps .workspace-card__head {
+    margin-bottom: 0.55rem;
+}
+
+.workspace-gap-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.workspace-gap-card {
+    border: 1px solid #e8edf5;
+    border-radius: 12px;
+    padding: 0.72rem;
+    background: #ffffff;
+}
+
+.workspace-gap-card__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.workspace-gap-card__top strong {
+    display: block;
+    color: #0f172a;
+    font-size: 0.86rem;
+    font-weight: 650;
+    line-height: 1.25;
+}
+
+.workspace-gap-card__top p {
+    margin: 0.2rem 0 0;
+    color: #64748b;
+    font-size: 0.78rem;
+}
+
+.workspace-gap-card__top a {
+    flex: 0 0 auto;
+    font-size: 0.78rem;
+    font-weight: 550;
+    text-decoration: none;
+}
+
+.workspace-gap-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.55rem;
+    color: #64748b;
+    font-size: 0.76rem;
+    line-height: 1.35;
+}
+
+.workspace-gap-summary strong {
+    color: #334155;
+    font-weight: 550;
+}
+
+.workspace-gap-summary em {
+    color: #64748b;
+    font-style: normal;
+}
+
+.workspace-gap-details-native {
+    margin-top: 0.55rem;
+}
+
+.workspace-gap-details-native summary {
+    cursor: pointer;
+    color: #2454c6;
+    font-size: 0.78rem;
+    font-weight: 550;
+}
+
+.workspace-gap-details-native summary:hover {
+    text-decoration: underline;
+}
+
+.workspace-gap-details {
+    margin-top: 0.65rem;
+    border-top: 1px solid #edf2f7;
+    padding-top: 0.55rem;
+}
+
+.workspace-gap-detail-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0;
+}
+
+.workspace-gap-detail-row + .workspace-gap-detail-row {
+    border-top: 1px dashed #edf2f7;
+}
+
+.workspace-gap-detail-row strong {
+    display: block;
+    color: #334155;
+    font-size: 0.78rem;
+    font-weight: 550;
+    line-height: 1.25;
+}
+
+.workspace-gap-detail-row a {
+    color: #2454c6;
+    font-size: 0.76rem;
+    font-weight: 550;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.workspace-gap-detail-row a:hover {
+    text-decoration: underline;
+}
+
+.workspace-gap-detail-icon {
+    width: 1.55rem;
+    height: 1.55rem;
+    border-radius: 999px;
+    display: inline-grid;
+    place-items: center;
+    background: #f8fafc;
+    color: #475569;
+}
+
+.workspace-gap-detail-icon i {
+    font-size: 0.78rem;
+}
+
+.workspace-gap-detail-warning {
+    background: #fff7ed;
+    color: #9a5b00;
+}
+
+.workspace-gap-detail-danger {
+    background: #fff1f2;
+    color: #be123c;
+}


### PR DESCRIPTION
### Motivation

- The right-rail "Project Data Gaps" card only showed a count (e.g. `6 details pending`) and did not tell the Project Officer what exactly was missing or where to click to fix it.  
- The change uses the existing record-health `Gaps` output to provide actionable, discoverable fixes while keeping the current workspace structure, scoring model and database schema intact.  

### Description

- Added a new view model `WorkspaceProjectGapDetailVm` to carry per-gap `Label`, `ActionText`, `ActionUrl`, `Icon` and `Severity` and extended `WorkspaceProjectImprovementVm` with `GapDetails`, `PreviewGapDetails` and `HiddenGapCount` to support collapsed summaries and expanded details in the right rail (file: `ViewModels/Workspace/WorkspaceViewModels.cs`).  
- Populated `GapDetails` in the workspace builder by updating `BuildImproveProjects` to map each raw gap to an actionable item via a new `BuildGapDetail` mapper and by using `WorkspaceRouteHelper` routes for direct correction links (file: `Services/Workspace/ProjectOfficerWorkspaceService.cs`).  
- Kept existing gap sources and labels but added `ShortGapLabel` (in `WorkspaceDisplayHelpers`) to produce compact collapsed summaries like `Photos, Documents, Video +3 more` (file: `ViewModels/Workspace/WorkspaceViewModels.cs`).  
- Reworked the right-rail UI to show missing-item previews and a native expandable details list with per-gap action links (no inline scripts; uses native `<details>` for reliability), and added compact styling for the card and rows (files: `Pages/Workspace/Index.cshtml`, `wwwroot/css/workspace.css`).  

### Testing

- Ran `git diff --check` to ensure no obvious whitespace or index errors, which completed successfully in this environment.  
- Attempted `dotnet build` but it could not be executed here because the `dotnet` CLI is not available in this environment, so full compile verification should be run in CI or a developer environment (`dotnet build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33511ae7148329954c63c9fb2d5ac1)