### PR TITLE
Add missing Analytics namespace import to DashboardPageTests

### DIFF
--- a/ProjectManagement.Tests/DashboardPageTests.cs
+++ b/ProjectManagement.Tests/DashboardPageTests.cs
@@ -22,6 +22,7 @@ using ProjectManagement.Data;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Models;
 using ProjectManagement.Pages.Dashboard;
+using ProjectManagement.Services.Analytics;
 using ProjectManagement.Services.Dashboard;
 using ProjectManagement.Services.Notebook;
 using ProjectManagement.Services.Projects;


### PR DESCRIPTION
### Motivation
- Tests in `ProjectManagement.Tests/DashboardPageTests.cs` referenced `StageDistributionResult` and `StageDistributionItem` which were not resolving due to a missing analytics namespace import.  

### Description
- Added the `using ProjectManagement.Services.Analytics;` directive to `ProjectManagement.Tests/DashboardPageTests.cs` so analytics DTO records resolve correctly.  

### Testing
- Attempted to run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj`, but the `dotnet` CLI is not available in the environment so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35629291c88329adc6c6f87c788da1)