### PR TITLE
Harden notebook mutation reconciliation and card rendering

### DIFF
--- a/Contracts/Notebook/NotebookContracts.cs
+++ b/Contracts/Notebook/NotebookContracts.cs
@@ -126,5 +126,5 @@ public sealed class NotebookMutationResponse
 
     public string? CardHtml { get; init; }
 
-    public NotebookCountsResponse Counts { get; init; } = new();
+    public NotebookCountsResponse? Counts { get; init; }
 }

--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -57,7 +57,7 @@ public sealed class NotebookController : Controller
     }
 
     [HttpGet("{id:guid}/card")]
-    public async Task<IActionResult> Card(Guid id, [FromQuery] string view = "home", CancellationToken ct = default)
+    public async Task<IActionResult> Card(Guid id, [FromQuery] string view = NotebookCardContexts.Home, CancellationToken ct = default)
     {
         try
         {
@@ -75,6 +75,10 @@ public sealed class NotebookController : Controller
             var model = _cardModelFactory.Create(item, new NotebookCardContext { View = view });
             var html = await _cardRenderer.RenderAsync(model, ct);
             return Content(html, "text/html; charset=utf-8");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -94,7 +98,7 @@ public sealed class NotebookController : Controller
         if (validation is not null) return validation;
         var uid = CurrentUserId();
         var item = await _notebook.CreateAsync(uid, ToInput(request), ct);
-        return CreatedAtAction(nameof(Get), new { id = item.Id }, await BuildMutationResponseAsync(item, includeCard: true, view: "home", ct));
+        return CreatedAtAction(nameof(Get), new { id = item.Id }, await BuildMutationResponseAsync(item, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPatch("{id:guid}")]
@@ -116,7 +120,7 @@ public sealed class NotebookController : Controller
         var uid = CurrentUserId();
         var updated = await _notebook.UpdateAsync(uid, id, ToInput(request), request.Version, ct);
 
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/pin")]
@@ -124,7 +128,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.SetPinnedAsync(CurrentUserId(), id, request.IsPinned, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/archive")]
@@ -132,7 +136,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ArchiveAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/complete")]
@@ -140,7 +144,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.CompleteAsync(CurrentUserId(), id, true, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/reopen")]
@@ -148,7 +152,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ReopenAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
     }
 
 
@@ -165,7 +169,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.RestoreAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/show-checkboxes")]
@@ -173,7 +177,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ConvertTypeAsync(CurrentUserId(), id, NotebookItemType.Checklist, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/hide-checkboxes")]
@@ -181,7 +185,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ConvertTypeAsync(CurrentUserId(), id, NotebookItemType.Note, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
 
@@ -194,14 +198,14 @@ public sealed class NotebookController : Controller
         }
 
         var item = await _notebook.ToggleChecklistItemAsync(CurrentUserId(), itemId, rowId, request.IsDone, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(item, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(item, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     [HttpPost("{id:guid}/duplicate")]
     public async Task<IActionResult> Duplicate(Guid id, CancellationToken ct)
     {
         var copy = await _notebook.DuplicateAsync(CurrentUserId(), id, ct);
-        return Ok(await BuildMutationResponseAsync(copy, includeCard: true, view: "home", ct));
+        return Ok(await BuildMutationResponseAsync(copy, includeCard: true, view: NotebookCardContexts.Home, ct));
     }
 
     // SECTION: Mapping and validation helpers
@@ -245,13 +249,14 @@ public sealed class NotebookController : Controller
 
     private async Task<NotebookMutationResponse> BuildMutationResponseAsync(NotebookItemDetailVm item, bool includeCard, string view, CancellationToken ct)
     {
-        var cardHtml = includeCard ? await TryRenderCardAsync(item, view, ct) : null;
+        var ownerId = CurrentUserId();
+        var cardHtml = includeCard ? await TryRenderCardAsync(item, NotebookCardContexts.Home, ct) : null;
 
         return new NotebookMutationResponse
         {
             Item = ToResponse(item),
             CardHtml = cardHtml,
-            Counts = ToCountsResponse(await _notebook.GetCountsAsync(CurrentUserId(), ct))
+            Counts = await TryGetCountsAsync(ownerId, ct)
         };
     }
 
@@ -262,6 +267,10 @@ public sealed class NotebookController : Controller
         {
             var model = _cardModelFactory.Create(ToListItem(item), new NotebookCardContext { View = view });
             return await _cardRenderer.RenderAsync(model, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -289,8 +298,26 @@ public sealed class NotebookController : Controller
     private async Task<NotebookMutationResponse> BuildRemovalResponseAsync(Guid removedItemId, CancellationToken ct) => new()
     {
         RemovedItemId = removedItemId,
-        Counts = ToCountsResponse(await _notebook.GetCountsAsync(CurrentUserId(), ct))
+        Counts = await TryGetCountsAsync(CurrentUserId(), ct)
     };
+
+    // SECTION: Best-effort count refresh for saved mutations
+    private async Task<NotebookCountsResponse?> TryGetCountsAsync(string ownerId, CancellationToken ct)
+    {
+        try
+        {
+            return ToCountsResponse(await _notebook.GetCountsAsync(ownerId, ct));
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Notebook mutation succeeded, but counts could not be refreshed for owner {OwnerId}.", ownerId);
+            return null;
+        }
+    }
 
     private static NotebookCountsResponse ToCountsResponse(IReadOnlyDictionary<string, int> counts) => new()
     {

--- a/Pages/Notebook/Index.cshtml.cs
+++ b/Pages/Notebook/Index.cshtml.cs
@@ -185,18 +185,6 @@ public class IndexModel : PageModel
         return RedirectToCurrent(SelectedId);
     }
 
-    public async Task<IActionResult> OnPostToggleFavoriteAsync(Guid id, CancellationToken ct)
-    {
-        var uid = _users.GetUserId(User);
-        if (uid is null)
-        {
-            return Unauthorized();
-        }
-
-        await _notebook.ToggleFavoriteAsync(uid, id, ct);
-        return RedirectToCurrent(SelectedId);
-    }
-
     public async Task<IActionResult> OnPostCompleteAsync(Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct)
     {
         var uid = _users.GetUserId(User);

--- a/Services/Notebook/INotebookCardModelFactory.cs
+++ b/Services/Notebook/INotebookCardModelFactory.cs
@@ -8,10 +8,16 @@ public interface INotebookCardModelFactory
     NotebookCardRenderVm Create(NotebookItemListVm item, NotebookCardContext context);
 }
 
+// SECTION: Supported notebook card render contexts
+public static class NotebookCardContexts
+{
+    public const string Home = "home";
+}
+
 // SECTION: Notebook card ambient render context
 public sealed class NotebookCardContext
 {
-    public string View { get; init; } = "home";
+    public string View { get; init; } = NotebookCardContexts.Home;
 
     public string? Query { get; init; }
 

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -49,9 +49,6 @@ public interface INotebookService
 
     Task<NotebookItemDetailVm?> GetDetailAsync(string ownerId, Guid id, CancellationToken ct = default);
 
-    Task ToggleFavoriteAsync(string ownerId, Guid id, CancellationToken ct = default);
-
-
     Task<NotebookItemDetailVm> CompleteAsync(string ownerId, Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct = default);
 
     Task<NotebookItemDetailVm> ConvertTypeAsync(string ownerId, Guid id, NotebookItemType newType, Guid expectedVersion, CancellationToken ct = default);

--- a/Services/Notebook/NotebookCardModelFactory.cs
+++ b/Services/Notebook/NotebookCardModelFactory.cs
@@ -15,7 +15,7 @@ public sealed class NotebookCardModelFactory : INotebookCardModelFactory
 
     public NotebookCardRenderVm Create(NotebookItemListVm item, NotebookCardContext context)
     {
-        var view = string.IsNullOrWhiteSpace(context.View) ? "home" : context.View;
+        var view = NormalizeView(context.View);
         var routeValues = new RouteValueDictionary
         {
             ["view"] = view,
@@ -47,6 +47,17 @@ public sealed class NotebookCardModelFactory : INotebookCardModelFactory
             }
         };
     }
+
+    // SECTION: View context helpers
+    private static string NormalizeView(string? view) => view?.Trim().ToLowerInvariant() switch
+    {
+        "today" => "today",
+        "reminders" => "reminders",
+        "labels" => "labels",
+        "archive" => "archive",
+        "completed" => "completed",
+        _ => NotebookCardContexts.Home
+    };
 
     // SECTION: Route value helpers
     private static void AddOptionalRouteValue(RouteValueDictionary values, string key, string? value)

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -383,14 +383,6 @@ public sealed class NotebookService : INotebookService
         return MapDetail(item);
     }
 
-    public async Task ToggleFavoriteAsync(string ownerId, Guid id, CancellationToken ct = default)
-    {
-        var item = await LoadOwned(ownerId, id, ct);
-        item.IsFavorite = !item.IsFavorite;
-        Touch(item, _clock.UtcNow);
-        await _db.SaveChangesAsync(ct);
-    }
-
     public async Task<NotebookItemDetailVm> CompleteAsync(string ownerId, Guid id, bool isComplete, Guid expectedVersion, CancellationToken ct = default)
     {
         var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);

--- a/wwwroot/js/notebook/notebook-board.js
+++ b/wwwroot/js/notebook/notebook-board.js
@@ -1,3 +1,5 @@
+import { NotebookBoardTargetError, NotebookCardHtmlError } from './notebook-errors.js';
+
 // SECTION: Notebook board DOM updates
 export function createNotebookBoard(root = document) {
   // SECTION: Board lookup helpers
@@ -8,7 +10,7 @@ export function createNotebookBoard(root = document) {
   // SECTION: Safe server-rendered card parsing
   function htmlToCardElement(html, expectedId) {
     if (typeof html !== 'string' || !html.trim()) {
-      throw new Error('Notebook card HTML was empty.');
+      throw new NotebookCardHtmlError('Notebook card HTML was empty.');
     }
 
     const template = document.createElement('template');
@@ -16,16 +18,16 @@ export function createNotebookBoard(root = document) {
     const elements = template.content.children;
 
     if (elements.length !== 1) {
-      throw new Error('Notebook card response must contain exactly one root element.');
+      throw new NotebookCardHtmlError('Notebook card response must contain exactly one root element.');
     }
 
     const card = elements[0];
     if (!card.matches('[data-note-id]')) {
-      throw new Error('Notebook card response did not contain a note card.');
+      throw new NotebookCardHtmlError('Notebook card response did not contain a note card.');
     }
 
     if (expectedId !== undefined && expectedId !== null && card.dataset.noteId !== String(expectedId)) {
-      throw new Error('Notebook card response did not match the requested note.');
+      throw new NotebookCardHtmlError('Notebook card response did not match the requested note.');
     }
 
     return card;
@@ -36,9 +38,9 @@ export function createNotebookBoard(root = document) {
   const refreshEmptyState = () => { const empty = root.querySelector('[data-notebook-empty-state="current"]') || root.querySelector('[data-notebook-empty-state]') || root.querySelector('[data-notebook-empty]'); if (!empty) return; const count = [...root.querySelectorAll('[data-notebook-board]')].reduce((total, board) => total + board.querySelectorAll(':scope > [data-note-id]').length, 0); empty.hidden = count > 0; };
 
   // SECTION: Card mutation helpers
-  const upsertCard = (id, html, isPinned, options = {}) => { const current = findCard(id); const targetBoard = getBoard(isPinned); if (!targetBoard) throw new Error(`Notebook board "${isPinned ? 'pinned' : 'others'}" was not found.`); const fragment = htmlToCardElement(html, id); const sameBoard = current && current.parentElement === targetBoard; const preservePosition = options.preservePosition !== false; if (sameBoard && preservePosition) { current.replaceWith(fragment); } else { current?.remove(); options.prepend === false ? targetBoard.append(fragment) : targetBoard.prepend(fragment); } refreshSectionVisibility(); refreshEmptyState(); return fragment; };
+  const upsertCard = (id, html, isPinned, options = {}) => { const current = findCard(id); const targetBoard = getBoard(isPinned); if (!targetBoard) throw new NotebookBoardTargetError(`Notebook board "${isPinned ? 'pinned' : 'others'}" was not found.`); const fragment = htmlToCardElement(html, id); const sameBoard = current && current.parentElement === targetBoard; const preservePosition = options.preservePosition !== false; if (sameBoard && preservePosition) { current.replaceWith(fragment); } else { current?.remove(); options.prepend === false ? targetBoard.append(fragment) : targetBoard.prepend(fragment); } refreshSectionVisibility(); refreshEmptyState(); return fragment; };
   const replaceCard = (id, html) => { const current = findCard(id); if (!current) return null; const fragment = htmlToCardElement(html, id); current.replaceWith(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
-  const insertCard = (html, pinned = false) => { const fragment = htmlToCardElement(html); const board = getBoard(pinned); if (!board) throw new Error(`Notebook board "${pinned ? 'pinned' : 'others'}" was not found.`); board.prepend(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
+  const insertCard = (html, pinned = false) => { const fragment = htmlToCardElement(html); const board = getBoard(pinned); if (!board) throw new NotebookBoardTargetError(`Notebook board "${pinned ? 'pinned' : 'others'}" was not found.`); board.prepend(fragment); refreshSectionVisibility(); refreshEmptyState(); return fragment; };
   const removeCard = (id) => { findCard(id)?.remove(); refreshSectionVisibility(); refreshEmptyState(); };
   return { findCard, getSection, getBoard, replaceCard, insertCard, upsertCard, removeCard, refreshSectionVisibility, refreshEmptyState, htmlToCardElement };
 }

--- a/wwwroot/js/notebook/notebook-board.test.js
+++ b/wwwroot/js/notebook/notebook-board.test.js
@@ -9,7 +9,9 @@ function loadBoard(dom) {
   global.document = dom.window.document;
   global.CSS = dom.window.CSS || { escape: (value) => String(value).replace(/"/g, '\\"') };
   const scriptPath = path.resolve(__dirname, 'notebook-board.js');
-  const script = fs.readFileSync(scriptPath, 'utf8').replace('export function createNotebookBoard', 'function createNotebookBoard');
+  const script = fs.readFileSync(scriptPath, 'utf8')
+    .replace(/import .*notebook-errors\.js';\n/, 'class NotebookCardHtmlError extends Error { constructor(message) { super(message); this.code = \'notebook_invalid_card_html\'; } } class NotebookBoardTargetError extends Error { constructor(message) { super(message); this.code = \'notebook_target_board_missing\'; } }\n')
+    .replace('export function createNotebookBoard', 'function createNotebookBoard');
   const context = vm.createContext({ document: dom.window.document, CSS: global.CSS });
   vm.runInContext(`${script}; globalThis.__createNotebookBoard = createNotebookBoard;`, context);
   return context.__createNotebookBoard(dom.window.document);
@@ -45,4 +47,23 @@ test('notebook board inserts a valid card into the requested board only', async 
   const card = board.upsertCard('note-1', '<article data-note-id="note-1" data-version="v1"></article>', false);
   assert.equal(card.dataset.noteId, 'note-1');
   assert.equal(dom.window.document.querySelector('[data-notebook-board="others"] > [data-note-id="note-1"]'), card);
+});
+
+
+test('notebook board throws typed error for missing target board', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(
+    () => board.upsertCard('note-1', '<article data-note-id="note-1"></article>', true),
+    (error) => error.code === 'notebook_target_board_missing'
+  );
+});
+
+test('notebook board throws typed error for invalid card HTML', async () => {
+  const dom = new JSDOM('<div data-notebook-board="others"></div>');
+  const board = loadBoard(dom);
+  assert.throws(
+    () => board.upsertCard('note-1', '<article data-note-id="note-2"></article>', false),
+    (error) => error.code === 'notebook_invalid_card_html'
+  );
 });

--- a/wwwroot/js/notebook/notebook-errors.js
+++ b/wwwroot/js/notebook/notebook-errors.js
@@ -1,0 +1,24 @@
+// SECTION: Typed notebook reconciliation errors
+export class NotebookCardHtmlError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NotebookCardHtmlError';
+    this.code = 'notebook_invalid_card_html';
+  }
+}
+
+export class NotebookBoardTargetError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NotebookBoardTargetError';
+    this.code = 'notebook_target_board_missing';
+  }
+}
+
+export class NotebookBoardUpdateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NotebookBoardUpdateError';
+    this.code = 'notebook_board_update_failed';
+  }
+}

--- a/wwwroot/js/notebook/notebook-reconcile.js
+++ b/wwwroot/js/notebook/notebook-reconcile.js
@@ -1,4 +1,5 @@
 import { NotebookApiError } from './notebook-api.js';
+import { NotebookCardHtmlError } from './notebook-errors.js';
 
 // SECTION: Notebook mutation response validation
 export function requireMutationItem(response, message = 'The notebook response did not contain an updated item.') {
@@ -54,7 +55,7 @@ export async function reconcileMutation({
   }
 
   if (typeof html !== 'string' || !html.trim()) {
-    const error = new Error('Notebook card response was empty.');
+    const error = new NotebookCardHtmlError('Notebook card response was empty.');
     logReconciliationFailure(item, 'empty-card-response', error);
     showGlobalError?.(renderFailureMessage);
     return { item, reconciled: false, code: 'notebook_empty_card_response' };
@@ -65,14 +66,25 @@ export async function reconcileMutation({
     board.upsertCard(item.id, html, item.isPinned, { preservePosition, prepend });
     return { item, reconciled: true };
   } catch (error) {
-    const stage = String(error?.message || '').includes('board')
-      ? 'target-board'
-      : String(error?.message || '').includes('card response') || String(error?.message || '').includes('card HTML')
-        ? 'invalid-card-html'
-        : 'card-replacement';
-    logReconciliationFailure(item, stage, error);
-    showGlobalError?.(stage === 'invalid-card-html' ? renderFailureMessage : reconcileFailureMessage);
+    const classification = classifyReconciliationError(error);
+    logReconciliationFailure(item, classification.stage, error);
+    showGlobalError?.(classification.isRenderFailure ? renderFailureMessage : reconcileFailureMessage);
     updateCardConcurrencyState(existingCard || board?.findCard?.(item.id), item);
-    return { item, reconciled: false, code: stage === 'invalid-card-html' ? 'notebook_invalid_card_html' : 'notebook_board_reconcile_failed' };
+    return { item, reconciled: false, code: classification.code };
+  }
+}
+
+
+// SECTION: Typed reconciliation error classification
+export function classifyReconciliationError(error) {
+  switch (error?.code) {
+    case 'notebook_invalid_card_html':
+      return { stage: 'invalid-card-html', code: 'notebook_invalid_card_html', isRenderFailure: true };
+    case 'notebook_target_board_missing':
+      return { stage: 'target-board', code: 'notebook_target_board_missing', isRenderFailure: false };
+    case 'notebook_board_update_failed':
+      return { stage: 'card-replacement', code: 'notebook_board_update_failed', isRenderFailure: false };
+    default:
+      return { stage: 'card-replacement', code: 'notebook_board_reconcile_failed', isRenderFailure: false };
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure committed Notebook mutations are never marked failed by best-effort presentation work such as card rendering or counts aggregation.
- Reduce fragile message-based reconciliation logic in the client and make card reconciliation errors explicit and typed.
- Remove the remaining non-versioned Favorite mutation path and formalise a canonical card render context to avoid inconsistent card HTML insertion.

### Description

- Make `NotebookMutationResponse.Counts` nullable and add `TryGetCountsAsync` to the controller so count refresh is best-effort and does not convert a successful mutation into HTTP 500 responses.
- Preserve request cancellation semantics by rethrowing `OperationCanceledException` in the card endpoint and `TryRenderCardAsync`, and return `null` card HTML on render failures while still returning a successful mutation response.
- Introduce `NotebookCardContexts.Home` and `NormalizeView(...)` in the card model factory and always render canonical Home card HTML for mutation responses rather than accepting arbitrary view strings.
- Remove the non-versioned `ToggleFavoriteAsync` surface from the service and Razor page handler, add typed client errors in `wwwroot/js/notebook/notebook-errors.js`, update `notebook-board.js` to throw typed errors, and replace message-based classification with `classifyReconciliationError()` in `notebook-reconcile.js`.
- Add/adjust JS tests to assert typed error behaviour and board parsing expectations in `wwwroot/js/notebook/notebook-board.test.js` and preserve existing autosave/reconciliation JS tests.

### Testing

- Ran `npm ci` which completed successfully (audit warnings reported but install finished). 
- Ran `npm test` (the repo's JS test runner) and the test suite passed with `32` tests (TAP output showing all tests OK).
- The JS tests added exercise typed error paths for `htmlToCardElement` and board target errors and passed.
- Attempts to run `dotnet restore`, `dotnet build` and `dotnet test` could not be executed in this environment because `dotnet` is not installed, so C# integration/unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3617319ed483298989f40222fc3917)