### PR TITLE
Add NotebookEditInput DTO to restore notebook editor contract

### DIFF
--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -30,3 +30,29 @@ public interface INotebookService
 
     Task ToggleChecklistItemAsync(string ownerId, int checklistItemId, bool isDone, CancellationToken ct = default);
 }
+
+// SECTION: My Notebook editor contract
+public sealed class NotebookEditInput
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string? BodyMarkdown { get; set; }
+
+    public NotebookItemType Type { get; set; } = NotebookItemType.Note;
+
+    public NotebookPriority Priority { get; set; } = NotebookPriority.Normal;
+
+    public DateTimeOffset? ReminderAtUtc { get; set; }
+
+    public string? ReminderLocal { get; set; }
+
+    public bool IsPinned { get; set; }
+
+    public bool IsFavorite { get; set; }
+
+    public string? ColorKey { get; set; }
+
+    public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> ChecklistItems { get; set; } = Array.Empty<string>();
+}


### PR DESCRIPTION
### Motivation
- Fix compilation errors `CS0246` caused by the missing `NotebookEditInput` type which is referenced by `INotebookService`, `NotebookService`, and the Notebook Razor page model.

### Description
- Add the `NotebookEditInput` DTO to `Services/Notebook/INotebookService.cs` with the editor fields `Title`, `BodyMarkdown`, `Type`, `Priority`, `ReminderAtUtc`, `ReminderLocal`, `IsPinned`, `IsFavorite`, `ColorKey`, `Tags`, and `ChecklistItems` to restore the notebook create/update contract.

### Testing
- Attempted to run `dotnet build` but the `dotnet` CLI is not installed in this environment, so no automated build or tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3406374efc83299697be985dff8d69)