### PR TITLE
Fix notebook Version migration and concurrency safeguards

### DIFF
--- a/Controllers/Api/NotebookApiExceptionFilter.cs
+++ b/Controllers/Api/NotebookApiExceptionFilter.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Services.Notebook;
 
 namespace ProjectManagement.Controllers.Api;
 
@@ -13,6 +14,12 @@ public sealed class NotebookApiExceptionFilter : IAsyncExceptionFilter
         {
             KeyNotFoundException => new NotFoundResult(),
             ArgumentException => new BadRequestObjectResult(new { message = "The notebook request is invalid." }),
+            NotebookConcurrencyException ex => new ConflictObjectResult(new
+            {
+                code = "notebook_concurrency_conflict",
+                message = "This note was changed elsewhere. Reload the latest version before continuing.",
+                currentVersion = ex.CurrentVersion.ToString("N")
+            }),
             DbUpdateConcurrencyException => new ConflictObjectResult(new
             {
                 code = "notebook_concurrency_conflict",

--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -58,15 +58,17 @@ public sealed class NotebookController : Controller
     {
         var validation = ValidateRequest(request);
         if (validation is not null) return validation;
+        if (!Guid.TryParse(request.Version, out var parsedVersion) || parsedVersion == Guid.Empty)
+        {
+            return BadRequest(new
+            {
+                code = "notebook_version_required",
+                message = "A valid notebook version is required before saving an existing note."
+            });
+        }
+
         var uid = CurrentUserId();
-        if (!string.IsNullOrWhiteSpace(request.Version))
-        {
-            await _notebook.UpdateAsync(uid, id, ToInput(request), request.Version, ct);
-        }
-        else
-        {
-            await _notebook.UpdateAsync(uid, id, ToInput(request), ct);
-        }
+        await _notebook.UpdateAsync(uid, id, ToInput(request), parsedVersion.ToString("N"), ct);
 
         return Ok(ToResponse((await _notebook.GetDetailAsync(uid, id, ct))!));
     }

--- a/Migrations/20261125231000_AddNotebookItemVersion.cs
+++ b/Migrations/20261125231000_AddNotebookItemVersion.cs
@@ -1,11 +1,14 @@
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
 
 #nullable disable
 
 namespace ProjectManagement.Migrations
 {
-    /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125231000_AddNotebookItemVersion")]
     public partial class AddNotebookItemVersion : Migration
     {
         /// <inheritdoc />
@@ -16,14 +19,28 @@ namespace ProjectManagement.Migrations
                 name: "Version",
                 table: "NotebookItems",
                 type: "uuid",
-                nullable: false,
-                defaultValue: Guid.Empty);
+                nullable: true);
+
+            // SECTION: Existing row version backfill
+            migrationBuilder.Sql("""
+                CREATE EXTENSION IF NOT EXISTS pgcrypto;
+                """);
 
             migrationBuilder.Sql("""
                 UPDATE "NotebookItems"
                 SET "Version" = gen_random_uuid()
-                WHERE "Version" = '00000000-0000-0000-0000-000000000000';
+                WHERE "Version" IS NULL
+                   OR "Version" = '00000000-0000-0000-0000-000000000000';
                 """);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "Version",
+                table: "NotebookItems",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
         }
 
         /// <inheritdoc />

--- a/Migrations/20261125232000_RepairMissingNotebookItemVersion.cs
+++ b/Migrations/20261125232000_RepairMissingNotebookItemVersion.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261125232000_RepairMissingNotebookItemVersion")]
+    public partial class RepairMissingNotebookItemVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // SECTION: Idempotent Notebook Version schema repair
+            migrationBuilder.Sql("""
+                CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+                ALTER TABLE "NotebookItems"
+                ADD COLUMN IF NOT EXISTS "Version" uuid;
+
+                UPDATE "NotebookItems"
+                SET "Version" = gen_random_uuid()
+                WHERE "Version" IS NULL
+                   OR "Version" = '00000000-0000-0000-0000-000000000000';
+
+                ALTER TABLE "NotebookItems"
+                ALTER COLUMN "Version" SET NOT NULL;
+                """);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // SECTION: Repair migration rollback intentionally preserves Version
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -673,19 +673,41 @@ using (var scope = app.Services.CreateScope())
     if (db.Database.IsRelational())
     {
         databaseIsRelational = true;
-        await db.Database.MigrateAsync();
 
-        var applied = (await db.Database.GetAppliedMigrationsAsync()).ToList();
-        latestAppliedMigration = applied.Count > 0 ? applied[^1] : "(none)";
+        // SECTION: Startup database identity and migration gate
+        var connection = db.Database.GetDbConnection();
+        app.Logger.LogInformation(
+            "Database provider: {Provider}; Server: {Server}; Database: {Database}",
+            db.Database.ProviderName,
+            connection.DataSource,
+            connection.Database);
 
         pendingMigrations = (await db.Database.GetPendingMigrationsAsync()).ToList();
         if (pendingMigrations.Count > 0)
         {
             var message = $"Database has {pendingMigrations.Count} pending migration(s): {string.Join(", ", pendingMigrations)}";
             app.Logger.LogCritical(message);
+
+            if (!app.Environment.IsDevelopment())
+            {
+                throw new InvalidOperationException(message);
+            }
+
+            await db.Database.MigrateAsync();
+            pendingMigrations = (await db.Database.GetPendingMigrationsAsync()).ToList();
+        }
+
+        var applied = (await db.Database.GetAppliedMigrationsAsync()).ToList();
+        latestAppliedMigration = applied.Count > 0 ? applied[^1] : "(none)";
+
+        if (pendingMigrations.Count > 0)
+        {
+            var message = $"Database still has {pendingMigrations.Count} pending migration(s): {string.Join(", ", pendingMigrations)}";
+            app.Logger.LogCritical(message);
             throw new InvalidOperationException(message);
         }
 
+        await EnsureNotebookVersionSchemaAsync(db, app.Logger);
         await EnsureDocRepoFavouritesSchemaAsync(db, app.Logger);
         await ProjectDocumentSearchVectorMaintenance.EnsureUpToDateAsync(db);
     }
@@ -2429,6 +2451,84 @@ using (var scope = app.Services.CreateScope())
 
     await ProjectManagement.Data.StageFlowSeeder.SeedAsync(services);
     await ProjectManagement.Data.IdentitySeeder.SeedAsync(services);
+}
+
+
+static async Task EnsureNotebookVersionSchemaAsync(ApplicationDbContext db, ILogger logger)
+{
+    if (!db.Database.IsRelational())
+    {
+        return;
+    }
+
+    // SECTION: Validate Notebook migration ordering and schema compatibility
+    var migrations = (await db.Database.GetAppliedMigrationsAsync()).ToList();
+    var moduleIndex = migrations.FindIndex(x => x.EndsWith("_AddNotebookModule", StringComparison.Ordinal));
+    var versionIndex = migrations.FindIndex(x => x.EndsWith("_AddNotebookItemVersion", StringComparison.Ordinal));
+
+    if (moduleIndex < 0 || versionIndex < 0 || moduleIndex >= versionIndex)
+    {
+        var message = "Required Notebook migrations are missing or out of order. AddNotebookModule must precede AddNotebookItemVersion.";
+        logger.LogCritical(message);
+        throw new InvalidOperationException(message);
+    }
+
+    var connection = db.Database.GetDbConnection();
+    var shouldClose = false;
+    if (connection.State != ConnectionState.Open)
+    {
+        await connection.OpenAsync();
+        shouldClose = true;
+    }
+
+    try
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = db.Database.IsNpgsql()
+            ? """
+              SELECT EXISTS (
+                  SELECT 1
+                  FROM information_schema.columns
+                  WHERE table_schema = 'public'
+                    AND table_name = 'NotebookItems'
+                    AND column_name = 'Version'
+                    AND data_type = 'uuid'
+                    AND is_nullable = 'NO'
+              );
+              """
+            : """
+              SELECT CASE WHEN EXISTS (
+                  SELECT 1
+                  FROM information_schema.columns
+                  WHERE table_name = 'NotebookItems'
+                    AND column_name = 'Version'
+                    AND is_nullable = 'NO'
+              ) THEN 1 ELSE 0 END;
+              """;
+
+        var result = await command.ExecuteScalarAsync();
+        var valid = result switch
+        {
+            bool boolean => boolean,
+            int number => number == 1,
+            long number => number == 1,
+            _ => false
+        };
+
+        if (!valid)
+        {
+            var message = "Notebook schema is incompatible: NotebookItems.Version must exist as a non-null uuid column.";
+            logger.LogCritical(message);
+            throw new InvalidOperationException(message);
+        }
+    }
+    finally
+    {
+        if (shouldClose)
+        {
+            await connection.CloseAsync();
+        }
+    }
 }
 
 static async Task EnsureDocRepoFavouritesSchemaAsync(ApplicationDbContext db, ILogger logger)

--- a/ProjectManagement.Tests/NotebookConcurrencyTests.cs
+++ b/ProjectManagement.Tests/NotebookConcurrencyTests.cs
@@ -1,0 +1,30 @@
+using ProjectManagement.Controllers.Api;
+using ProjectManagement.Services.Notebook;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+
+namespace ProjectManagement.Tests;
+
+public sealed class NotebookConcurrencyTests
+{
+    [Fact]
+    public async Task Notebook_filter_maps_stale_version_to_conflict_with_current_version()
+    {
+        // SECTION: API concurrency response regression guard
+        var currentVersion = Guid.NewGuid();
+        var filter = new NotebookApiExceptionFilter();
+        var context = new ExceptionContext(new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor()), [])
+        {
+            Exception = new NotebookConcurrencyException(Guid.NewGuid(), Guid.NewGuid(), currentVersion)
+        };
+
+        await filter.OnExceptionAsync(context);
+
+        var result = Assert.IsType<ConflictObjectResult>(context.Result);
+        Assert.True(context.ExceptionHandled);
+        Assert.Contains(currentVersion.ToString("N"), result.Value!.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/ProjectManagement.Tests/NotebookMigrationTests.cs
+++ b/ProjectManagement.Tests/NotebookMigrationTests.cs
@@ -1,0 +1,64 @@
+using System.Text.RegularExpressions;
+
+namespace ProjectManagement.Tests;
+
+public sealed class NotebookMigrationTests
+{
+    [Fact]
+    public void Notebook_version_migration_sorts_after_module_migration()
+    {
+        // SECTION: Migration order regression guard
+        var migrations = Directory.EnumerateFiles(GetRepoRoot(), "*.cs", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(name => name is not null && Regex.IsMatch(name, @"^\d{14}_"))
+            .Select(name => name!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var module = Assert.Single(migrations.Where(name => name.EndsWith("_AddNotebookModule", StringComparison.Ordinal)));
+        var version = Assert.Single(migrations.Where(name => name.EndsWith("_AddNotebookItemVersion", StringComparison.Ordinal)));
+
+        Assert.True(string.CompareOrdinal(module, version) < 0, $"{module} must sort before {version}.");
+    }
+
+    [Fact]
+    public void Notebook_version_migration_backfills_before_enforcing_not_null()
+    {
+        // SECTION: Existing database upgrade regression guard
+        var migration = File.ReadAllText(Path.Combine(GetRepoRoot(), "20261125231000_AddNotebookItemVersion.cs"));
+
+        Assert.Contains("nullable: true", migration, StringComparison.Ordinal);
+        Assert.Contains("CREATE EXTENSION IF NOT EXISTS pgcrypto", migration, StringComparison.Ordinal);
+        Assert.Contains("SET \"Version\" = gen_random_uuid()", migration, StringComparison.Ordinal);
+        Assert.Contains("OR \"Version\" = '00000000-0000-0000-0000-000000000000'", migration, StringComparison.Ordinal);
+        Assert.Contains("nullable: false", migration, StringComparison.Ordinal);
+        Assert.DoesNotContain("defaultValue: Guid.Empty", migration, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Notebook_version_repair_migration_is_idempotent()
+    {
+        // SECTION: Retained database repair guard
+        var migration = File.ReadAllText(Path.Combine(GetRepoRoot(), "20261125232000_RepairMissingNotebookItemVersion.cs"));
+
+        Assert.Contains("ADD COLUMN IF NOT EXISTS \"Version\" uuid", migration, StringComparison.Ordinal);
+        Assert.Contains("ALTER COLUMN \"Version\" SET NOT NULL", migration, StringComparison.Ordinal);
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrWhiteSpace(current))
+        {
+            var migrations = Path.Combine(current, "Migrations");
+            if (Directory.Exists(migrations))
+            {
+                return migrations;
+            }
+
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate the repository Migrations directory.");
+    }
+}

--- a/Services/Notebook/NotebookConcurrencyException.cs
+++ b/Services/Notebook/NotebookConcurrencyException.cs
@@ -1,0 +1,19 @@
+namespace ProjectManagement.Services.Notebook;
+
+// SECTION: Notebook optimistic concurrency exception
+public sealed class NotebookConcurrencyException : Exception
+{
+    public NotebookConcurrencyException(Guid itemId, Guid expectedVersion, Guid currentVersion)
+        : base("The notebook item version no longer matches the submitted version.")
+    {
+        ItemId = itemId;
+        ExpectedVersion = expectedVersion;
+        CurrentVersion = currentVersion;
+    }
+
+    public Guid ItemId { get; }
+
+    public Guid ExpectedVersion { get; }
+
+    public Guid CurrentVersion { get; }
+}

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -508,26 +508,21 @@ public sealed class NotebookService : INotebookService
 
         if (!string.IsNullOrWhiteSpace(expectedVersion))
         {
-            query = Guid.TryParse(expectedVersion, out var parsedVersion)
-                ? query.Where(item => item.Version == parsedVersion)
-                : query.Where(item => false);
-        }
+            if (!Guid.TryParse(expectedVersion, out var parsedVersion) || parsedVersion == Guid.Empty)
+            {
+                throw new ArgumentException("A valid notebook version is required.", nameof(expectedVersion));
+            }
 
-        var item = await query.FirstOrDefaultAsync(ct);
-        if (item is not null)
-        {
+            var item = await query.FirstOrDefaultAsync(ct) ?? throw new KeyNotFoundException();
+            if (item.Version != parsedVersion)
+            {
+                throw new NotebookConcurrencyException(id, parsedVersion, item.Version);
+            }
+
             return item;
         }
 
-        var exists = await _db.NotebookItems.AnyAsync(item =>
-            item.Id == id &&
-            item.OwnerId == ownerId &&
-            item.DeletedAtUtc == null,
-            ct);
-
-        throw exists && !string.IsNullOrWhiteSpace(expectedVersion)
-            ? new DbUpdateConcurrencyException("The notebook item version no longer matches the submitted version.")
-            : new KeyNotFoundException();
+        return await query.FirstOrDefaultAsync(ct) ?? throw new KeyNotFoundException();
     }
 
     private static string CleanTitle(string title)


### PR DESCRIPTION
### Motivation
- The app crashed with `PostgresException: column n.Version does not exist` due to an out-of-order/incorrect Notebook migration and missing runtime checks.  
- We must reconcile the EF model (mapped `Version` concurrency token) with the physical schema, populate valid UUIDs for existing rows, and prevent fresh or running deployments from proceeding with inconsistent migrations.  
- Updates to the Notebook aggregate must always rotate the `Version` and provide clear concurrency responses (HTTP 409) instead of silent failures.

### Description
- Reworked `AddNotebookItemVersion` migration so it is discoverable by EF (`[DbContext]/[Migration]`) and performs a safe staged change: add nullable `Version` column, backfill with `gen_random_uuid()` (creates `pgcrypto` if required), then alter to non-nullable (file: `Migrations/20261125231000_AddNotebookItemVersion.cs`).
- Added an idempotent repair migration `RepairMissingNotebookItemVersion` that conditionally adds/populates the `Version` column and sets it NOT NULL for retained databases where history/schema are inconsistent (`Migrations/20261125232000_RepairMissingNotebookItemVersion.cs`).
- Added startup checks and logging: log safe DB identity, detect pending migrations and fail in non-development environments (auto-apply in Development if accepted), and run `EnsureNotebookVersionSchemaAsync` to validate the `NotebookItems.Version` column exists as non-null `uuid` before serving traffic (`Program.cs`).
- Enforced update contracts: require a valid `Version` on API `PATCH` updates and return `400` when missing/invalid (`Controllers/Api/NotebookController.cs`).
- Implemented domain concurrency handling: added `NotebookConcurrencyException`, changed `LoadOwnedForUpdate` to validate and compare expected `Version` and throw `NotebookConcurrencyException` on mismatch, and mapped that exception to a `409 Conflict` with `currentVersion` in the API exception filter (`Services/Notebook/NotebookConcurrencyException.cs`, `Services/Notebook/NotebookService.cs`, `Controllers/Api/NotebookApiExceptionFilter.cs`).
- Centralized mutation touches were already present (`Touch`), and create/duplicate flows continue to set `Version = Guid.NewGuid()` as part of object construction and mutations.
- Added regression/unit tests that guard migration ordering and behaviour and verify API concurrency error mapping (`ProjectManagement.Tests/NotebookMigrationTests.cs`, `ProjectManagement.Tests/NotebookConcurrencyTests.cs`).

### Testing
- Added automated tests: `ProjectManagement.Tests/NotebookMigrationTests.cs` (migration-order and backfill/repair assertions) and `ProjectManagement.Tests/NotebookConcurrencyTests.cs` (API exception mapping), but the test run was not executed in this environment.  
- Ran repository validation: `git diff --check` (succeeded).  
- Attempted `dotnet ef migrations list --no-build` but the `dotnet` CLI was unavailable in the container so EF CLI commands and full test runs could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3564f5ed1483299a21dfb3a35764ab)