### PR TITLE
Fix notebook home recent empty states

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -76,6 +76,9 @@
                 (Title: "Recent", Items: Model.Notebook.RecentItems)
             };
 
+            var hasAnyHomeItems = sections.Any(notebookSection => notebookSection.Items.Any());
+
+            @* SECTION: Home sections only show an empty state when the whole home board is empty *@
             foreach (var notebookSection in sections.Where(notebookSection => notebookSection.Items.Any() || notebookSection.Title == "Recent"))
             {
                 <section class="notebook-section">
@@ -89,7 +92,7 @@
                             }
                         </div>
                     }
-                    else if (notebookSection.Title == "Recent")
+                    else if (notebookSection.Title == "Recent" && !hasAnyHomeItems)
                     {
                         <div class="notebook-empty notebook-empty-compact"><h3>@emptyTitle</h3><p>@emptyText</p></div>
                     }

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -113,13 +113,14 @@ public sealed class NotebookService : INotebookService
             .Concat(due.Select(item => item.Id))
             .ToHashSet();
 
+        // SECTION: Home recent items exclude cards already shown in priority sections before limiting
         var recent = (await activeQuery
-                .Where(item => item.Status == NotebookItemStatus.Active)
+                .Where(item =>
+                    item.Status == NotebookItemStatus.Active &&
+                    !homeShownIds.Contains(item.Id))
                 .OrderByDescending(item => item.UpdatedAtUtc)
-                .Take(30)
+                .Take(12)
                 .ToListAsync(ct))
-            .Where(item => !homeShownIds.Contains(item.Id))
-            .Take(12)
             .Select(item => ToListVm(item, bounds))
             .ToArray();
 


### PR DESCRIPTION
### Motivation
- The home-board Recent section could show a compact empty state even when Pinned/Today had items, and Recent selection logic filtered out already-shown items after applying the result limit, reducing useful results.

### Description
- Update `Services/Notebook/NotebookService.cs` to exclude `homeShownIds` before applying `.Take(...)` and limit the recent query to `Take(12)` so Recent can be populated by older active items that were not already rendered in Pinned/Due sections.
- Update `Pages/Notebook/Index.cshtml` to compute `hasAnyHomeItems` and only render the compact Recent empty state when every home section is empty, preventing the misleading empty message under populated sections.
- Add short inline SECTION comments to clarify the intent of the new behavior in both files.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted to run `dotnet test` but it could not be executed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34154059548329a35dee97d0e7f9eb)