### PR TITLE
Polish workspace navigation and data insights

### DIFF
--- a/Pages/Workspace/Index.cshtml
+++ b/Pages/Workspace/Index.cshtml
@@ -52,6 +52,29 @@
                     <p class="workspace-eyebrow">My Workspace</p>
                     <h1>@dailyActionTitle</h1>
                     <p>Daily updates and documents requiring your action.</p>
+
+                    @if (Model.Workspace.CommandChips.Any())
+                    {
+                        <div class="workspace-command-chips" aria-label="Attention summary">
+                            @foreach (var chip in Model.Workspace.CommandChips)
+                            {
+                                var chipState = chip.State?.ToLowerInvariant() ?? "neutral";
+
+                                <span class="workspace-command-chip workspace-command-chip-@chipState">
+                                    <i class="bi @chip.Icon"></i>
+                                    @if (chip.Count > 0)
+                                    {
+                                        <strong>@chip.Count</strong>
+                                        <span>@chip.Label</span>
+                                    }
+                                    else
+                                    {
+                                        <span>@chip.Label clear</span>
+                                    }
+                                </span>
+                            }
+                        </div>
+                    }
                 </div>
             </div>
 
@@ -261,7 +284,8 @@
                             }
                         </div>
 
-                        <div id="reminders">
+                        <div>
+                            <span id="reminders" class="workspace-anchor"></span>
                             <div class="workspace-subhead">
                                 <h3>Personal Reminders</h3>
                                 <a href="/Tasks">Open reminders</a>
@@ -289,6 +313,82 @@
                         </div>
                     </div>
                 </section>
+
+                @* SECTION: Compact data completeness analytics for assigned-project records *@
+                @if (Model.Workspace.AssignedProjectCount > 0)
+                {
+                    var insight = Model.Workspace.DataCompletenessInsight;
+
+                    <section id="data-completeness-insights" class="workspace-card workspace-data-insights">
+                        <div class="workspace-card__head">
+                            <div>
+                                <h2>Project Data Completeness Insights</h2>
+                                <p class="workspace-section-subtitle">
+                                    Common data gaps across your assigned projects.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="workspace-insight-grid">
+                            <div class="workspace-insight-summary">
+                                <div class="workspace-insight-metric">
+                                    <span>Average completeness</span>
+                                    <strong>@insight.AverageCompletenessPercent%</strong>
+                                </div>
+
+                                <div class="workspace-insight-metric">
+                                    <span>Projects with gaps</span>
+                                    <strong>@insight.ProjectsWithGapsCount / @insight.AssignedProjectsCount</strong>
+                                </div>
+
+                                <div class="workspace-insight-metric">
+                                    <span>Most common gap</span>
+                                    <strong>@insight.MostCommonGapLabel</strong>
+                                </div>
+                            </div>
+
+                            <div class="workspace-gap-bars">
+                                @if (insight.GapFrequencies.Any())
+                                {
+                                    @foreach (var gap in insight.GapFrequencies)
+                                    {
+                                        <div class="workspace-gap-bar-row">
+                                            <div class="workspace-gap-bar-label">
+                                                <span>@gap.Label</span>
+                                                <strong>@gap.Count</strong>
+                                            </div>
+                                            <progress class="workspace-gap-bar-progress" value="@gap.PercentOfMax" max="100">@gap.PercentOfMax%</progress>
+                                        </div>
+                                    }
+                                }
+                                else
+                                {
+                                    <p class="workspace-inline-clear">No recurring data gaps found.</p>
+                                }
+                            </div>
+                        </div>
+
+                        <div class="workspace-insight-footer">
+                            @if (!string.IsNullOrWhiteSpace(insight.NeedsMostAttentionProjectName))
+                            {
+                                <span>
+                                    Needs most attention:
+                                    <strong>@insight.NeedsMostAttentionProjectName</strong>
+                                    (@insight.NeedsMostAttentionProjectScore%)
+                                </span>
+                            }
+
+                            @if (!string.IsNullOrWhiteSpace(insight.BestProjectName))
+                            {
+                                <span>
+                                    Best record:
+                                    <strong>@insight.BestProjectName</strong>
+                                    (@insight.BestProjectScore%)
+                                </span>
+                            }
+                        </div>
+                    </section>
+                }
             </main>
 
             <aside class="workspace-rail">

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -144,6 +144,12 @@ public sealed class ProjectOfficerWorkspaceService
             RecordGapCount = health.Values.Sum(h => h.Gaps.Count),
             AssignedIdeaCount = ideaVms.Count,
             Engagement = engagement,
+            CommandChips = BuildCommandChips(
+                remarksDue.Count,
+                aotsUnreadCount,
+                officialTasksDue.Count,
+                ideasNeedingUpdate.Count),
+            DataCompletenessInsight = BuildDataCompletenessInsight(projects.Count, health),
             PendingWithMe = pending.Take(5).ToList(),
             ActionQueue = actionQueue,
             ActionQueueTotalCount = actionQueueResult.TotalCount,
@@ -904,18 +910,93 @@ public sealed class ProjectOfficerWorkspaceService
         };
     }
 
-    // SECTION: Local workspace rail anchors daily-action sections without changing global navigation.
+    // SECTION: Command-bar composition chips summarize actionable work without adding dashboard clutter.
+    private static IReadOnlyList<WorkspaceCommandChipVm> BuildCommandChips(
+        int remarksDueCount,
+        int aotsUnreadCount,
+        int otherAssignedTasksDueCount,
+        int ideasNeedingUpdateCount)
+    {
+        return new List<WorkspaceCommandChipVm>
+        {
+            new() { Label = remarksDueCount == 1 ? "Remark" : "Remarks", Count = remarksDueCount, Icon = "bi-chat-left-text", State = remarksDueCount > 0 ? "Attention" : "Clear" },
+            new() { Label = "AOTS", Count = aotsUnreadCount, Icon = "bi-file-earmark-text", State = aotsUnreadCount > 0 ? "Attention" : "Clear" },
+            new() { Label = "Other Tasks", Count = otherAssignedTasksDueCount, Icon = "bi-list-check", State = otherAssignedTasksDueCount > 0 ? "Attention" : "Clear" },
+            new() { Label = "Ideas", Count = ideasNeedingUpdateCount, Icon = "bi-lightbulb", State = ideasNeedingUpdateCount > 0 ? "Attention" : "Clear" }
+        };
+    }
+
+    // SECTION: Project data completeness insights convert record-health gaps into useful portfolio signals.
+    private static WorkspaceDataCompletenessInsightVm BuildDataCompletenessInsight(
+        int assignedProjectsCount,
+        IReadOnlyDictionary<int, WorkspaceRecordHealthVm> health)
+    {
+        if (assignedProjectsCount == 0)
+        {
+            return new WorkspaceDataCompletenessInsightVm();
+        }
+
+        var healthItems = health.Values.ToList();
+        if (!healthItems.Any())
+        {
+            return new WorkspaceDataCompletenessInsightVm { AssignedProjectsCount = assignedProjectsCount };
+        }
+
+        var gapGroups = healthItems
+            .SelectMany(h => h.Gaps)
+            .Select(WorkspaceDisplayHelpers.ShortGapLabel)
+            .GroupBy(label => label)
+            .Select(group => new { Label = group.Key, Count = group.Count() })
+            .OrderByDescending(group => group.Count)
+            .ThenBy(group => group.Label)
+            .Take(6)
+            .ToList();
+
+        var maxGapCount = gapGroups.Count > 0 ? gapGroups.Max(group => group.Count) : 0;
+        var gapFrequencies = gapGroups
+            .Select(group => new WorkspaceGapFrequencyVm
+            {
+                Label = group.Label,
+                Count = group.Count,
+                PercentOfMax = maxGapCount == 0 ? 0 : Math.Max(8, (int)Math.Round(group.Count * 100m / maxGapCount))
+            })
+            .ToList();
+
+        var best = healthItems
+            .OrderByDescending(h => h.HealthPercent)
+            .ThenBy(h => h.ProjectName)
+            .FirstOrDefault();
+        var worst = healthItems
+            .OrderBy(h => h.HealthPercent)
+            .ThenByDescending(h => h.Gaps.Count)
+            .ThenBy(h => h.ProjectName)
+            .FirstOrDefault();
+
+        return new WorkspaceDataCompletenessInsightVm
+        {
+            AverageCompletenessPercent = (int)Math.Round(healthItems.Average(h => h.HealthPercent)),
+            ProjectsWithGapsCount = healthItems.Count(h => h.Gaps.Any()),
+            AssignedProjectsCount = assignedProjectsCount,
+            MostCommonGapLabel = gapFrequencies.FirstOrDefault()?.Label ?? "None",
+            BestProjectName = best?.ProjectName,
+            BestProjectScore = best?.HealthPercent,
+            NeedsMostAttentionProjectName = worst?.ProjectName,
+            NeedsMostAttentionProjectScore = worst?.HealthPercent,
+            GapFrequencies = gapFrequencies
+        };
+    }
+
+    // SECTION: Local workspace rail uses unique section anchors for deterministic scroll navigation.
     private static IReadOnlyList<WorkspaceRailItemVm> BuildRailItems(ProjectOfficerWorkspaceVm vm)
     {
-        return new[]
+        return new List<WorkspaceRailItemVm>
         {
-            new WorkspaceRailItemVm { Label = "Today", Icon = "bi-calendar-check", Count = vm.DailyActionCount, Anchor = "#today", IsPrimary = true },
-            new WorkspaceRailItemVm { Label = "Remarks Due", Icon = "bi-chat-left-text", Count = vm.RemarksDueCount, Anchor = "#action-queue" },
-            new WorkspaceRailItemVm { Label = "Other Assigned Tasks", Icon = "bi-list-check", Count = vm.OfficialTaskCount, Anchor = "#action-queue" },
-            new WorkspaceRailItemVm { Label = "My Ideas", Icon = "bi-lightbulb", Count = vm.AssignedIdeaCount, Anchor = "#my-ideas-reminders" },
-            new WorkspaceRailItemVm { Label = "AOTS", Icon = "bi-file-earmark-text", Count = vm.AotsUnreadCount, Anchor = "#action-queue" },
-            new WorkspaceRailItemVm { Label = "Assigned Projects", Icon = "bi-kanban", Count = vm.AssignedProjectCount, Anchor = "#assigned-projects" },
-            new WorkspaceRailItemVm { Label = "Reminders", Icon = "bi-bell", Count = vm.PersonalReminders.Count, Anchor = "#reminders" }
+            new() { Label = "Today", Icon = "bi-calendar-check", Anchor = "#today", Count = vm.DailyActionCount, IsPrimary = true },
+            new() { Label = "Action Queue", Icon = "bi-list-check", Anchor = "#action-queue", Count = vm.ActionQueueTotalCount },
+            new() { Label = "Assigned Projects", Icon = "bi-kanban", Anchor = "#assigned-projects", Count = vm.AssignedProjectCount },
+            new() { Label = "Project Data Gaps", Icon = "bi-folder-x", Anchor = "#project-data-gaps", Count = vm.ImproveProjectsTotalCount },
+            new() { Label = "My Ideas", Icon = "bi-lightbulb", Anchor = "#my-ideas-reminders", Count = vm.AssignedIdeaCount },
+            new() { Label = "Reminders", Icon = "bi-bell", Anchor = "#reminders", Count = vm.PersonalReminders.Count }
         };
     }
 }

--- a/ViewModels/Workspace/WorkspaceViewModels.cs
+++ b/ViewModels/Workspace/WorkspaceViewModels.cs
@@ -21,6 +21,8 @@ public sealed class ProjectOfficerWorkspaceVm
     public int AotsUnreadCount { get; set; }
     public string AotsUrl { get; set; } = "/DocumentRepository/Documents?scope=aots";
     public WorkspaceEngagementVm Engagement { get; set; } = new();
+    public IReadOnlyList<WorkspaceCommandChipVm> CommandChips { get; set; } = Array.Empty<WorkspaceCommandChipVm>();
+    public WorkspaceDataCompletenessInsightVm DataCompletenessInsight { get; set; } = new();
     public IReadOnlyList<WorkspaceRailItemVm> RailItems { get; set; } = Array.Empty<WorkspaceRailItemVm>();
     public IReadOnlyList<WorkspaceAttentionItemVm> PendingWithMe { get; set; } = Array.Empty<WorkspaceAttentionItemVm>();
     public IReadOnlyList<WorkspaceActionQueueItemVm> ActionQueue { get; set; } = Array.Empty<WorkspaceActionQueueItemVm>();
@@ -47,6 +49,47 @@ public sealed class ProjectOfficerWorkspaceVm
     public WorkspaceAttentionItemVm? NextBestAction { get; set; }
     public IReadOnlyList<WorkspaceQuickActionVm> QuickActions { get; set; } = Array.Empty<WorkspaceQuickActionVm>();
     public IReadOnlyList<WorkspaceReminderVm> PersonalReminders { get; set; } = Array.Empty<WorkspaceReminderVm>();
+}
+
+public sealed class WorkspaceCommandChipVm
+{
+    public string Label { get; set; } = string.Empty;
+
+    public int Count { get; set; }
+
+    public string State { get; set; } = "Neutral";
+
+    public string Icon { get; set; } = "bi-dot";
+}
+
+public sealed class WorkspaceDataCompletenessInsightVm
+{
+    public int AverageCompletenessPercent { get; set; }
+
+    public int ProjectsWithGapsCount { get; set; }
+
+    public int AssignedProjectsCount { get; set; }
+
+    public string MostCommonGapLabel { get; set; } = "None";
+
+    public string? BestProjectName { get; set; }
+
+    public int? BestProjectScore { get; set; }
+
+    public string? NeedsMostAttentionProjectName { get; set; }
+
+    public int? NeedsMostAttentionProjectScore { get; set; }
+
+    public IReadOnlyList<WorkspaceGapFrequencyVm> GapFrequencies { get; set; } = Array.Empty<WorkspaceGapFrequencyVm>();
+}
+
+public sealed class WorkspaceGapFrequencyVm
+{
+    public string Label { get; set; } = string.Empty;
+
+    public int Count { get; set; }
+
+    public int PercentOfMax { get; set; }
 }
 
 public sealed class WorkspaceRailItemVm

--- a/wwwroot/css/workspace.css
+++ b/wwwroot/css/workspace.css
@@ -1068,3 +1068,173 @@
     background: #fff1f2;
     color: #be123c;
 }
+
+/* SECTION: Stable workspace anchor offsets */
+#today,
+#action-queue,
+#assigned-projects,
+#project-data-gaps,
+#my-ideas-reminders,
+#reminders {
+    scroll-margin-top: 92px;
+}
+
+/* SECTION: Compact command-bar action composition chips */
+.workspace-command-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.38rem;
+    margin-top: 0.45rem;
+}
+
+.workspace-command-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.28rem;
+    min-height: 1.65rem;
+    border-radius: 999px;
+    padding: 0.18rem 0.55rem;
+    border: 1px solid #e6ebf2;
+    background: #f8fafc;
+    color: #64748b;
+    font-size: 0.74rem;
+    font-weight: 500;
+}
+
+.workspace-command-chip i {
+    font-size: 0.78rem;
+}
+
+.workspace-command-chip strong {
+    color: #0f172a;
+    font-weight: 700;
+}
+
+.workspace-command-chip-attention {
+    background: #fff7ed;
+    border-color: #fed7aa;
+    color: #9a5b00;
+}
+
+.workspace-command-chip-attention strong {
+    color: #8a4b00;
+}
+
+.workspace-command-chip-clear {
+    background: #f8fafc;
+    color: #64748b;
+}
+
+/* SECTION: Project data completeness insights card */
+.workspace-data-insights {
+    margin-top: 0.9rem;
+}
+
+.workspace-insight-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.4fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.workspace-insight-summary {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.workspace-insight-metric {
+    border: 1px solid #e8edf5;
+    border-radius: 10px;
+    background: #f8fafc;
+    padding: 0.65rem 0.75rem;
+}
+
+.workspace-insight-metric span {
+    display: block;
+    color: #64748b;
+    font-size: 0.74rem;
+    margin-bottom: 0.2rem;
+}
+
+.workspace-insight-metric strong {
+    color: #0f172a;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.workspace-gap-bars {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.workspace-gap-bar-row {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.workspace-gap-bar-label {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    color: #334155;
+    font-size: 0.78rem;
+}
+
+.workspace-gap-bar-label span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workspace-gap-bar-label strong {
+    color: #0f172a;
+    font-weight: 650;
+}
+
+.workspace-gap-bar-progress {
+    width: 100%;
+    height: 0.45rem;
+    border: 0;
+    border-radius: 999px;
+    overflow: hidden;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.workspace-gap-bar-progress::-webkit-progress-bar {
+    background: #edf2f7;
+    border-radius: 999px;
+}
+
+.workspace-gap-bar-progress::-webkit-progress-value {
+    background: linear-gradient(90deg, #315fba, #7aa2ff);
+    border-radius: 999px;
+}
+
+.workspace-gap-bar-progress::-moz-progress-bar {
+    background: linear-gradient(90deg, #315fba, #7aa2ff);
+    border-radius: 999px;
+}
+
+.workspace-insight-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.1rem;
+    margin-top: 0.85rem;
+    padding-top: 0.75rem;
+    border-top: 1px dashed #e2e8f0;
+    color: #64748b;
+    font-size: 0.77rem;
+}
+
+.workspace-insight-footer strong {
+    color: #0f172a;
+    font-weight: 650;
+}
+
+@media (max-width: 900px) {
+    .workspace-insight-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/wwwroot/js/pages/workspace-index.js
+++ b/wwwroot/js/pages/workspace-index.js
@@ -1,91 +1,113 @@
-// SECTION: Workspace left-rail scroll spy
+// SECTION: Workspace deterministic left-rail smooth scroll navigation
 (() => {
     const links = Array.from(document.querySelectorAll('.workspace-rail-link'));
     if (!links.length) {
         return;
     }
 
-    // SECTION: Build a section index that supports several rail links sharing one target.
-    const sectionMap = new Map();
-    const activeLinkByTarget = new Map();
+    const sectionEntries = links
+        .map(link => {
+            const target = link.getAttribute('data-workspace-section');
+            const section = target ? document.getElementById(target) : null;
 
-    for (const link of links) {
-        const target = link.getAttribute('data-workspace-section');
-        if (!target) {
-            continue;
-        }
+            return {
+                target,
+                section,
+                link
+            };
+        })
+        .filter(entry => entry.target && entry.section);
 
-        const section = document.getElementById(target);
-        if (!section) {
-            continue;
-        }
-
-        const mapped = sectionMap.get(target) || { section, links: [] };
-        mapped.links.push(link);
-        sectionMap.set(target, mapped);
-
-        if (link.classList.contains('active') || !activeLinkByTarget.has(target)) {
-            activeLinkByTarget.set(target, link);
-        }
+    if (!sectionEntries.length) {
+        return;
     }
 
-    // SECTION: Activate one rail link while remembering the user's choice for shared targets.
-    const setActive = (target, preferredLink = null) => {
+    let manualScrollInProgress = false;
+    let manualScrollTimer = null;
+
+    const setActive = (target) => {
         for (const link of links) {
             link.classList.remove('active');
             link.removeAttribute('aria-current');
         }
 
-        const mapped = sectionMap.get(target);
-        if (!mapped) {
-            return;
+        const entry = sectionEntries.find(item => item.target === target);
+        if (entry) {
+            entry.link.classList.add('active');
+            entry.link.setAttribute('aria-current', 'true');
         }
-
-        const linkToActivate = mapped.links.includes(preferredLink)
-            ? preferredLink
-            : activeLinkByTarget.get(target) || mapped.links[0];
-
-        activeLinkByTarget.set(target, linkToActivate);
-        linkToActivate.classList.add('active');
-        linkToActivate.setAttribute('aria-current', 'true');
     };
 
-    // SECTION: Preserve the exact clicked rail item even when anchors are shared.
-    for (const link of links) {
-        link.addEventListener('click', () => {
-            const target = link.getAttribute('data-workspace-section');
-            if (target) {
-                setActive(target, link);
+    for (const entry of sectionEntries) {
+        entry.link.addEventListener('click', event => {
+            event.preventDefault();
+
+            manualScrollInProgress = true;
+            setActive(entry.target);
+
+            entry.section.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start'
+            });
+
+            window.history.replaceState(null, '', `#${entry.target}`);
+
+            if (manualScrollTimer) {
+                window.clearTimeout(manualScrollTimer);
             }
+
+            manualScrollTimer = window.setTimeout(() => {
+                manualScrollInProgress = false;
+            }, 700);
         });
     }
 
-    if (!('IntersectionObserver' in window)) {
-        return;
-    }
+    const getCurrentSection = () => {
+        const viewportReference = window.scrollY + 120;
+        const orderedEntries = sectionEntries
+            .map(entry => ({
+                ...entry,
+                top: entry.section.getBoundingClientRect().top + window.scrollY
+            }))
+            .sort((a, b) => a.top - b.top);
+        let current = orderedEntries[0];
 
-    // SECTION: Observe workspace content sections and keep the rail synced while scrolling.
-    const preferredTargets = ['today', 'action-queue', 'assigned-projects', 'my-ideas-reminders', 'reminders']
-        .filter(target => sectionMap.has(target));
+        for (const entry of orderedEntries) {
+            if (entry.top <= viewportReference) {
+                current = entry;
+            } else {
+                break;
+            }
+        }
 
-    const observer = new IntersectionObserver((entries) => {
-        const visible = entries
-            .filter(entry => entry.isIntersecting)
-            .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+        return current;
+    };
 
-        if (!visible.length) {
+    const updateActiveFromScroll = () => {
+        if (manualScrollInProgress) {
             return;
         }
 
-        const target = visible[0].target.id;
-        setActive(target);
-    }, {
-        root: null,
-        rootMargin: '-18% 0px -65% 0px',
-        threshold: [0.15, 0.35, 0.55]
-    });
+        const current = getCurrentSection();
+        if (current) {
+            setActive(current.target);
+        }
+    };
 
-    for (const target of preferredTargets) {
-        observer.observe(sectionMap.get(target).section);
-    }
+    let ticking = false;
+
+    window.addEventListener('scroll', () => {
+        if (ticking) {
+            return;
+        }
+
+        window.requestAnimationFrame(() => {
+            updateActiveFromScroll();
+            ticking = false;
+        });
+
+        ticking = true;
+    }, { passive: true });
+
+    updateActiveFromScroll();
 })();


### PR DESCRIPTION
### Motivation

- Stabilise left-rail navigation so each rail item targets a unique page section and the active state is deterministic while scrolling.  
- Surface the composition of the daily work in a compact, non-intrusive way via command-bar chips so counts (Remarks, AOTS, Other Tasks, Ideas) are visible without adding charts.  
- Provide one useful, compact analytics card (Project Data Completeness Insights) to highlight average completeness, common gaps and projects needing attention without adding heavy visuals or external chart dependencies.

### Description

- Reworked rail model to section-based navigation and updated `BuildRailItems` to emit: `Today`, `Action Queue`, `Assigned Projects`, `Project Data Gaps`, `My Ideas`, `Reminders` in `Services/Workspace/ProjectOfficerWorkspaceService.cs`.  
- Replaced fragile scroll-spy with deterministic smooth-scroll logic and single-active-section behaviour in `wwwroot/js/pages/workspace-index.js`, including URL hash replacement and manual-scroll suppression to avoid flicker.  
- Added command-chip ViewModel `WorkspaceCommandChipVm` and data-insight VMs `WorkspaceDataCompletenessInsightVm` / `WorkspaceGapFrequencyVm` to `ViewModels/Workspace/WorkspaceViewModels.cs`, and implemented `BuildCommandChips(...)` and `BuildDataCompletenessInsight(...)` in `ProjectOfficerWorkspaceService`.  
- Updated `Pages/Workspace/Index.cshtml` to render the compact command-bar chips under the command bar title, to add the `reminders` anchor in the Ideas/Reminders card, and to insert the `data-completeness-insights` card after My Ideas & Reminders.  
- Added CSS rules in `wwwroot/css/workspace.css` to set `scroll-margin-top` for anchors, style command chips, and style the insights card (including a compact progress bar style), keeping the visual tone restrained and responsive.  
- Preserved existing counts and behaviour by mapping existing counters into the new chips and insights (no data aggregation removed), and ensured changes are CSP-friendly (no inline scripts added) and suitable for offline deployment.

### Testing

- Ran `git diff --check` to validate whitespace and simple diffs; it passed.  
- Attempted `dotnet build` and `dotnet test` in the environment but both could not be executed because the `dotnet` SDK/runtime is not installed in this execution environment; no build/test results are available from this run.  
- Static verification performed: updated Razor anchors and JS/CSS files were lint-checked visually in the repo (no inline scripts were introduced).  

If you want, I can provide a short manual test checklist or run the build/tests in an environment with `dotnet` available and report back.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33963ee7988329af68c7c8efaa4ef9)