### PR TITLE
Notebook: add version-aware updates, restore action, and editor field sync

### DIFF
--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -57,14 +57,28 @@ public sealed class NotebookController : Controller
     {
         var validation = ValidateRequest(request);
         if (validation is not null) return validation;
-        var existing = await _notebook.GetDetailAsync(CurrentUserId(), id, ct);
+        var uid = CurrentUserId();
+        var existing = await _notebook.GetDetailAsync(uid, id, ct);
         if (existing is null) return NotFound();
-        if (!string.IsNullOrWhiteSpace(request.Version) && !string.Equals(existing.Version, request.Version, StringComparison.OrdinalIgnoreCase))
+
+        try
         {
-            return Conflict(new { message = "This note was changed in another tab. Reload the latest version before continuing.", version = existing.Version });
+            if (!string.IsNullOrWhiteSpace(request.Version))
+            {
+                await _notebook.UpdateAsync(uid, id, ToInput(request), request.Version, ct);
+            }
+            else
+            {
+                await _notebook.UpdateAsync(uid, id, ToInput(request), ct);
+            }
         }
-        await _notebook.UpdateAsync(CurrentUserId(), id, ToInput(request), ct);
-        return Ok(ToResponse((await _notebook.GetDetailAsync(CurrentUserId(), id, ct))!));
+        catch (Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException)
+        {
+            var latest = await _notebook.GetDetailAsync(uid, id, ct);
+            return Conflict(new { message = "This note was changed in another tab. Reload the latest version before continuing.", version = latest?.Version });
+        }
+
+        return Ok(ToResponse((await _notebook.GetDetailAsync(uid, id, ct))!));
     }
 
     [HttpPost("{id:guid}/pin")]

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -25,6 +25,10 @@
             <button asp-page-handler="Convert" name="newType" value="@(Model.Item.Type == NotebookItemType.Checklist ? NotebookItemType.Note : NotebookItemType.Checklist)" type="submit" role="menuitem">@(Model.Item.Type == NotebookItemType.Checklist ? "Hide checkboxes" : "Show checkboxes")</button>
             @if (Model.Item.Status == NotebookItemStatus.Archived)
             {
+                <button asp-page-handler="Restore" type="submit" role="menuitem" data-action="restore-note">Restore</button>
+            }
+            else if (Model.Item.Status == NotebookItemStatus.Completed)
+            {
                 <button asp-page-handler="Complete" name="isComplete" value="false" type="submit" role="menuitem" data-action="reopen-note">Reopen</button>
             }
             else

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -30,6 +30,8 @@ public interface INotebookService
 
     Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, CancellationToken ct = default);
 
+    Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string expectedVersion, CancellationToken ct = default);
+
     Task ArchiveAsync(string ownerId, Guid id, CancellationToken ct = default);
 
     Task RestoreAsync(string ownerId, Guid id, CancellationToken ct = default);

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -268,9 +268,15 @@ public sealed class NotebookService : INotebookService
         return item.Id;
     }
 
-    public async Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, CancellationToken ct = default)
+    public Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, CancellationToken ct = default) =>
+        UpdateAsync(ownerId, id, input, expectedVersion: null, ct);
+
+    public async Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string expectedVersion, CancellationToken ct = default) =>
+        await UpdateAsync(ownerId, id, input, string.IsNullOrWhiteSpace(expectedVersion) ? null : expectedVersion, ct);
+
+    private async Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string? expectedVersion, CancellationToken ct)
     {
-        var item = await LoadOwned(ownerId, id, ct);
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
         item.Title = CleanTitle(input.Title);
         item.BodyMarkdown = input.BodyMarkdown;
         item.Type = input.Type;
@@ -486,6 +492,42 @@ public sealed class NotebookService : INotebookService
                 item.OwnerId == ownerId &&
                 item.DeletedAtUtc == null,
                 ct) ?? throw new KeyNotFoundException();
+
+
+    private async Task<NotebookItem> LoadOwnedForUpdate(string ownerId, Guid id, string? expectedVersion, CancellationToken ct)
+    {
+        var query = _db.NotebookItems
+            .Include(item => item.Tags)
+                .ThenInclude(itemTag => itemTag.NotebookTag)
+            .Include(item => item.ChecklistItems)
+            .Where(item =>
+                item.Id == id &&
+                item.OwnerId == ownerId &&
+                item.DeletedAtUtc == null);
+
+        if (!string.IsNullOrWhiteSpace(expectedVersion))
+        {
+            query = Guid.TryParse(expectedVersion, out var parsedVersion)
+                ? query.Where(item => item.Version == parsedVersion)
+                : query.Where(item => false);
+        }
+
+        var item = await query.FirstOrDefaultAsync(ct);
+        if (item is not null)
+        {
+            return item;
+        }
+
+        var exists = await _db.NotebookItems.AnyAsync(item =>
+            item.Id == id &&
+            item.OwnerId == ownerId &&
+            item.DeletedAtUtc == null,
+            ct);
+
+        throw exists && !string.IsNullOrWhiteSpace(expectedVersion)
+            ? new DbUpdateConcurrencyException("The notebook item version no longer matches the submitted version.")
+            : new KeyNotFoundException();
+    }
 
     private static string CleanTitle(string title)
     {

--- a/wwwroot/js/pages/notebook-index.js
+++ b/wwwroot/js/pages/notebook-index.js
@@ -3,10 +3,34 @@ import { initNotebookApp } from '../notebook/notebook-app.js';
 
 // SECTION: Legacy textarea autosize and board view preference
 function initLegacyNotebookEnhancements() {
+  // SECTION: Textarea sizing helpers
   document.querySelectorAll('[data-autoresize]').forEach((textarea) => {
     const resize = () => { textarea.style.height = 'auto'; textarea.style.height = `${textarea.scrollHeight}px`; };
     textarea.addEventListener('input', resize); resize();
   });
+
+  // SECTION: Drawer type-specific editor fields
+  const typeSelect = document.querySelector('[data-notebook-type-select]');
+  const fieldGroups = Array.from(document.querySelectorAll('[data-notebook-type-fields]'));
+  const normalize = (value) => (value || '').toString().trim().toLowerCase();
+  const selectedTypeName = () => normalize(typeSelect?.options[typeSelect.selectedIndex]?.text || typeSelect?.value);
+  const setGroupEnabled = (group, isEnabled) => {
+    group.hidden = !isEnabled;
+    group.querySelectorAll('input, select, textarea, button').forEach((control) => { control.disabled = !isEnabled; });
+  };
+  const updateFields = () => {
+    const selected = selectedTypeName();
+    fieldGroups.forEach((group) => {
+      const allowedTypes = (group.dataset.notebookTypeFields || '').split(',').map(normalize);
+      setGroupEnabled(group, allowedTypes.includes(selected));
+    });
+  };
+  if (typeSelect && fieldGroups.length) {
+    typeSelect.addEventListener('change', updateFields);
+    updateFields();
+  }
+
+  // SECTION: Lightweight server-rendered form helpers
   document.querySelectorAll('[data-submit-on-change]').forEach((input) => input.addEventListener('change', () => input.form?.submit()));
   const root = document.querySelector('.notebook-shell');
   const saved = localStorage.getItem('notebook-board-view') || 'grid';


### PR DESCRIPTION
### Motivation
- Prevent stale asynchronous edits from silently overwriting newer notebook data by validating the submitted version as part of the write path and surface conflicts when versions diverge.
- Restore the notebook editor UX that shows/hides type-specific fields (and disables inactive controls) in a CSP-safe external script so server-rendered forms behave correctly.
- Make archived item actions use `Restore` while keeping completed item reopen behavior distinct to avoid ambiguous UI behavior.

### Description
- Added a version-aware overload `UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string expectedVersion, CancellationToken ct)` to `INotebookService` while preserving the original signature.
- Implemented the overload in `NotebookService` and introduced a private `LoadOwnedForUpdate` helper that validates `expectedVersion` (parses GUID) and throws `DbUpdateConcurrencyException` when the stored version no longer matches.
- Updated `Controllers/Api/NotebookController.Update` to call the version-aware update and catch `DbUpdateConcurrencyException` to return `409 Conflict` including the latest version in the response.
- Restored the drawer type-field synchronizer in `wwwroot/js/pages/notebook-index.js` so groups tagged with `data-notebook-type-fields` are hidden/disabled when not applicable, and updated `Pages/Notebook/_NotebookActions.cshtml` to route archived items to `Restore` while preserving reopen logic for completed items.

### Testing
- Ran `git diff --check` which completed without errors.
- Attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed, so build verification is pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3559f2388c83299996b3ed5fdb6caa)