### PR TITLE
Make Document.SearchVector provider-aware (ignore for non-Postgres)

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -345,7 +345,15 @@ namespace ProjectManagement.Data
                 e.Property(x => x.DeleteReason).HasMaxLength(512);
                 e.Property(x => x.OcrStatus).HasDefaultValue(DocOcrStatus.None);
                 e.Property(x => x.OcrFailureReason).HasMaxLength(1024);
-                e.Property(x => x.SearchVector).HasColumnType("tsvector");
+                // SECTION: PostgreSQL full-text search configuration
+                if (Database.IsNpgsql())
+                {
+                    e.Property(x => x.SearchVector).HasColumnType("tsvector");
+                }
+                else
+                {
+                    e.Ignore(x => x.SearchVector);
+                }
                 e.Property(x => x.IsAots).HasDefaultValue(false);
                 e.HasIndex(x => new { x.OfficeCategoryId, x.DocumentCategoryId });
                 e.HasIndex(x => x.Sha256).IsUnique();


### PR DESCRIPTION
### Motivation
- Many tests initialize `ApplicationDbContext` using non-PostgreSQL providers (SQLite/InMemory), and mapping the PostgreSQL-specific `NpgsqlTsVector` property `Document.SearchVector` unconditionally caused EF model building to fail during context initialization.
- The intent is to allow the test-suite to construct the EF model with non-Postgres providers without encountering provider-specific mapping errors.

### Description
- Updated the `Document` entity configuration in `ApplicationDbContext` to only map `SearchVector` as PostgreSQL `tsvector` when `Database.IsNpgsql()` is true and to `Ignore` the property for other providers.
- This change avoids referencing `NpgsqlTsVector` mapping on SQLite/InMemory/SQL Server, aligning the `Document` mapping with the provider-aware pattern already used elsewhere.
- Added a brief comment clarifying the PostgreSQL full-text search configuration.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it succeeded.
- Attempted to run `dotnet test` for the test project (`ProjectManagement.Tests`) but could not execute because `dotnet` is not installed in the current environment, so no test-suite run was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a362d59177483298764846c9e9b7107)