### PR TITLE
Stabilize notebook card rendering

### DIFF
--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using ProjectManagement.Contracts.Notebook;
 using ProjectManagement.Models;
@@ -17,13 +20,23 @@ public sealed class NotebookController : Controller
 {
     private readonly INotebookService _notebook;
     private readonly INotebookCardRenderer _cardRenderer;
+    private readonly INotebookCardModelFactory _cardModelFactory;
+    private readonly IWebHostEnvironment _environment;
     private readonly UserManager<ApplicationUser> _users;
     private readonly ILogger<NotebookController> _logger;
 
-    public NotebookController(INotebookService notebook, INotebookCardRenderer cardRenderer, UserManager<ApplicationUser> users, ILogger<NotebookController> logger)
+    public NotebookController(
+        INotebookService notebook,
+        INotebookCardRenderer cardRenderer,
+        INotebookCardModelFactory cardModelFactory,
+        IWebHostEnvironment environment,
+        UserManager<ApplicationUser> users,
+        ILogger<NotebookController> logger)
     {
         _notebook = notebook;
         _cardRenderer = cardRenderer;
+        _cardModelFactory = cardModelFactory;
+        _environment = environment;
         _users = users;
         _logger = logger;
     }
@@ -46,10 +59,31 @@ public sealed class NotebookController : Controller
     [HttpGet("{id:guid}/card")]
     public async Task<IActionResult> Card(Guid id, [FromQuery] string view = "home", CancellationToken ct = default)
     {
-        var uid = CurrentUserId();
-        var item = await _notebook.GetDetailAsync(uid, id, ct);
-        if (item is null) return NotFound();
-        return PartialView("~/Pages/Notebook/_NotebookCard.cshtml", new NotebookCardRenderVm { Item = item, View = view });
+        try
+        {
+            var uid = CurrentUserId();
+            var item = await _notebook.GetDetailAsync(uid, id, ct);
+            if (item is null)
+            {
+                return NotFound(new
+                {
+                    code = "notebook_not_found",
+                    message = "The note could not be found."
+                });
+            }
+
+            var model = _cardModelFactory.Create(item, new NotebookCardContext { View = view });
+            var html = await _cardRenderer.RenderAsync(model, ct);
+            return Content(html, "text/html; charset=utf-8");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Notebook card endpoint failed for item {ItemId}.", id);
+
+            return _environment.IsDevelopment()
+                ? Problem(title: "Notebook card rendering failed", detail: ex.ToString(), statusCode: StatusCodes.Status500InternalServerError)
+                : Problem(title: "Notebook card rendering failed", statusCode: StatusCodes.Status500InternalServerError);
+        }
     }
 
     // SECTION: Item mutation endpoints
@@ -226,11 +260,28 @@ public sealed class NotebookController : Controller
     {
         try
         {
-            return await _cardRenderer.RenderAsync(ToListItem(item), view, ct);
+            var model = _cardModelFactory.Create(ToListItem(item), new NotebookCardContext { View = view });
+            return await _cardRenderer.RenderAsync(model, ct);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Notebook mutation for item {ItemId} succeeded, but card rendering failed.", item.Id);
+            _logger.LogError(
+                ex,
+                """
+                Notebook card rendering failed.
+                ItemId: {ItemId}
+                View: {NotebookView}
+                PartialPath: {PartialPath}
+                ExceptionType: {ExceptionType}
+                InnerException: {InnerException}
+                RouteValues: {@RouteValues}
+                """,
+                item.Id,
+                view,
+                RazorNotebookCardRenderer.CardPartialPath,
+                ex.GetType().FullName,
+                ex.InnerException?.ToString(),
+                HttpContext.GetRouteData()?.Values);
             return null;
         }
     }

--- a/Pages/Notebook/Index.cshtml
+++ b/Pages/Notebook/Index.cshtml
@@ -2,6 +2,7 @@
 @model ProjectManagement.Pages.Notebook.IndexModel
 @using ProjectManagement.Models
 @using ProjectManagement.ViewModels.Notebook
+@inject ProjectManagement.Services.Notebook.INotebookCardModelFactory CardModelFactory
 @{
     ViewData["Title"] = "My Notebook";
     ViewData["UseFullWidth"] = true;
@@ -108,7 +109,7 @@
                 <div class="notebook-board" data-notebook-board="pinned">
                     @foreach (var item in Model.Notebook.PinnedItems)
                     {
-                        <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
+                        <partial name="_NotebookCard" model="@(CardModelFactory.Create(item, new ProjectManagement.Services.Notebook.NotebookCardContext { View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id }))" />
                     }
                 </div>
             </section>
@@ -117,7 +118,7 @@
                 <div class="notebook-board" data-notebook-board="others">
                     @foreach (var item in Model.Notebook.OtherItems)
                     {
-                        <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
+                        <partial name="_NotebookCard" model="@(CardModelFactory.Create(item, new ProjectManagement.Services.Notebook.NotebookCardContext { View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id }))" />
                     }
                 </div>
                 @if (!hasAnyHomeItems)
@@ -132,7 +133,7 @@
                 <div class="notebook-board" data-notebook-board>
                     @foreach (var item in Model.Notebook.Items)
                     {
-                        <partial name="_NotebookCard" model="@(new NotebookCardRenderVm { Item = item, View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id })" />
+                        <partial name="_NotebookCard" model="@(CardModelFactory.Create(item, new ProjectManagement.Services.Notebook.NotebookCardContext { View = Model.Notebook.View, Query = Model.Notebook.Query, Filter = Model.Notebook.Filter, Tag = Model.Notebook.Tag, SelectedId = selected?.Id }))" />
                     }
                 </div>
                 @if (!Model.Notebook.Items.Any())

--- a/Pages/Notebook/_NotebookActions.cshtml
+++ b/Pages/Notebook/_NotebookActions.cshtml
@@ -1,8 +1,8 @@
-@model ProjectManagement.ViewModels.Notebook.NotebookItemActionVm
+@model ProjectManagement.ViewModels.Notebook.NotebookCardActionsVm
 @using ProjectManagement.Models
 
 @* SECTION: API-only notebook card actions *@
-<div class="notebook-actions">
+<div class="notebook-actions" data-note-actions aria-label="Note actions">
     <button title="@(Model.Item.IsPinned ? "Unpin" : "Pin")" aria-label="@(Model.Item.IsPinned ? "Unpin note" : "Pin note")" type="button" class="notebook-action-icon notebook-action-pin" data-action="pin-note" data-is-pinned="@Model.Item.IsPinned.ToString().ToLowerInvariant()">
         <i class="bi @(Model.Item.IsPinned ? "bi-pin-angle-fill" : "bi-pin-angle")"></i>
     </button>
@@ -12,7 +12,7 @@
     }
 
     <details class="notebook-card-more">
-        <summary aria-label="More actions"><i class="bi bi-three-dots"></i></summary>
+        <summary class="notebook-action-button" aria-label="More actions"><i class="bi bi-three-dots"></i></summary>
         <div class="notebook-card-more__menu" role="menu">
             <button type="button" role="menuitem" data-action="duplicate-note">Make a copy</button>
             <button type="button" role="menuitem" data-action="convert-note" data-convert-to="@(Model.Item.Type == NotebookItemType.Checklist ? NotebookItemType.Note : NotebookItemType.Checklist)">@(Model.Item.Type == NotebookItemType.Checklist ? "Hide checkboxes" : "Show checkboxes")</button>

--- a/Pages/Notebook/_NotebookCard.cshtml
+++ b/Pages/Notebook/_NotebookCard.cshtml
@@ -13,7 +13,7 @@
 @* SECTION: Notebook board card *@
 <article data-note-id="@item.Id" data-notebook-card-id="@item.Id" data-version="@item.Version" data-is-pinned="@item.IsPinned.ToString().ToLowerInvariant()" class="notebook-card @colorClass @(isSelected ? "is-selected" : string.Empty) @(item.ReminderAtUtc is not null ? "has-due-action" : string.Empty)">
     <div class="notebook-card-body">
-        <a class="notebook-card-link notebook-card__open-area" data-action="open-note" asp-page="/Notebook/Index" asp-route-view="@Model.View" asp-route-query="@Model.Query" asp-route-filter="@Model.Filter" asp-route-tag="@Model.Tag" asp-route-note="@item.Id">
+        <a href="@Model.OpenUrl" class="notebook-card-link notebook-card__open-area" data-action="open-note" aria-label="Open @item.Title">
             <div class="notebook-card-topline">
                 <span class="notebook-card-indicators">
                     @if (item.IsPinned) { <i class="bi bi-pin-angle-fill" title="Pinned"></i> }
@@ -82,6 +82,6 @@
         }
     </div>
     <div class="notebook-card-actions">
-        <partial name="_NotebookActions" model="@(new NotebookItemActionVm { Item = item, View = Model.View, Query = Model.Query, Filter = Model.Filter, Tag = Model.Tag, SelectedId = Model.SelectedId })" />
+        <partial name="~/Pages/Notebook/_NotebookActions.cshtml" model="Model.Actions" />
     </div>
 </article>

--- a/Program.cs
+++ b/Program.cs
@@ -387,6 +387,7 @@ builder.Services.AddSingleton<IActionTrackerClock, SystemActionTrackerClock>();
 builder.Services.AddScoped<ITodoService, TodoService>();
 // SECTION: My Notebook services
 builder.Services.AddScoped<INotebookService, NotebookService>();
+builder.Services.AddScoped<INotebookCardModelFactory, NotebookCardModelFactory>();
 builder.Services.AddScoped<INotebookCardRenderer, RazorNotebookCardRenderer>();
 builder.Services.AddScoped<INotebookTodoImportService, NotebookTodoImportService>();
 // SECTION: Project Ideas services

--- a/Services/Notebook/INotebookCardModelFactory.cs
+++ b/Services/Notebook/INotebookCardModelFactory.cs
@@ -1,0 +1,23 @@
+using ProjectManagement.ViewModels.Notebook;
+
+namespace ProjectManagement.Services.Notebook;
+
+// SECTION: Notebook card model creation abstraction
+public interface INotebookCardModelFactory
+{
+    NotebookCardRenderVm Create(NotebookItemListVm item, NotebookCardContext context);
+}
+
+// SECTION: Notebook card ambient render context
+public sealed class NotebookCardContext
+{
+    public string View { get; init; } = "home";
+
+    public string? Query { get; init; }
+
+    public string? Filter { get; init; }
+
+    public string? Tag { get; init; }
+
+    public Guid? SelectedId { get; init; }
+}

--- a/Services/Notebook/INotebookCardRenderer.cs
+++ b/Services/Notebook/INotebookCardRenderer.cs
@@ -5,5 +5,5 @@ namespace ProjectManagement.Services.Notebook;
 // SECTION: Notebook card rendering abstraction
 public interface INotebookCardRenderer
 {
-    Task<string> RenderAsync(NotebookItemListVm item, string view, CancellationToken ct = default);
+    Task<string> RenderAsync(NotebookCardRenderVm model, CancellationToken ct = default);
 }

--- a/Services/Notebook/NotebookCardModelFactory.cs
+++ b/Services/Notebook/NotebookCardModelFactory.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Routing;
+using ProjectManagement.ViewModels.Notebook;
+
+namespace ProjectManagement.Services.Notebook;
+
+// SECTION: Centralized notebook card render model creation
+public sealed class NotebookCardModelFactory : INotebookCardModelFactory
+{
+    private readonly LinkGenerator _linkGenerator;
+
+    public NotebookCardModelFactory(LinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    public NotebookCardRenderVm Create(NotebookItemListVm item, NotebookCardContext context)
+    {
+        var view = string.IsNullOrWhiteSpace(context.View) ? "home" : context.View;
+        var routeValues = new RouteValueDictionary
+        {
+            ["view"] = view,
+            ["note"] = item.Id
+        };
+
+        AddOptionalRouteValue(routeValues, "query", context.Query);
+        AddOptionalRouteValue(routeValues, "filter", context.Filter);
+        AddOptionalRouteValue(routeValues, "tag", context.Tag);
+
+        return new NotebookCardRenderVm
+        {
+            Item = item,
+            View = view,
+            Query = context.Query,
+            Filter = context.Filter,
+            Tag = context.Tag,
+            SelectedId = context.SelectedId,
+            OpenUrl = _linkGenerator.GetPathByPage("/Notebook/Index", values: routeValues)
+                ?? $"/Notebook?view={Uri.EscapeDataString(view)}&note={Uri.EscapeDataString(item.Id.ToString())}",
+            Actions = new NotebookCardActionsVm
+            {
+                Item = item,
+                View = view,
+                Query = context.Query,
+                Filter = context.Filter,
+                Tag = context.Tag,
+                SelectedId = context.SelectedId
+            }
+        };
+    }
+
+    // SECTION: Route value helpers
+    private static void AddOptionalRouteValue(RouteValueDictionary values, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            values[key] = value;
+        }
+    }
+}

--- a/Services/Notebook/RazorNotebookCardRenderer.cs
+++ b/Services/Notebook/RazorNotebookCardRenderer.cs
@@ -13,32 +13,59 @@ namespace ProjectManagement.Services.Notebook;
 // SECTION: Razor partial based notebook card renderer
 public sealed class RazorNotebookCardRenderer : INotebookCardRenderer
 {
-    private const string CardPartialPath = "~/Pages/Notebook/_NotebookCard.cshtml";
+    public const string CardPartialPath = "~/Pages/Notebook/_NotebookCard.cshtml";
+
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IModelMetadataProvider _metadataProvider;
+    private readonly IServiceProvider _serviceProvider;
     private readonly ITempDataProvider _tempDataProvider;
     private readonly IRazorViewEngine _viewEngine;
 
-    public RazorNotebookCardRenderer(IRazorViewEngine viewEngine, ITempDataProvider tempDataProvider, IHttpContextAccessor httpContextAccessor)
+    public RazorNotebookCardRenderer(
+        IRazorViewEngine viewEngine,
+        ITempDataProvider tempDataProvider,
+        IModelMetadataProvider metadataProvider,
+        IHttpContextAccessor httpContextAccessor,
+        IServiceProvider serviceProvider)
     {
         _viewEngine = viewEngine;
         _tempDataProvider = tempDataProvider;
+        _metadataProvider = metadataProvider;
         _httpContextAccessor = httpContextAccessor;
+        _serviceProvider = serviceProvider;
     }
 
-    public async Task<string> RenderAsync(NotebookItemListVm item, string view, CancellationToken ct = default)
+    public async Task<string> RenderAsync(NotebookCardRenderVm model, CancellationToken ct = default)
     {
+        // SECTION: Rendering context setup
         ct.ThrowIfCancellationRequested();
         var httpContext = _httpContextAccessor.HttpContext ?? new DefaultHttpContext();
-        var actionContext = new ActionContext(httpContext, httpContext.GetRouteData() ?? new RouteData(), new ActionDescriptor());
-        var viewResult = _viewEngine.GetView(executingFilePath: null, viewPath: CardPartialPath, isMainPage: false);
+        httpContext.RequestServices ??= _serviceProvider;
+
+        var actionContext = new ActionContext(
+            httpContext,
+            httpContext.GetRouteData() ?? new RouteData(),
+            new ActionDescriptor());
+
+        // SECTION: Partial view lookup
+        var viewResult = _viewEngine.GetView(
+            executingFilePath: CardPartialPath,
+            viewPath: CardPartialPath,
+            isMainPage: false);
+
         if (!viewResult.Success)
         {
-            throw new InvalidOperationException($"Notebook card partial '{CardPartialPath}' could not be found.");
+            throw new InvalidOperationException(
+                "Notebook card partial could not be located. " +
+                string.Join(Environment.NewLine, viewResult.SearchedLocations));
         }
 
+        // SECTION: Partial rendering
         await using var writer = new StringWriter();
-        var model = new NotebookCardRenderVm { Item = item, View = string.IsNullOrWhiteSpace(view) ? "home" : view };
-        var viewData = new ViewDataDictionary<NotebookCardRenderVm>(new EmptyModelMetadataProvider(), new ModelStateDictionary()) { Model = model };
+        var viewData = new ViewDataDictionary<NotebookCardRenderVm>(_metadataProvider, new ModelStateDictionary())
+        {
+            Model = model
+        };
         var tempData = new TempDataDictionary(httpContext, _tempDataProvider);
         var viewContext = new ViewContext(actionContext, viewResult.View, viewData, tempData, writer, new HtmlHelperOptions());
         await viewResult.View.RenderAsync(viewContext);

--- a/ViewModels/Notebook/NotebookViewModels.cs
+++ b/ViewModels/Notebook/NotebookViewModels.cs
@@ -177,32 +177,36 @@ public sealed class NotebookWidgetItemVm
 
 public sealed class NotebookCardRenderVm
 {
-    public NotebookItemListVm Item { get; set; } = new();
+    public NotebookItemListVm Item { get; init; } = new();
 
-    public string View { get; set; } = "home";
+    public string View { get; init; } = "home";
 
-    public string? Query { get; set; }
+    public string? Query { get; init; }
 
-    public string? Filter { get; set; }
+    public string? Filter { get; init; }
 
-    public string? Tag { get; set; }
+    public string? Tag { get; init; }
 
-    public Guid? SelectedId { get; set; }
+    public string OpenUrl { get; init; } = string.Empty;
 
-    public bool UseStickySurface { get; set; }
+    public NotebookCardActionsVm Actions { get; init; } = new();
+
+    public Guid? SelectedId { get; init; }
+
+    public bool UseStickySurface { get; init; }
 }
 
-public sealed class NotebookItemActionVm
+public sealed class NotebookCardActionsVm
 {
-    public NotebookItemListVm Item { get; set; } = new();
+    public NotebookItemListVm Item { get; init; } = new();
 
-    public string View { get; set; } = "home";
+    public string View { get; init; } = "home";
 
-    public string? Query { get; set; }
+    public string? Query { get; init; }
 
-    public string? Filter { get; set; }
+    public string? Filter { get; init; }
 
-    public string? Tag { get; set; }
+    public string? Tag { get; init; }
 
-    public Guid? SelectedId { get; set; }
+    public Guid? SelectedId { get; init; }
 }

--- a/wwwroot/js/notebook/notebook-board.js
+++ b/wwwroot/js/notebook/notebook-board.js
@@ -1,14 +1,44 @@
 // SECTION: Notebook board DOM updates
 export function createNotebookBoard(root = document) {
+  // SECTION: Board lookup helpers
   const findCard = (id) => root.querySelector(`[data-note-id="${CSS.escape(id)}"]`);
   const getSection = (isPinned) => root.querySelector(`[data-notebook-section="${isPinned ? 'pinned' : 'others'}"]`);
-  const getBoard = (isPinned) => root.querySelector(`[data-notebook-board="${isPinned ? 'pinned' : 'others'}"]`) || root.querySelector('[data-notebook-board]');
-  const htmlToElement = (html) => { const t = document.createElement('template'); t.innerHTML = html.trim(); return t.content.firstElementChild; };
+  const getBoard = (isPinned) => root.querySelector(`[data-notebook-board="${isPinned ? 'pinned' : 'others'}"]`);
+
+  // SECTION: Safe server-rendered card parsing
+  function htmlToCardElement(html, expectedId) {
+    if (typeof html !== 'string' || !html.trim()) {
+      throw new Error('Notebook card HTML was empty.');
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    const elements = template.content.children;
+
+    if (elements.length !== 1) {
+      throw new Error('Notebook card response must contain exactly one root element.');
+    }
+
+    const card = elements[0];
+    if (!card.matches('[data-note-id]')) {
+      throw new Error('Notebook card response did not contain a note card.');
+    }
+
+    if (expectedId !== undefined && expectedId !== null && card.dataset.noteId !== String(expectedId)) {
+      throw new Error('Notebook card response did not match the requested note.');
+    }
+
+    return card;
+  }
+
+  // SECTION: Board state refresh helpers
   const refreshSectionVisibility = () => { ['pinned','others'].forEach((name) => { const section = root.querySelector(`[data-notebook-section="${name}"]`); const board = root.querySelector(`[data-notebook-board="${name}"]`); if (!section || !board) return; const count = board.querySelectorAll('[data-note-id]').length; if (name === 'pinned') section.hidden = count === 0; const countEl = root.querySelector(`[data-notebook-count="${name}"]`); if (countEl) countEl.textContent = String(count); }); };
   const refreshEmptyState = () => { const empty = root.querySelector('[data-notebook-empty-state="current"]') || root.querySelector('[data-notebook-empty-state]') || root.querySelector('[data-notebook-empty]'); if (!empty) return; const count = [...root.querySelectorAll('[data-notebook-board]')].reduce((total, board) => total + board.querySelectorAll(':scope > [data-note-id]').length, 0); empty.hidden = count > 0; };
-  const upsertCard = (id, html, isPinned, options = {}) => { const current = findCard(id); const targetBoard = getBoard(isPinned); if (!targetBoard) throw new Error('Notebook target board was not found.'); const fragment = htmlToElement(html); const sameBoard = current && current.parentElement === targetBoard; const preservePosition = options.preservePosition !== false; if (sameBoard && preservePosition) { current.replaceWith(fragment); } else { current?.remove(); options.prepend === false ? targetBoard.append(fragment) : targetBoard.prepend(fragment); } refreshSectionVisibility(); refreshEmptyState(); return fragment; };
-  const replaceCard = (id, html) => { const current = findCard(id); if (!current) return null; const fragment = htmlToElement(html); current.replaceWith(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
-  const insertCard = (html, pinned = false) => { const fragment = htmlToElement(html); const board = getBoard(pinned); if (!board) throw new Error('Notebook target board was not found.'); board.prepend(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
+
+  // SECTION: Card mutation helpers
+  const upsertCard = (id, html, isPinned, options = {}) => { const current = findCard(id); const targetBoard = getBoard(isPinned); if (!targetBoard) throw new Error(`Notebook board "${isPinned ? 'pinned' : 'others'}" was not found.`); const fragment = htmlToCardElement(html, id); const sameBoard = current && current.parentElement === targetBoard; const preservePosition = options.preservePosition !== false; if (sameBoard && preservePosition) { current.replaceWith(fragment); } else { current?.remove(); options.prepend === false ? targetBoard.append(fragment) : targetBoard.prepend(fragment); } refreshSectionVisibility(); refreshEmptyState(); return fragment; };
+  const replaceCard = (id, html) => { const current = findCard(id); if (!current) return null; const fragment = htmlToCardElement(html, id); current.replaceWith(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
+  const insertCard = (html, pinned = false) => { const fragment = htmlToCardElement(html); const board = getBoard(pinned); if (!board) throw new Error(`Notebook board "${pinned ? 'pinned' : 'others'}" was not found.`); board.prepend(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
   const removeCard = (id) => { findCard(id)?.remove(); refreshSectionVisibility(); refreshEmptyState(); };
-  return { findCard, getSection, getBoard, replaceCard, insertCard, upsertCard, removeCard, refreshSectionVisibility, refreshEmptyState };
+  return { findCard, getSection, getBoard, replaceCard, insertCard, upsertCard, removeCard, refreshSectionVisibility, refreshEmptyState, htmlToCardElement };
 }

--- a/wwwroot/js/notebook/notebook-board.test.js
+++ b/wwwroot/js/notebook/notebook-board.test.js
@@ -1,0 +1,48 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadBoard(dom) {
+  global.document = dom.window.document;
+  global.CSS = dom.window.CSS || { escape: (value) => String(value).replace(/"/g, '\\"') };
+  const scriptPath = path.resolve(__dirname, 'notebook-board.js');
+  const script = fs.readFileSync(scriptPath, 'utf8').replace('export function createNotebookBoard', 'function createNotebookBoard');
+  const context = vm.createContext({ document: dom.window.document, CSS: global.CSS });
+  vm.runInContext(`${script}; globalThis.__createNotebookBoard = createNotebookBoard;`, context);
+  return context.__createNotebookBoard(dom.window.document);
+}
+
+test('notebook board rejects empty card HTML', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(() => board.upsertCard('note-1', '', false), /empty/);
+});
+
+test('notebook board rejects error page HTML', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(() => board.upsertCard('note-1', '<html><body>Error</body></html>', false), /note card|exactly one root/);
+});
+
+test('notebook board rejects multiple card roots', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(() => board.upsertCard('note-1', '<article data-note-id="note-1"></article><article data-note-id="note-1"></article>', false), /exactly one root/);
+});
+
+test('notebook board rejects mismatched note id', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(() => board.upsertCard('note-1', '<article data-note-id="note-2"></article>', false), /did not match/);
+});
+
+test('notebook board inserts a valid card into the requested board only', async () => {
+  const dom = new JSDOM('<section><div data-notebook-board="pinned"></div><div data-notebook-board="others"></div></section>');
+  const board = loadBoard(dom);
+  const card = board.upsertCard('note-1', '<article data-note-id="note-1" data-version="v1"></article>', false);
+  assert.equal(card.dataset.noteId, 'note-1');
+  assert.equal(dom.window.document.querySelector('[data-notebook-board="others"] > [data-note-id="note-1"]'), card);
+});

--- a/wwwroot/js/notebook/notebook-reconcile.js
+++ b/wwwroot/js/notebook/notebook-reconcile.js
@@ -16,6 +16,11 @@ export function updateCardConcurrencyState(card, item) {
   card.dataset.status = item.status;
 }
 
+// SECTION: Reconciliation diagnostics
+function logReconciliationFailure(item, stage, error) {
+  console.error('Notebook card reconciliation failed', { itemId: item?.id, stage, error });
+}
+
 // SECTION: Shared post-mutation board reconciliation
 export async function reconcileMutation({
   response,
@@ -27,6 +32,7 @@ export async function reconcileMutation({
   prepend = false,
   showGlobalError,
   existingCard = null,
+  command = 'unknown',
   renderFailureMessage = 'The note was updated, but its card could not be rendered. Reload the page.',
   reconcileFailureMessage = 'The note was updated, but the board could not refresh. Reload the page.'
 }) {
@@ -34,22 +40,39 @@ export async function reconcileMutation({
   applyCounts?.(response.counts);
   updateCardConcurrencyState(existingCard || board?.findCard?.(item.id), item);
 
+  // SECTION: Server-rendered card acquisition
   let html = response.cardHtml;
   if (!html) {
+    console.warn('Notebook mutation response did not contain card HTML.', { itemId: item.id, command });
     try {
       html = await getCardHtml(item.id, view);
     } catch (error) {
+      logReconciliationFailure(item, 'server-card-rendering', error);
       showGlobalError?.(renderFailureMessage);
       return { item, reconciled: false, code: 'notebook_card_render_failed' };
     }
   }
 
+  if (typeof html !== 'string' || !html.trim()) {
+    const error = new Error('Notebook card response was empty.');
+    logReconciliationFailure(item, 'empty-card-response', error);
+    showGlobalError?.(renderFailureMessage);
+    return { item, reconciled: false, code: 'notebook_empty_card_response' };
+  }
+
+  // SECTION: Board reconciliation
   try {
     board.upsertCard(item.id, html, item.isPinned, { preservePosition, prepend });
     return { item, reconciled: true };
   } catch (error) {
-    showGlobalError?.(reconcileFailureMessage);
+    const stage = String(error?.message || '').includes('board')
+      ? 'target-board'
+      : String(error?.message || '').includes('card response') || String(error?.message || '').includes('card HTML')
+        ? 'invalid-card-html'
+        : 'card-replacement';
+    logReconciliationFailure(item, stage, error);
+    showGlobalError?.(stage === 'invalid-card-html' ? renderFailureMessage : reconcileFailureMessage);
     updateCardConcurrencyState(existingCard || board?.findCard?.(item.id), item);
-    return { item, reconciled: false, code: 'notebook_board_reconcile_failed' };
+    return { item, reconciled: false, code: stage === 'invalid-card-html' ? 'notebook_invalid_card_html' : 'notebook_board_reconcile_failed' };
   }
 }


### PR DESCRIPTION
### Motivation

- Fix intermittent failures where notebook mutations persist but server-side card rendering/reconciliation fails by exposing the rendering error and removing Razor Page context-dependencies. 
- Make the card partial renderable outside a full Razor Page so mutation responses and the card GET endpoint produce identical HTML. 
- Prevent unsafe DOM fallbacks and validate server-rendered card HTML before inserting into the board.

### Description

- Introduced `INotebookCardModelFactory` and `NotebookCardContext` and implemented `NotebookCardModelFactory` to centralize card view model creation and URL generation outside the partial. 
- Updated `INotebookCardRenderer` and strengthened `RazorNotebookCardRenderer` to accept `NotebookCardRenderVm`, build a proper rendering `ActionContext`, use the configured `IModelMetadataProvider` and request services, and to fail fast so orchestration can log and decide handling. 
- Switched the API card endpoint and mutation rendering path to use the shared factory + renderer pipeline and expanded server-side diagnostic logging to include item id, view, partial path, exception type, inner exception and route values (development-only details). 
- Made `_NotebookCard.cshtml` independent of Razor Page tag helpers by using `Model.OpenUrl` and resolved nested actions partial via an application-rooted path; added `NotebookCardActionsVm` and updated `_NotebookActions.cshtml` to plain API-driven markup. 
- Client-side: replaced the arbitrary board fallback and added strict server-rendered card validation in `notebook-board.js` (single root element, data-note-id present and matching, non-empty HTML) and added richer reconciliation diagnostics in `notebook-reconcile.js`. 
- Registered the new factory in DI and updated usages in `Index.cshtml` to consume `INotebookCardModelFactory` so full-page rendering and server renderer share the same model. 
- Added JS unit tests (`wwwroot/js/notebook/notebook-board.test.js`) to assert empty/malformed/multi-root/mismatched-id handling and successful insertion into the correct board.

### Testing

- Ran the repository JS test suite for the notebook board subset with `npm test -- --test-name-pattern="notebook board"`, and all relevant tests (including the new board validation tests) passed. 
- `dotnet test --no-restore` could not be executed in the environment because `dotnet` is not installed, so server-side unit/test runs were not executed here. 
- Manual/CI note: server-side tests should be executed in CI (or a local environment with the .NET SDK) to validate Razor rendering paths and controller behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35f96fa3e883298b90557320d142cd)