### PR TITLE
Harden notebook renderer test baseline

### DIFF
--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -98,7 +98,7 @@ public sealed class NotebookController : Controller
         if (validation is not null) return validation;
         var uid = CurrentUserId();
         var item = await _notebook.CreateAsync(uid, ToInput(request), ct);
-        return CreatedAtAction(nameof(Get), new { id = item.Id }, await BuildMutationResponseAsync(item, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return CreatedAtAction(nameof(Get), new { id = item.Id }, await BuildMutationResponseAsync(item, includeCard: true, ct));
     }
 
     [HttpPatch("{id:guid}")]
@@ -120,7 +120,7 @@ public sealed class NotebookController : Controller
         var uid = CurrentUserId();
         var updated = await _notebook.UpdateAsync(uid, id, ToInput(request), request.Version, ct);
 
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/pin")]
@@ -128,7 +128,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.SetPinnedAsync(CurrentUserId(), id, request.IsPinned, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/archive")]
@@ -136,7 +136,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ArchiveAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
     }
 
     [HttpPost("{id:guid}/complete")]
@@ -144,7 +144,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.CompleteAsync(CurrentUserId(), id, true, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
     }
 
     [HttpPost("{id:guid}/reopen")]
@@ -152,7 +152,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ReopenAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
     }
 
 
@@ -169,7 +169,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.RestoreAsync(CurrentUserId(), id, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: false, ct));
     }
 
     [HttpPost("{id:guid}/show-checkboxes")]
@@ -177,7 +177,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ConvertTypeAsync(CurrentUserId(), id, NotebookItemType.Checklist, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/hide-checkboxes")]
@@ -185,7 +185,7 @@ public sealed class NotebookController : Controller
     {
         if (request.Version == Guid.Empty) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "version", "A valid notebook version is required."));
         var updated = await _notebook.ConvertTypeAsync(CurrentUserId(), id, NotebookItemType.Note, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(updated, includeCard: true, ct));
     }
 
 
@@ -198,14 +198,14 @@ public sealed class NotebookController : Controller
         }
 
         var item = await _notebook.ToggleChecklistItemAsync(CurrentUserId(), itemId, rowId, request.IsDone, request.Version, ct);
-        return Ok(await BuildMutationResponseAsync(item, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(item, includeCard: true, ct));
     }
 
     [HttpPost("{id:guid}/duplicate")]
     public async Task<IActionResult> Duplicate(Guid id, CancellationToken ct)
     {
         var copy = await _notebook.DuplicateAsync(CurrentUserId(), id, ct);
-        return Ok(await BuildMutationResponseAsync(copy, includeCard: true, view: NotebookCardContexts.Home, ct));
+        return Ok(await BuildMutationResponseAsync(copy, includeCard: true, ct));
     }
 
     // SECTION: Mapping and validation helpers
@@ -247,8 +247,9 @@ public sealed class NotebookController : Controller
     }
 
 
-    private async Task<NotebookMutationResponse> BuildMutationResponseAsync(NotebookItemDetailVm item, bool includeCard, string view, CancellationToken ct)
+    private async Task<NotebookMutationResponse> BuildMutationResponseAsync(NotebookItemDetailVm item, bool includeCard, CancellationToken ct)
     {
+        // SECTION: Mutation responses always render canonical Home-board card markup.
         var ownerId = CurrentUserId();
         var cardHtml = includeCard ? await TryRenderCardAsync(item, NotebookCardContexts.Home, ct) : null;
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,5 +13,7 @@
     <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
     <RestoreOutputPath>$(BaseIntermediateOutputPath)</RestoreOutputPath>
     <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <!-- SECTION: Exclude generated artifacts from SDK default globs across all projects -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**;$(MSBuildProjectDirectory)\TestResults\**</DefaultItemExcludes>
   </PropertyGroup>
 </Project>

--- a/ProjectManagement.Tests/NotebookCardRendererTests.cs
+++ b/ProjectManagement.Tests/NotebookCardRendererTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectManagement.Models;
+using ProjectManagement.Services.Notebook;
+using ProjectManagement.ViewModels.Notebook;
+
+namespace ProjectManagement.Tests;
+
+public sealed class NotebookCardRendererTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public NotebookCardRendererTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task RenderAsync_returns_valid_note_card_html()
+    {
+        // SECTION: Arrange hosted Razor card renderer dependencies
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var renderer = scope.ServiceProvider.GetRequiredService<INotebookCardRenderer>();
+        var modelFactory = scope.ServiceProvider.GetRequiredService<INotebookCardModelFactory>();
+        var item = CreateNote();
+        var model = modelFactory.Create(item, new NotebookCardContext { View = NotebookCardContexts.Home });
+
+        // SECTION: Act
+        var html = await renderer.RenderAsync(model, CancellationToken.None);
+
+        // SECTION: Assert card essentials
+        Assert.False(string.IsNullOrWhiteSpace(html));
+        Assert.Contains($"data-note-id=\"{item.Id}\"", html, StringComparison.Ordinal);
+        Assert.Contains($"data-version=\"{item.Version}\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-action=\"open-note\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-action=\"pin-note\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenderAsync_returns_valid_checklist_card_html()
+    {
+        // SECTION: Arrange checklist card
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var renderer = scope.ServiceProvider.GetRequiredService<INotebookCardRenderer>();
+        var modelFactory = scope.ServiceProvider.GetRequiredService<INotebookCardModelFactory>();
+        var item = CreateChecklist();
+        var model = modelFactory.Create(item, new NotebookCardContext { View = NotebookCardContexts.Home });
+
+        // SECTION: Act
+        var html = await renderer.RenderAsync(model, CancellationToken.None);
+
+        // SECTION: Assert checklist-specific rendering
+        Assert.Contains("First checklist row", html, StringComparison.Ordinal);
+        Assert.Contains("Second checklist row", html, StringComparison.Ordinal);
+        Assert.Contains("data-action=\"toggle-checklist\"", html, StringComparison.Ordinal);
+        Assert.Contains("1/2", html, StringComparison.Ordinal);
+        Assert.Contains($"data-version=\"{item.Version}\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenderAsync_returns_partial_card_without_layout_markup()
+    {
+        // SECTION: Arrange pinned card
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var renderer = scope.ServiceProvider.GetRequiredService<INotebookCardRenderer>();
+        var modelFactory = scope.ServiceProvider.GetRequiredService<INotebookCardModelFactory>();
+        var item = CreateNote(isPinned: true);
+        var model = modelFactory.Create(item, new NotebookCardContext { View = "unsupported-view" });
+
+        // SECTION: Act
+        var html = await renderer.RenderAsync(model, CancellationToken.None);
+
+        // SECTION: Assert partial isolation and nested actions
+        Assert.Contains("data-is-pinned=\"true\"", html, StringComparison.Ordinal);
+        Assert.Contains("aria-label=\"Unpin note\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-action=\"archive-note\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-action=\"duplicate-note\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<html", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<head", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<body", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("PRISM ERP", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, CountOccurrences(html, "data-note-id=\""));
+    }
+
+    private static NotebookItemListVm CreateNote(bool isPinned = false) => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = "Renderer note",
+        Preview = "Renderer body",
+        Type = NotebookItemType.Note,
+        Status = NotebookItemStatus.Active,
+        Priority = NotebookPriority.Normal,
+        IsPinned = isPinned,
+        ColorKey = "white",
+        UpdatedAtUtc = DateTimeOffset.UtcNow,
+        Version = Guid.NewGuid()
+    };
+
+    private static NotebookItemListVm CreateChecklist() => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = "Renderer checklist",
+        Type = NotebookItemType.Checklist,
+        Status = NotebookItemStatus.Active,
+        Priority = NotebookPriority.Normal,
+        ColorKey = "white",
+        UpdatedAtUtc = DateTimeOffset.UtcNow,
+        ChecklistTotal = 2,
+        ChecklistDone = 1,
+        ChecklistPreviewItems = new[]
+        {
+            new NotebookChecklistItemVm { Id = 1, Text = "First checklist row", IsDone = true, SortOrder = 1 },
+            new NotebookChecklistItemVm { Id = 2, Text = "Second checklist row", IsDone = false, SortOrder = 2 }
+        },
+        Version = Guid.NewGuid()
+    };
+
+    private static int CountOccurrences(string value, string token)
+    {
+        // SECTION: Simple literal occurrence count
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(token, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += token.Length;
+        }
+
+        return count;
+    }
+}

--- a/ProjectManagement.Tests/NotebookMigrationTests.cs
+++ b/ProjectManagement.Tests/NotebookMigrationTests.cs
@@ -27,11 +27,13 @@ public sealed class NotebookMigrationTests
         // SECTION: Existing database upgrade regression guard
         var migration = File.ReadAllText(Path.Combine(GetRepoRoot(), "20261125231000_AddNotebookItemVersion.cs"));
 
-        Assert.Contains("nullable: true", migration, StringComparison.Ordinal);
-        Assert.Contains("CREATE EXTENSION IF NOT EXISTS pgcrypto", migration, StringComparison.Ordinal);
-        Assert.Contains("SET \"Version\" = gen_random_uuid()", migration, StringComparison.Ordinal);
-        Assert.Contains("OR \"Version\" = '00000000-0000-0000-0000-000000000000'", migration, StringComparison.Ordinal);
-        Assert.Contains("nullable: false", migration, StringComparison.Ordinal);
+        var addColumnIndex = migration.IndexOf("ADD COLUMN IF NOT EXISTS \"Version\" uuid", StringComparison.Ordinal);
+        var updateIndex = migration.IndexOf("SET \"Version\" = gen_random_uuid()", StringComparison.Ordinal);
+        var setNotNullIndex = migration.IndexOf("ALTER COLUMN \"Version\" SET NOT NULL", StringComparison.Ordinal);
+
+        Assert.True(addColumnIndex >= 0, "The Version column must be added conditionally.");
+        Assert.True(updateIndex > addColumnIndex, "Existing rows must be backfilled after the column is added.");
+        Assert.True(setNotNullIndex > updateIndex, "NOT NULL must be enforced only after backfilling.");
         Assert.DoesNotContain("defaultValue: Guid.Empty", migration, StringComparison.Ordinal);
     }
 

--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -10,17 +10,6 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <!--
-      SECTION: Stable build output paths
-      Pin output/intermediate paths to the project directory to avoid recursive
-      "bin/.../ProjectManagement.Tests/bin/..." copy chains on Windows builds.
-    -->
-    <BaseOutputPath>$(MSBuildProjectDirectory)\bin\</BaseOutputPath>
-    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
-    <MSBuildProjectExtensionsPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
-
-    <!-- SECTION: Exclude generated artifacts from default item globs -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,10 +40,18 @@
 
   <ItemGroup>
     <!-- SECTION: Defensive cleanup for generated artifacts -->
+    <Compile Remove="bin\**" />
+    <Compile Remove="obj\**" />
+    <Compile Remove="TestResults\**" />
     <Content Remove="bin\**" />
     <Content Remove="obj\**" />
+    <Content Remove="TestResults\**" />
+    <EmbeddedResource Remove="bin\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <EmbeddedResource Remove="TestResults\**" />
     <None Remove="bin\**" />
     <None Remove="obj\**" />
+    <None Remove="TestResults\**" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation

- Stabilise Notebook test and rendering surface by adding executable integration coverage for the Razor card renderer and bringing migration assertions and project output configuration into alignment with the runtime implementation.
- Remove misleading API surface that implied mutation responses could render arbitrary views and document that mutation responses always return canonical Home-board card markup.
- Reduce flaky test-discovery and duplicate output assembly problems by centralising output/exclude configuration and ensuring test project globs do not re-include generated artifacts.

### Description

- Removed the unused `view` parameter from `BuildMutationResponseAsync` and updated all mutation endpoints to call `BuildMutationResponseAsync(..., includeCard, ct)`, and documented that mutation responses render canonical `NotebookCardContexts.Home` markup inside the method. (Controllers/Api/NotebookController.cs)
- Replaced fragile source-text migration assertions with checks for the actual PostgreSQL SQL ordering (conditional `ADD COLUMN`, `gen_random_uuid()` backfill, then `ALTER ... SET NOT NULL`) in the Notebook migration regression test. (ProjectManagement.Tests/NotebookMigrationTests.cs)
- Added hosted Razor renderer integration tests using `WebApplicationFactory<Program>` that exercise note card, checklist card, pinned state, nested actions and partial isolation (one-root assertion). (ProjectManagement.Tests/NotebookCardRendererTests.cs)
- Centralised SDK default globs exclusions in `Directory.Build.props` and removed duplicate output-path properties from the test project while keeping defensive removals for `bin`, `obj` and `TestResults` in the test project file to avoid recursive/duplicate outputs. (Directory.Build.props, ProjectManagement.Tests/ProjectManagement.Tests.csproj)

### Testing

- Ran `npm ci` which completed successfully. 
- Ran `npm test` which completed successfully and reported `# tests 32` with all tests passing. 
- Attempted to run the CLI `.NET` restore/build/test baseline (`dotnet restore` / `dotnet build` / `dotnet test`) but this environment does not have `dotnet` installed so the .NET test run was blocked and could not be executed here; please run `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj` locally or in CI to execute the new C# integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a362f44f64c8329b6dd1a6966ca7f07)