### PR TITLE
Redesign notebook board foundation

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -40,33 +40,27 @@
             <form method="get" class="notebook-search"><input type="hidden" name="view" value="@Model.Notebook.View" /><input type="hidden" name="filter" value="@Model.Notebook.Filter" /><input type="hidden" name="tag" value="@Model.Notebook.Tag" /><i class="bi bi-search"></i><input name="Query" value="@Model.Query" placeholder="Search notes or labels" /></form>
         </section>
 
-        @* SECTION: Integrated quick capture and creation chips *@
-        <section class="notebook-capture-panel">
-            <form method="post" asp-page-handler="QuickCapture" class="notebook-capture-form">
+        @* SECTION: Board-first inline composer fallback *@
+        <section class="notebook-composer" aria-label="Create a notebook item">
+            <form method="post" asp-page-handler="QuickCapture" class="notebook-composer__form">
                 <input type="hidden" asp-for="View" />
                 <input type="hidden" asp-for="Query" />
                 <input type="hidden" asp-for="Filter" />
                 <input type="hidden" asp-for="Tag" />
-                <input asp-for="QuickCaptureText" placeholder="Take a note..." autocomplete="off" />
-                <button class="notebook-capture-primary" type="submit">Capture</button>
-                <button class="notebook-capture-chip" type="submit" name="ForcedType" value="Sticky"><i class="bi bi-sticky"></i> Sticky</button>
-                <button class="notebook-capture-chip" type="submit" name="ForcedType" value="Checklist"><i class="bi bi-check2-square"></i> Checklist</button>
+                <input asp-for="QuickCaptureText" placeholder="Take a note…" autocomplete="off" aria-label="Take a note" />
+                <button class="notebook-composer__checklist" type="submit" name="ForcedType" value="Checklist" aria-label="Create checklist"><i class="bi bi-check2-square"></i><span>Checklist</span></button>
+                <button class="notebook-composer__save" type="submit">Close</button>
             </form>
-            <div class="notebook-create-row" aria-label="Create notebook item">
-                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Note" class="notebook-create-chip"><i class="bi bi-journal-text"></i> Note</a>
-                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Sticky" class="notebook-create-chip"><i class="bi bi-sticky"></i> Sticky</a>
-                <a asp-page="/Notebook/Index" asp-route-view="home" asp-route-mode="new" asp-route-type="Checklist" class="notebook-create-chip"><i class="bi bi-check2-square"></i> Checklist</a>
-                <a asp-page="/Notebook/Index" asp-route-view="reminders" asp-route-mode="new" asp-route-type="Reminder" class="notebook-create-chip"><i class="bi bi-bell"></i> Reminder</a>
-            </div>
         </section>
 
-        @* SECTION: Keep-style board filters *@
-        <nav class="notebook-filter-chips" aria-label="Notebook type filters">
-            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-tag="@Model.Notebook.Tag" class="@(string.IsNullOrWhiteSpace(Model.Notebook.Filter) ? "is-active" : "")">All</a>
-            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="notes" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "notes" ? "is-active" : "")">Notes</a>
-            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="sticky" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "sticky" ? "is-active" : "")">Sticky</a>
-            <a asp-page="/Notebook/Index" asp-route-view="@Model.Notebook.View" asp-route-query="@Model.Notebook.Query" asp-route-filter="checklists" asp-route-tag="@Model.Notebook.Tag" class="@(Model.Notebook.Filter == "checklists" ? "is-active" : "")">Checklists</a>
-        </nav>
+        @* SECTION: Toolbar view controls *@
+        <section class="notebook-viewbar" aria-label="Notebook view controls">
+            <span>@(Model.Notebook.View == "home" ? "Notes" : Model.Notebook.View)</span>
+            <div class="notebook-view-toggle" role="group" aria-label="Board layout">
+                <button type="button" data-notebook-view="grid" aria-label="Grid view"><i class="bi bi-grid-3x3-gap"></i></button>
+                <button type="button" data-notebook-view="list" aria-label="List view"><i class="bi bi-list-ul"></i></button>
+            </div>
+        </section>
 
         @* SECTION: Card-first notebook board *@
         @if (Model.Notebook.View == "labels")
@@ -86,28 +80,27 @@
 
             var sections = new[]
             {
-                (Title: "Pinned", Items: Model.Notebook.PinnedItems),
-                (Title: "Today & Overdue", Items: Model.Notebook.DueItems),
-                (Title: "Recent", Items: Model.Notebook.RecentItems)
+                (Title: "Pinned", Items: Model.Notebook.PinnedItems, AlwaysShow: false),
+                (Title: "Others", Items: Model.Notebook.RecentItems, AlwaysShow: true)
             };
 
             var hasAnyHomeItems = sections.Any(notebookSection => notebookSection.Items.Any());
 
-            @* SECTION: Home sections only show an empty state when the whole home board is empty *@
-            foreach (var notebookSection in sections.Where(notebookSection => notebookSection.Items.Any() || notebookSection.Title == "Recent"))
+            @* SECTION: Manual-order friendly home board sections *@
+            foreach (var notebookSection in sections.Where(notebookSection => notebookSection.Items.Any() || notebookSection.AlwaysShow))
             {
                 <section class="notebook-board-section">
                     <div class="notebook-section-header"><h2>@notebookSection.Title</h2><span>@notebookSection.Items.Count item(s)</span></div>
                     @if (notebookSection.Items.Any())
                     {
-                        <div class="notebook-board">
+                        <div class="notebook-board" data-notebook-board>
                             @foreach (var item in notebookSection.Items)
                             {
                                 <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
                             }
                         </div>
                     }
-                    else if (notebookSection.Title == "Recent" && !hasAnyHomeItems)
+                    else if (!hasAnyHomeItems)
                     {
                         <div class="notebook-empty notebook-empty-compact"><h3>@emptyTitle</h3><p>@emptyText</p></div>
                     }
@@ -117,7 +110,7 @@
         else
         {
             <section class="notebook-board-section">
-                <div class="notebook-board">
+                <div class="notebook-board" data-notebook-board>
                     @foreach (var item in Model.Notebook.Items)
                     {
                         <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
@@ -156,7 +149,27 @@
 
             </div>
             <div class="notebook-editor-fields" data-notebook-type-fields="Checklist">
-                <label class="notebook-field-prominent">Checklist items<textarea asp-for="ChecklistText" placeholder="One checklist item per line"></textarea></label>
+                <div class="notebook-field-prominent notebook-checklist-edit-list">
+                    <span>Checklist items</span>
+                    @if (selected?.ChecklistItems.Any() == true)
+                    {
+                        var rowIndex = 0;
+                        foreach (var row in selected.ChecklistItems)
+                        {
+                            <label class="notebook-checklist-edit-row">
+                                <input type="hidden" name="ChecklistRows[@rowIndex].Id" value="@row.Id" />
+                                <input type="hidden" name="ChecklistRows[@rowIndex].SortOrder" value="@row.SortOrder" />
+                                <input type="hidden" name="ChecklistRows[@rowIndex].IsDone" value="@(row.IsDone ? "true" : "false")" />
+                                <input name="ChecklistRows[@rowIndex].Text" value="@row.Text" maxlength="300" />
+                            </label>
+                            rowIndex++;
+                        }
+                    }
+                    else
+                    {
+                        <textarea asp-for="ChecklistText" placeholder="One checklist item per line"></textarea>
+                    }
+                </div>
                 <label data-notebook-checklist-reminder>Reminder (IST)<input asp-for="Input.ReminderLocal" type="datetime-local" /></label>
                 <label>Priority<select asp-for="Input.Priority" asp-items="Html.GetEnumSelectList<NotebookPriority>()"></select></label>
                 <label>Optional notes<textarea asp-for="Input.BodyMarkdown" data-autoresize></textarea></label>

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -132,6 +132,19 @@ public class IndexModel : PageModel
         return RedirectToPage(new { view = "archived", query = Query, selectedId = id });
     }
 
+
+    public async Task<IActionResult> OnPostDuplicateAsync(Guid id, CancellationToken ct)
+    {
+        var uid = _users.GetUserId(User);
+        if (uid is null)
+        {
+            return Unauthorized();
+        }
+
+        var copyId = await _notebook.DuplicateAsync(uid, id, ct);
+        return RedirectToCurrent(copyId);
+    }
+
     public async Task<IActionResult> OnPostDeleteAsync(Guid id, CancellationToken ct)
     {
         var uid = _users.GetUserId(User);
@@ -237,7 +250,8 @@ public class IndexModel : PageModel
             IsFavorite = selected.IsFavorite,
             ColorKey = selected.ColorKey,
             Tags = selected.Tags,
-            ChecklistItems = selected.ChecklistItems.Select(x => x.Text).ToArray()
+            ChecklistItems = selected.ChecklistItems.Select(x => x.Text).ToArray(),
+            ChecklistRows = selected.ChecklistItems.Select(x => new NotebookChecklistEditRow { Id = x.Id, Text = x.Text, IsDone = x.IsDone, SortOrder = x.SortOrder }).ToArray()
         };
         TagsText = string.Join(", ", selected.Tags);
         ChecklistText = string.Join("\n", selected.ChecklistItems.Select(x => x.Text));
@@ -250,6 +264,29 @@ public class IndexModel : PageModel
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         Input.ChecklistItems = (ChecklistText ?? string.Empty)
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // SECTION: Preserve checklist row identity when editable rows are posted.
+        Input.ChecklistRows = ReadChecklistRowsFromForm();
+    }
+
+
+    private IReadOnlyList<NotebookChecklistEditRow> ReadChecklistRowsFromForm()
+    {
+        var rowIndexes = Request.Form.Keys
+            .Where(key => key.StartsWith("ChecklistRows[", StringComparison.OrdinalIgnoreCase) && key.EndsWith("].Text", StringComparison.OrdinalIgnoreCase))
+            .Select(key => key[14..key.IndexOf(']')])
+            .Distinct()
+            .ToArray();
+
+        return rowIndexes.Select((index, fallbackOrder) => new NotebookChecklistEditRow
+            {
+                Id = int.TryParse(Request.Form[$"ChecklistRows[{index}].Id"].ToString(), out var id) ? id : null,
+                Text = Request.Form[$"ChecklistRows[{index}].Text"].ToString(),
+                IsDone = string.Equals(Request.Form[$"ChecklistRows[{index}].IsDone"].ToString(), "true", StringComparison.OrdinalIgnoreCase),
+                SortOrder = int.TryParse(Request.Form[$"ChecklistRows[{index}].SortOrder"].ToString(), out var order) ? order : fallbackOrder
+            })
+            .Where(row => !string.IsNullOrWhiteSpace(row.Text))
+            .ToArray();
     }
 
     private void NormalizeLegacyTypeView()

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -1,7 +1,7 @@
 @model ProjectManagement.ViewModels.Notebook.NotebookItemActionVm
 @using ProjectManagement.Models
 
-@* SECTION: Compact notebook card actions *@
+@* SECTION: Hover-first notebook card actions *@
 <form method="post" class="notebook-actions">
     <input type="hidden" name="id" value="@Model.Item.Id" />
     <input type="hidden" name="View" value="@Model.View" />
@@ -10,38 +10,33 @@
     <input type="hidden" name="Filter" value="@Model.Filter" />
     <input type="hidden" name="Tag" value="@Model.Tag" />
 
-    <button asp-page-handler="TogglePin" title="Pin" type="submit" class="notebook-action-icon">
+    <button asp-page-handler="TogglePin" title="@(Model.Item.IsPinned ? "Unpin" : "Pin")" aria-label="@(Model.Item.IsPinned ? "Unpin note" : "Pin note")" type="submit" class="notebook-action-icon notebook-action-pin">
         <i class="bi @(Model.Item.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
     </button>
-    <button asp-page-handler="ToggleFavorite" title="Favourite" type="submit" class="notebook-action-icon">
-        <i class="bi @(Model.Item.IsFavorite ? "bi-star-fill" : "bi-star")"></i>
-    </button>
+    <button type="button" title="Reminder" aria-label="Edit reminder" class="notebook-action-icon"><i class="bi bi-bell"></i></button>
+    <button type="button" title="Colour" aria-label="Change colour" class="notebook-action-icon"><i class="bi bi-palette"></i></button>
 
     @if (Model.Item.Type == NotebookItemType.Reminder || Model.Item.ReminderAtUtc is not null)
     {
-        <button asp-page-handler="Complete" name="isComplete" value="true" type="submit" class="notebook-action-done">
-            Done
-        </button>
+        <button asp-page-handler="Complete" name="isComplete" value="true" type="submit" class="notebook-action-done">Done</button>
     }
 
     <details class="notebook-card-more">
         <summary aria-label="More actions"><i class="bi bi-three-dots"></i></summary>
-        <div class="notebook-card-more__menu">
+        <div class="notebook-card-more__menu" role="menu">
+            <button type="button" role="menuitem">Add label</button>
+            <button asp-page-handler="Duplicate" type="submit" role="menuitem">Make a copy</button>
+            <button asp-page-handler="Convert" name="newType" value="@(Model.Item.Type == NotebookItemType.Checklist ? NotebookItemType.Note : NotebookItemType.Checklist)" type="submit" role="menuitem">@(Model.Item.Type == NotebookItemType.Checklist ? "Hide checkboxes" : "Show checkboxes")</button>
             @if (Model.Item.Status == NotebookItemStatus.Archived)
             {
-                <button asp-page-handler="Restore" type="submit">Restore</button>
+                <button asp-page-handler="Restore" type="submit" role="menuitem">Restore</button>
             }
             else
             {
-                <button asp-page-handler="Archive" type="submit">Archive</button>
+                <button asp-page-handler="Archive" type="submit" role="menuitem">Archive</button>
             }
-
-            @foreach (var type in Enum.GetValues<NotebookItemType>().Where(type => type != Model.Item.Type))
-            {
-                <button asp-page-handler="Convert" name="newType" value="@type" type="submit">Convert to @type</button>
-            }
-
-            <button asp-page-handler="Delete" class="text-danger" type="submit">Delete</button>
+            <span class="notebook-menu-separator" aria-hidden="true"></span>
+            <button asp-page-handler="Delete" class="text-danger" type="submit" role="menuitem">Delete</button>
         </div>
     </details>
 </form>

--- a/Pages/Notebook/_NotebookCard.cshtml
+++ b/Pages/Notebook/_NotebookCard.cshtml
@@ -11,11 +11,10 @@
 }
 
 @* SECTION: Notebook board card *@
-<article class="notebook-card @colorClass @(isSelected ? "is-selected" : string.Empty) @(item.ReminderAtUtc is not null ? "has-due-action" : string.Empty)">
+<article data-notebook-card-id="@item.Id" class="notebook-card @colorClass @(isSelected ? "is-selected" : string.Empty) @(item.ReminderAtUtc is not null ? "has-due-action" : string.Empty)">
     <div class="notebook-card-body">
         <a class="notebook-card-link" asp-page="/Notebook/Index" asp-route-view="@Model.View" asp-route-query="@Model.Query" asp-route-filter="@Model.Filter" asp-route-tag="@Model.Tag" asp-route-selectedId="@item.Id">
             <div class="notebook-card-topline">
-                <span class="notebook-type-chip">@item.Type</span>
                 <span class="notebook-card-indicators">
                     @if (item.IsPinned) { <i class="bi bi-pin-angle-fill" title="Pinned"></i> }
                     @if (item.IsFavorite) { <i class="bi bi-star-fill" title="Favourite"></i> }

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -45,6 +45,8 @@ public interface INotebookService
 
     Task ConvertTypeAsync(string ownerId, Guid id, NotebookItemType newType, CancellationToken ct = default);
 
+    Task<Guid> DuplicateAsync(string ownerId, Guid id, CancellationToken ct = default);
+
     Task ToggleChecklistItemAsync(string ownerId, int checklistItemId, bool isDone, CancellationToken ct = default);
 }
 
@@ -72,4 +74,17 @@ public sealed class NotebookEditInput
     public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
 
     public IReadOnlyList<string> ChecklistItems { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<NotebookChecklistEditRow> ChecklistRows { get; set; } = Array.Empty<NotebookChecklistEditRow>();
+}
+
+public sealed class NotebookChecklistEditRow
+{
+    public int? Id { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+
+    public bool IsDone { get; set; }
+
+    public int SortOrder { get; set; }
 }

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -90,9 +90,10 @@ public sealed class NotebookService : INotebookService
             .ToArray();
 
         var pinned = (await activeQuery
-                .Where(item => item.IsPinned)
-                .OrderByDescending(item => item.UpdatedAtUtc)
-                .Take(6)
+                .Where(item => item.Status == NotebookItemStatus.Active && item.IsPinned)
+                .OrderBy(item => item.SortOrder == 0 ? int.MaxValue : item.SortOrder)
+                .ThenByDescending(item => item.UpdatedAtUtc)
+                .Take(80)
                 .ToListAsync(ct))
             .Select(item => ToListVm(item, bounds))
             .ToArray();
@@ -117,17 +118,12 @@ public sealed class NotebookService : INotebookService
             .ToArray();
 
 
-        var homeShownIds = pinned.Select(item => item.Id)
-            .Concat(due.Select(item => item.Id))
-            .ToHashSet();
-
-        // SECTION: Home recent items exclude cards already shown in priority sections before limiting
+        // SECTION: Home board uses a manual-order friendly Others section.
         var recent = (await activeQuery
-                .Where(item =>
-                    item.Status == NotebookItemStatus.Active &&
-                    !homeShownIds.Contains(item.Id))
-                .OrderByDescending(item => item.UpdatedAtUtc)
-                .Take(12)
+                .Where(item => item.Status == NotebookItemStatus.Active && !item.IsPinned)
+                .OrderBy(item => item.SortOrder == 0 ? int.MaxValue : item.SortOrder)
+                .ThenByDescending(item => item.UpdatedAtUtc)
+                .Take(80)
                 .ToListAsync(ct))
             .Select(item => ToListVm(item, bounds))
             .ToArray();
@@ -268,7 +264,7 @@ public sealed class NotebookService : INotebookService
             UpdatedAtUtc = now
         };
 
-        ApplyChecklist(item, input.ChecklistItems, now);
+        ApplyChecklist(item, input.ChecklistRows.Any() ? input.ChecklistRows : input.ChecklistItems.Select((text, index) => new NotebookChecklistEditRow { Text = text, SortOrder = index }).ToArray(), now);
         _db.NotebookItems.Add(item);
         await SyncTags(item, ownerId, input.Tags, ct);
         await _db.SaveChangesAsync(ct);
@@ -289,7 +285,7 @@ public sealed class NotebookService : INotebookService
         item.ColorKey = CleanColor(input.ColorKey, input.Type);
         item.UpdatedAtUtc = _clock.UtcNow;
 
-        SyncChecklistItems(item, input.ChecklistItems, item.UpdatedAtUtc);
+        SyncChecklistItems(item, input.ChecklistRows.Any() ? input.ChecklistRows : input.ChecklistItems.Select((text, index) => new NotebookChecklistEditRow { Text = text, SortOrder = index }).ToArray(), item.UpdatedAtUtc);
         await SyncTags(item, ownerId, input.Tags, ct);
         await _db.SaveChangesAsync(ct);
         await _audit.LogAsync("Notebook.Update", userId: ownerId, data: new Dictionary<string, string?> { ["Id"] = id.ToString() });
@@ -357,6 +353,49 @@ public sealed class NotebookService : INotebookService
         await _db.SaveChangesAsync(ct);
     }
 
+
+    public async Task<Guid> DuplicateAsync(string ownerId, Guid id, CancellationToken ct = default)
+    {
+        var source = await LoadOwned(ownerId, id, ct);
+        var now = _clock.UtcNow;
+        var copy = new NotebookItem
+        {
+            OwnerId = ownerId,
+            Title = CleanTitle($"{source.Title} copy"),
+            BodyMarkdown = source.BodyMarkdown,
+            Type = source.Type,
+            Priority = source.Priority,
+            ReminderAtUtc = source.ReminderAtUtc,
+            IsPinned = source.IsPinned,
+            IsFavorite = false,
+            ColorKey = CleanColor(source.ColorKey, source.Type),
+            CreatedAtUtc = now,
+            UpdatedAtUtc = now
+        };
+
+        foreach (var row in source.ChecklistItems.OrderBy(row => row.SortOrder))
+        {
+            copy.ChecklistItems.Add(new NotebookChecklistItem
+            {
+                Text = row.Text,
+                IsDone = row.IsDone,
+                SortOrder = row.SortOrder,
+                CreatedAtUtc = now,
+                CompletedAtUtc = row.IsDone ? now : null
+            });
+        }
+
+        foreach (var tag in source.Tags.Where(tag => tag.NotebookTag is not null))
+        {
+            copy.Tags.Add(new NotebookItemTag { NotebookItem = copy, NotebookTag = tag.NotebookTag });
+        }
+
+        _db.NotebookItems.Add(copy);
+        await _db.SaveChangesAsync(ct);
+        await _audit.LogAsync("Notebook.Duplicate", userId: ownerId, data: new Dictionary<string, string?> { ["SourceId"] = id.ToString(), ["Id"] = copy.Id.ToString() });
+        return copy.Id;
+    }
+
     public async Task ToggleChecklistItemAsync(string ownerId, int checklistItemId, bool isDone, CancellationToken ct = default)
     {
         var checklistItem = await _db.NotebookChecklistItems
@@ -369,6 +408,7 @@ public sealed class NotebookService : INotebookService
 
         checklistItem.IsDone = isDone;
         checklistItem.CompletedAtUtc = isDone ? _clock.UtcNow : null;
+        checklistItem.NotebookItem!.UpdatedAtUtc = _clock.UtcNow;
         await _db.SaveChangesAsync(ct);
     }
 
@@ -667,60 +707,60 @@ public sealed class NotebookService : INotebookService
             .ToArrayAsync(ct);
     }
 
-    private static void ApplyChecklist(NotebookItem item, IReadOnlyList<string> lines, DateTimeOffset now)
+    private static void ApplyChecklist(NotebookItem item, IReadOnlyList<NotebookChecklistEditRow> rows, DateTimeOffset now)
     {
         var sortOrder = 0;
-        foreach (var line in lines.Select(line => line.Trim()).Where(line => line.Length > 0))
+        foreach (var row in rows.Where(row => !string.IsNullOrWhiteSpace(row.Text)).OrderBy(row => row.SortOrder))
         {
+            var text = row.Text.Trim();
             item.ChecklistItems.Add(new NotebookChecklistItem
             {
-                Text = line[..Math.Min(line.Length, 300)],
+                Text = text[..Math.Min(text.Length, 300)],
+                IsDone = row.IsDone,
                 SortOrder = sortOrder++,
-                CreatedAtUtc = now
+                CreatedAtUtc = now,
+                CompletedAtUtc = row.IsDone ? now : null
             });
         }
     }
 
-    private void SyncChecklistItems(NotebookItem item, IReadOnlyList<string> lines, DateTimeOffset now)
+    private void SyncChecklistItems(NotebookItem item, IReadOnlyList<NotebookChecklistEditRow> rows, DateTimeOffset now)
     {
-        var desiredLines = lines
-            .Select(line => line?.Trim())
-            .Where(line => !string.IsNullOrWhiteSpace(line))
-            .Select(line => line![..Math.Min(line.Length, 300)])
-            .ToList();
-
-        var existingItems = item.ChecklistItems
+        var requestedRows = rows
+            .Where(row => !string.IsNullOrWhiteSpace(row.Text))
             .OrderBy(row => row.SortOrder)
             .ToList();
 
-        var usedExistingIds = new HashSet<int>();
+        var existingById = item.ChecklistItems.ToDictionary(row => row.Id);
+        var requestedIds = requestedRows.Where(row => row.Id.HasValue).Select(row => row.Id!.Value).ToHashSet();
         var nextSortOrder = 0;
 
-        foreach (var desiredText in desiredLines)
+        foreach (var requested in requestedRows)
         {
-            var existing = existingItems.FirstOrDefault(row =>
-                !usedExistingIds.Contains(row.Id) &&
-                string.Equals(row.Text.Trim(), desiredText, StringComparison.OrdinalIgnoreCase));
+            var text = requested.Text.Trim();
+            text = text[..Math.Min(text.Length, 300)];
 
-            if (existing is not null)
+            if (requested.Id.HasValue && existingById.TryGetValue(requested.Id.Value, out var existing))
             {
-                existing.Text = desiredText;
+                existing.Text = text;
+                existing.IsDone = requested.IsDone;
+                existing.CompletedAtUtc = requested.IsDone ? existing.CompletedAtUtc ?? now : null;
                 existing.SortOrder = nextSortOrder++;
-                usedExistingIds.Add(existing.Id);
                 continue;
             }
 
             item.ChecklistItems.Add(new NotebookChecklistItem
             {
                 NotebookItemId = item.Id,
-                Text = desiredText,
-                IsDone = false,
+                Text = text,
+                IsDone = requested.IsDone,
                 SortOrder = nextSortOrder++,
-                CreatedAtUtc = now
+                CreatedAtUtc = now,
+                CompletedAtUtc = requested.IsDone ? now : null
             });
         }
 
-        foreach (var row in existingItems.Where(row => !usedExistingIds.Contains(row.Id)))
+        foreach (var row in item.ChecklistItems.Where(row => row.Id != 0 && !requestedIds.Contains(row.Id)).ToList())
         {
             item.ChecklistItems.Remove(row);
         }

--- a/wwwroot/css/notebook.css
+++ b/wwwroot/css/notebook.css
@@ -40,7 +40,7 @@
 .notebook-search { display: flex; align-items: center; gap: .45rem; min-width: min(340px, 100%); padding: .5rem .72rem; background: #fff; border: 1px solid #dfe7f2; border-radius: 999px; }
 .notebook-search input { width: 100%; border: 0; outline: 0; background: transparent; color: #0f172a; }
 
-.notebook-capture-panel {
+.notebook-composer {
     max-width: 760px;
     width: 100%;
     margin: 0 auto .2rem;
@@ -51,23 +51,20 @@
     padding: .45rem;
 }
 
-.notebook-capture-form { display: flex; align-items: center; gap: .35rem; }
-.notebook-capture-form input { flex: 1; border: 0; outline: 0; background: transparent; border-radius: 10px; padding: .7rem .85rem; font-size: .94rem; }
-.notebook-capture-primary { border: 0; border-radius: 999px; background: #315fba; color: #fff; padding: .58rem .9rem; font-weight: 750; }
-.notebook-capture-chip,
-.notebook-create-chip { display: inline-flex; align-items: center; gap: .32rem; border-radius: 999px; border: 1px solid #d8e2f0; background: #fff; color: #315fba; padding: .38rem .62rem; font-size: .76rem; font-weight: 650; text-decoration: none; }
-.notebook-capture-chip:hover,
-.notebook-create-chip:hover { background: #f5f9ff; color: #1d4ed8; }
-.notebook-create-row { display: flex; flex-wrap: wrap; gap: .38rem; margin-top: .35rem; padding-top: .35rem; border-top: 1px solid #eef2f7; }
+.notebook-composer__form { display: flex; align-items: center; gap: .35rem; }
+.notebook-composer__form input { flex: 1; border: 0; outline: 0; background: transparent; border-radius: 10px; padding: .78rem .85rem; font-size: .96rem; }
+.notebook-composer__checklist,
+.notebook-composer__save { display: inline-flex; align-items: center; gap: .32rem; border-radius: 999px; border: 1px solid #d8e2f0; background: #fff; color: #315fba; padding: .5rem .72rem; font-size: .78rem; font-weight: 700; }
+.notebook-composer__save { background: #315fba; border-color: #315fba; color: #fff; }
+.notebook-composer__checklist:hover { background: #f5f9ff; color: #1d4ed8; }
 
-/* SECTION: Board filters, labels and masonry */
-.notebook-filter-chips,
+/* SECTION: Board controls, labels and grid */
 .notebook-label-chips { display: flex; flex-wrap: wrap; gap: .45rem; align-items: center; }
-.notebook-filter-chips { justify-content: center; }
-.notebook-filter-chips a,
+.notebook-viewbar { display: flex; align-items: center; justify-content: space-between; gap: .75rem; color: #64748b; font-size: .78rem; font-weight: 800; text-transform: uppercase; letter-spacing: .08em; }
+.notebook-view-toggle { display: inline-flex; padding: .18rem; border: 1px solid #dce6f2; border-radius: 999px; background: #fff; }
+.notebook-view-toggle button { width: 2rem; height: 2rem; border: 0; border-radius: 999px; background: transparent; color: #64748b; }
+.notebook-view-toggle button.is-active { background: #eef5ff; color: #1d4ed8; }
 .notebook-label-chips a { border: 1px solid #dce6f2; border-radius: 999px; background: #fff; color: #475569; padding: .35rem .72rem; font-size: .78rem; font-weight: 700; text-decoration: none; }
-.notebook-filter-chips a:hover,
-.notebook-filter-chips a.is-active,
 .notebook-label-chips a:hover,
 .notebook-label-chips a.is-active { background: #eef5ff; border-color: #bfd2f1; color: #1d4ed8; }
 .notebook-label-chips span { color: #94a3b8; margin-left: .35rem; }
@@ -76,16 +73,16 @@
 .notebook-section-header { display: flex; align-items: center; justify-content: space-between; margin: .95rem 0 .5rem; }
 .notebook-section-header h2 { margin: 0; font-size: .88rem; font-weight: 700; color: #0f172a; }
 .notebook-section-header span { font-size: .74rem; color: #64748b; }
-.notebook-board { column-width: 245px; column-gap: .9rem; }
+.notebook-board { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; align-items: start; }
+.notebook-board.is-list-view { grid-template-columns: minmax(0, 760px); justify-content: center; }
 
 /* SECTION: Compact Keep-inspired cards */
 .notebook-card {
     position: relative;
     z-index: 1;
-    display: inline-block;
+    display: block;
     width: 100%;
-    margin: 0 0 .9rem;
-    break-inside: avoid;
+    margin: 0;
     overflow: visible;
     border: 1px solid #dfe5ee;
     border-radius: 12px;
@@ -110,7 +107,7 @@
 .notebook-type-chip,
 .notebook-card-meta span { display: inline-flex; align-items: center; gap: .3rem; border-radius: 999px; background: rgba(255, 255, 255, .72); border: 1px solid rgba(148, 163, 184, .28); padding: .16rem .46rem; color: #475569; font-size: .68rem; font-weight: 750; }
 .notebook-card-title { margin: .35rem 0 .25rem; font-size: .95rem; font-weight: 700; line-height: 1.28; }
-.notebook-card-preview { margin: .25rem 0 .4rem; color: #334155; font-size: .82rem; line-height: 1.38; white-space: pre-line; }
+.notebook-card-preview { margin: .25rem 0 .4rem; color: #334155; font-size: .82rem; line-height: 1.38; white-space: pre-line; display: -webkit-box; -webkit-line-clamp: 7; -webkit-box-orient: vertical; overflow: hidden; }
 .notebook-card-meta { flex-wrap: wrap; margin-top: .35rem; }
 .notebook-card-tags { display: flex; flex-wrap: wrap; gap: .3rem; margin-top: .42rem; }
 .notebook-tag-chip { border-radius: 999px; background: rgba(15, 23, 42, .06); color: #475569; padding: .15rem .42rem; font-size: .68rem; font-weight: 700; }
@@ -131,7 +128,9 @@
 .notebook-card-more summary { list-style: none; }
 .notebook-card-more summary::-webkit-details-marker { display: none; }
 .notebook-card-more__menu { position: absolute; right: 0; bottom: calc(100% + .35rem); top: auto; z-index: 120; display: grid; gap: .25rem; min-width: 180px; padding: .35rem; background: #fff; border: 1px solid #dbe4f0; border-radius: 12px; box-shadow: 0 18px 40px rgba(15,23,42,.18); }
-.notebook-card-more__menu button { width: 100%; text-align: left; }
+.notebook-card-more__menu button { width: 100%; min-height: 38px; border: 0; border-radius: 8px; background: transparent; padding: .45rem .65rem; color: #334155; text-align: left; font-weight: 650; }
+.notebook-card-more__menu button:hover { background: #f1f5f9; }
+.notebook-menu-separator { height: 1px; margin: .25rem .35rem; background: #e2e8f0; }
 
 /* SECTION: Card colors and checklist previews */
 .notebook-card-color-white { background: #fff; }
@@ -187,7 +186,6 @@
 .notebook-empty h3 { color: #0f172a; font-size: 1rem; }
 .notebook-empty-compact { padding: 1.25rem; }
 
-@media (min-width: 1600px) { .notebook-board { column-width: 265px; } }
 @media (hover: none) { .notebook-card-actions { opacity: 1; } }
-@media (max-width: 900px) { .notebook-board { column-width: auto; columns: 1; } }
-@media (max-width: 820px) { .notebook-shell { display: block; } .notebook-rail { position: static; margin-bottom: 1rem; } .notebook-commandbar, .notebook-capture-form { flex-direction: column; align-items: stretch; } .notebook-search { min-width: 0; } .notebook-editor-drawer { inset: .75rem; width: auto; border-radius: 16px; } }
+@media (max-width: 900px) { .notebook-board { grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); } }
+@media (max-width: 820px) { .notebook-shell { display: block; } .notebook-rail { position: static; margin-bottom: 1rem; } .notebook-commandbar, .notebook-composer__form { flex-direction: column; align-items: stretch; } .notebook-search { min-width: 0; } .notebook-editor-drawer { inset: .75rem; width: auto; border-radius: 16px; } }

--- a/wwwroot/js/pages/notebook-index.js
+++ b/wwwroot/js/pages/notebook-index.js
@@ -88,3 +88,31 @@
   typeSelect.addEventListener('change', updateFields);
   updateFields();
 })();
+
+// SECTION: Notebook board view preference
+(() => {
+    const storageKey = 'prism.notebook.boardView';
+    const boards = Array.from(document.querySelectorAll('[data-notebook-board]'));
+    const buttons = Array.from(document.querySelectorAll('[data-notebook-view]'));
+
+    if (!boards.length || !buttons.length) {
+        return;
+    }
+
+    const applyView = (view) => {
+        const isList = view === 'list';
+        boards.forEach((board) => board.classList.toggle('is-list-view', isList));
+        buttons.forEach((button) => button.classList.toggle('is-active', button.dataset.notebookView === view));
+    };
+
+    const savedView = window.localStorage.getItem(storageKey) || 'grid';
+    applyView(savedView);
+
+    buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const view = button.dataset.notebookView || 'grid';
+            window.localStorage.setItem(storageKey, view);
+            applyView(view);
+        });
+    });
+})();


### PR DESCRIPTION
### Motivation
- Move the notebook UI from a form-driven side-drawer workflow toward a board-first, card-centric experience with a single inline composer entry point and checklist shortcut to reduce friction when creating notes.
- Make the primary All/Notes view suitable for manual ordering and later drag-and-drop by introducing distinct Pinned and Others sections and activating `SortOrder` semantics.
- Fix checklist data correctness by preserving checklist row identity, completion state and sort order during edits rather than matching rows by text, and add basic duplication support.

### Description
- Replace the multi-chip capture UI with a board-first inline composer and add a toolbar grid/list toggle persisted in `localStorage`, implemented in `Pages/Notebook/Index.cshtml` and `wwwroot/js/pages/notebook-index.js`.
- Convert the home board to `Pinned` and `Others` sections and migrate layout from CSS multi-column to CSS Grid with a list view option in `wwwroot/css/notebook.css` and updated Razor views (`Pages/Notebook/Index.cshtml`, `_NotebookCard.cshtml`).
- Simplify card actions and the more-menu to user-facing actions (Add label, Make a copy, Show/Hide checkboxes, Archive/Restore, Delete) and move action markup into `Pages/Notebook/_NotebookActions.cshtml`.
- Add duplicate-note support and checklist-row-aware APIs and helpers by extending `INotebookService` and updating `NotebookService` to use a new `NotebookChecklistEditRow` model, preserve checklist row `Id`/`IsDone`/`SortOrder`, update parent `UpdatedAtUtc` when checklist toggles change, and adjust create/update flows to accept `ChecklistRows`.
- Keep changes CSP-safe (no inline scripts) by placing all interactive logic in `wwwroot/js/pages/notebook-index.js` and maintain server-side fallback handlers in `Pages/Notebook/Index.cshtml.cs` (including a new `OnPostDuplicateAsync` handler).

### Testing
- Automated build/test attempted with `dotnet build --no-restore` could not be executed because the `dotnet` runtime is not available in this environment, so no automated build or test run completed and no CI validation was performed.
- All code changes were committed locally (`Redesign notebook board foundation`) but no automated unit or integration tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34fb42336483298bb05bb64636bca1)