### PR TITLE
Polish workspace scroll-spy and project data gaps rail

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -21,7 +21,14 @@
         <nav aria-label="Workspace sections">
             @foreach (var item in Model.Workspace.RailItems)
             {
-                <a href="@item.Anchor" class="@(item.IsPrimary ? "active" : string.Empty)">
+                var targetId = item.Anchor?.StartsWith("#") == true
+                    ? item.Anchor[1..]
+                    : string.Empty;
+
+                <a href="@item.Anchor"
+                   class="workspace-rail-link @(item.IsPrimary ? "active" : string.Empty)"
+                   data-workspace-section="@targetId"
+                   aria-current="@(item.IsPrimary ? "true" : null)">
                     <span><i class="bi @item.Icon"></i>@item.Label</span>
                     <em>@item.Count</em>
                 </a>
@@ -305,19 +312,8 @@
                     }
                 </section>
 
-                @* SECTION: Durable workspace destinations *@
-                <section class="workspace-card workspace-card-clean">
-                    <h2>Quick Actions</h2>
-                    <div class="workspace-quick-actions">
-                        @foreach (var action in Model.Workspace.QuickActions)
-                        {
-                            <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a>
-                        }
-                    </div>
-                </section>
-
                 @* SECTION: Actionable project data gaps with direct correction routes *@
-                <section class="workspace-card workspace-project-gaps">
+                <section id="project-data-gaps" class="workspace-card workspace-project-gaps">
                     <div class="workspace-card__head">
                         <div>
                             <h2>Project Data Gaps</h2>
@@ -338,12 +334,15 @@
                             {
                                 <article class="workspace-gap-card">
                                     <div class="workspace-gap-card__top">
-                                        <div>
+                                        <div class="workspace-gap-card__title">
                                             <strong title="@item.ProjectName">@item.ProjectName</strong>
-                                            <p>@item.FixCount detail@(item.FixCount == 1 ? "" : "s") pending</p>
+                                            <p>
+                                                @item.FixCount detail@(item.FixCount == 1 ? "" : "s") pending
+                                                <span class="workspace-gap-band">Needs Work</span>
+                                            </p>
                                         </div>
 
-                                        <a href="@item.Url">Open</a>
+                                        <a class="workspace-subtle-link" href="@item.Url">Open <span aria-hidden="true">→</span></a>
                                     </div>
 
                                     @if (item.PreviewGapDetails.Any())
@@ -360,7 +359,7 @@
                                     }
 
                                     <details class="workspace-gap-details-native">
-                                        <summary>Show details</summary>
+                                        <summary>View pending details</summary>
 
                                         <div class="workspace-gap-details">
                                             @foreach (var gap in item.GapDetails)
@@ -382,7 +381,28 @@
                                 </article>
                             }
                         </div>
+
+                        @if (Model.Workspace.ImproveProjectsHiddenCount > 0)
+                        {
+                            <div class="workspace-gap-more">
+                                <span>
+                                    @Model.Workspace.ImproveProjectsHiddenCount more project@(Model.Workspace.ImproveProjectsHiddenCount == 1 ? "" : "s") with data gaps
+                                </span>
+                                <a href="@Model.Workspace.MyProjectsUrl">View projects</a>
+                            </div>
+                        }
                     }
+                </section>
+
+                @* SECTION: Durable workspace destinations *@
+                <section class="workspace-card workspace-card-clean">
+                    <h2>Quick Actions</h2>
+                    <div class="workspace-quick-actions">
+                        @foreach (var action in Model.Workspace.QuickActions)
+                        {
+                            <a href="@action.Url"><i class="bi @action.Icon"></i>@action.Text</a>
+                        }
+                    </div>
                 </section>
 
                 @* SECTION: ERP engagement remains quiet and factual *@
@@ -400,3 +420,7 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script src="~/js/pages/workspace-index.js" asp-append-version="true"></script>
+}

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -121,6 +121,7 @@ public sealed class ProjectOfficerWorkspaceService
         var matrix = projects.Take(6).Select(p => BuildMatrixRow(p, health[p.Id], userId, today)).ToList();
         var engagement = await BuildEngagementAsync(userId, user, monthStartUtc, ct);
         var avgHealth = health.Count == 0 ? 100 : (int)Math.Round(health.Values.Average(h => h.HealthPercent));
+        var improveProjectsResult = BuildImproveProjects(health.Values, maxProjects: 3);
 
         var vm = new ProjectOfficerWorkspaceVm
         {
@@ -161,7 +162,8 @@ public sealed class ProjectOfficerWorkspaceService
                 .ToList(),
             RecordHealth = health.Values.OrderBy(h => h.HealthPercent).Take(5).ToList(),
             ImproveScoreItems = BuildImproveScoreItems(health.Values, maxItems: 4),
-            ImproveProjects = BuildImproveProjects(health.Values, maxProjects: 3),
+            ImproveProjects = improveProjectsResult.Items,
+            ImproveProjectsTotalCount = improveProjectsResult.TotalCount,
             NextBestAction = BuildNextBestAction(actionQueue, timelineAlerts),
             PersonalReminders = reminders,
             QuickActions = BuildQuickActions(userId),
@@ -726,15 +728,22 @@ public sealed class ProjectOfficerWorkspaceService
         return WorkspaceRouteHelper.ProjectOverview(projectId);
     }
 
+    private sealed record WorkspaceImproveProjectsBuildResult(
+        IReadOnlyList<WorkspaceProjectImprovementVm> Items,
+        int TotalCount);
+
     // SECTION: Group record-health gaps by project to avoid repetitive right-rail rows.
-    private static IReadOnlyList<WorkspaceProjectImprovementVm> BuildImproveProjects(
+    private static WorkspaceImproveProjectsBuildResult BuildImproveProjects(
         IEnumerable<WorkspaceRecordHealthVm> healthRows,
         int maxProjects)
     {
-        return healthRows
+        var projectsWithGaps = healthRows
             .Where(h => h.Gaps.Any())
             .OrderBy(h => h.HealthPercent)
             .ThenByDescending(h => h.Gaps.Count)
+            .ToList();
+
+        var items = projectsWithGaps
             .Take(maxProjects)
             .Select(h =>
             {
@@ -757,6 +766,8 @@ public sealed class ProjectOfficerWorkspaceService
                 };
             })
             .ToList();
+
+        return new WorkspaceImproveProjectsBuildResult(items, projectsWithGaps.Count);
     }
 
     // SECTION: Gap details map record-health service output to direct workspace correction actions.

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -42,6 +42,8 @@ public sealed class ProjectOfficerWorkspaceVm
     public IReadOnlyList<WorkspaceRecordHealthVm> RecordHealth { get; set; } = Array.Empty<WorkspaceRecordHealthVm>();
     public IReadOnlyList<WorkspaceImprovementVm> ImproveScoreItems { get; set; } = Array.Empty<WorkspaceImprovementVm>();
     public IReadOnlyList<WorkspaceProjectImprovementVm> ImproveProjects { get; set; } = Array.Empty<WorkspaceProjectImprovementVm>();
+    public int ImproveProjectsTotalCount { get; set; }
+    public int ImproveProjectsHiddenCount => Math.Max(0, ImproveProjectsTotalCount - ImproveProjects.Count);
     public WorkspaceAttentionItemVm? NextBestAction { get; set; }
     public IReadOnlyList<WorkspaceQuickActionVm> QuickActions { get; set; } = Array.Empty<WorkspaceQuickActionVm>();
     public IReadOnlyList<WorkspaceReminderVm> PersonalReminders { get; set; } = Array.Empty<WorkspaceReminderVm>();

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -6,6 +6,32 @@
     color: #1f2937;
 }
 
+.workspace-workbench {
+    display: grid;
+    grid-template-columns: 230px minmax(0, 1fr);
+    gap: 0;
+    padding: 0;
+    background: #f6f8fb;
+}
+
+.workspace-workarea {
+    padding: 0.85rem;
+    min-width: 0;
+}
+
+.workspace-main-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 0.85rem;
+}
+
+.workspace-main,
+.workspace-rail {
+    display: grid;
+    gap: 0.85rem;
+    align-content: start;
+}
+
 
 .workspace-eyebrow {
     margin: 0 0 0.12rem;
@@ -92,6 +118,70 @@
 .workspace-local-rail nav {
     display: grid;
     gap: 0.28rem;
+}
+
+.workspace-local-rail__title {
+    font-size: 0.9rem;
+    font-weight: 650;
+    color: #0f172a;
+    margin: 0 0 0.75rem;
+}
+
+.workspace-local-rail .workspace-rail-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    padding: 0.55rem 0.6rem;
+    border-radius: 9px;
+    color: #334155;
+    text-decoration: none;
+    font-size: 0.84rem;
+    font-weight: 520;
+}
+
+.workspace-local-rail .workspace-rail-link span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.workspace-local-rail .workspace-rail-link i {
+    color: #476083;
+    font-size: 0.95rem;
+}
+
+.workspace-local-rail .workspace-rail-link em {
+    min-width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    display: inline-grid;
+    place-items: center;
+    background: #f1f5f9;
+    color: #475569;
+    font-style: normal;
+    font-size: 0.74rem;
+    font-weight: 600;
+}
+
+.workspace-local-rail .workspace-rail-link.active,
+.workspace-local-rail .workspace-rail-link:hover {
+    background: #edf4ff;
+    color: #17366f;
+}
+
+.workspace-local-rail .workspace-rail-link.active {
+    box-shadow: inset 3px 0 0 #315fba;
+}
+
+.workspace-local-rail .workspace-rail-link.active i {
+    color: #315fba;
+}
+
+.workspace-local-rail .workspace-rail-link.active em {
+    background: #dce8ff;
+    color: #17366f;
 }
 
 .workspace-local-rail__footer {
@@ -619,6 +709,43 @@
 }
 
 /* SECTION: Responsive behavior */
+@media (max-width: 1100px) {
+    .workspace-workbench {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-local-rail {
+        position: static;
+        min-height: auto;
+        border-right: 0;
+        border-bottom: 1px solid #e6ebf2;
+    }
+
+    .workspace-local-rail nav {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .workspace-main-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .workspace-split-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .workspace-commandbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .workspace-refresh {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
 @media (max-width: 576px) {
     .workspace-page {
         padding: 0.75rem;
@@ -776,218 +903,12 @@
     text-decoration: none;
 }
 
-@media (max-width: 1100px) {
-    .workspace-split-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-/* SECTION: Workbench shell with local left rail */
-.workspace-workbench {
-    display: grid;
-    grid-template-columns: 230px minmax(0, 1fr);
-    gap: 0;
-    padding: 0;
-    background: #f6f8fb;
-}
-
-.workspace-local-rail {
-    position: sticky;
-    top: 72px;
-    align-self: start;
-    min-height: calc(100vh - 92px);
-    background: #ffffff;
-    border-right: 1px solid #e6ebf2;
-    padding: 0.95rem 0.75rem;
-}
-
-.workspace-local-rail__title {
-    font-size: 0.9rem;
-    font-weight: 650;
-    color: #0f172a;
-    margin: 0 0 0.75rem;
-}
-
-.workspace-local-rail nav {
-    display: grid;
-    gap: 0.28rem;
-}
-
-.workspace-local-rail a {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.65rem;
-    padding: 0.55rem 0.6rem;
-    border-radius: 9px;
-    color: #334155;
-    text-decoration: none;
-    font-size: 0.84rem;
-    font-weight: 520;
-}
-
-.workspace-local-rail a span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-width: 0;
-}
-
-.workspace-local-rail a i {
-    color: #476083;
-    font-size: 0.95rem;
-}
-
-.workspace-local-rail a em {
-    min-width: 1.5rem;
-    height: 1.5rem;
-    border-radius: 999px;
-    display: inline-grid;
-    place-items: center;
-    background: #f1f5f9;
-    color: #475569;
-    font-style: normal;
-    font-size: 0.74rem;
-    font-weight: 600;
-}
-
-.workspace-local-rail a.active,
-.workspace-local-rail a:hover {
-    background: #edf4ff;
-    color: #17366f;
-}
-
-.workspace-workarea {
-    padding: 0.85rem;
-    min-width: 0;
-}
-
-/* SECTION: Workbench command bar and compact counts */
-.workspace-commandbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    background: #fff;
-    border: 1px solid #e8edf5;
-    border-radius: 12px;
-    padding: 0.8rem 0.95rem;
-    box-shadow: 0 4px 14px rgba(20, 32, 55, 0.035);
-    margin-bottom: 0.75rem;
-}
-
-.workspace-commandbar h1 {
-    margin: 0;
-    font-size: 1.12rem;
-    font-weight: 650;
-    color: #0f172a;
-}
-
-.workspace-commandbar p {
-    margin: 0.14rem 0 0;
-    color: #64748b;
-    font-size: 0.84rem;
-}
-
-.workspace-refresh {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.65rem;
-    color: #64748b;
-    font-size: 0.78rem;
-    white-space: nowrap;
-}
-
-
-/* SECTION: Workbench content grid */
-.workspace-main-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 320px;
-    gap: 0.85rem;
-}
-
-.workspace-main,
-.workspace-rail {
-    display: grid;
-    gap: 0.85rem;
-    align-content: start;
-}
-
-
 .workspace-section-link {
     display: inline-block;
     margin-top: 0.55rem;
     font-size: 0.76rem;
     font-weight: 550;
     text-decoration: none;
-}
-
-@media (max-width: 1100px) {
-    .workspace-workbench {
-        grid-template-columns: 1fr;
-    }
-
-    .workspace-local-rail {
-        position: static;
-        min-height: auto;
-        border-right: 0;
-        border-bottom: 1px solid #e6ebf2;
-    }
-
-    .workspace-local-rail nav {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .workspace-main-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .workspace-commandbar {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-}
-
-@media (max-width: 1100px) {
-    .workspace-workbench {
-        grid-template-columns: 1fr;
-    }
-
-    .workspace-local-rail {
-        position: static;
-        min-height: auto;
-        border-right: 0;
-        border-bottom: 1px solid #e6ebf2;
-    }
-
-    .workspace-main-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 700px) {
-    .workspace-commandbar {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-
-    .workspace-refresh {
-        width: 100%;
-        justify-content: space-between;
-    }
-}
-
-/* SECTION: Production polish overrides for compact workspace shell */
-.workspace-commandbar {
-    background: #ffffff;
-    border: 1px solid #e8edf5;
-    border-left: 4px solid #315fba;
-    padding: 0.85rem 1rem;
-}
-
-.workspace-local-rail {
-    display: flex;
-    flex-direction: column;
 }
 
 .workspace-status-good,
@@ -1039,12 +960,18 @@
     gap: 0.75rem;
 }
 
-.workspace-gap-card__top strong {
+.workspace-gap-card__title {
+    min-width: 0;
+}
+
+.workspace-gap-card__title strong {
     display: block;
     color: #0f172a;
     font-size: 0.86rem;
     font-weight: 650;
     line-height: 1.25;
+    max-width: 100%;
+    overflow-wrap: anywhere;
 }
 
 .workspace-gap-card__top p {
@@ -1058,6 +985,53 @@
     font-size: 0.78rem;
     font-weight: 550;
     text-decoration: none;
+}
+
+
+.workspace-gap-band {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.25rem;
+    border-radius: 999px;
+    padding: 0.08rem 0.38rem;
+    background: #fff1f2;
+    color: #9f303a;
+    font-size: 0.66rem;
+    font-weight: 650;
+    vertical-align: 0.05rem;
+}
+
+.workspace-subtle-link {
+    color: #315fba;
+    font-weight: 550;
+    text-decoration: none;
+}
+
+.workspace-subtle-link:hover {
+    text-decoration: underline;
+}
+
+.workspace-gap-more {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin-top: 0.6rem;
+    padding-top: 0.55rem;
+    border-top: 1px dashed #e2e8f0;
+    color: #64748b;
+    font-size: 0.76rem;
+}
+
+.workspace-gap-more a {
+    color: #315fba;
+    font-weight: 550;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.workspace-gap-more a:hover {
+    text-decoration: underline;
 }
 
 .workspace-gap-summary {

--- a/wwwroot/js/pages/workspace-index.js
+++ b/wwwroot/js/pages/workspace-index.js
@@ -1,0 +1,73 @@
+// SECTION: Workspace left-rail scroll spy
+(() => {
+    const links = Array.from(document.querySelectorAll('.workspace-rail-link'));
+    if (!links.length) {
+        return;
+    }
+
+    const sectionMap = new Map();
+
+    for (const link of links) {
+        const target = link.getAttribute('data-workspace-section');
+        if (!target) {
+            continue;
+        }
+
+        const section = document.getElementById(target);
+        if (!section) {
+            continue;
+        }
+
+        sectionMap.set(target, { section, link });
+    }
+
+    const setActive = (target) => {
+        for (const link of links) {
+            link.classList.remove('active');
+            link.removeAttribute('aria-current');
+        }
+
+        const mapped = sectionMap.get(target);
+        if (mapped) {
+            mapped.link.classList.add('active');
+            mapped.link.setAttribute('aria-current', 'true');
+        }
+    };
+
+    for (const link of links) {
+        link.addEventListener('click', () => {
+            const target = link.getAttribute('data-workspace-section');
+            if (target) {
+                setActive(target);
+            }
+        });
+    }
+
+    if (!('IntersectionObserver' in window)) {
+        return;
+    }
+
+    const preferredTargets = ['today', 'action-queue', 'assigned-projects', 'my-ideas-reminders', 'reminders']
+        .filter(target => sectionMap.has(target));
+
+    const observer = new IntersectionObserver((entries) => {
+        const visible = entries
+            .filter(entry => entry.isIntersecting)
+            .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+        if (!visible.length) {
+            return;
+        }
+
+        const target = visible[0].target.id;
+        setActive(target === 'action-queue' ? 'today' : target);
+    }, {
+        root: null,
+        rootMargin: '-18% 0px -65% 0px',
+        threshold: [0.15, 0.35, 0.55]
+    });
+
+    for (const target of preferredTargets) {
+        observer.observe(sectionMap.get(target).section);
+    }
+})();


### PR DESCRIPTION
### Motivation
- Improve left rail navigation so the active item follows the user as they scroll (light scroll-spy) to make the workspace feel like a real navigator.
- Surface the most useful right-rail content earlier by moving Project Data Gaps above Quick Actions and make the gaps card more informative and less visually noisy.
- Tighten CSS by consolidating duplicate/overriding rules and add small UI polish (subtle link tone, Needs Work chip, better wording) while keeping CSP-safe practices.

### Description
- Added stable rail link hooks and attributes in `Pages/Workspace/Index.cshtml` (`workspace-rail-link`, `data-workspace-section`, `aria-current`) and ensured `id="project-data-gaps"` exists for the gaps card.
- Implemented a CSP-safe external script `wwwroot/js/pages/workspace-index.js` that uses `IntersectionObserver` for light scroll-spy mapping (including `#action-queue` → `today`) and sets active state immediately on rail clicks.
- Reordered right rail so `Project Data Gaps` appears above `Quick Actions`, and updated the gaps card in `Index.cshtml` to use `View pending details`, add an inline `Needs Work` chip, and replace `Open` with `Open →` using a subtle link class.
- Preserved total gap counts: extended `ProjectOfficerWorkspaceService` to return a `WorkspaceImproveProjectsBuildResult` (items + total count) and added `ImproveProjectsTotalCount` / `ImproveProjectsHiddenCount` to `ProjectOfficerWorkspaceVm`, then surfaced a quiet “X more project(s) with data gaps” footer in the UI when appropriate.
- Consolidated and cleaned `wwwroot/css/workspace.css` to remove duplicate selectors, add the new `workspace-rail-link` active styles, responsive consolidation (`@media (max-width: 1100px)` and `700px`) and styling for `workspace-gap-band`, `workspace-subtle-link`, and `workspace-gap-more`.

### Testing
- Ran selector and file checks with `rg`/`grep` to confirm canonical CSS selectors and presence of new attributes and IDs, which succeeded.
- Ran `git diff --check` to detect whitespace/merge issues, which returned no blocking errors.
- Attempted a build with `dotnet build`, but the `dotnet` CLI is not available in this environment so a full compile test could not be executed (manual CI/build should verify this before merge).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3361c9b0bc8329986a405c3efd6b7b)