### PR TITLE
Notebook: bind expectedVersion for Update and include hidden version in legacy form

### DIFF
--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -154,6 +154,11 @@
             <input type="hidden" asp-for="Query" />
             <input type="hidden" asp-for="Filter" />
             <input type="hidden" asp-for="Tag" />
+            @* SECTION: Preserve optimistic concurrency version for legacy form edits *@
+            @if (selected is not null)
+            {
+                <input type="hidden" name="expectedVersion" value="@selected.Version" />
+            }
             <label class="notebook-title-field">Title<input asp-for="Input.Title" class="notebook-editor-title-input" required maxlength="220" /></label>
             <section class="notebook-editor-primary">
             <div class="notebook-editor-fields" data-notebook-type-fields="Note,Idea,Draft">

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -105,7 +105,7 @@ public class IndexModel : PageModel
         return RedirectToCurrent(SelectedId);
     }
 
-    public async Task<IActionResult> OnPostUpdateAsync(Guid id, CancellationToken ct)
+    public async Task<IActionResult> OnPostUpdateAsync(Guid id, Guid expectedVersion, CancellationToken ct)
     {
         var uid = _users.GetUserId(User);
         if (uid is null)
@@ -114,7 +114,7 @@ public class IndexModel : PageModel
         }
 
         HydrateInput();
-        await _notebook.UpdateAsync(uid, id, Input, ct);
+        await _notebook.UpdateAsync(uid, id, Input, expectedVersion, ct);
         return RedirectToCurrent(id);
     }
 


### PR DESCRIPTION
### Motivation
- Fix the mismatch between the page handler and the `INotebookService.UpdateAsync` contract so the optimistic-concurrency `expectedVersion` (a `Guid`) is passed instead of a `CancellationToken` being bound as the fourth argument.

### Description
- Change the page handler signature to `OnPostUpdateAsync(Guid id, Guid expectedVersion, CancellationToken ct)` and pass `expectedVersion` into `_notebook.UpdateAsync(uid, id, Input, expectedVersion, ct)` to match `INotebookService.UpdateAsync`.
- Add a hidden `expectedVersion` input to the legacy editor form (`Index.cshtml`) when a `selected` item exists so the posted form includes the optimistic-concurrency token.
- Add a short section comment near the new hidden field to document why the field is present.

### Testing
- Attempted to run `dotnet build` but the `dotnet` CLI is not available in this environment, so no automated build or test run was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35de30ba408329a002ac6286e44a30)