### PR TITLE
Avoid Razor `@section` directive conflict in Notebook Index view

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -76,20 +76,20 @@
                 (Title: "Recent", Items: Model.Notebook.RecentItems)
             };
 
-            foreach (var section in sections.Where(section => section.Items.Any() || section.Title == "Recent"))
+            foreach (var notebookSection in sections.Where(notebookSection => notebookSection.Items.Any() || notebookSection.Title == "Recent"))
             {
                 <section class="notebook-section">
-                    <div class="notebook-section-header"><h2>@section.Title</h2><span>@section.Items.Count item(s)</span></div>
-                    @if (section.Items.Any())
+                    <div class="notebook-section-header"><h2>@notebookSection.Title</h2><span>@notebookSection.Items.Count item(s)</span></div>
+                    @if (notebookSection.Items.Any())
                     {
                         <div class="notebook-board">
-                            @foreach (var item in section.Items)
+                            @foreach (var item in notebookSection.Items)
                             {
                                 <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, SelectedId = selected?.Id })" />
                             }
                         </div>
                     }
-                    else if (section.Title == "Recent")
+                    else if (notebookSection.Title == "Recent")
                     {
                         <div class="notebook-empty notebook-empty-compact"><h3>@emptyTitle</h3><p>@emptyText</p></div>
                     }


### PR DESCRIPTION
### Motivation
- Razor was mis-parsing `@section.Title` and `@section.Items` inside a `foreach` because the loop variable was named `section`, which collides with the Razor `section` directive syntax.
- Rename the loop variable to remove the conflict so the Notebook home view renders correctly and Razor directives are not triggered unintentionally.

### Description
- Renamed the home view loop variable from `section` to `notebookSection` inside `Pages/Notebook/Index.cshtml` to avoid `@section` directive collisions.
- Updated all references within the loop to use `notebookSection` (title, items enumeration and empty-state checks) and updated the `@foreach` item enumeration accordingly.
- Kept existing layout and markup intact; this is a minimal, local change limited to the Razor view.

### Testing
- Ran `git diff --check` to validate the workspace for whitespace and diff issues and it passed without errors.
- Attempted to run `dotnet build` but the `dotnet` CLI is not available in this environment, so a build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3414690fb48329b5d5539971b2887b)