### PR TITLE
Productize My Notebook V1 UX

### DIFF
--- a/Models/NotebookItem.cs
+++ b/Models/NotebookItem.cs
@@ -3,32 +3,77 @@ using System.ComponentModel.DataAnnotations;
 // SECTION: My Notebook module types
 namespace ProjectManagement.Models;
 
-public enum NotebookItemType : byte { Note = 0, Sticky = 1, Checklist = 2, Reminder = 3, Idea = 4, Draft = 5 }
-public enum NotebookItemStatus : byte { Active = 0, Completed = 1, Archived = 2 }
-public enum NotebookPriority : byte { Low = 0, Normal = 1, High = 2 }
+public enum NotebookItemType : byte
+{
+    Note = 0,
+    Sticky = 1,
+    Checklist = 2,
+    Reminder = 3,
+    Idea = 4,
+    Draft = 5
+}
+
+public enum NotebookItemStatus : byte
+{
+    Active = 0,
+    Completed = 1,
+    Archived = 2
+}
+
+public enum NotebookPriority : byte
+{
+    Low = 0,
+    Normal = 1,
+    High = 2
+}
 
 public class NotebookItem
 {
     public Guid Id { get; set; } = Guid.NewGuid();
-    [Required] public string OwnerId { get; set; } = string.Empty;
+
+    [Required]
+    public string OwnerId { get; set; } = string.Empty;
+
     public ApplicationUser? Owner { get; set; }
-    [Required, MaxLength(220)] public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(220)]
+    public string Title { get; set; } = string.Empty;
+
     public string? BodyMarkdown { get; set; }
+
     public NotebookItemType Type { get; set; } = NotebookItemType.Note;
+
     public NotebookItemStatus Status { get; set; } = NotebookItemStatus.Active;
+
     public NotebookPriority Priority { get; set; } = NotebookPriority.Normal;
+
     public DateTimeOffset? ReminderAtUtc { get; set; }
+
     public DateTimeOffset? CompletedAtUtc { get; set; }
+
     public bool IsPinned { get; set; }
+
     public bool IsFavorite { get; set; }
-    [MaxLength(24)] public string? ColorKey { get; set; }
+
+    [MaxLength(24)]
+    public string? ColorKey { get; set; }
+
     public int SortOrder { get; set; }
+
     public Guid? LegacyTodoItemId { get; set; }
+
     public DateTimeOffset CreatedAtUtc { get; set; }
+
     public DateTimeOffset UpdatedAtUtc { get; set; }
+
     public DateTimeOffset? ArchivedAtUtc { get; set; }
+
     public DateTimeOffset? DeletedAtUtc { get; set; }
+
     public ICollection<NotebookChecklistItem> ChecklistItems { get; set; } = new List<NotebookChecklistItem>();
+
     public ICollection<NotebookItemTag> Tags { get; set; } = new List<NotebookItemTag>();
+
     public ICollection<NotebookAttachment> Attachments { get; set; } = new List<NotebookAttachment>();
 }

--- a/Pages/Dashboard/Index.cshtml
+++ b/Pages/Dashboard/Index.cshtml
@@ -70,7 +70,7 @@
     <div class="col-12 col-lg-3">
         <div class="dashboard-sidebar dashboard-right-column">
             <div class="d-flex flex-column gap-3">
-                <partial name="_TodoWidget" model="Model.TodoWidget" />
+                <partial name="_NotebookWidget" model="Model.NotebookWidget" />
                 <partial name="~/Pages/Dashboard/Partials/_SearchHealthWidget.cshtml" model="Model.SearchHealth" />
             </div>
 

--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -9,6 +9,7 @@ using ProjectManagement.Areas.ProjectOfficeReports.Pages.FFC;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Models;
 using ProjectManagement.Services;
+using ProjectManagement.Services.Notebook;
 using ProjectManagement.Services.Dashboard;
 using ProjectManagement.Helpers;
 using System;
@@ -23,6 +24,7 @@ using ProjectManagement.Configuration;
 using ProjectManagement.Models.Stages;
 using ProjectManagement.Models.Execution;
 using ProjectManagement.ViewModels.Dashboard;
+using ProjectManagement.ViewModels.Notebook;
 using Microsoft.Extensions.Logging;
 
 namespace ProjectManagement.Pages.Dashboard
@@ -31,6 +33,7 @@ namespace ProjectManagement.Pages.Dashboard
     public class IndexModel : PageModel
     {
         private readonly ITodoService _todo;
+        private readonly INotebookService _notebook;
         private readonly UserManager<ApplicationUser> _users;
         private readonly Data.ApplicationDbContext _db;
         private readonly IProjectPulseService _projectPulse;
@@ -41,6 +44,7 @@ namespace ProjectManagement.Pages.Dashboard
 
         public IndexModel(
             ITodoService todo,
+            INotebookService notebook,
             UserManager<ApplicationUser> users,
             Data.ApplicationDbContext db,
             IProjectPulseService projectPulse,
@@ -49,6 +53,7 @@ namespace ProjectManagement.Pages.Dashboard
             ILogger<IndexModel> logger)
         {
             _todo = todo;
+            _notebook = notebook;
             _users = users;
             _db = db;
             _projectPulse = projectPulse;
@@ -57,7 +62,7 @@ namespace ProjectManagement.Pages.Dashboard
             _logger = logger;
         }
 
-        public TodoWidgetResult? TodoWidget { get; set; }
+        public NotebookWidgetVm? NotebookWidget { get; set; }
         public List<UpcomingEventVM> UpcomingEvents { get; set; } = new();
         public List<MyProjectsSection> MyProjectSections { get; private set; } = new();
         public bool HasMyProjects => MyProjectSections.Any(section => section.Items.Count > 0);
@@ -87,17 +92,17 @@ namespace ProjectManagement.Pages.Dashboard
         public async Task OnGetAsync(CancellationToken cancellationToken)
         {
             var uid = _users.GetUserId(User);
-            // SECTION: Todo widget load with fault isolation
+            // SECTION: Notebook widget load with fault isolation
             if (uid != null)
             {
                 try
                 {
-                    TodoWidget = await _todo.GetWidgetAsync(uid, take: 20);
+                    NotebookWidget = await _notebook.GetWidgetAsync(uid, take: 5, cancellationToken);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Dashboard widget failed: Todo");
-                    TodoWidget = null;
+                    _logger.LogError(ex, "Dashboard widget failed: Notebook");
+                    NotebookWidget = null;
                 }
             }
             // END SECTION

--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -7,6 +7,25 @@
     ViewData["UseFullWidth"] = true;
     var selected = Model.Notebook.SelectedItem;
     var selectedType = Model.Input.Type;
+    var isCreateMode = string.Equals(Model.Mode, "new", StringComparison.OrdinalIgnoreCase);
+    var emptyTitle = Model.Notebook.View switch
+    {
+        "notes" => "No notes yet.",
+        "sticky" => "No sticky notes yet.",
+        "checklists" => "No checklists yet.",
+        "today" or "reminders" => "No reminders due.",
+        "archived" => "No archived items.",
+        _ => "No notebook items yet."
+    };
+    var emptyText = Model.Notebook.View switch
+    {
+        "notes" => "Capture a note or create a new note for longer writing.",
+        "sticky" => "Use Sticky for quick thoughts, reminders and temporary points.",
+        "checklists" => "Create a checklist for personal follow-ups or small task lists.",
+        "today" or "reminders" => "Add a reminder to any note, checklist or sticky item.",
+        "archived" => "Archived notes will appear here.",
+        _ => "Use quick capture or create a structured notebook item."
+    };
 }
 @section Styles { <link rel="stylesheet" href="~/css/notebook.css" asp-append-version="true" /> }
 
@@ -34,6 +53,12 @@
                 <button class="btn btn-outline-primary" type="submit" name="ForcedType" value="Sticky">Sticky</button>
                 <button class="btn btn-outline-secondary" type="submit" name="ForcedType" value="Checklist">Checklist</button>
             </form>
+        </section>
+
+        <section class="notebook-new-actions" aria-label="Create notebook item">
+            <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Note" class="btn btn-sm btn-outline-primary">New Note</a>
+            <a asp-page="/Notebook/Index" asp-route-view="sticky" asp-route-mode="new" asp-route-type="Sticky" class="btn btn-sm btn-outline-primary">New Sticky</a>
+            <a asp-page="/Notebook/Index" asp-route-view="checklists" asp-route-mode="new" asp-route-type="Checklist" class="btn btn-sm btn-outline-primary">New Checklist</a>
         </section>
 
         @if (Model.Notebook.View == "home")
@@ -70,7 +95,16 @@
                                 <div class="notebook-checklist-preview">
                                     @foreach (var checklistItem in item.ChecklistPreviewItems)
                                     {
-                                        <div class="@(checklistItem.IsDone ? "is-done" : "")"><i class="bi @(checklistItem.IsDone ? "bi-check-square" : "bi-square")"></i><span>@checklistItem.Text</span></div>
+                                        <form method="post" asp-page-handler="ToggleChecklistItem" class="notebook-check-row">
+                                            <input type="hidden" name="checklistItemId" value="@checklistItem.Id" />
+                                            <input type="hidden" name="isDone" value="@(!checklistItem.IsDone)" />
+                                            <input type="hidden" name="selectedId" value="@item.Id" />
+                                            <input type="hidden" asp-for="View" />
+                                            <input type="hidden" asp-for="Query" />
+                                            <button type="submit" class="notebook-check-toggle @(checklistItem.IsDone ? "is-done" : "")">
+                                                <i class="bi @(checklistItem.IsDone ? "bi-check-square" : "bi-square")"></i><span>@checklistItem.Text</span>
+                                            </button>
+                                        </form>
                                     }
                                     <strong>@item.ChecklistDone/@item.ChecklistTotal complete</strong>
                                 </div>
@@ -81,33 +115,50 @@
                     </article>
                 }
             }
-            @if (!Model.Notebook.Items.Any()) { <div class="notebook-empty">No notebook items yet. Use quick capture to start.</div> }
+            @if (!Model.Notebook.Items.Any()) { <div class="notebook-empty"><h3>@emptyTitle</h3><p>@emptyText</p><a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-mode="new" asp-route-type="Note" class="btn btn-sm btn-primary">Create new note</a></div> }
         </section>
     </main>
 
     <aside class="notebook-editor-panel">
-        <h2>@(selected is null ? "New item" : "Edit item")</h2>
+        <h2>@(isCreateMode || selected is null ? $"New {Model.Input.Type.ToString().ToLowerInvariant()}" : "Edit item")</h2>
         <form method="post" asp-page-handler="@(selected is null ? "Create" : "Update")" asp-route-id="@selected?.Id" class="notebook-editor-form">
             <input type="hidden" asp-for="View" />
             <input type="hidden" asp-for="Query" />
             <label>Title<input asp-for="Input.Title" required maxlength="220" /></label>
             <label>Type<select asp-for="Input.Type" asp-items="Html.GetEnumSelectList<NotebookItemType>()" data-notebook-type-select></select></label>
-            <label>Body<textarea asp-for="Input.BodyMarkdown" data-autoresize></textarea></label>
-            <div class="notebook-editor-fields" data-notebook-type-fields="Checklist">
-                <label class="notebook-field-prominent">Checklist items<textarea asp-for="ChecklistText" placeholder="One checklist item per line"></textarea></label>
+            <div class="notebook-editor-fields" data-notebook-type-fields="Note,Idea,Draft">
+                <label>Body<textarea asp-for="Input.BodyMarkdown" data-autoresize></textarea></label>
             </div>
             <div class="notebook-editor-fields" data-notebook-type-fields="Sticky">
+                <label>Quick note<textarea asp-for="Input.BodyMarkdown" class="notebook-sticky-editor" data-autoresize></textarea></label>
                 <label>Colour<select asp-for="Input.ColorKey"><option>blue</option><option>amber</option><option>green</option><option>rose</option><option>slate</option></select></label>
             </div>
+            <div class="notebook-editor-fields" data-notebook-type-fields="Checklist">
+                <label class="notebook-field-prominent">Checklist items<textarea asp-for="ChecklistText" placeholder="One checklist item per line"></textarea></label>
+                <label data-notebook-checklist-reminder>Reminder (IST)<input asp-for="Input.ReminderLocal" type="datetime-local" /></label>
+                <label>Priority<select asp-for="Input.Priority" asp-items="Html.GetEnumSelectList<NotebookPriority>()"></select></label>
+                <label>Optional notes<textarea asp-for="Input.BodyMarkdown" data-autoresize></textarea></label>
+            </div>
             <div class="notebook-editor-fields" data-notebook-type-fields="Reminder">
-                <p class="notebook-editor-hint">Use the Reminder (IST) field below to schedule this item.</p>
+                <label class="notebook-field-prominent">Reminder (IST)<input asp-for="Input.ReminderLocal" type="datetime-local" /></label>
+                <label>Priority<select asp-for="Input.Priority" asp-items="Html.GetEnumSelectList<NotebookPriority>()"></select></label>
+                <label>Notes<textarea asp-for="Input.BodyMarkdown" data-autoresize></textarea></label>
             </div>
             <label>Tags<input asp-for="TagsText" placeholder="procurement, docs" /></label>
             <label data-notebook-shared-reminder>Reminder (IST)<input asp-for="Input.ReminderLocal" type="datetime-local" /></label>
-            <label>Priority<select asp-for="Input.Priority" asp-items="Html.GetEnumSelectList<NotebookPriority>()"></select></label>
+            <label data-notebook-shared-priority>Priority<select asp-for="Input.Priority" asp-items="Html.GetEnumSelectList<NotebookPriority>()"></select></label>
             <div class="notebook-checks"><label><input asp-for="Input.IsPinned" /> Pin</label><label><input asp-for="Input.IsFavorite" /> Favourite</label></div>
-            <button class="btn btn-primary" type="submit">Save</button>
+            <button class="btn btn-primary" type="submit">@(isCreateMode || selected is null ? "Create" : "Save")</button>
         </form>
+        @if (selected is not null && (selected.Type == NotebookItemType.Reminder || selected.ReminderAtUtc is not null))
+        {
+            <form method="post" asp-page-handler="Complete" asp-route-id="@selected.Id" class="notebook-editor-complete">
+                <input type="hidden" asp-for="View" />
+                <input type="hidden" asp-for="Query" />
+                <input type="hidden" name="isComplete" value="true" />
+                <button class="btn btn-success w-100" type="submit"><i class="bi bi-check2-circle"></i> Mark done</button>
+            </form>
+        }
         @if (selected?.ChecklistItems.Any() == true)
         {
             <div class="notebook-checklist-toggle">@foreach (var c in selected.ChecklistItems) { <form method="post" asp-page-handler="ToggleChecklistItem"><input type="hidden" name="checklistItemId" value="@c.Id" /><input type="hidden" name="selectedId" value="@selected.Id" /><input type="hidden" asp-for="View" /><input type="hidden" asp-for="Query" /><label><input type="checkbox" name="isDone" value="true" checked="@c.IsDone" data-submit-on-change /> @c.Text</label></form> }</div>

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -23,42 +23,202 @@ public class IndexModel : PageModel
     }
 
     // SECTION: Bound notebook state
-    [BindProperty(SupportsGet = true)] public string View { get; set; } = "home";
-    [BindProperty(SupportsGet = true)] public string? Query { get; set; }
-    [BindProperty(SupportsGet = true)] public Guid? SelectedId { get; set; }
-    [BindProperty] public string? QuickCaptureText { get; set; }
-    [BindProperty] public NotebookItemType? ForcedType { get; set; }
-    [BindProperty] public NotebookEditInput Input { get; set; } = new();
-    [BindProperty] public string? TagsText { get; set; }
-    [BindProperty] public string? ChecklistText { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string View { get; set; } = "home";
+    [BindProperty(SupportsGet = true)]
+    public string? Query { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public Guid? SelectedId { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? Mode { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public NotebookItemType? Type { get; set; }
+    [BindProperty]
+    public string? QuickCaptureText { get; set; }
+    [BindProperty]
+    public NotebookItemType? ForcedType { get; set; }
+    [BindProperty]
+    public NotebookEditInput Input { get; set; } = new();
+    [BindProperty]
+    public string? TagsText { get; set; }
+    [BindProperty]
+    public string? ChecklistText { get; set; }
     public NotebookIndexVm Notebook { get; set; } = new();
 
     public async Task<IActionResult> OnGetAsync(CancellationToken ct)
     {
-        var uid = _users.GetUserId(User); if (uid is null) return Unauthorized();
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
         await _import.ImportForUserIfRequiredAsync(uid, ct);
-        Notebook = await _notebook.GetIndexAsync(uid, View, Query, SelectedId, ct);
+        var isCreateMode = IsCreateMode();
+        Notebook = await _notebook.GetIndexAsync(uid, View, Query, SelectedId, isCreateMode, ct);
         PopulateEditorInput();
         return Page();
     }
 
     // SECTION: Thin post handlers
-    public async Task<IActionResult> OnPostQuickCaptureAsync(CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); if (!string.IsNullOrWhiteSpace(QuickCaptureText)) SelectedId = await _notebook.QuickCaptureAsync(uid, QuickCaptureText, ForcedType, ct); return RedirectToCurrent(SelectedId); }
-    public async Task<IActionResult> OnPostCreateAsync(CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); HydrateInput(); SelectedId = await _notebook.CreateAsync(uid, Input, ct); return RedirectToCurrent(SelectedId); }
-    public async Task<IActionResult> OnPostUpdateAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); HydrateInput(); await _notebook.UpdateAsync(uid, id, Input, ct); return RedirectToCurrent(id); }
-    public async Task<IActionResult> OnPostArchiveAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.ArchiveAsync(uid, id, ct); return RedirectToCurrent(); }
-    public async Task<IActionResult> OnPostRestoreAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.RestoreAsync(uid, id, ct); return RedirectToPage(new { view = "archived", query = Query, selectedId = id }); }
-    public async Task<IActionResult> OnPostDeleteAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.DeleteAsync(uid, id, ct); return RedirectToCurrent(); }
-    public async Task<IActionResult> OnPostTogglePinAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.TogglePinAsync(uid, id, ct); return RedirectToCurrent(SelectedId ?? id); }
-    public async Task<IActionResult> OnPostToggleFavoriteAsync(Guid id, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.ToggleFavoriteAsync(uid, id, ct); return RedirectToCurrent(SelectedId ?? id); }
-    public async Task<IActionResult> OnPostCompleteAsync(Guid id, bool isComplete, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.CompleteAsync(uid, id, isComplete, ct); return RedirectToCurrent(SelectedId ?? id); }
-    public async Task<IActionResult> OnPostConvertAsync(Guid id, NotebookItemType? newType, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); if (newType is not null) await _notebook.ConvertTypeAsync(uid, id, newType.Value, ct); return RedirectToCurrent(id); }
-    public async Task<IActionResult> OnPostToggleChecklistItemAsync(int checklistItemId, bool isDone, Guid selectedId, CancellationToken ct) { var uid = _users.GetUserId(User); if (uid is null) return Unauthorized(); await _notebook.ToggleChecklistItemAsync(uid, checklistItemId, isDone, ct); return RedirectToCurrent(selectedId); }
+    public async Task<IActionResult> OnPostQuickCaptureAsync(CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        if (!string.IsNullOrWhiteSpace(QuickCaptureText))
+        {
+            SelectedId = await _notebook.QuickCaptureAsync(uid, QuickCaptureText, ForcedType, ct);
+        }
+
+        return RedirectToCurrent(SelectedId);
+    }
+
+    public async Task<IActionResult> OnPostCreateAsync(CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        HydrateInput();
+        SelectedId = await _notebook.CreateAsync(uid, Input, ct);
+        return RedirectToCurrent(SelectedId);
+    }
+
+    public async Task<IActionResult> OnPostUpdateAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        HydrateInput();
+        await _notebook.UpdateAsync(uid, id, Input, ct);
+        return RedirectToCurrent(id);
+    }
+
+    public async Task<IActionResult> OnPostArchiveAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.ArchiveAsync(uid, id, ct);
+        return RedirectToCurrent();
+    }
+
+    public async Task<IActionResult> OnPostRestoreAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.RestoreAsync(uid, id, ct);
+        return RedirectToPage(new { view = "archived", query = Query, selectedId = id });
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.DeleteAsync(uid, id, ct);
+        return RedirectToCurrent();
+    }
+
+    public async Task<IActionResult> OnPostTogglePinAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.TogglePinAsync(uid, id, ct);
+        return RedirectToCurrent(SelectedId ?? id);
+    }
+
+    public async Task<IActionResult> OnPostToggleFavoriteAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.ToggleFavoriteAsync(uid, id, ct);
+        return RedirectToCurrent(SelectedId ?? id);
+    }
+
+    public async Task<IActionResult> OnPostCompleteAsync(Guid id, bool isComplete, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.CompleteAsync(uid, id, isComplete, ct);
+        return RedirectToCurrent();
+    }
+
+    public async Task<IActionResult> OnPostConvertAsync(Guid id, NotebookItemType? newType, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        if (newType is not null)
+        {
+            await _notebook.ConvertTypeAsync(uid, id, newType.Value, ct);
+        }
+
+        return RedirectToCurrent(id);
+    }
+
+    public async Task<IActionResult> OnPostToggleChecklistItemAsync(
+        int checklistItemId,
+        bool isDone,
+        Guid selectedId,
+        CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        await _notebook.ToggleChecklistItemAsync(uid, checklistItemId, isDone, ct);
+        return RedirectToCurrent(selectedId);
+    }
 
     private void PopulateEditorInput()
     {
+        if (IsCreateMode())
+        {
+            Input = new NotebookEditInput { Type = Type ?? NotebookItemType.Note };
+            return;
+        }
+
         var selected = Notebook.SelectedItem;
-        if (selected is null) return;
+        if (selected is null)
+        {
+            return;
+        }
         Input = new NotebookEditInput
         {
             Title = selected.Title,
@@ -85,6 +245,8 @@ public class IndexModel : PageModel
         Input.ChecklistItems = (ChecklistText ?? string.Empty)
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
+
+    private bool IsCreateMode() => string.Equals(Mode, "new", StringComparison.OrdinalIgnoreCase);
 
     private IActionResult RedirectToCurrent(Guid? selectedId = null)
     {

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -1,30 +1,45 @@
 @model ProjectManagement.ViewModels.Notebook.NotebookItemActionVm
 @using ProjectManagement.Models
+
+@* SECTION: Compact notebook card actions *@
 <form method="post" class="notebook-actions">
     <input type="hidden" name="id" value="@Model.Item.Id" />
     <input type="hidden" name="View" value="@Model.View" />
     <input type="hidden" name="Query" value="@Model.Query" />
     <input type="hidden" name="SelectedId" value="@Model.SelectedId" />
-    <button asp-page-handler="TogglePin" title="Pin" type="submit"><i class="bi @(Model.Item.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i></button>
-    <button asp-page-handler="ToggleFavorite" title="Favourite" type="submit"><i class="bi @(Model.Item.IsFavorite ? "bi-star-fill" : "bi-star")"></i></button>
-    @if (Model.Item.Status == NotebookItemStatus.Archived)
+
+    <button asp-page-handler="TogglePin" title="Pin" type="submit" class="notebook-icon-action">
+        <i class="bi @(Model.Item.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
+    </button>
+    <button asp-page-handler="ToggleFavorite" title="Favourite" type="submit" class="notebook-icon-action">
+        <i class="bi @(Model.Item.IsFavorite ? "bi-star-fill" : "bi-star")"></i>
+    </button>
+
+    @if (Model.Item.Type == NotebookItemType.Reminder || Model.Item.ReminderAtUtc is not null)
     {
-        <button asp-page-handler="Restore" type="submit">Restore</button>
+        <button asp-page-handler="Complete" name="isComplete" value="true" type="submit" class="notebook-action-done">
+            Done
+        </button>
     }
-    else
-    {
-        <button asp-page-handler="Archive" type="submit">Archive</button>
-    }
-    <label class="notebook-convert-action">
-        <span class="visually-hidden">Convert type</span>
-        <select name="newType" aria-label="Convert item type">
-            <option value="">Convert…</option>
+
+    <details class="notebook-card-more">
+        <summary aria-label="More actions"><i class="bi bi-three-dots"></i></summary>
+        <div class="notebook-card-more__menu">
+            @if (Model.Item.Status == NotebookItemStatus.Archived)
+            {
+                <button asp-page-handler="Restore" type="submit">Restore</button>
+            }
+            else
+            {
+                <button asp-page-handler="Archive" type="submit">Archive</button>
+            }
+
             @foreach (var type in Enum.GetValues<NotebookItemType>().Where(type => type != Model.Item.Type))
             {
-                <option value="@type">Convert to @type</option>
+                <button asp-page-handler="Convert" name="newType" value="@type" type="submit">Convert to @type</button>
             }
-        </select>
-        <button asp-page-handler="Convert" type="submit">Go</button>
-    </label>
-    <button asp-page-handler="Delete" class="text-danger" type="submit">Delete</button>
+
+            <button asp-page-handler="Delete" class="text-danger" type="submit">Delete</button>
+        </div>
+    </details>
 </form>

--- a/Pages/Shared/_NotebookWidget.cshtml
+++ b/Pages/Shared/_NotebookWidget.cshtml
@@ -1,0 +1,37 @@
+@model ProjectManagement.ViewModels.Notebook.NotebookWidgetVm
+
+@* SECTION: Dashboard notebook widget *@
+<div class="card shadow-sm border-0 notebook-widget">
+    <div class="card-body">
+        <div class="d-flex align-items-center justify-content-between mb-2">
+            <div>
+                <p class="text-uppercase text-muted small fw-bold mb-1">My Notebook</p>
+                <h2 class="h6 mb-0">Personal reminders</h2>
+            </div>
+            <i class="bi bi-journal-bookmark text-primary fs-4" aria-hidden="true"></i>
+        </div>
+
+        <div class="d-flex gap-2 mb-3">
+            <span class="badge text-bg-primary">Due today: @(Model?.DueTodayCount ?? 0)</span>
+            <span class="badge text-bg-danger">Overdue: @(Model?.OverdueCount ?? 0)</span>
+        </div>
+
+        @if (Model is null)
+        {
+            <p class="text-muted small mb-3">Notebook reminders are unavailable right now.</p>
+        }
+        else
+        {
+            <div class="small fw-bold text-muted mb-1">Due / Overdue</div>
+            @await Html.PartialAsync("_NotebookWidgetList", Model.DueItems)
+
+            <div class="small fw-bold text-muted mt-3 mb-1">Pinned</div>
+            @await Html.PartialAsync("_NotebookWidgetList", Model.PinnedItems)
+
+            <div class="small fw-bold text-muted mt-3 mb-1">Sticky Notes</div>
+            @await Html.PartialAsync("_NotebookWidgetList", Model.StickyItems)
+        }
+
+        <a class="btn btn-sm btn-primary w-100 mt-3" asp-page="/Notebook/Index">Open My Notebook</a>
+    </div>
+</div>

--- a/Pages/Shared/_NotebookWidgetList.cshtml
+++ b/Pages/Shared/_NotebookWidgetList.cshtml
@@ -1,0 +1,19 @@
+@model IReadOnlyList<ProjectManagement.ViewModels.Notebook.NotebookWidgetItemVm>
+
+@if (!Model.Any())
+{
+    <p class="text-muted small mb-0">Nothing here.</p>
+}
+else
+{
+    <ul class="list-unstyled mb-0 small">
+        @foreach (var item in Model)
+        {
+            <li class="d-flex align-items-start gap-2 py-1">
+                <i class="bi @(item.IsOverdue ? "bi-exclamation-circle text-danger" : "bi-dot text-primary")" aria-hidden="true"></i>
+                <a class="text-decoration-none flex-grow-1" href="@item.OpenUrl">@item.Title</a>
+                <span class="text-muted">@item.Type</span>
+            </li>
+        }
+    </ul>
+}

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -6,9 +6,24 @@ namespace ProjectManagement.Services.Notebook;
 
 public interface INotebookService
 {
-    Task<NotebookIndexVm> GetIndexAsync(string ownerId, string view, string? query, Guid? selectedId, CancellationToken ct = default);
+    Task<NotebookIndexVm> GetIndexAsync(
+        string ownerId,
+        string view,
+        string? query,
+        Guid? selectedId,
+        bool suppressAutoSelect = false,
+        CancellationToken ct = default);
 
-    Task<Guid> QuickCaptureAsync(string ownerId, string input, NotebookItemType? forcedType = null, CancellationToken ct = default);
+    Task<NotebookWidgetVm> GetWidgetAsync(
+        string ownerId,
+        int take = 5,
+        CancellationToken ct = default);
+
+    Task<Guid> QuickCaptureAsync(
+        string ownerId,
+        string input,
+        NotebookItemType? forcedType = null,
+        CancellationToken ct = default);
 
     Task<Guid> CreateAsync(string ownerId, NotebookEditInput input, CancellationToken ct = default);
 

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -28,6 +28,7 @@ public sealed class NotebookService : INotebookService
         string view,
         string? query,
         Guid? selectedId,
+        bool suppressAutoSelect = false,
         CancellationToken ct = default)
     {
         view = NormalizeView(view);
@@ -40,7 +41,7 @@ public sealed class NotebookService : INotebookService
             .Include(item => item.ChecklistItems)
             .Where(item => item.OwnerId == ownerId && item.DeletedAtUtc == null);
 
-        var activeQuery = VisibleItems(baseQuery);
+        var activeQuery = ActiveItems(baseQuery);
 
         if (!string.IsNullOrWhiteSpace(query))
         {
@@ -107,7 +108,8 @@ public sealed class NotebookService : INotebookService
             .Select(item => ToListVm(item, bounds))
             .ToArray();
 
-        var selected = await LoadSelectedAsync(ownerId, selectedId ?? items.FirstOrDefault()?.Id, bounds, ct);
+        var autoSelectedId = suppressAutoSelect ? selectedId : selectedId ?? items.FirstOrDefault()?.Id;
+        var selected = await LoadSelectedAsync(ownerId, autoSelectedId, bounds, ct);
 
         return new NotebookIndexVm
         {
@@ -121,6 +123,80 @@ public sealed class NotebookService : INotebookService
             Summary = await BuildSummary(ownerId, bounds, ct),
             RailItems = await BuildRail(ownerId, view, bounds, ct),
             Tags = await BuildTags(ownerId, ct)
+        };
+    }
+
+
+    public async Task<NotebookWidgetVm> GetWidgetAsync(
+        string ownerId,
+        int take = 5,
+        CancellationToken ct = default)
+    {
+        var nowUtc = _clock.UtcNow;
+        var bounds = TodayBounds(nowUtc);
+
+        var baseQuery = _db.NotebookItems
+            .AsNoTracking()
+            .Where(item =>
+                item.OwnerId == ownerId &&
+                item.DeletedAtUtc == null &&
+                item.Status == NotebookItemStatus.Active);
+
+        var reminderQuery = baseQuery.Where(item => item.ReminderAtUtc != null);
+
+        var dueItems = await reminderQuery
+            .Where(item => item.ReminderAtUtc < bounds.EndUtc)
+            .OrderBy(item => item.ReminderAtUtc)
+            .Take(take)
+            .Select(item => new NotebookWidgetItemVm
+            {
+                Id = item.Id,
+                Title = item.Title,
+                Type = item.Type,
+                ReminderAtUtc = item.ReminderAtUtc,
+                IsOverdue = item.ReminderAtUtc < nowUtc,
+                OpenUrl = $"/Notebook?view=today&selectedId={item.Id}"
+            })
+            .ToListAsync(ct);
+
+        var pinnedItems = await baseQuery
+            .Where(item => item.IsPinned)
+            .OrderByDescending(item => item.UpdatedAtUtc)
+            .Take(take)
+            .Select(item => new NotebookWidgetItemVm
+            {
+                Id = item.Id,
+                Title = item.Title,
+                Type = item.Type,
+                ReminderAtUtc = item.ReminderAtUtc,
+                OpenUrl = $"/Notebook?view=home&selectedId={item.Id}"
+            })
+            .ToListAsync(ct);
+
+        var stickyItems = await baseQuery
+            .Where(item => item.Type == NotebookItemType.Sticky)
+            .OrderByDescending(item => item.UpdatedAtUtc)
+            .Take(take)
+            .Select(item => new NotebookWidgetItemVm
+            {
+                Id = item.Id,
+                Title = item.Title,
+                Type = item.Type,
+                ReminderAtUtc = item.ReminderAtUtc,
+                OpenUrl = $"/Notebook?view=sticky&selectedId={item.Id}"
+            })
+            .ToListAsync(ct);
+
+        return new NotebookWidgetVm
+        {
+            DueTodayCount = await reminderQuery.CountAsync(item =>
+                item.ReminderAtUtc >= bounds.StartUtc &&
+                item.ReminderAtUtc < bounds.EndUtc,
+                ct),
+            OverdueCount = await reminderQuery.CountAsync(item => item.ReminderAtUtc < bounds.StartUtc, ct),
+            DueItems = dueItems,
+            PinnedItems = pinnedItems,
+            StickyItems = stickyItems
         };
     }
 
@@ -297,7 +373,7 @@ public sealed class NotebookService : INotebookService
 
     private static IQueryable<NotebookItem> VisibleItems(IQueryable<NotebookItem> query)
     {
-        return query.Where(item => item.Status != NotebookItemStatus.Archived);
+        return query.Where(item => item.Status == NotebookItemStatus.Active);
     }
 
     private static IQueryable<NotebookItem> ActiveItems(IQueryable<NotebookItem> query)
@@ -435,7 +511,7 @@ public sealed class NotebookService : INotebookService
             .Where(item =>
                 item.OwnerId == ownerId &&
                 item.DeletedAtUtc == null &&
-                item.Status != NotebookItemStatus.Archived);
+                item.Status == NotebookItemStatus.Active);
 
         return new NotebookSummaryVm
         {
@@ -460,7 +536,7 @@ public sealed class NotebookService : INotebookService
 
         async Task<int> CountAsync(string view) => view switch
         {
-            "home" => await query.CountAsync(item => item.Status != NotebookItemStatus.Archived, ct),
+            "home" => await query.CountAsync(item => item.Status == NotebookItemStatus.Active, ct),
             "today" => await query.CountAsync(item =>
                 item.Status == NotebookItemStatus.Active &&
                 item.ReminderAtUtc != null &&

--- a/Services/Workspace/ProjectOfficerWorkspaceService.cs
+++ b/Services/Workspace/ProjectOfficerWorkspaceService.cs
@@ -266,7 +266,7 @@ public sealed class ProjectOfficerWorkspaceService
                 Priority = item.Priority.ToString(),
                 DueAtUtc = item.ReminderAtUtc,
                 IsPinned = item.IsPinned,
-                OpenUrl = WorkspaceRouteHelper.PersonalReminders()
+                OpenUrl = WorkspaceRouteHelper.PersonalReminder(item.Id)
             })
             .ToListAsync(ct);
     }
@@ -916,7 +916,7 @@ public sealed class ProjectOfficerWorkspaceService
             new WorkspaceQuickActionVm { Text = "View Other Assigned Tasks", Url = WorkspaceRouteHelper.ActionTasksMyWork(), Icon = "bi-list-check" },
             new WorkspaceQuickActionVm { Text = "Open My Project Ideas", Url = WorkspaceRouteHelper.ProjectIdeasMine(), Icon = "bi-lightbulb" },
             new WorkspaceQuickActionVm { Text = "Open AOTS Inbox", Url = WorkspaceRouteHelper.AotsInbox(), Icon = "bi-file-earmark-text" },
-            new WorkspaceQuickActionVm { Text = "Open Personal Reminders", Url = WorkspaceRouteHelper.PersonalReminders(), Icon = "bi-pin-angle" }
+            new WorkspaceQuickActionVm { Text = "Open My Notebook", Url = WorkspaceRouteHelper.PersonalReminders(), Icon = "bi-journal-bookmark" }
         };
     }
 

--- a/Services/Workspace/WorkspaceRouteHelper.cs
+++ b/Services/Workspace/WorkspaceRouteHelper.cs
@@ -57,6 +57,9 @@ internal static class WorkspaceRouteHelper
     public static string PersonalReminders()
         => "/Notebook?view=today";
 
+    public static string PersonalReminder(Guid itemId)
+        => $"/Notebook?view=today&selectedId={itemId}";
+
     public static string AotsInbox()
         => "/DocumentRepository/Documents?scope=aots";
 

--- a/ViewModels/Notebook/NotebookViewModels.cs
+++ b/ViewModels/Notebook/NotebookViewModels.cs
@@ -135,6 +135,34 @@ public sealed class NotebookSummaryVm
     public int ChecklistCount { get; set; }
 }
 
+public sealed class NotebookWidgetVm
+{
+    public int DueTodayCount { get; set; }
+
+    public int OverdueCount { get; set; }
+
+    public IReadOnlyList<NotebookWidgetItemVm> DueItems { get; set; } = Array.Empty<NotebookWidgetItemVm>();
+
+    public IReadOnlyList<NotebookWidgetItemVm> PinnedItems { get; set; } = Array.Empty<NotebookWidgetItemVm>();
+
+    public IReadOnlyList<NotebookWidgetItemVm> StickyItems { get; set; } = Array.Empty<NotebookWidgetItemVm>();
+}
+
+public sealed class NotebookWidgetItemVm
+{
+    public Guid Id { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public NotebookItemType Type { get; set; }
+
+    public DateTimeOffset? ReminderAtUtc { get; set; }
+
+    public bool IsOverdue { get; set; }
+
+    public string OpenUrl { get; set; } = string.Empty;
+}
+
 public sealed class NotebookItemActionVm
 {
     public NotebookItemListVm Item { get; set; } = new();

--- a/wwwroot/css/notebook.css
+++ b/wwwroot/css/notebook.css
@@ -415,3 +415,88 @@
     color: #64748b;
     font-size: .85rem;
 }
+
+/* SECTION: New item flow */
+.notebook-new-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    margin: -.25rem 0 1rem;
+}
+
+/* SECTION: Interactive checklist rows */
+.notebook-check-row {
+    margin: 0;
+}
+
+.notebook-check-toggle {
+    display: flex;
+    width: 100%;
+    gap: .45rem;
+    align-items: center;
+    padding: 0;
+    color: #334155;
+    text-align: left;
+    background: transparent;
+    border: 0;
+}
+
+.notebook-check-toggle.is-done {
+    color: #64748b;
+    text-decoration: line-through;
+}
+
+/* SECTION: Quiet card overflow actions */
+.notebook-card-more {
+    position: relative;
+}
+
+.notebook-card-more summary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    list-style: none;
+    cursor: pointer;
+    background: rgba(248, 250, 252, .9);
+    border-radius: 999px;
+}
+
+.notebook-card-more summary::-webkit-details-marker {
+    display: none;
+}
+
+.notebook-card-more__menu {
+    position: absolute;
+    right: 0;
+    z-index: 5;
+    display: grid;
+    min-width: 10rem;
+    padding: .35rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, .14);
+}
+
+.notebook-card-more__menu button {
+    width: 100%;
+    text-align: left;
+    border-radius: 8px;
+}
+
+.notebook-action-done {
+    color: #166534 !important;
+    background: #dcfce7 !important;
+}
+
+.notebook-editor-complete {
+    margin-top: .75rem;
+}
+
+.notebook-empty h3 {
+    margin: 0 0 .35rem;
+    color: #0f172a;
+    font-size: 1rem;
+}

--- a/wwwroot/js/pages/notebook-index.js
+++ b/wwwroot/js/pages/notebook-index.js
@@ -36,17 +36,40 @@
     });
   };
 
-  const updateFields = () => {
+  let updateFields = () => {
     const selected = selectedTypeName();
 
     for (const group of fieldGroups) {
-      const groupType = normalise(group.getAttribute('data-notebook-type-fields'));
-      const shouldShow = groupType === selected
-        || (selected === 'idea' && groupType === 'note')
-        || (selected === 'draft' && groupType === 'note');
+      const groupTypes = normalise(group.getAttribute('data-notebook-type-fields'))
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+      const shouldShow = groupTypes.includes(selected);
 
       setGroupEnabled(group, shouldShow);
     }
+  };
+
+  const sharedReminder = document.querySelector('[data-notebook-shared-reminder]');
+  const sharedPriority = document.querySelector('[data-notebook-shared-priority]');
+
+  const setSharedEnabled = (container, isEnabled) => {
+    if (!container) {
+      return;
+    }
+
+    container.hidden = !isEnabled;
+    container.querySelectorAll('input, select, textarea').forEach((control) => {
+      control.disabled = !isEnabled;
+    });
+  };
+
+  const originalUpdateFields = updateFields;
+  updateFields = () => {
+    originalUpdateFields();
+    const selected = selectedTypeName();
+    setSharedEnabled(sharedReminder, selected !== 'checklist' && selected !== 'reminder');
+    setSharedEnabled(sharedPriority, selected !== 'checklist' && selected !== 'reminder');
   };
 
   typeSelect.addEventListener('change', updateFields);


### PR DESCRIPTION
### Motivation
- Move the Dashboard personal productivity surface from the legacy Todo model to the Notebook model so dashboard reminders, pinned items and stickies reflect the new Notebook data and link to `/Notebook`.
- Provide clear, purpose-built full-create flows (`New Note`, `New Sticky`, `New Checklist`) and a create-mode editor so users can deliberately create structured items without overwriting existing selection.
- Make reminder completion and checklist interactions obvious and quieten card actions so the Notebook feels like a personal notebook rather than a management table.
- Improve editor ergonomics by ordering fields by item type and add helpful empty states.

### Description
- Dashboard widget: added `NotebookWidgetVm`/`NotebookWidgetItemVm`, implemented `INotebookService.GetWidgetAsync` and `NotebookService.GetWidgetAsync`, and introduced `Pages/Shared/_NotebookWidget.cshtml` and `_NotebookWidgetList.cshtml`; Dashboard now renders the notebook widget instead of the old Todo widget (`Pages/Dashboard/Index.cshtml`).
- New-create flow: added GET parameters `Mode` and `Type` to `Pages/Notebook/Index.cshtml.cs`, added `suppressAutoSelect` to `INotebookService.GetIndexAsync` and `NotebookService.GetIndexAsync` to prevent auto-selection when creating, and added top-level create buttons in `Pages/Notebook/Index.cshtml` that open the editor in create mode and use the `Create` button label.
- Completion and workspace linking: exposed a `Done` action on reminder-bearing cards and in the editor panel that calls the existing `CompleteAsync` flow, ensured active views filter out `Completed` items; updated `Services/Workspace/WorkspaceRouteHelper` and `ProjectOfficerWorkspaceService` so workspace personal reminders open `/Notebook?view=today&selectedId={id}` and updated quick action label to `Open My Notebook`.
- Editor & checklist UX: reordered editor field groups by type in `Pages/Notebook/Index.cshtml`, updated client script `wwwroot/js/pages/notebook-index.js` to control field visibility, made checklist preview rows interactive (form buttons posting to `OnPostToggleChecklistItemAsync`), and kept checklist toggles and editor toggles consistent.
- Card actions & styling: simplified `_NotebookActions.cshtml` to show only Pin/Favourite/Done inline and move Archive/Restore/Convert/Delete into a quiet overflow (`<details>`) menu; added CSS in `wwwroot/css/notebook.css` for new flows, quiet overflow menu, interactive checklist rows and empty-state styles.
- Formatting & small helpers: tidied `Models/NotebookItem.cs` formatting and expanded compact declarations to improve readability while preserving behavior.

### Testing
- Ran `git diff --check` to surface whitespace/format issues (no problems reported).
- Attempted `dotnet build` in the runtime container but the `dotnet` CLI is not available (`dotnet: command not found`), so a full build could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a340d94029883299358c8693422f71b)