### PR TITLE
Fix notebook checklist and label actions

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -164,6 +164,13 @@
                             </label>
                             rowIndex++;
                         }
+
+                        @* SECTION: Blank checklist append row for existing checklists *@
+                        <label class="notebook-checklist-edit-row notebook-checklist-add-row">
+                            <input type="hidden" name="ChecklistRows[@rowIndex].SortOrder" value="@rowIndex" />
+                            <input type="hidden" name="ChecklistRows[@rowIndex].IsDone" value="false" />
+                            <input name="ChecklistRows[@rowIndex].Text" value="" maxlength="300" placeholder="Add another checklist item" />
+                        </label>
                     }
                     else
                     {

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -209,6 +209,12 @@ public class IndexModel : PageModel
         return RedirectToCurrent(id);
     }
 
+    public IActionResult OnPostAddLabel(Guid id)
+    {
+        // SECTION: Open the selected card editor so labels can be managed without JavaScript.
+        return RedirectToCurrent(id);
+    }
+
     public async Task<IActionResult> OnPostToggleChecklistItemAsync(
         int checklistItemId,
         bool isDone,

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -24,7 +24,7 @@
     <details class="notebook-card-more">
         <summary aria-label="More actions"><i class="bi bi-three-dots"></i></summary>
         <div class="notebook-card-more__menu" role="menu">
-            <button type="button" role="menuitem">Add label</button>
+            <button asp-page-handler="AddLabel" type="submit" role="menuitem">Add label</button>
             <button asp-page-handler="Duplicate" type="submit" role="menuitem">Make a copy</button>
             <button asp-page-handler="Convert" name="newType" value="@(Model.Item.Type == NotebookItemType.Checklist ? NotebookItemType.Note : NotebookItemType.Checklist)" type="submit" role="menuitem">@(Model.Item.Type == NotebookItemType.Checklist ? "Hide checkboxes" : "Show checkboxes")</button>
             @if (Model.Item.Status == NotebookItemStatus.Archived)


### PR DESCRIPTION
### Motivation
- Allow users to add a new checklist row when editing an existing checklist without relying on JavaScript.
- Make the card "Add label" action functional in a non-JS context by routing it to server-side handling.
- Improve UX by opening the selected card editor so labels can be managed safely and accessibly.

### Description
- Added a blank append row to the checklist editor in `Pages/Notebook/Index.cshtml` so an extra empty input is submitted for existing checklists.
- Updated the more-menu in `Pages/Notebook/_NotebookActions.cshtml` to submit the "Add label" action to an `AddLabel` page handler instead of an inert button.
- Implemented an `OnPostAddLabel(Guid id)` handler in `Pages/Notebook/Index.cshtml.cs` that redirects to the current page with the selected ID so the editor opens for label management.

### Testing
- Ran `git diff --check`, which completed cleanly.
- Attempted `dotnet test`, but it could not be executed in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3513d31bb08329bb88e852dca5929d)