### PR TITLE
Notebook: Keep-style board UI — fix dropdown, compact cards, simplified rail & drawer editor

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -10,18 +10,14 @@
     var isCreateMode = string.Equals(Model.Mode, "new", StringComparison.OrdinalIgnoreCase);
     var emptyTitle = Model.Notebook.View switch
     {
-        "notes" => "No notes yet.",
-        "sticky" => "No sticky notes yet.",
-        "checklists" => "No checklists yet.",
+        "labels" => "No labels yet.",
         "today" or "reminders" => "No reminders due.",
         "archived" => "No archived items.",
         _ => "No notebook items yet."
     };
     var emptyText = Model.Notebook.View switch
     {
-        "notes" => "Create a note for longer writing, meeting points or draft text.",
-        "sticky" => "Use sticky notes for quick thoughts and temporary reminders.",
-        "checklists" => "Create a checklist for personal follow-ups or small task lists.",
+        "labels" => "Add tags to notebook items, then browse by label here.",
         "today" or "reminders" => "Add a reminder to any note, checklist or sticky item.",
         "archived" => "Archived notes will appear here.",
         _ => "Use quick capture or create a structured notebook item."
@@ -41,7 +37,7 @@
     <main class="notebook-main">
         <section class="notebook-commandbar">
             <div><p class="eyebrow">Personal workspace</p><h1>My Notebook</h1><p>Notes, reminders, checklists, ideas and drafts in one professional place.</p></div>
-            <form method="get" class="notebook-search"><input type="hidden" name="view" value="@Model.Notebook.View" /><i class="bi bi-search"></i><input name="Query" value="@Model.Query" placeholder="Search title, body or tags" /></form>
+            <form method="get" class="notebook-search"><input type="hidden" name="view" value="@Model.Notebook.View" /><input type="hidden" name="filter" value="@Model.Notebook.Filter" /><input type="hidden" name="tag" value="@Model.Notebook.Tag" /><i class="bi bi-search"></i><input name="Query" value="@Model.Query" placeholder="Search notes or labels" /></form>
         </section>
 
         @* SECTION: Integrated quick capture and creation chips *@
@@ -49,25 +45,44 @@
             <form method="post" asp-page-handler="QuickCapture" class="notebook-capture-form">
                 <input type="hidden" asp-for="View" />
                 <input type="hidden" asp-for="Query" />
+                <input type="hidden" asp-for="Filter" />
+                <input type="hidden" asp-for="Tag" />
                 <input asp-for="QuickCaptureText" placeholder="Take a note..." autocomplete="off" />
                 <button class="notebook-capture-primary" type="submit">Capture</button>
                 <button class="notebook-capture-chip" type="submit" name="ForcedType" value="Sticky"><i class="bi bi-sticky"></i> Sticky</button>
                 <button class="notebook-capture-chip" type="submit" name="ForcedType" value="Checklist"><i class="bi bi-check2-square"></i> Checklist</button>
             </form>
             <div class="notebook-create-row" aria-label="Create notebook item">
-                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Note" class="notebook-create-chip"><i class="bi bi-journal-text"></i> New Note</a>
-                <a asp-page="/Notebook/Index" asp-route-view="sticky" asp-route-mode="new" asp-route-type="Sticky" class="notebook-create-chip"><i class="bi bi-sticky"></i> New Sticky</a>
-                <a asp-page="/Notebook/Index" asp-route-view="checklists" asp-route-mode="new" asp-route-type="Checklist" class="notebook-create-chip"><i class="bi bi-check2-square"></i> New Checklist</a>
-                <a asp-page="/Notebook/Index" asp-route-view="reminders" asp-route-mode="new" asp-route-type="Reminder" class="notebook-create-chip"><i class="bi bi-bell"></i> New Reminder</a>
+                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Note" class="notebook-create-chip"><i class="bi bi-journal-text"></i> Note</a>
+                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Sticky" class="notebook-create-chip"><i class="bi bi-sticky"></i> Sticky</a>
+                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Checklist" class="notebook-create-chip"><i class="bi bi-check2-square"></i> Checklist</a>
+                <a asp-page="/Notebook/Index" asp-route-view="reminders" asp-route-mode="new" asp-route-type="Reminder" class="notebook-create-chip"><i class="bi bi-bell"></i> Reminder</a>
             </div>
         </section>
 
+        @* SECTION: Keep-style board filters *@
+        <nav class="notebook-filter-chips" aria-label="Notebook type filters">
+            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-tag="@Model.Notebook.Tag" class="@(string.IsNullOrWhiteSpace(Model.Notebook.Filter) ? "is-active" : "")">All</a>
+            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="notes" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "notes" ? "is-active" : "")">Notes</a>
+            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="sticky" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "sticky" ? "is-active" : "")">Sticky</a>
+            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="checklists" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "checklists" ? "is-active" : "")">Checklists</a>
+        </nav>
+
         @* SECTION: Card-first notebook board *@
+        @if (Model.Notebook.View == "labels")
+        {
+            <section class="notebook-labels-panel" aria-label="Notebook labels">
+                <div class="notebook-section-header"><h2>Labels</h2><span>@Model.Notebook.Tags.Count label(s)</span></div>
+                <div class="notebook-label-chips">
+                    @foreach (var tag in Model.Notebook.Tags)
+                    {
+                        <a asp-page="/Notebook/Index" asp-route-view="labels" asp-route-tag="@tag.Name" class="@(Model.Notebook.Tag == tag.Name.ToUpperInvariant() ? "is-active" : "")">#@tag.Name <span>@tag.Count</span></a>
+                    }
+                </div>
+            </section>
+        }
         @if (Model.Notebook.View == "home")
         {
-            <section class="notebook-home-grid" aria-label="Notebook summary">
-                <article><span>Due today</span><strong>@Model.Notebook.Summary.DueToday</strong></article><article><span>Overdue</span><strong>@Model.Notebook.Summary.Overdue</strong></article><article><span>Pinned</span><strong>@Model.Notebook.Summary.PinnedCount</strong></article><article><span>Sticky notes</span><strong>@Model.Notebook.Summary.StickyCount</strong></article>
-            </section>
 
             var sections = new[]
             {
@@ -88,7 +103,7 @@
                         <div class="notebook-board">
                             @foreach (var item in notebookSection.Items)
                             {
-                                <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, SelectedId = selected?.Id })" />
+                                <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
                             }
                         </div>
                     }
@@ -102,18 +117,16 @@
         else
         {
             <section class="notebook-board-section">
-                <div class="notebook-board @(Model.Notebook.View == "sticky" ? "notebook-board-wide" : string.Empty)">
+                <div class="notebook-board">
                     @foreach (var item in Model.Notebook.Items)
                     {
-                        <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, SelectedId = selected?.Id, UseStickySurface = Model.Notebook.View == "sticky" })" />
+                        <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
                     }
                 </div>
                 @if (!Model.Notebook.Items.Any())
                 {
                     var emptyType = Model.Notebook.View switch
                     {
-                        "sticky" => "Sticky",
-                        "checklists" => "Checklist",
                         "reminders" or "today" => "Reminder",
                         _ => "Note"
                     };
@@ -127,10 +140,12 @@
     @if (Model.HasEditorOpen)
     {
     <aside class="notebook-editor-drawer">
-        <div class="notebook-editor-header"><h2>@(isCreateMode || selected is null ? $"New {Model.Input.Type.ToString().ToLowerInvariant()}" : "Edit item")</h2><a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" class="notebook-editor-close" aria-label="Close editor"><i class="bi bi-x-lg"></i></a></div>
+        <div class="notebook-editor-header"><h2>@(isCreateMode || selected is null ? $"New {Model.Input.Type.ToString().ToLowerInvariant()}" : "Edit item")</h2><a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="@Model.Notebook.Filter" asp-route-tag="@Model.Notebook.Tag" class="notebook-editor-close" aria-label="Close editor"><i class="bi bi-x-lg"></i></a></div>
         <form method="post" asp-page-handler="@(selected is null ? "Create" : "Update")" asp-route-id="@selected?.Id" class="notebook-editor-form">
             <input type="hidden" asp-for="View" />
             <input type="hidden" asp-for="Query" />
+            <input type="hidden" asp-for="Filter" />
+            <input type="hidden" asp-for="Tag" />
             <label class="notebook-title-field">Title<input asp-for="Input.Title" class="notebook-editor-title-input" required maxlength="220" /></label>
             <section class="notebook-editor-primary">
             <div class="notebook-editor-fields" data-notebook-type-fields="Note,Idea,Draft">

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -33,6 +33,10 @@ public class IndexModel : PageModel
     public string? Mode { get; set; }
     [BindProperty(SupportsGet = true)]
     public NotebookItemType? Type { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? Filter { get; set; }
+    [BindProperty(SupportsGet = true)]
+    public string? Tag { get; set; }
     [BindProperty]
     public string? QuickCaptureText { get; set; }
     [BindProperty]
@@ -54,8 +58,9 @@ public class IndexModel : PageModel
             return Unauthorized();
         }
         await _import.ImportForUserIfRequiredAsync(uid, ct);
+        NormalizeLegacyTypeView();
         var isCreateMode = IsCreateMode();
-        Notebook = await _notebook.GetIndexAsync(uid, View, Query, SelectedId, isCreateMode, ct);
+        Notebook = await _notebook.GetIndexAsync(uid, View, Query, Filter, Tag, SelectedId, isCreateMode, ct);
         PopulateEditorInput();
         return Page();
     }
@@ -247,6 +252,25 @@ public class IndexModel : PageModel
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
+    private void NormalizeLegacyTypeView()
+    {
+        if (string.Equals(View, "sticky", StringComparison.OrdinalIgnoreCase))
+        {
+            View = "home";
+            Filter ??= "sticky";
+        }
+        else if (string.Equals(View, "notes", StringComparison.OrdinalIgnoreCase))
+        {
+            View = "home";
+            Filter ??= "notes";
+        }
+        else if (string.Equals(View, "checklists", StringComparison.OrdinalIgnoreCase))
+        {
+            View = "home";
+            Filter ??= "checklists";
+        }
+    }
+
     private bool IsCreateMode() => string.Equals(Mode, "new", StringComparison.OrdinalIgnoreCase);
 
     private IActionResult RedirectToCurrent(Guid? selectedId = null)
@@ -255,6 +279,8 @@ public class IndexModel : PageModel
         {
             view = View,
             query = Query,
+            filter = Filter,
+            tag = Tag,
             selectedId
         });
     }

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -7,6 +7,8 @@
     <input type="hidden" name="View" value="@Model.View" />
     <input type="hidden" name="Query" value="@Model.Query" />
     <input type="hidden" name="SelectedId" value="@Model.SelectedId" />
+    <input type="hidden" name="Filter" value="@Model.Filter" />
+    <input type="hidden" name="Tag" value="@Model.Tag" />
 
     <button asp-page-handler="TogglePin" title="Pin" type="submit" class="notebook-action-icon">
         <i class="bi @(Model.Item.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>

--- a/Pages/Notebook/_NotebookCard.cshtml
+++ b/Pages/Notebook/_NotebookCard.cshtml
@@ -6,15 +6,14 @@
     var isSelected = Model.SelectedId == item.Id;
     var fallbackColor = string.IsNullOrWhiteSpace(item.ColorKey) && item.Type == NotebookItemType.Reminder ? "amber" : "white";
     var colorClass = $"notebook-card-color-{(string.IsNullOrWhiteSpace(item.ColorKey) ? fallbackColor : item.ColorKey)}";
-    var stickyClass = Model.UseStickySurface ? $"notebook-sticky-surface notebook-sticky-{item.ColorKey}" : string.Empty;
     var tags = item.Tags.Take(3).ToArray();
     var extraTags = Math.Max(0, item.Tags.Count - tags.Length);
 }
 
 @* SECTION: Notebook board card *@
-<article class="notebook-card @colorClass @stickyClass @(isSelected ? "is-selected" : string.Empty) @(item.ReminderAtUtc is not null ? "has-due-action" : string.Empty)">
+<article class="notebook-card @colorClass @(isSelected ? "is-selected" : string.Empty) @(item.ReminderAtUtc is not null ? "has-due-action" : string.Empty)">
     <div class="notebook-card-body">
-        <a class="notebook-card-link" asp-page="/Notebook/Index" asp-route-view="@Model.View" asp-route-query="@Model.Query" asp-route-selectedId="@item.Id">
+        <a class="notebook-card-link" asp-page="/Notebook/Index" asp-route-view="@Model.View" asp-route-query="@Model.Query" asp-route-filter="@Model.Filter" asp-route-tag="@Model.Tag" asp-route-selectedId="@item.Id">
             <div class="notebook-card-topline">
                 <span class="notebook-type-chip">@item.Type</span>
                 <span class="notebook-card-indicators">
@@ -83,6 +82,6 @@
         }
     </div>
     <div class="notebook-card-actions">
-        <partial name="_NotebookActions" model="@(new NotebookItemActionVm { Item = item, View = Model.View, Query = Model.Query, SelectedId = Model.SelectedId })" />
+        <partial name="_NotebookActions" model="@(new NotebookItemActionVm { Item = item, View = Model.View, Query = Model.Query, Filter = Model.Filter, Tag = Model.Tag, SelectedId = Model.SelectedId })" />
     </div>
 </article>

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -10,6 +10,8 @@ public interface INotebookService
         string ownerId,
         string view,
         string? query,
+        string? filter,
+        string? tag,
         Guid? selectedId,
         bool suppressAutoSelect = false,
         CancellationToken ct = default);

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -27,11 +27,15 @@ public sealed class NotebookService : INotebookService
         string ownerId,
         string view,
         string? query,
+        string? filter,
+        string? tag,
         Guid? selectedId,
         bool suppressAutoSelect = false,
         CancellationToken ct = default)
     {
         view = NormalizeView(view);
+        filter = NormalizeFilter(filter);
+        tag = NormalizeTagFilter(tag);
         var bounds = TodayBounds(_clock.UtcNow);
 
         var baseQuery = _db.NotebookItems
@@ -52,6 +56,14 @@ public sealed class NotebookService : INotebookService
                 item.Tags.Any(tag => EF.Functions.ILike(tag.NotebookTag!.Name, $"%{search}%")));
         }
 
+        if (!string.IsNullOrWhiteSpace(tag))
+        {
+            activeQuery = activeQuery.Where(item => item.Tags.Any(itemTag =>
+                itemTag.NotebookTag != null && itemTag.NotebookTag.NormalizedName == tag));
+        }
+
+        activeQuery = ApplyTypeFilter(activeQuery, filter);
+
         var activeStatusQuery = ActiveItems(activeQuery);
         var remindersQuery = ReminderItems(activeStatusQuery);
 
@@ -61,11 +73,7 @@ public sealed class NotebookService : INotebookService
                 item.Status == NotebookItemStatus.Active &&
                 item.ReminderAtUtc != null &&
                 item.ReminderAtUtc < bounds.EndUtc),
-            "sticky" => activeQuery.Where(item =>
-                item.Type == NotebookItemType.Sticky &&
-                item.Status == NotebookItemStatus.Active),
-            "notes" => activeQuery.Where(item => item.Type == NotebookItemType.Note),
-            "checklists" => activeQuery.Where(item => item.Type == NotebookItemType.Checklist),
+            "labels" => activeQuery,
             "reminders" => remindersQuery,
             "archived" => baseQuery.Where(item => item.Status == NotebookItemStatus.Archived),
             _ => activeQuery
@@ -135,6 +143,8 @@ public sealed class NotebookService : INotebookService
         {
             View = view,
             Query = query,
+            Filter = filter,
+            Tag = tag,
             Items = items,
             PinnedItems = pinned,
             StickyItems = sticky,
@@ -388,8 +398,52 @@ public sealed class NotebookService : INotebookService
 
     private static string NormalizeView(string? view)
     {
-        var allowedViews = new[] { "home", "today", "sticky", "notes", "checklists", "reminders", "archived" };
+        var legacyTypeViews = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sticky"] = "home",
+            ["notes"] = "home",
+            ["checklists"] = "home"
+        };
+
+        if (!string.IsNullOrWhiteSpace(view) && legacyTypeViews.TryGetValue(view, out var normalizedLegacy))
+        {
+            return normalizedLegacy;
+        }
+
+        var allowedViews = new[] { "home", "today", "reminders", "labels", "archived" };
         return allowedViews.Contains(view) ? view! : "home";
+    }
+
+    private static string? NormalizeFilter(string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return null;
+        }
+
+        return filter.Trim().ToLowerInvariant() switch
+        {
+            "note" or "notes" => "notes",
+            "sticky" => "sticky",
+            "checklist" or "checklists" => "checklists",
+            _ => null
+        };
+    }
+
+    private static string? NormalizeTagFilter(string? tag)
+    {
+        return string.IsNullOrWhiteSpace(tag) ? null : NormalizeTag(tag.Trim());
+    }
+
+    private static IQueryable<NotebookItem> ApplyTypeFilter(IQueryable<NotebookItem> query, string? filter)
+    {
+        return filter switch
+        {
+            "notes" => query.Where(item => item.Type == NotebookItemType.Note),
+            "sticky" => query.Where(item => item.Type == NotebookItemType.Sticky),
+            "checklists" => query.Where(item => item.Type == NotebookItemType.Checklist),
+            _ => query
+        };
     }
 
     private static IQueryable<NotebookItem> VisibleItems(IQueryable<NotebookItem> query)
@@ -563,32 +617,19 @@ public sealed class NotebookService : INotebookService
                 item.ReminderAtUtc != null &&
                 item.ReminderAtUtc < bounds.EndUtc,
                 ct),
-            "sticky" => await query.CountAsync(item =>
-                item.Status == NotebookItemStatus.Active &&
-                item.Type == NotebookItemType.Sticky,
-                ct),
-            "notes" => await query.CountAsync(item =>
-                item.Status == NotebookItemStatus.Active &&
-                item.Type == NotebookItemType.Note,
-                ct),
-            "checklists" => await query.CountAsync(item =>
-                item.Status == NotebookItemStatus.Active &&
-                item.Type == NotebookItemType.Checklist,
-                ct),
             "reminders" => await ReminderItems(ActiveItems(query)).CountAsync(ct),
+            "labels" => await _db.NotebookTags.AsNoTracking().CountAsync(tag => tag.OwnerId == ownerId, ct),
             "archived" => await query.CountAsync(item => item.Status == NotebookItemStatus.Archived, ct),
             _ => 0
         };
 
         var rows = new[]
         {
-            ("home", "Home", "bi-house"),
+            ("home", "All Notes", "bi-journal-text"),
             ("today", "Today", "bi-calendar-check"),
-            ("sticky", "Sticky Board", "bi-sticky"),
-            ("notes", "Notes", "bi-journal-text"),
-            ("checklists", "Checklists", "bi-check2-square"),
             ("reminders", "Reminders", "bi-bell"),
-            ("archived", "Archived", "bi-archive")
+            ("labels", "Labels", "bi-tags"),
+            ("archived", "Archive", "bi-archive")
         };
 
         var list = new List<NotebookRailItemVm>();

--- a/ViewModels/Notebook/NotebookViewModels.cs
+++ b/ViewModels/Notebook/NotebookViewModels.cs
@@ -9,6 +9,10 @@ public sealed class NotebookIndexVm
 
     public string? Query { get; set; }
 
+    public string? Filter { get; set; }
+
+    public string? Tag { get; set; }
+
     public IReadOnlyList<NotebookRailItemVm> RailItems { get; set; } = Array.Empty<NotebookRailItemVm>();
 
     public IReadOnlyList<NotebookItemListVm> Items { get; set; } = Array.Empty<NotebookItemListVm>();
@@ -173,6 +177,10 @@ public sealed class NotebookCardRenderVm
 
     public string? Query { get; set; }
 
+    public string? Filter { get; set; }
+
+    public string? Tag { get; set; }
+
     public Guid? SelectedId { get; set; }
 
     public bool UseStickySurface { get; set; }
@@ -185,6 +193,10 @@ public sealed class NotebookItemActionVm
     public string View { get; set; } = "home";
 
     public string? Query { get; set; }
+
+    public string? Filter { get; set; }
+
+    public string? Tag { get; set; }
 
     public Guid? SelectedId { get; set; }
 }

--- a/wwwroot/css/notebook.css
+++ b/wwwroot/css/notebook.css
@@ -1,129 +1,193 @@
-/* SECTION: Shell */
+/* SECTION: Notebook shell and rail */
 .notebook-shell {
     display: grid;
     grid-template-columns: 220px minmax(0, 1fr);
-    gap: 1rem;
+    gap: 1.1rem;
     align-items: start;
-    min-height: calc(100vh - 2rem);
+    padding: 1rem;
+    background: #f7f9fc;
 }
 
-.notebook-shell.has-editor { grid-template-columns: 220px minmax(0, 1fr) minmax(320px, 380px); }
-.notebook-main, .notebook-rail, .notebook-editor-drawer { min-width: 0; }
+.notebook-main,
+.notebook-rail,
+.notebook-editor-drawer { min-width: 0; }
+
 .notebook-main { display: grid; gap: 1rem; }
 
-/* SECTION: Rail */
 .notebook-rail {
     position: sticky;
     top: 1rem;
     display: grid;
-    gap: .35rem;
-    padding: .8rem;
+    gap: .25rem;
+    padding: .65rem;
     background: #fff;
     border: 1px solid #dfe7f2;
     border-radius: 18px;
-    box-shadow: 0 10px 26px rgba(15, 23, 42, .055);
+    box-shadow: 0 10px 28px rgba(15, 23, 42, .055);
 }
+
 .notebook-rail__brand { display: flex; align-items: center; gap: .5rem; padding: .55rem .6rem .8rem; color: #0f172a; font-weight: 800; }
 .notebook-rail__item { display: flex; align-items: center; gap: .55rem; padding: .58rem .65rem; color: #475569; border-radius: 12px; text-decoration: none; font-weight: 650; }
-.notebook-rail__item:hover, .notebook-rail__item.is-active { background: #eef5ff; color: #1d4ed8; }
+.notebook-rail__item:hover,
+.notebook-rail__item.is-active { background: #eef5ff; color: #1d4ed8; }
 .notebook-rail__item b { margin-left: auto; color: #94a3b8; font-size: .75rem; }
 
-/* SECTION: Command bar */
-.notebook-commandbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .25rem .1rem; }
-.notebook-commandbar h1 { margin: 0; color: #0f172a; font-size: 1.5rem; font-weight: 800; }
+/* SECTION: Notebook command bar and capture */
+.notebook-commandbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .15rem .1rem; }
+.notebook-commandbar h1 { margin: 0; color: #0f172a; font-size: 1.45rem; font-weight: 800; }
 .notebook-commandbar p { margin: 0; color: #64748b; }
 .notebook-commandbar .eyebrow { color: #315fba; font-size: .72rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-.notebook-search { display: flex; align-items: center; gap: .45rem; min-width: min(360px, 100%); padding: .55rem .75rem; background: #fff; border: 1px solid #dfe7f2; border-radius: 999px; }
+.notebook-search { display: flex; align-items: center; gap: .45rem; min-width: min(340px, 100%); padding: .5rem .72rem; background: #fff; border: 1px solid #dfe7f2; border-radius: 999px; }
 .notebook-search input { width: 100%; border: 0; outline: 0; background: transparent; color: #0f172a; }
 
-/* SECTION: Capture */
-.notebook-capture-panel { background: #fff; border: 1px solid #dfe7f2; border-radius: 18px; box-shadow: 0 10px 24px rgba(15, 23, 42, .055); padding: .55rem; }
-.notebook-capture-form { display: flex; align-items: center; gap: .45rem; }
-.notebook-capture-form input { flex: 1; border: 0; outline: 0; background: #f8fafc; border-radius: 14px; padding: .85rem .95rem; font-size: .94rem; }
-.notebook-capture-primary { border: 0; border-radius: 999px; background: #315fba; color: #fff; padding: .68rem 1rem; font-weight: 750; }
-.notebook-capture-chip, .notebook-create-chip { display: inline-flex; align-items: center; gap: .35rem; border-radius: 999px; border: 1px solid #d8e2f0; background: #fff; color: #315fba; padding: .48rem .72rem; font-size: .78rem; font-weight: 650; text-decoration: none; }
-.notebook-capture-chip:hover, .notebook-create-chip:hover { background: #f5f9ff; color: #1d4ed8; }
-.notebook-create-row { display: flex; flex-wrap: wrap; gap: .45rem; margin-top: .55rem; padding-top: .55rem; border-top: 1px solid #edf2f7; }
+.notebook-capture-panel {
+    max-width: 760px;
+    width: 100%;
+    margin: 0 auto .2rem;
+    background: #fff;
+    border: 1px solid #e1e7f0;
+    border-radius: 12px;
+    box-shadow: 0 3px 10px rgba(15, 23, 42, .09);
+    padding: .45rem;
+}
 
-/* SECTION: Board */
-.notebook-home-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .65rem; }
-.notebook-home-grid article { padding: .75rem; background: #fff; border: 1px solid #e4ebf5; border-radius: 14px; }
-.notebook-home-grid span { display: block; color: #64748b; font-size: .75rem; font-weight: 700; }
-.notebook-home-grid strong { color: #0f172a; font-size: 1.25rem; }
+.notebook-capture-form { display: flex; align-items: center; gap: .35rem; }
+.notebook-capture-form input { flex: 1; border: 0; outline: 0; background: transparent; border-radius: 10px; padding: .7rem .85rem; font-size: .94rem; }
+.notebook-capture-primary { border: 0; border-radius: 999px; background: #315fba; color: #fff; padding: .58rem .9rem; font-weight: 750; }
+.notebook-capture-chip,
+.notebook-create-chip { display: inline-flex; align-items: center; gap: .32rem; border-radius: 999px; border: 1px solid #d8e2f0; background: #fff; color: #315fba; padding: .38rem .62rem; font-size: .76rem; font-weight: 650; text-decoration: none; }
+.notebook-capture-chip:hover,
+.notebook-create-chip:hover { background: #f5f9ff; color: #1d4ed8; }
+.notebook-create-row { display: flex; flex-wrap: wrap; gap: .38rem; margin-top: .35rem; padding-top: .35rem; border-top: 1px solid #eef2f7; }
+
+/* SECTION: Board filters, labels and masonry */
+.notebook-filter-chips,
+.notebook-label-chips { display: flex; flex-wrap: wrap; gap: .45rem; align-items: center; }
+.notebook-filter-chips { justify-content: center; }
+.notebook-filter-chips a,
+.notebook-label-chips a { border: 1px solid #dce6f2; border-radius: 999px; background: #fff; color: #475569; padding: .35rem .72rem; font-size: .78rem; font-weight: 700; text-decoration: none; }
+.notebook-filter-chips a:hover,
+.notebook-filter-chips a.is-active,
+.notebook-label-chips a:hover,
+.notebook-label-chips a.is-active { background: #eef5ff; border-color: #bfd2f1; color: #1d4ed8; }
+.notebook-label-chips span { color: #94a3b8; margin-left: .35rem; }
+.notebook-labels-panel { padding: .75rem 0 .1rem; }
 .notebook-board-section { margin-top: .25rem; }
-.notebook-section-header { display: flex; align-items: center; justify-content: space-between; margin: 1.1rem 0 .55rem; }
+.notebook-section-header { display: flex; align-items: center; justify-content: space-between; margin: .95rem 0 .5rem; }
 .notebook-section-header h2 { margin: 0; font-size: .88rem; font-weight: 700; color: #0f172a; }
 .notebook-section-header span { font-size: .74rem; color: #64748b; }
-.notebook-board { column-width: 255px; column-gap: 1rem; }
-@media (min-width: 1600px) { .notebook-board { column-width: 280px; } }
+.notebook-board { column-width: 245px; column-gap: .9rem; }
 
-/* SECTION: Card */
-.notebook-card { display: inline-block; width: 100%; margin: 0 0 1rem; break-inside: avoid; border: 1px solid #dfe7f2; border-radius: 16px; overflow: hidden; color: #0f172a; box-shadow: 0 8px 20px rgba(15, 23, 42, .045); transition: border-color .15s ease, box-shadow .15s ease, transform .15s ease; }
-.notebook-card:hover { border-color: #b9c9e3; box-shadow: 0 12px 26px rgba(15, 23, 42, .075); transform: translateY(-1px); }
-.notebook-card.is-selected { border-color: #315fba; box-shadow: 0 0 0 2px rgba(49, 95, 186, .14), 0 12px 26px rgba(15, 23, 42, .075); }
-.notebook-card-body { padding: .85rem .9rem .35rem; }
-.notebook-card-link, .notebook-card-link:hover { color: inherit; text-decoration: none; }
-.notebook-card-topline, .notebook-card-indicators, .notebook-card-meta, .notebook-card-actions { display: flex; align-items: center; gap: .45rem; }
+/* SECTION: Compact Keep-inspired cards */
+.notebook-card {
+    position: relative;
+    z-index: 1;
+    display: inline-block;
+    width: 100%;
+    margin: 0 0 .9rem;
+    break-inside: avoid;
+    overflow: visible;
+    border: 1px solid #dfe5ee;
+    border-radius: 12px;
+    background: #fff;
+    color: #0f172a;
+    box-shadow: 0 4px 14px rgba(15, 23, 42, .06);
+    transition: border-color .15s ease, box-shadow .15s ease, transform .15s ease;
+}
+.notebook-card:hover { border-color: #b9c9e3; box-shadow: 0 8px 20px rgba(15, 23, 42, .075); transform: translateY(-1px); }
+.notebook-card.is-selected { border-color: #315fba; box-shadow: 0 0 0 2px rgba(49, 95, 186, .14), 0 8px 20px rgba(15, 23, 42, .075); }
+.notebook-card:has(.notebook-card-more[open]),
+.notebook-card.has-open-menu { z-index: 80; }
+.notebook-card-body { padding: .85rem .9rem .55rem; }
+.notebook-card-link,
+.notebook-card-link:hover { color: inherit; text-decoration: none; }
+.notebook-card-topline,
+.notebook-card-indicators,
+.notebook-card-meta,
+.notebook-card-actions { display: flex; align-items: center; gap: .4rem; }
 .notebook-card-topline { justify-content: space-between; }
 .notebook-card-indicators { color: #64748b; }
-.notebook-type-chip, .notebook-card-meta span { display: inline-flex; align-items: center; gap: .3rem; border-radius: 999px; background: rgba(255, 255, 255, .72); border: 1px solid rgba(148, 163, 184, .28); padding: .18rem .5rem; color: #475569; font-size: .7rem; font-weight: 750; }
-.notebook-card-title { margin: .62rem 0 .35rem; font-size: 1rem; font-weight: 800; line-height: 1.25; }
-.notebook-card-preview { margin: 0 0 .55rem; color: #334155; font-size: .88rem; line-height: 1.45; white-space: pre-line; }
-.notebook-card-meta { flex-wrap: wrap; margin-top: .45rem; }
-.notebook-card-tags { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .55rem; }
-.notebook-tag-chip { border-radius: 999px; background: rgba(15, 23, 42, .06); color: #475569; padding: .18rem .45rem; font-size: .7rem; font-weight: 700; }
-.notebook-card-actions { justify-content: flex-end; min-height: 2.35rem; padding: .25rem .55rem .55rem; opacity: 0; transition: opacity .15s ease; }
-.notebook-card:hover .notebook-card-actions, .notebook-card:focus-within .notebook-card-actions, .notebook-card.is-selected .notebook-card-actions, .notebook-card.has-due-action .notebook-card-actions { opacity: 1; }
-.notebook-actions { display: flex; flex-wrap: wrap; gap: .35rem; width: 100%; justify-content: flex-end; }
-.notebook-action-icon, .notebook-card-more summary { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; min-height: 2rem; border: 1px solid transparent; border-radius: 999px; background: transparent; color: #475569; cursor: pointer; }
-.notebook-action-icon:hover, .notebook-card-more summary:hover { background: rgba(255,255,255,.75); border-color: rgba(148,163,184,.35); color: #1d4ed8; }
-.notebook-action-done { border-color: #bbf7d0; background: #ecfdf5; color: #15803d; padding: .35rem .65rem; border-radius: 999px; font-weight: 750; }
+.notebook-type-chip,
+.notebook-card-meta span { display: inline-flex; align-items: center; gap: .3rem; border-radius: 999px; background: rgba(255, 255, 255, .72); border: 1px solid rgba(148, 163, 184, .28); padding: .16rem .46rem; color: #475569; font-size: .68rem; font-weight: 750; }
+.notebook-card-title { margin: .35rem 0 .25rem; font-size: .95rem; font-weight: 700; line-height: 1.28; }
+.notebook-card-preview { margin: .25rem 0 .4rem; color: #334155; font-size: .82rem; line-height: 1.38; white-space: pre-line; }
+.notebook-card-meta { flex-wrap: wrap; margin-top: .35rem; }
+.notebook-card-tags { display: flex; flex-wrap: wrap; gap: .3rem; margin-top: .42rem; }
+.notebook-tag-chip { border-radius: 999px; background: rgba(15, 23, 42, .06); color: #475569; padding: .15rem .42rem; font-size: .68rem; font-weight: 700; }
+
+/* SECTION: Quiet card actions and more menu */
+.notebook-card-actions { justify-content: flex-end; min-height: 0; padding: .15rem .55rem .45rem; opacity: 0; transition: opacity .14s ease; }
+.notebook-card:hover .notebook-card-actions,
+.notebook-card:focus-within .notebook-card-actions,
+.notebook-card.is-selected .notebook-card-actions,
+.notebook-card.has-due-action .notebook-card-actions { opacity: 1; }
+.notebook-actions { display: flex; flex-wrap: wrap; gap: .28rem; width: 100%; justify-content: flex-end; }
+.notebook-action-icon,
+.notebook-card-more summary { display: inline-flex; align-items: center; justify-content: center; min-width: 1.85rem; min-height: 1.85rem; border: 1px solid transparent; border-radius: 999px; background: transparent; color: #475569; cursor: pointer; }
+.notebook-action-icon:hover,
+.notebook-card-more summary:hover { background: rgba(255,255,255,.78); border-color: rgba(148,163,184,.35); color: #1d4ed8; }
+.notebook-action-done { border: 1px solid #bbf7d0; background: #ecfdf5; color: #15803d; padding: .28rem .58rem; border-radius: 999px; font-weight: 750; }
 .notebook-card-more { position: relative; }
 .notebook-card-more summary { list-style: none; }
 .notebook-card-more summary::-webkit-details-marker { display: none; }
-.notebook-card-more__menu { position: absolute; right: 0; z-index: 5; display: grid; gap: .25rem; min-width: 180px; padding: .45rem; background: #fff; border: 1px solid #dfe7f2; border-radius: 12px; box-shadow: 0 16px 34px rgba(15,23,42,.14); }
+.notebook-card-more__menu { position: absolute; right: 0; bottom: calc(100% + .35rem); top: auto; z-index: 120; display: grid; gap: .25rem; min-width: 180px; padding: .35rem; background: #fff; border: 1px solid #dbe4f0; border-radius: 12px; box-shadow: 0 18px 40px rgba(15,23,42,.18); }
 .notebook-card-more__menu button { width: 100%; text-align: left; }
+
+/* SECTION: Card colors and checklist previews */
 .notebook-card-color-white { background: #fff; }
 .notebook-card-color-blue { background: #edf5ff; border-color: #c8dbff; }
 .notebook-card-color-amber { background: #fff5d9; border-color: #efd48a; }
 .notebook-card-color-green { background: #ecf9ef; border-color: #bae8c8; }
 .notebook-card-color-rose { background: #fff0f3; border-color: #f3bbc7; }
 .notebook-card-color-slate { background: #f5f7fa; border-color: #d6dee9; }
-.notebook-sticky-surface { min-height: 150px; }
-
-/* SECTION: Checklist */
-.notebook-checklist-preview { display: grid; gap: .35rem; margin-top: .5rem; }
+.notebook-checklist-preview { display: grid; gap: .28rem; margin-top: .42rem; }
 .notebook-check-row { margin: 0; }
-.notebook-check-toggle { display: flex; align-items: center; gap: .4rem; width: 100%; border: 0; background: transparent; padding: .18rem 0; color: #334155; text-align: left; }
+.notebook-check-toggle { display: flex; align-items: center; gap: .4rem; width: 100%; border: 0; background: transparent; padding: .14rem 0; color: #334155; text-align: left; }
 .notebook-check-toggle.is-done { color: #94a3b8; text-decoration: line-through; }
-.notebook-checklist-preview strong, .notebook-checklist-empty { color: #64748b; font-size: .76rem; }
+.notebook-checklist-preview strong,
+.notebook-checklist-empty { color: #64748b; font-size: .76rem; }
 .notebook-checklist-toggle { display: grid; gap: .4rem; margin-top: .75rem; padding-top: .75rem; border-top: 1px solid #edf2f7; }
 .notebook-checks { display: flex; flex-wrap: wrap; gap: .8rem; }
 
-/* SECTION: Editor drawer */
-.notebook-editor-drawer { position: sticky; top: 1rem; max-height: calc(100vh - 2rem); overflow: auto; padding: .9rem; background: #fff; border: 1px solid #dfe7f2; border-radius: 18px; box-shadow: 0 14px 34px rgba(15,23,42,.09); }
+/* SECTION: Drawer-style editor */
+.notebook-editor-drawer {
+    position: fixed;
+    top: var(--app-header-height, 76px);
+    right: 1.25rem;
+    bottom: 1.25rem;
+    width: min(420px, calc(100vw - 2rem));
+    z-index: 90;
+    overflow: auto;
+    padding: .9rem;
+    background: #fff;
+    border: 1px solid #dfe7f2;
+    border-radius: 18px;
+    box-shadow: 0 24px 70px rgba(15,23,42,.22);
+}
 .notebook-editor-header { display: flex; align-items: center; justify-content: space-between; gap: .75rem; margin-bottom: .75rem; }
 .notebook-editor-header h2 { margin: 0; color: #0f172a; font-size: 1rem; font-weight: 800; }
 .notebook-editor-close { display: inline-flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; border-radius: 999px; color: #64748b; text-decoration: none; }
 .notebook-editor-close:hover { background: #f1f5f9; color: #0f172a; }
 .notebook-editor-form { display: grid; gap: .75rem; }
 .notebook-editor-form label { display: grid; gap: .32rem; color: #475569; font-size: .78rem; font-weight: 750; }
-.notebook-editor-form input, .notebook-editor-form select, .notebook-editor-form textarea { width: 100%; border: 1px solid #dfe7f2; border-radius: 12px; padding: .65rem .75rem; background: #fff; color: #0f172a; }
+.notebook-editor-form input,
+.notebook-editor-form select,
+.notebook-editor-form textarea { width: 100%; border: 1px solid #dfe7f2; border-radius: 12px; padding: .65rem .75rem; background: #fff; color: #0f172a; }
 .notebook-editor-form textarea { min-height: 130px; resize: vertical; }
 .notebook-editor-title-input { width: 100%; border: 1px solid #dfe7f2; border-radius: 14px; padding: .85rem .95rem; font-size: 1.1rem; font-weight: 750; color: #0f172a; }
 .notebook-editor-primary { display: grid; gap: .75rem; padding: .75rem; background: #fbfdff; border: 1px solid #e7eef7; border-radius: 16px; }
 .notebook-editor-details { display: grid; gap: .7rem; padding-top: .25rem; }
 .notebook-editor-section-title { font-size: .75rem; font-weight: 800; color: #64748b; text-transform: uppercase; letter-spacing: .08em; margin: .8rem 0 .1rem; }
-.notebook-sticky-editor { min-height: 180px; }
+.notebook-sticky-editor { min-height: 150px; }
 .notebook-editor-footer { position: sticky; bottom: 0; background: linear-gradient(180deg, rgba(255,255,255,.9), #fff 30%); padding: .75rem 0 0; border-top: 1px solid #edf2f7; }
 .notebook-editor-complete { margin-top: .75rem; }
 
-/* SECTION: Empty states */
+/* SECTION: Empty and responsive states */
 .notebook-empty { margin-top: 1rem; padding: 2rem; text-align: center; background: #fff; border: 1px dashed #cbd5e1; border-radius: 18px; color: #64748b; }
 .notebook-empty h3 { color: #0f172a; font-size: 1rem; }
 .notebook-empty-compact { padding: 1.25rem; }
 
-/* SECTION: Responsive */
+@media (min-width: 1600px) { .notebook-board { column-width: 265px; } }
 @media (hover: none) { .notebook-card-actions { opacity: 1; } }
-@media (max-width: 1180px) { .notebook-shell, .notebook-shell.has-editor { grid-template-columns: 190px minmax(0,1fr); } .notebook-editor-drawer { position: static; grid-column: 2; } }
-@media (max-width: 820px) { .notebook-shell, .notebook-shell.has-editor { display: block; } .notebook-rail { position: static; margin-bottom: 1rem; } .notebook-commandbar, .notebook-capture-form { flex-direction: column; align-items: stretch; } .notebook-search { min-width: 0; } .notebook-home-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 900px) { .notebook-board { column-width: auto; columns: 1; } }
+@media (max-width: 820px) { .notebook-shell { display: block; } .notebook-rail { position: static; margin-bottom: 1rem; } .notebook-commandbar, .notebook-capture-form { flex-direction: column; align-items: stretch; } .notebook-search { min-width: 0; } .notebook-editor-drawer { inset: .75rem; width: auto; border-radius: 16px; } }

--- a/wwwroot/js/pages/notebook-index.js
+++ b/wwwroot/js/pages/notebook-index.js
@@ -15,6 +15,19 @@
     input.addEventListener('change', () => input.form?.submit());
   });
 
+  // SECTION: Lift open card menus above neighboring masonry cards
+  document.querySelectorAll('.notebook-card-more').forEach((menu) => {
+    menu.addEventListener('toggle', () => {
+      const card = menu.closest('.notebook-card');
+
+      if (!card) {
+        return;
+      }
+
+      card.classList.toggle('has-open-menu', menu.open);
+    });
+  });
+
   // SECTION: Keep editor type-specific fields in sync with the type dropdown
   const typeSelect = document.querySelector('[data-notebook-type-select]');
   const fieldGroups = Array.from(document.querySelectorAll('[data-notebook-type-fields]'));


### PR DESCRIPTION
### Motivation

- Align the My Notebook experience with a Google Keep–style card board while retaining PRISM’s professional styling.
- Fix a critical UI bug where the card three-dot `More` menu was clipped by the card boundary and could not overlay neighbouring cards.
- Reduce the dashboard/KPI feel, make cards compact and content-led, and make the editor behave as a transient drawer.
- Move type-based navigation out of the left rail and into board-level chips so Sticky/Notes/Checklists are filters, not separate modules.

### Description

- UI/CSS: Rewrote/cleaned `wwwroot/css/notebook.css` to make cards compact, use CSS columns for masonry, set `.notebook-card { overflow: visible; position: relative; }`, raise cards when their `More` menu is open, and style the `More` menu to open upward with a higher `z-index` and absolute positioning. 
- Views/Markup: Updated `Pages/Notebook/Index.cshtml` to remove the large home KPI tile grid, add board filter chips (`All | Notes | Sticky | Checklists`) and a lightweight `Labels` view, keep capture centred and lighter, and include `filter`/`tag` parameters across links and hidden inputs so view state is preserved.
- Service & ViewModel: Extended `INotebookService` and `NotebookService.GetIndexAsync` with `filter` and `tag` parameters and added `Filter`/`Tag` to `NotebookIndexVm` so type and label filtering are applied server-side via `ApplyTypeFilter` and tag normalization. Also normalized legacy routes (`sticky`, `notes`, `checklists`) to the new `home`+`filter` pattern.
- Card & Actions: Simplified `_NotebookCard.cshtml` (removed sticky-only surface coupling) and `_NotebookActions.cshtml` so actions are quiet by default; `Delete`/Archive/Convert remain in the `More` menu and `Filter`/`Tag` state is preserved when submitting actions.
- Editor behavior: Converted the editor to a drawer-like surface via CSS so it overlays the board (`.notebook-editor-drawer` fixed positioning) rather than permanently resizing the page column.
- JS: Added a CSP-friendly external JS fallback in `wwwroot/js/pages/notebook-index.js` that toggles a `has-open-menu` class on the card when the `<details>` More menu toggles so cards lift above neighbours without inline scripts.

### Testing

- Ran `git diff --check` to ensure no whitespace or trivial diff issues (passed).
- Searched for legacy Dashboard Todo handlers to confirm no reintroduction of old Todo mutations via `rg` (results indicate Dashboard remains Notebook-based and no legacy Todo handlers were exposed). 
- Attempted to run `dotnet build` but the container environment does not have the `dotnet` SDK installed, so a full build/test could not be executed here. 

If you’d like, I can follow up with a local build/run checklist to execute in your CI or on a developer machine and address any build or runtime issues found there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34f62e0f1c8329bb5d483f96f7fdc3)