### PR TITLE
Restore test-overridable GetNowIst in Dashboard IndexModel

### DIFF
--- a/Pages/Dashboard/Index.cshtml.cs
+++ b/Pages/Dashboard/Index.cshtml.cs
@@ -83,6 +83,13 @@ namespace ProjectManagement.Pages.Dashboard
             public bool IsHoliday { get; set; }
         }
 
+        // SECTION: Testable dashboard clock
+        internal virtual DateTimeOffset GetNowIst()
+        {
+            return TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, IST);
+        }
+        // END SECTION
+
 
         public async Task OnGetAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
### Motivation
- Unit tests define `TestableIndexModel.GetNowIst()` as `internal override`, and the base `IndexModel` lacked a matching virtual method which caused CS0115 errors, so a test-overridable clock helper is required.

### Description
- Added an `internal virtual DateTimeOffset GetNowIst()` helper to `Pages/Dashboard/Index.cshtml.cs` that returns `TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, IST)` and included section comments to mark the testable clock.
- The method is `internal` and `virtual` to exactly match the test subclass's `internal override` and preserve existing runtime behavior.

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj --no-restore --filter DashboardPageTests` but the `dotnet` CLI is not installed in this environment, so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355d8b1488832998a3578e60346308)