### PR TITLE
Fix notebook update build errors

### DIFF
--- a/Contracts/Notebook/NotebookContracts.cs
+++ b/Contracts/Notebook/NotebookContracts.cs
@@ -5,7 +5,7 @@ using ProjectManagement.Services.Notebook;
 namespace ProjectManagement.Contracts.Notebook;
 
 // SECTION: Notebook API request contracts
-public sealed class CreateNotebookItemRequest
+public class CreateNotebookItemRequest
 {
     [StringLength(200)] public string? Title { get; set; }
     [StringLength(20000)] public string? Body { get; set; }

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -269,12 +269,12 @@ public sealed class NotebookService : INotebookService
     }
 
     public Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, CancellationToken ct = default) =>
-        UpdateAsync(ownerId, id, input, expectedVersion: null, ct);
+        UpdateCoreAsync(ownerId, id, input, expectedVersion: null, ct);
 
     public async Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string expectedVersion, CancellationToken ct = default) =>
-        await UpdateAsync(ownerId, id, input, string.IsNullOrWhiteSpace(expectedVersion) ? null : expectedVersion, ct);
+        await UpdateCoreAsync(ownerId, id, input, string.IsNullOrWhiteSpace(expectedVersion) ? null : expectedVersion, ct);
 
-    private async Task UpdateAsync(string ownerId, Guid id, NotebookEditInput input, string? expectedVersion, CancellationToken ct)
+    private async Task UpdateCoreAsync(string ownerId, Guid id, NotebookEditInput input, string? expectedVersion, CancellationToken ct)
     {
         var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
         item.Title = CleanTitle(input.Title);


### PR DESCRIPTION
### Motivation
- Resolve two compiler errors: `CS0509` caused by inheriting from a sealed request type, and `CS0111` caused by a private `UpdateAsync` conflicting with public overloads.

### Description
- Made `CreateNotebookItemRequest` non-sealed so `UpdateNotebookItemRequest` can inherit shared fields (`Contracts/Notebook/NotebookContracts.cs`).
- Renamed the private nullable-version helper from `UpdateAsync` to `UpdateCoreAsync` and updated the public overloads to call it to avoid signature collision (`Services/Notebook/NotebookService.cs`).

### Testing
- Attempted to run `dotnet build` but the `dotnet` CLI is not available in this environment so a build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355bf814248329b2cb6178b5bf47b0)