### PR TITLE
Notebook: Reliable mutations — antiforgery, partial-success handling, versioning and idempotent create

### DIFF
--- a/Contracts/Notebook/NotebookContracts.cs
+++ b/Contracts/Notebook/NotebookContracts.cs
@@ -24,6 +24,9 @@ public class CreateNotebookItemRequest
     public List<NotebookChecklistEditRow> ChecklistRows { get; set; } = [];
     [Required]
     public List<string> Labels { get; set; } = [];
+
+    [Required]
+    public Guid ClientRequestId { get; set; }
 }
 
 public sealed class UpdateNotebookItemRequest : CreateNotebookItemRequest
@@ -38,6 +41,22 @@ public sealed class SetNotebookPinRequest : NotebookVersionedRequest
 }
 
 public sealed class ConvertNotebookItemRequest : NotebookVersionedRequest
+{
+}
+
+public sealed class ArchiveNotebookItemRequest : NotebookVersionedRequest
+{
+}
+
+public sealed class CompleteNotebookItemRequest : NotebookVersionedRequest
+{
+}
+
+public sealed class ReopenNotebookItemRequest : NotebookVersionedRequest
+{
+}
+
+public sealed class RestoreNotebookItemRequest : NotebookVersionedRequest
 {
 }
 
@@ -83,4 +102,15 @@ public sealed class NotebookItemResponse
     public List<NotebookChecklistRowResponse> ChecklistRows { get; set; } = [];
     public List<NotebookLabelResponse> Labels { get; set; } = [];
     public Guid Version { get; set; }
+}
+
+
+// SECTION: Notebook composite mutation responses
+public sealed class NotebookMutationResponse
+{
+    public NotebookItemResponse Item { get; init; } = default!;
+
+    public string? CardHtml { get; init; }
+
+    public IReadOnlyDictionary<string, int>? Counts { get; init; }
 }

--- a/Controllers/Api/NotebookApiExceptionFilter.cs
+++ b/Controllers/Api/NotebookApiExceptionFilter.cs
@@ -12,8 +12,8 @@ public sealed class NotebookApiExceptionFilter : IAsyncExceptionFilter
     {
         context.Result = context.Exception switch
         {
-            KeyNotFoundException => new NotFoundResult(),
-            ArgumentException => new BadRequestObjectResult(new { message = "The notebook request is invalid." }),
+            KeyNotFoundException => new NotFoundObjectResult(new { code = "notebook_not_found", message = "The note could not be found." }),
+            ArgumentException => new BadRequestObjectResult(new { code = "notebook_validation_failed", message = "The notebook request is invalid." }),
             NotebookConcurrencyException ex => new ConflictObjectResult(new
             {
                 code = "notebook_concurrency_conflict",

--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -54,9 +54,10 @@ public sealed class NotebookController : Controller
     {
         var validation = ValidateRequest(request);
         if (validation is not null) return validation;
-        var id = await _notebook.CreateAsync(CurrentUserId(), ToInput(request), ct);
-        var item = await _notebook.GetDetailAsync(CurrentUserId(), id, ct);
-        return CreatedAtAction(nameof(Get), new { id }, ToResponse(item!));
+        var uid = CurrentUserId();
+        var id = await _notebook.CreateAsync(uid, ToInput(request), ct);
+        var item = await _notebook.GetDetailAsync(uid, id, ct);
+        return CreatedAtAction(nameof(Get), new { id }, await BuildMutationResponseAsync(item!, includeCard: true, ct));
     }
 
     [HttpPatch("{id:guid}")]
@@ -86,31 +87,48 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.SetPinnedAsync(CurrentUserId(), id, request.IsPinned, request.Version, ct);
-        return Ok(ToResponse(updated));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/archive")]
-    public async Task<IActionResult> Archive(Guid id, CancellationToken ct) { await _notebook.ArchiveAsync(CurrentUserId(), id, ct); return NoContent(); }
+    public async Task<IActionResult> Archive(Guid id, [FromBody] ArchiveNotebookItemRequest request, CancellationToken ct)
+    {
+        if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
+        var updated = await _notebook.ArchiveAsync(CurrentUserId(), id, request.Version, ct);
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
+    }
 
     [HttpPost("{id:guid}/complete")]
-    public async Task<IActionResult> Complete(Guid id, CancellationToken ct) { await _notebook.CompleteAsync(CurrentUserId(), id, true, ct); return NoContent(); }
+    public async Task<IActionResult> Complete(Guid id, [FromBody] CompleteNotebookItemRequest request, CancellationToken ct)
+    {
+        if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
+        var updated = await _notebook.CompleteAsync(CurrentUserId(), id, true, request.Version, ct);
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
+    }
 
     [HttpPost("{id:guid}/reopen")]
-    public async Task<IActionResult> Reopen(Guid id, CancellationToken ct) { await _notebook.ReopenAsync(CurrentUserId(), id, ct); return NoContent(); }
+    public async Task<IActionResult> Reopen(Guid id, [FromBody] ReopenNotebookItemRequest request, CancellationToken ct)
+    {
+        if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
+        var updated = await _notebook.ReopenAsync(CurrentUserId(), id, request.Version, ct);
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
+    }
 
 
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> Delete(Guid id, [FromBody] DeleteNotebookItemRequest? request, CancellationToken ct)
     {
-        await _notebook.DeleteAsync(CurrentUserId(), id, ct);
-        return NoContent();
+        if (request is null || request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
+        var updated = await _notebook.DeleteAsync(CurrentUserId(), id, request.Version, ct);
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
     }
 
     [HttpPost("{id:guid}/restore")]
-    public async Task<IActionResult> Restore(Guid id, CancellationToken ct)
+    public async Task<IActionResult> Restore(Guid id, [FromBody] RestoreNotebookItemRequest request, CancellationToken ct)
     {
-        await _notebook.RestoreAsync(CurrentUserId(), id, ct);
-        return Ok(ToResponse((await _notebook.GetDetailAsync(CurrentUserId(), id, ct))!));
+        if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
+        var updated = await _notebook.RestoreAsync(CurrentUserId(), id, request.Version, ct);
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/show-checkboxes")]
@@ -161,6 +179,7 @@ public sealed class NotebookController : Controller
         ReminderAtUtc = request.ReminderAtUtc,
         ColorKey = request.ColorKey,
         IsPinned = request.IsPinned,
+        ClientRequestId = request.ClientRequestId == Guid.Empty ? null : request.ClientRequestId,
         Tags = request.Labels ?? [],
         ChecklistRows = request.ChecklistRows ?? []
     };
@@ -186,6 +205,17 @@ public sealed class NotebookController : Controller
         return null;
     }
 
+
+    private async Task<NotebookMutationResponse> BuildMutationResponseAsync(NotebookItemDetailVm item, bool includeCard, CancellationToken ct)
+    {
+        return new NotebookMutationResponse
+        {
+            Item = ToResponse(item),
+            CardHtml = null,
+            Counts = await _notebook.GetCountsAsync(CurrentUserId(), ct)
+        };
+    }
+
     private static object ApiError(string code, string message, string field, string error) => new { code, message, errors = new Dictionary<string, string[]> { [field] = new[] { error } } };
 
     private static NotebookItemResponse ToResponse(NotebookItemDetailVm item) => new()
@@ -201,7 +231,7 @@ public sealed class NotebookController : Controller
         ReminderAtUtc = item.ReminderAtUtc,
         ReminderDisplay = item.ReminderDisplay,
         UpdatedAtUtc = item.UpdatedAtUtc,
-        Version = Guid.TryParse(item.Version, out var version) ? version : Guid.Empty,
+        Version = item.Version,
         ChecklistRows = item.ChecklistItems.Select(row => new NotebookChecklistRowResponse { Id = row.Id, Text = row.Text, IsDone = row.IsDone, SortOrder = row.SortOrder }).ToList(),
         Labels = item.Tags.Select(tag => new NotebookLabelResponse { Name = tag }).ToList()
     };

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -215,6 +215,7 @@ namespace ProjectManagement.Data
                 entity.HasIndex(x => new { x.OwnerId, x.IsPinned, x.UpdatedAtUtc });
                 entity.HasIndex(x => new { x.OwnerId, x.ReminderAtUtc });
                 entity.HasIndex(x => new { x.OwnerId, x.LegacyTodoItemId });
+                entity.HasIndex(x => new { x.OwnerId, x.ClientRequestId }).IsUnique().HasFilter("\"ClientRequestId\" IS NOT NULL");
                 entity.HasIndex(x => x.DeletedAtUtc);
                 entity.Property(x => x.Type).HasConversion<byte>();
                 entity.Property(x => x.Status).HasConversion<byte>();

--- a/Migrations/20261126090000_AddNotebookClientRequestId.cs
+++ b/Migrations/20261126090000_AddNotebookClientRequestId.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20261126090000_AddNotebookClientRequestId")]
+    public partial class AddNotebookClientRequestId : Migration
+    {
+        // SECTION: Add idempotency key for Notebook creates
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ClientRequestId",
+                table: "NotebookItems",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotebookItems_OwnerId_ClientRequestId",
+                table: "NotebookItems",
+                columns: new[] { "OwnerId", "ClientRequestId" },
+                unique: true,
+                filter: "\"ClientRequestId\" IS NOT NULL");
+        }
+
+        // SECTION: Remove idempotency key for Notebook creates
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NotebookItems_OwnerId_ClientRequestId",
+                table: "NotebookItems");
+
+            migrationBuilder.DropColumn(
+                name: "ClientRequestId",
+                table: "NotebookItems");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -8177,6 +8177,7 @@ namespace ProjectManagement.Migrations
                     b.Property<bool>("IsFavorite").HasColumnType("boolean");
                     b.Property<bool>("IsPinned").HasColumnType("boolean");
                     b.Property<Guid?>("LegacyTodoItemId").HasColumnType("uuid");
+                    b.Property<Guid?>("ClientRequestId").HasColumnType("uuid");
                     b.Property<string>("OwnerId").IsRequired().HasColumnType("text");
                     b.Property<byte>("Priority").HasColumnType("smallint");
                     b.Property<DateTimeOffset?>("ReminderAtUtc").HasColumnType("timestamp with time zone");
@@ -8190,6 +8191,7 @@ namespace ProjectManagement.Migrations
                     b.HasIndex("DeletedAtUtc");
                     b.HasIndex("OwnerId", "IsPinned", "UpdatedAtUtc");
                     b.HasIndex("OwnerId", "LegacyTodoItemId");
+                    b.HasIndex("OwnerId", "ClientRequestId").IsUnique().HasFilter("\"ClientRequestId\" IS NOT NULL");
                     b.HasIndex("OwnerId", "ReminderAtUtc");
                     b.HasIndex("OwnerId", "Status", "Type");
                     b.ToTable("NotebookItems");

--- a/Models/NotebookItem.cs
+++ b/Models/NotebookItem.cs
@@ -64,6 +64,8 @@ public class NotebookItem
 
     public Guid? LegacyTodoItemId { get; set; }
 
+    public Guid? ClientRequestId { get; set; }
+
     public DateTimeOffset CreatedAtUtc { get; set; }
 
     [ConcurrencyCheck]

--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -28,6 +28,10 @@
 @section Styles { <link rel="stylesheet" href="~/css/notebook.css" asp-append-version="true" /> }
 
 <div class="notebook-shell @(Model.UseLegacyEditor ? "has-editor" : "editor-collapsed")" data-board-view="grid">
+    @* SECTION: Dedicated anti-forgery token for Notebook API mutations *@
+    <div id="notebook-antiforgery-token" hidden>
+        @Html.AntiForgeryToken()
+    </div>
     <aside class="notebook-rail" aria-label="Notebook views">
         <div class="notebook-rail__brand"><i class="bi bi-journal-bookmark"></i><span>My Notebook</span></div>
         @foreach (var item in Model.Notebook.RailItems)

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -221,9 +221,9 @@ public class IndexModel : PageModel
         if (newType is not null)
         {
             var current = await _notebook.GetDetailAsync(uid, id, ct);
-            if (current is not null && Guid.TryParse(current.Version, out var version))
+            if (current is not null)
             {
-                await _notebook.ConvertTypeAsync(uid, id, newType.Value, version, ct);
+                await _notebook.ConvertTypeAsync(uid, id, newType.Value, current.Version, ct);
             }
         }
 

--- a/ProjectManagement.Tests/DashboardPageTests.cs
+++ b/ProjectManagement.Tests/DashboardPageTests.cs
@@ -193,13 +193,25 @@ namespace ProjectManagement.Tests
             public Task ArchiveAsync(string ownerId, Guid id, CancellationToken ct = default) =>
                 throw new NotImplementedException();
 
+            public Task<NotebookItemDetailVm> ArchiveAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default) =>
+                throw new NotImplementedException();
+
             public Task RestoreAsync(string ownerId, Guid id, CancellationToken ct = default) =>
+                throw new NotImplementedException();
+
+            public Task<NotebookItemDetailVm> RestoreAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default) =>
                 throw new NotImplementedException();
 
             public Task ReopenAsync(string ownerId, Guid id, CancellationToken ct = default) =>
                 throw new NotImplementedException();
 
+            public Task<NotebookItemDetailVm> ReopenAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default) =>
+                throw new NotImplementedException();
+
             public Task DeleteAsync(string ownerId, Guid id, CancellationToken ct = default) =>
+                throw new NotImplementedException();
+
+            public Task<NotebookItemDetailVm> DeleteAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default) =>
                 throw new NotImplementedException();
 
             public Task TogglePinAsync(string ownerId, Guid id, CancellationToken ct = default) =>
@@ -215,6 +227,9 @@ namespace ProjectManagement.Tests
                 throw new NotImplementedException();
 
             public Task CompleteAsync(string ownerId, Guid id, bool isComplete, CancellationToken ct = default) =>
+                throw new NotImplementedException();
+
+            public Task<NotebookItemDetailVm> CompleteAsync(string ownerId, Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct = default) =>
                 throw new NotImplementedException();
 
             public Task<NotebookItemDetailVm> ConvertTypeAsync(string ownerId, Guid id, NotebookItemType newType, Guid expectedVersion, CancellationToken ct = default) =>

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -34,11 +34,19 @@ public interface INotebookService
 
     Task ArchiveAsync(string ownerId, Guid id, CancellationToken ct = default);
 
+    Task<NotebookItemDetailVm> ArchiveAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default);
+
     Task RestoreAsync(string ownerId, Guid id, CancellationToken ct = default);
+
+    Task<NotebookItemDetailVm> RestoreAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default);
 
     Task ReopenAsync(string ownerId, Guid id, CancellationToken ct = default);
 
+    Task<NotebookItemDetailVm> ReopenAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default);
+
     Task DeleteAsync(string ownerId, Guid id, CancellationToken ct = default);
+
+    Task<NotebookItemDetailVm> DeleteAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default);
 
     Task TogglePinAsync(string ownerId, Guid id, CancellationToken ct = default);
 
@@ -49,6 +57,8 @@ public interface INotebookService
     Task ToggleFavoriteAsync(string ownerId, Guid id, CancellationToken ct = default);
 
     Task CompleteAsync(string ownerId, Guid id, bool isComplete, CancellationToken ct = default);
+
+    Task<NotebookItemDetailVm> CompleteAsync(string ownerId, Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct = default);
 
     Task<NotebookItemDetailVm> ConvertTypeAsync(string ownerId, Guid id, NotebookItemType newType, Guid expectedVersion, CancellationToken ct = default);
 
@@ -85,6 +95,8 @@ public sealed class NotebookEditInput
     public IReadOnlyList<string> ChecklistItems { get; set; } = Array.Empty<string>();
 
     public IReadOnlyList<NotebookChecklistEditRow> ChecklistRows { get; set; } = Array.Empty<NotebookChecklistEditRow>();
+
+    public Guid? ClientRequestId { get; set; }
 }
 
 public sealed class NotebookChecklistEditRow

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using ProjectManagement.Data;
 using ProjectManagement.Infrastructure;
 using ProjectManagement.Models;
@@ -14,12 +15,14 @@ public sealed class NotebookService : INotebookService
     private readonly IAuditService _audit;
     private readonly IClock _clock;
     private readonly ApplicationDbContext _db;
+    private readonly ILogger<NotebookService> _logger;
 
-    public NotebookService(ApplicationDbContext db, IAuditService audit, IClock clock)
+    public NotebookService(ApplicationDbContext db, IAuditService audit, IClock clock, ILogger<NotebookService> logger)
     {
         _db = db;
         _audit = audit;
         _clock = clock;
+        _logger = logger;
     }
 
     // SECTION: Read model composition
@@ -264,6 +267,22 @@ public sealed class NotebookService : INotebookService
 
     public async Task<Guid> CreateAsync(string ownerId, NotebookEditInput input, CancellationToken ct = default)
     {
+        if (input.ClientRequestId is Guid clientRequestId)
+        {
+            var existing = await _db.NotebookItems
+                .AsNoTracking()
+                .FirstOrDefaultAsync(item =>
+                    item.OwnerId == ownerId &&
+                    item.ClientRequestId == clientRequestId &&
+                    item.DeletedAtUtc == null,
+                    ct);
+
+            if (existing is not null)
+            {
+                return existing.Id;
+            }
+        }
+
         var now = _clock.UtcNow;
         var item = new NotebookItem
         {
@@ -278,14 +297,15 @@ public sealed class NotebookService : INotebookService
             ColorKey = CleanColor(input.ColorKey, input.Type),
             CreatedAtUtc = now,
             UpdatedAtUtc = now,
-            Version = Guid.NewGuid()
+            Version = Guid.NewGuid(),
+            ClientRequestId = input.ClientRequestId
         };
 
         ApplyChecklist(item, input.ChecklistRows.Any() ? input.ChecklistRows : input.ChecklistItems.Select((text, index) => new NotebookChecklistEditRow { Text = text, SortOrder = index }).ToArray(), now);
         _db.NotebookItems.Add(item);
         await SyncTags(item, ownerId, input.Tags, ct);
         await _db.SaveChangesAsync(ct);
-        await _audit.LogAsync("Notebook.Create", userId: ownerId, data: new Dictionary<string, string?> { ["Id"] = item.Id.ToString() });
+        await TryWriteAuditAsync("Notebook.Create", ownerId, item.Id, ct);
         return item.Id;
     }
 
@@ -308,45 +328,60 @@ public sealed class NotebookService : INotebookService
         SyncChecklistItems(item, input.ChecklistRows.Any() ? input.ChecklistRows : input.ChecklistItems.Select((text, index) => new NotebookChecklistEditRow { Text = text, SortOrder = index }).ToArray(), item.UpdatedAtUtc);
         await SyncTags(item, ownerId, input.Tags, ct);
         await _db.SaveChangesAsync(ct);
-        await _audit.LogAsync("Notebook.Update", userId: ownerId, data: new Dictionary<string, string?> { ["Id"] = id.ToString() });
+        await TryWriteAuditAsync("Notebook.Update", ownerId, item.Id, ct);
         return MapDetail(item);
     }
 
     public async Task ArchiveAsync(string ownerId, Guid id, CancellationToken ct = default)
     {
         var item = await LoadOwned(ownerId, id, ct);
-        item.Status = NotebookItemStatus.Archived;
-        item.ArchivedAtUtc = _clock.UtcNow;
-        Touch(item, item.ArchivedAtUtc.Value);
-        await _db.SaveChangesAsync(ct);
-        await _audit.LogAsync("Notebook.Archive", userId: ownerId);
+        await ArchiveLoadedAsync(item, ownerId, ct);
+    }
+
+    public async Task<NotebookItemDetailVm> ArchiveAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default)
+    {
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
+        await ArchiveLoadedAsync(item, ownerId, ct);
+        return MapDetail(item);
     }
 
     public async Task RestoreAsync(string ownerId, Guid id, CancellationToken ct = default)
     {
         var item = await LoadOwned(ownerId, id, ct);
-        item.Status = NotebookItemStatus.Active;
-        item.ArchivedAtUtc = null;
-        Touch(item, _clock.UtcNow);
-        await _db.SaveChangesAsync(ct);
+        await RestoreLoadedAsync(item, ct);
+    }
+
+    public async Task<NotebookItemDetailVm> RestoreAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default)
+    {
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
+        await RestoreLoadedAsync(item, ct);
+        return MapDetail(item);
     }
 
     public async Task ReopenAsync(string ownerId, Guid id, CancellationToken ct = default)
     {
         var item = await LoadOwned(ownerId, id, ct);
-        item.Status = NotebookItemStatus.Active;
-        item.CompletedAtUtc = null;
-        Touch(item, _clock.UtcNow);
-        await _db.SaveChangesAsync(ct);
+        await ReopenLoadedAsync(item, ct);
+    }
+
+    public async Task<NotebookItemDetailVm> ReopenAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default)
+    {
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
+        await ReopenLoadedAsync(item, ct);
+        return MapDetail(item);
     }
 
     public async Task DeleteAsync(string ownerId, Guid id, CancellationToken ct = default)
     {
         var item = await LoadOwned(ownerId, id, ct);
-        item.DeletedAtUtc = _clock.UtcNow;
-        Touch(item, item.DeletedAtUtc.Value);
-        await _db.SaveChangesAsync(ct);
-        await _audit.LogAsync("Notebook.Delete", userId: ownerId);
+        await DeleteLoadedAsync(item, ownerId, ct);
+    }
+
+    public async Task<NotebookItemDetailVm> DeleteAsync(string ownerId, Guid id, Guid expectedVersion, CancellationToken ct = default)
+    {
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
+        await DeleteLoadedAsync(item, ownerId, ct);
+        return MapDetail(item);
     }
 
     public async Task TogglePinAsync(string ownerId, Guid id, CancellationToken ct = default)
@@ -377,11 +412,14 @@ public sealed class NotebookService : INotebookService
     public async Task CompleteAsync(string ownerId, Guid id, bool isComplete, CancellationToken ct = default)
     {
         var item = await LoadOwned(ownerId, id, ct);
-        item.Status = isComplete ? NotebookItemStatus.Completed : NotebookItemStatus.Active;
-        var now = _clock.UtcNow;
-        item.CompletedAtUtc = isComplete ? now : null;
-        Touch(item, now);
-        await _db.SaveChangesAsync(ct);
+        await CompleteLoadedAsync(item, isComplete, ct);
+    }
+
+    public async Task<NotebookItemDetailVm> CompleteAsync(string ownerId, Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct = default)
+    {
+        var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
+        await CompleteLoadedAsync(item, isComplete, ct);
+        return MapDetail(item);
     }
 
     public async Task<NotebookItemDetailVm> ConvertTypeAsync(string ownerId, Guid id, NotebookItemType newType, Guid expectedVersion, CancellationToken ct = default)
@@ -509,6 +547,61 @@ public sealed class NotebookService : INotebookService
     }
 
     // SECTION: Helpers
+
+
+    private async Task ArchiveLoadedAsync(NotebookItem item, string ownerId, CancellationToken ct)
+    {
+        item.Status = NotebookItemStatus.Archived;
+        item.ArchivedAtUtc = _clock.UtcNow;
+        Touch(item, item.ArchivedAtUtc.Value);
+        await _db.SaveChangesAsync(ct);
+        await TryWriteAuditAsync("Notebook.Archive", ownerId, item.Id, ct);
+    }
+
+    private async Task RestoreLoadedAsync(NotebookItem item, CancellationToken ct)
+    {
+        item.Status = NotebookItemStatus.Active;
+        item.ArchivedAtUtc = null;
+        Touch(item, _clock.UtcNow);
+        await _db.SaveChangesAsync(ct);
+    }
+
+    private async Task ReopenLoadedAsync(NotebookItem item, CancellationToken ct)
+    {
+        item.Status = NotebookItemStatus.Active;
+        item.CompletedAtUtc = null;
+        Touch(item, _clock.UtcNow);
+        await _db.SaveChangesAsync(ct);
+    }
+
+    private async Task DeleteLoadedAsync(NotebookItem item, string ownerId, CancellationToken ct)
+    {
+        item.DeletedAtUtc = _clock.UtcNow;
+        Touch(item, item.DeletedAtUtc.Value);
+        await _db.SaveChangesAsync(ct);
+        await TryWriteAuditAsync("Notebook.Delete", ownerId, item.Id, ct);
+    }
+
+    private async Task CompleteLoadedAsync(NotebookItem item, bool isComplete, CancellationToken ct)
+    {
+        item.Status = isComplete ? NotebookItemStatus.Completed : NotebookItemStatus.Active;
+        var now = _clock.UtcNow;
+        item.CompletedAtUtc = isComplete ? now : null;
+        Touch(item, now);
+        await _db.SaveChangesAsync(ct);
+    }
+
+    private async Task TryWriteAuditAsync(string action, string ownerId, Guid itemId, CancellationToken ct)
+    {
+        try
+        {
+            await _audit.LogAsync(action, userId: ownerId, data: new Dictionary<string, string?> { ["Id"] = itemId.ToString() });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Notebook action {Action} succeeded for item {ItemId}, but audit logging failed.", action, itemId);
+        }
+    }
 
     private static void Touch(NotebookItem item, DateTimeOffset now)
     {
@@ -716,7 +809,7 @@ public sealed class NotebookService : INotebookService
         IsFavorite = item.IsFavorite,
         ColorKey = item.ColorKey ?? "white",
         UpdatedAtUtc = item.UpdatedAtUtc,
-        Version = item.Version.ToString("N"),
+        Version = item.Version,
         Tags = item.Tags
             .Select(tag => tag.NotebookTag?.Name ?? string.Empty)
             .Where(tag => tag.Length > 0)

--- a/ViewModels/Notebook/NotebookViewModels.cs
+++ b/ViewModels/Notebook/NotebookViewModels.cs
@@ -83,7 +83,7 @@ public class NotebookItemListVm
 
     public bool IsDueToday { get; set; }
 
-    public string Version { get; set; } = string.Empty;
+    public Guid Version { get; set; }
 }
 
 public sealed class NotebookItemDetailVm : NotebookItemListVm

--- a/wwwroot/js/notebook/notebook-api.js
+++ b/wwwroot/js/notebook/notebook-api.js
@@ -1,23 +1,73 @@
 // SECTION: Notebook API error type and fetch wrapper
 export class NotebookApiError extends Error {
-  constructor(message, { status = 0, code = null, errors = null } = {}) {
-    super(message); this.name = 'NotebookApiError'; this.status = status; this.code = code; this.errors = errors;
+  constructor(message, { status = 0, code = null, errors = null, responseText = null } = {}) {
+    super(message);
+    this.name = 'NotebookApiError';
+    this.status = status;
+    this.code = code;
+    this.errors = errors;
+    this.responseText = responseText;
   }
 }
-const token = () => document.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
-async function request(url, options = {}) {
-  const headers = { Accept: 'application/json', ...(options.headers || {}) };
-  if (!(options.body instanceof FormData) && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
-  if (token()) headers.RequestVerificationToken = token();
-  let response;
-  try { response = await fetch(url, { credentials: 'same-origin', ...options, headers }); }
-  catch (error) { throw new NotebookApiError('Unable to reach the notebook service.', { status: 0, errors: error }); }
-  if (response.status === 204) return null;
-  const contentType = response.headers.get('content-type') || '';
-  const payload = contentType.includes('application/json') ? await response.json() : await response.text();
-  if (!response.ok) throw new NotebookApiError(payload?.message || payload?.error || 'The notebook operation failed.', { status: response.status, code: payload?.code, errors: payload?.errors });
-  return payload;
+
+// SECTION: Anti-forgery token handling
+function getAntiForgeryToken() {
+  const tokenInput = document.querySelector('#notebook-antiforgery-token input[name="__RequestVerificationToken"]');
+  const value = tokenInput?.value?.trim();
+  if (!value) {
+    throw new NotebookApiError('Notebook security token is unavailable. Refresh the page and try again.', {
+      status: 0,
+      code: 'notebook_antiforgery_missing'
+    });
+  }
+  return value;
 }
+
+function isUnsafeMethod(method) {
+  const normalised = (method || 'GET').toUpperCase();
+  return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(normalised);
+}
+
+function getDefaultNotebookErrorMessage(status) {
+  switch (status) {
+    case 400: return 'The notebook request was invalid.';
+    case 401: return 'Your session has expired. Sign in again.';
+    case 403: return 'You do not have permission to perform this action.';
+    case 404: return 'The note could not be found.';
+    case 409: return 'This note was changed elsewhere. Reload the latest version.';
+    case 500: return 'The notebook operation could not be completed.';
+    default: return `Notebook request failed with HTTP ${status}.`;
+  }
+}
+
+// SECTION: Fetch wrapper and API surface
+async function request(url, options = {}) {
+  const method = (options.method || 'GET').toUpperCase();
+  const headers = { Accept: 'application/json', ...(options.headers || {}) };
+  if (!(options.body instanceof FormData) && options.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
+  if (isUnsafeMethod(method)) headers.RequestVerificationToken = getAntiForgeryToken();
+
+  let response;
+  try { response = await fetch(url, { credentials: 'same-origin', ...options, method, headers }); }
+  catch (error) { throw new NotebookApiError('The notebook service could not be reached.', { status: 0, code: 'notebook_network_error', errors: error }); }
+  if (response.status === 204) return null;
+
+  const contentType = response.headers.get('content-type') || '';
+  let payload = null; let rawText = null;
+  if (contentType.includes('application/json')) payload = await response.json();
+  else rawText = await response.text();
+
+  if (!response.ok) {
+    throw new NotebookApiError(payload?.message || payload?.title || payload?.error || getDefaultNotebookErrorMessage(response.status), {
+      status: response.status,
+      code: payload?.code,
+      errors: payload?.errors,
+      responseText: rawText
+    });
+  }
+  return payload ?? rawText;
+}
+
 export const NotebookApi = {
   createItem: (payload) => request('/api/notebook/items', { method: 'POST', body: JSON.stringify(payload) }),
   getItem: (id) => request(`/api/notebook/items/${id}`),

--- a/wwwroot/js/notebook/notebook-app.js
+++ b/wwwroot/js/notebook/notebook-app.js
@@ -10,11 +10,13 @@ export function initNotebookApp() {
   const view = new URL(location.href).searchParams.get('view') || 'home';
   const board = createNotebookBoard(shell);
   const editor = initNotebookEditor(board, view, { shell });
-  const composer = initNotebookComposer(shell.querySelector('[data-notebook-composer]'), board, view);
+  let composer;
   const globalError = document.querySelector('[data-notebook-global-error]');
   const globalErrorText = document.querySelector('[data-notebook-global-error-text]');
   const showGlobalError = (message) => { if (!globalError || !globalErrorText) { shell.dataset.error = message || 'Notebook action failed.'; return; } globalErrorText.textContent = message || 'Notebook action failed.'; globalError.hidden = false; };
-  const refreshCounts = async () => { const counts = await NotebookApi.getCounts(); Object.entries(counts).forEach(([key, value]) => shell.querySelectorAll(`[data-notebook-count="${key}"]`).forEach((el) => { el.textContent = String(value); })); };
+  const applyCounts = (counts) => { if (!counts) return; Object.entries(counts).forEach(([key, value]) => shell.querySelectorAll(`[data-notebook-count="${key}"]`).forEach((el) => { el.textContent = String(value); })); };
+  const refreshCounts = async () => applyCounts(await NotebookApi.getCounts());
+  composer = initNotebookComposer(shell.querySelector('[data-notebook-composer]'), board, view, { showGlobalError, applyCounts });
   document.querySelector('[data-notebook-global-error-close]')?.addEventListener('click', () => { globalError.hidden = true; globalErrorText.textContent = ''; });
   const storageKey = 'notebook.boardView';
   const viewButtons = [...shell.querySelectorAll('[data-notebook-view]')];
@@ -29,9 +31,12 @@ export function initNotebookApp() {
     if (action.dataset.action === 'toggle-checklist' && card) {
       event.preventDefault(); action.disabled = true;
       try {
-        const updated = await NotebookApi.toggleChecklistItem(card.dataset.noteId, action.dataset.rowId, action.dataset.isDone !== 'true', card.dataset.version);
-        const html = await NotebookApi.getCardHtml(card.dataset.noteId, view);
+        const updatedResponse = await NotebookApi.toggleChecklistItem(card.dataset.noteId, action.dataset.rowId, action.dataset.isDone !== 'true', card.dataset.version);
+        const updated = updatedResponse.item || updatedResponse;
+        updateCardConcurrencyState(card, updated);
+        const html = updatedResponse.cardHtml || await NotebookApi.getCardHtml(card.dataset.noteId, view);
         board.upsertCard(card.dataset.noteId, html, updated.isPinned, { preservePosition: true });
+        applyCounts(updatedResponse.counts);
         editor.syncExternalUpdate?.(updated);
       } catch (error) { showGlobalError(error.message || 'Checklist update failed.'); }
       finally { action.disabled = false; }
@@ -39,13 +44,22 @@ export function initNotebookApp() {
     if (['pin-note','archive-note','complete-note','reopen-note','restore-note','duplicate-note','delete-note','convert-note'].includes(action.dataset.action) && id) {
       event.preventDefault(); action.disabled = true;
       try {
-        if (action.dataset.action === 'pin-note') { const updated = await NotebookApi.setPinned(id, card.dataset.isPinned !== 'true', card.dataset.version); const html = await NotebookApi.getCardHtml(id, view); board.upsertCard(id, html, updated.isPinned, { preservePosition: false, prepend: true }); }
-        if (action.dataset.action === 'archive-note') { await NotebookApi.archiveItem(id, card.dataset.version); board.removeCard(id); }
-        if (action.dataset.action === 'complete-note') { await NotebookApi.completeItem(id, card.dataset.version); board.removeCard(id); }
-        if (action.dataset.action === 'reopen-note') { await NotebookApi.reopenItem(id, card.dataset.version); board.removeCard(id); }
-        if (action.dataset.action === 'restore-note') { await NotebookApi.restoreItem(id, card.dataset.version); board.removeCard(id); }
+        if (action.dataset.action === 'pin-note') {
+          const updatedResponse = await NotebookApi.setPinned(id, card.dataset.isPinned !== 'true', card.dataset.version);
+          const updated = updatedResponse.item || updatedResponse;
+          updateCardConcurrencyState(card, updated);
+          try {
+            const html = updatedResponse.cardHtml || await NotebookApi.getCardHtml(id, view);
+            board.upsertCard(id, html, updated.isPinned, { preservePosition: false, prepend: true });
+            applyCounts(updatedResponse.counts);
+          } catch (refreshError) { showGlobalError(`The note was ${updated.isPinned ? 'pinned' : 'unpinned'}, but the board could not refresh. Reload the page.`); }
+        }
+        if (action.dataset.action === 'archive-note') { const response = await NotebookApi.archiveItem(id, card.dataset.version); board.removeCard(id); applyCounts(response?.counts); }
+        if (action.dataset.action === 'complete-note') { const response = await NotebookApi.completeItem(id, card.dataset.version); board.removeCard(id); applyCounts(response?.counts); }
+        if (action.dataset.action === 'reopen-note') { const response = await NotebookApi.reopenItem(id, card.dataset.version); board.removeCard(id); applyCounts(response?.counts); }
+        if (action.dataset.action === 'restore-note') { const response = await NotebookApi.restoreItem(id, card.dataset.version); board.removeCard(id); applyCounts(response?.counts); }
         if (action.dataset.action === 'duplicate-note') { const copy = await NotebookApi.duplicateItem(id); const html = await NotebookApi.getCardHtml(copy.id, view); board.upsertCard(copy.id, html, copy.isPinned, { prepend: true }); }
-        if (action.dataset.action === 'delete-note') { await NotebookApi.deleteItem(id, card.dataset.version); board.removeCard(id); }
+        if (action.dataset.action === 'delete-note') { const response = await NotebookApi.deleteItem(id, card.dataset.version); board.removeCard(id); applyCounts(response?.counts); }
         if (action.dataset.action === 'convert-note') { const converted = action.dataset.convertTo === 'Checklist' ? await NotebookApi.showCheckboxes(id, card.dataset.version) : await NotebookApi.hideCheckboxes(id, card.dataset.version); const html = await NotebookApi.getCardHtml(id, view); board.upsertCard(id, html, converted.isPinned, { preservePosition: true }); }
         if (['archive-note','complete-note','reopen-note','restore-note','duplicate-note','delete-note'].includes(action.dataset.action)) await refreshCounts();
       } catch (error) { showGlobalError(error.message || 'Notebook action failed.'); }
@@ -55,4 +69,12 @@ export function initNotebookApp() {
   document.addEventListener('keydown', async (event) => { if (event.key !== 'Escape') return; if (editor.isOpen()) { event.preventDefault(); await editor.requestClose(); return; } if (composer?.isOpen()) { event.preventDefault(); await composer.close(); } });
   window.addEventListener('popstate', async () => { try { const id = new URL(location.href).searchParams.get('note'); id ? await editor.open(id, { pushHistory: false }) : await editor.requestClose({ fromHistory: true }); } catch (error) { showGlobalError(error.message || 'Unable to open the note.'); } });
   const directId = new URL(location.href).searchParams.get('note'); if (directId) editor.open(directId, { pushHistory: false }).catch((error) => { showGlobalError(error.message || 'Unable to open the note.'); const url = new URL(location.href); url.searchParams.delete('note'); history.replaceState(history.state, '', url); });
+}
+
+// SECTION: Card concurrency-state updates after successful mutations
+function updateCardConcurrencyState(card, item) {
+  if (!card || !item) return;
+  card.dataset.version = item.version;
+  card.dataset.isPinned = String(item.isPinned).toLowerCase();
+  card.dataset.status = item.status;
 }

--- a/wwwroot/js/notebook/notebook-composer.js
+++ b/wwwroot/js/notebook/notebook-composer.js
@@ -2,7 +2,7 @@ import { NotebookApi } from './notebook-api.js';
 import { createChecklistEditor } from './notebook-checklist-editor.js';
 
 // SECTION: Expandable notebook composer component
-export function initNotebookComposer(root, board, view) {
+export function initNotebookComposer(root, board, view, options = {}) {
   if (!root) return null;
   const collapsed = root.querySelector('[data-composer-collapsed]');
   const expanded = root.querySelector('[data-composer-expanded]');
@@ -14,25 +14,50 @@ export function initNotebookComposer(root, board, view) {
   const closeButton = root.querySelector('[data-composer-close]');
   const checklistButton = root.querySelector('[data-composer-open-checklist]');
   const checklist = createChecklistEditor(checklistRoot);
-  let mode = 'collapsed'; let isPinned = false; let createdItem = null; let isSaving = false;
+  const showGlobalError = options.showGlobalError || (() => {});
+  const applyCounts = options.applyCounts || (() => {});
+  let mode = 'collapsed'; let isPinned = false; let created = null; let isSaving = false; let clientRequestId = crypto.randomUUID();
   const setStatus = (text) => { if (status) status.textContent = text || ''; };
   const setDisabled = (disabled) => { if (closeButton) closeButton.disabled = disabled; if (checklistButton) checklistButton.disabled = disabled; if (pin) pin.disabled = disabled; };
   const setMode = (next) => { mode = next; root.dataset.state = next; collapsed.hidden = next !== 'collapsed'; expanded.hidden = next === 'collapsed'; body.hidden = next === 'checklist'; checklistRoot.hidden = next !== 'checklist'; };
-  const reset = () => { title.value = ''; body.value = ''; checklist.clear(); isPinned = false; createdItem = null; pin.classList.remove('is-active'); setStatus(''); };
-  const payload = () => ({ title: title.value.trim(), body: body.value.trim(), type: mode === 'checklist' ? 'Checklist' : 'Note', isPinned, checklistRows: mode === 'checklist' ? checklist.getRows() : [] });
+  const reset = () => { title.value = ''; body.value = ''; checklist.clear(); isPinned = false; created = null; clientRequestId = crypto.randomUUID(); pin.classList.remove('is-active'); setStatus(''); };
+
+  // SECTION: Composer payload composition
+  const payload = () => ({
+    title: title.value.trim(),
+    body: body.value.trim(),
+    type: mode === 'checklist' ? 'Checklist' : 'Note',
+    priority: 'Normal',
+    reminderAtUtc: null,
+    colorKey: null,
+    isPinned,
+    labels: [],
+    clientRequestId,
+    checklistRows: mode === 'checklist' ? checklist.getRows().map((row, index) => ({ id: row.id, text: row.text.trim(), isDone: row.isDone, sortOrder: (index + 1) * 1000 })).filter((row) => row.text.length > 0) : []
+  });
   const meaningful = (p) => Boolean(p.title || p.body || p.checklistRows.length);
+
+  // SECTION: Mutation and reconciliation lifecycle
   async function closeComposer() {
     const data = payload();
     if (!meaningful(data)) { reset(); setMode('collapsed'); return true; }
     if (isSaving) return false;
     isSaving = true; setDisabled(true); setStatus('Saving…');
     try {
-      if (!createdItem) createdItem = await NotebookApi.createItem(data);
-      const html = await NotebookApi.getCardHtml(createdItem.id, 'home');
-      board.upsertCard(createdItem.id, html, createdItem.isPinned, { prepend: true });
-      reset(); setMode('collapsed'); return true;
+      if (!created) created = await NotebookApi.createItem(data);
     } catch (error) { setStatus(error.message || 'Unable to save. Retry.'); return false; }
-    finally { isSaving = false; setDisabled(false); }
+
+    try {
+      const item = created.item || created;
+      const html = created.cardHtml || await NotebookApi.getCardHtml(item.id, view || 'home');
+      board.upsertCard(item.id, html, item.isPinned, { prepend: true, preservePosition: false });
+      applyCounts(created.counts);
+      reset(); setMode('collapsed'); return true;
+    } catch (error) {
+      reset(); setMode('collapsed');
+      showGlobalError('The note was saved, but the board could not refresh. Reload the page to view the latest state.');
+      return true;
+    } finally { isSaving = false; setDisabled(false); }
   }
   root.querySelector('[data-composer-open-note]')?.addEventListener('click', () => { if (isSaving) return; setMode('note'); body.focus(); });
   checklistButton?.addEventListener('click', () => { if (isSaving) return; setMode('checklist'); checklist.setRows([{ text: '' }]); checklist.focusFirst(); });


### PR DESCRIPTION
### Motivation
- Fix unreliable Notebook API behaviour where incidental missing anti-forgery tokens or card-render failures caused the client to report complete mutation failure despite committed database changes.  
- Separate data-mutation success from UI reconciliation so Phase B failures (card HTML, DOM update, counts) do not cause false-negative user feedback.  
- Ensure lifecycle commands are consistently version-aware and avoid unsafe non-versioned service paths.  
- Add idempotent create and make audit logging best-effort so committed changes are never mistakenly reported as failed.

### Description
- Render a dedicated anti-forgery token inside the Notebook shell (`Pages/Notebook/Index.cshtml`) and replace client token lookup with `getAntiForgeryToken()` used only for unsafe methods.  
- Replace the old fetch wrapper with a structured `NotebookApiError` and robust `request()` which classifies network, HTTP and JSON failures and includes `responseText`; `wwwroot/js/notebook/notebook-api.js` updated accordingly.  
- Return composite mutation responses (`NotebookMutationResponse`) from mutation endpoints and add `BuildMutationResponseAsync` to the API controller so responses can include `item`, optional `cardHtml` and `counts` (`Contracts/Notebook/NotebookContracts.cs`, `Controllers/Api/NotebookController.cs`).  
- Update client flows (composer and app) to separate Phase A (mutation) from Phase B (UI reconciliation), update card concurrency state immediately after mutation (`updateCardConcurrencyState`), apply counts from mutation responses, and report refresh warnings rather than mutation failures (`wwwroot/js/notebook/notebook-composer.js`, `wwwroot/js/notebook/notebook-app.js`).  
- Make lifecycle commands version-aware across controller and service layers, add versioned request contracts, and introduce version-aware service overloads that return updated aggregates (`Services/Notebook/INotebookService.cs`, `Services/Notebook/NotebookService.cs`, `Contracts/Notebook/NotebookContracts.cs`).  
- Implement create idempotency with `ClientRequestId` persisted on `NotebookItem`, a filtered unique index and pre-create lookup to reuse existing item on retry, plus a migration (`Models/NotebookItem.cs`, `Data/ApplicationDbContext.cs`, `Migrations/20261126090000_AddNotebookClientRequestId.cs`).  
- Treat audit logging as best-effort by wrapping audit calls in `TryWriteAuditAsync` so audit failures are logged but do not cause the user-facing mutation to fail (`Services/Notebook/NotebookService.cs`).  
- Standardise API error shaping for not-found, validation and concurrency errors via the exception filter (`Controllers/Api/NotebookApiExceptionFilter.cs`) and switch Version handling to `Guid` in view/response models (`ViewModels/Notebook/NotebookViewModels.cs`, `Controllers/Api/NotebookController.cs`).  
- Preserve CSP/no-inline-scripts constraints and add SECTION comments to changed files to aid future maintenance.

### Testing
- Ran static module checks for the modified client scripts which succeeded with `node --input-type=module --check` for `notebook-api.js`, `notebook-app.js` and `notebook-composer.js`.  
- Attempted to run `dotnet build --no-restore` but the environment does not have the `dotnet` CLI installed, so server-side builds and unit/integration test runs were not executed here.  
- Manual code inspection and local grep-based sanity checks were performed to ensure API contracts, viewmodels and migrations were updated consistently and to validate no obvious compilation regressions in the edited files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35e30c43108329bf5456465e5d0287)