### PR TITLE
Fix workspace rail shared target activation

### DIFF
--- a/tools/run-js-tests.js
+++ b/tools/run-js-tests.js
@@ -10,6 +10,7 @@ const path = require('node:path');
 const projectTestsRoot = path.join('wwwroot', 'js', 'projects');
 const explicitTests = [
   path.join('wwwroot', 'js', 'pages', 'action-tasks', 'index.test.js'),
+  path.join('wwwroot', 'js', 'pages', 'workspace-index.test.js'),
   path.join('wwwroot', 'js', 'calendar.test.js'),
 ];
 

--- a/wwwroot/js/pages/workspace-index.js
+++ b/wwwroot/js/pages/workspace-index.js
@@ -5,7 +5,9 @@
         return;
     }
 
+    // SECTION: Build a section index that supports several rail links sharing one target.
     const sectionMap = new Map();
+    const activeLinkByTarget = new Map();
 
     for (const link of links) {
         const target = link.getAttribute('data-workspace-section');
@@ -18,27 +20,42 @@
             continue;
         }
 
-        sectionMap.set(target, { section, link });
+        const mapped = sectionMap.get(target) || { section, links: [] };
+        mapped.links.push(link);
+        sectionMap.set(target, mapped);
+
+        if (link.classList.contains('active') || !activeLinkByTarget.has(target)) {
+            activeLinkByTarget.set(target, link);
+        }
     }
 
-    const setActive = (target) => {
+    // SECTION: Activate one rail link while remembering the user's choice for shared targets.
+    const setActive = (target, preferredLink = null) => {
         for (const link of links) {
             link.classList.remove('active');
             link.removeAttribute('aria-current');
         }
 
         const mapped = sectionMap.get(target);
-        if (mapped) {
-            mapped.link.classList.add('active');
-            mapped.link.setAttribute('aria-current', 'true');
+        if (!mapped) {
+            return;
         }
+
+        const linkToActivate = mapped.links.includes(preferredLink)
+            ? preferredLink
+            : activeLinkByTarget.get(target) || mapped.links[0];
+
+        activeLinkByTarget.set(target, linkToActivate);
+        linkToActivate.classList.add('active');
+        linkToActivate.setAttribute('aria-current', 'true');
     };
 
+    // SECTION: Preserve the exact clicked rail item even when anchors are shared.
     for (const link of links) {
         link.addEventListener('click', () => {
             const target = link.getAttribute('data-workspace-section');
             if (target) {
-                setActive(target);
+                setActive(target, link);
             }
         });
     }
@@ -47,6 +64,7 @@
         return;
     }
 
+    // SECTION: Observe workspace content sections and keep the rail synced while scrolling.
     const preferredTargets = ['today', 'action-queue', 'assigned-projects', 'my-ideas-reminders', 'reminders']
         .filter(target => sectionMap.has(target));
 
@@ -60,7 +78,7 @@
         }
 
         const target = visible[0].target.id;
-        setActive(target === 'action-queue' ? 'today' : target);
+        setActive(target);
     }, {
         root: null,
         rootMargin: '-18% 0px -65% 0px',

--- a/wwwroot/js/pages/workspace-index.test.js
+++ b/wwwroot/js/pages/workspace-index.test.js
@@ -1,0 +1,50 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const scriptPath = path.resolve(__dirname, 'workspace-index.js');
+const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+// SECTION: Workspace rail fixture with shared action queue anchors.
+function createWorkspaceRailDom() {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body>
+        <nav aria-label="Workspace sections">
+            <a href="#today" class="workspace-rail-link active" data-workspace-section="today" aria-current="true">Today</a>
+            <a href="#action-queue" class="workspace-rail-link" data-workspace-section="action-queue">Remarks Due</a>
+            <a href="#action-queue" class="workspace-rail-link" data-workspace-section="action-queue">Other Assigned Tasks</a>
+            <a href="#action-queue" class="workspace-rail-link" data-workspace-section="action-queue">AOTS</a>
+        </nav>
+        <div id="today"></div>
+        <section id="action-queue"></section>
+    </body></html>`, { url: 'https://example.test/Workspace', runScripts: 'dangerously' });
+
+    const { window } = dom;
+    window.IntersectionObserver = class {
+        observe() { }
+    };
+
+    const scriptEl = window.document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    window.document.body.appendChild(scriptEl);
+
+    return { window, document: window.document };
+}
+
+// SECTION: Shared target click behavior.
+test('workspace rail preserves the clicked item when multiple links share a section', () => {
+    const { window, document } = createWorkspaceRailDom();
+    const links = Array.from(document.querySelectorAll('.workspace-rail-link'));
+    const remarksLink = links[1];
+    const tasksLink = links[2];
+
+    remarksLink.dispatchEvent(new window.Event('click', { bubbles: true }));
+    assert.equal(document.querySelector('.workspace-rail-link.active'), remarksLink);
+    assert.equal(remarksLink.getAttribute('aria-current'), 'true');
+
+    tasksLink.dispatchEvent(new window.Event('click', { bubbles: true }));
+    assert.equal(document.querySelector('.workspace-rail-link.active'), tasksLink);
+    assert.equal(tasksLink.getAttribute('aria-current'), 'true');
+    assert.equal(remarksLink.hasAttribute('aria-current'), false);
+});


### PR DESCRIPTION
### Motivation
- The left-hand workspace rail had incorrect active-link behavior when multiple rail items pointed to the same section (e.g. several links target `#action-queue`), causing the wrong item to be shown as active while scrolling or after clicks.
- The change aims to preserve the exact rail item the user clicked for shared anchors while keeping the scroll-spy synced to visible sections.

### Description
- Updated `wwwroot/js/pages/workspace-index.js` to build a `sectionMap` that stores multiple links per target and added an `activeLinkByTarget` map to remember which link should be active for each section.
- Changed `setActive` to accept an optional `preferredLink` and to activate the correct link from the stored list instead of a single-map entry, and guarded against missing mappings.
- Preserved click behavior by passing the clicked link as the `preferredLink` so shared anchors keep the exact clicked item active, and adjusted the IntersectionObserver handling to set the active target directly.
- Added a regression test `wwwroot/js/pages/workspace-index.test.js` using `jsdom` and registered it in `tools/run-js-tests.js` so it runs under the existing `npm test` harness.

### Testing
- Ran `npm test` and all JavaScript tests passed (20 tests, 0 failures). 
- Verified the modified script with `node --check wwwroot/js/pages/workspace-index.js` which reported no syntax errors. 
- Ran `git diff --check` which produced no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3374ffb5788329822746707aacd7a6)