### PR TITLE
Fix notebook todo import hash set query

### DIFF
--- a/Services/Notebook/NotebookTodoImportService.cs
+++ b/Services/Notebook/NotebookTodoImportService.cs
@@ -16,13 +16,14 @@ public sealed class NotebookTodoImportService : INotebookTodoImportService
     // SECTION: Idempotent lazy import from legacy personal tasks
     public async Task ImportForUserIfRequiredAsync(string ownerId, CancellationToken ct = default)
     {
-        var importedTodoIds = await _db.NotebookItems
+        var importedTodoIds = (await _db.NotebookItems
             .AsNoTracking()
             .Where(item =>
                 item.OwnerId == ownerId &&
                 item.LegacyTodoItemId != null)
             .Select(item => item.LegacyTodoItemId!.Value)
-            .ToHashSetAsync(ct);
+            .ToListAsync(ct))
+            .ToHashSet();
 
         var todosToImport = await _db.TodoItems
             .AsNoTracking()


### PR DESCRIPTION
### Motivation
- The code was failing with `CS1061` because `IQueryable<Guid>` did not have a `ToHashSetAsync` extension available in this project, causing the notebook import to not compile.

### Description
- Replaced the unsupported `ToHashSetAsync(ct)` call with an asynchronous `ToListAsync(ct)` followed by an in-memory `ToHashSet()` in `Services/Notebook/NotebookTodoImportService.cs` to preserve the hash-based lookup while keeping the database call asynchronous.

### Testing
- Ran `git diff --check` which passed; attempted `dotnet build` but it could not be executed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33fe14b32c8329aaa0ac5d13741cf7)