### PR TITLE
Guard FFC breadcrumb URL generation and remove duplicate breadcrumb calls

### DIFF
--- a/Areas/ProjectOfficeReports/Pages/FFC/Countries/Manage.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Countries/Manage.cshtml.cs
@@ -84,11 +84,12 @@ public class ManageModel(ApplicationDbContext db, IAuditService audit, ILogger<M
         return RedirectToManage();
     }
 
+    // SECTION: Breadcrumb helpers
     private void ConfigureBreadcrumb()
     {
         FfcBreadcrumbs.Set(
             ViewData,
-            ("FFC Proposals", Url.Page("/FFC/Index", new { area = "ProjectOfficeReports" })),
+            ("FFC Proposals", Url?.Page("/FFC/Index", new { area = "ProjectOfficeReports" })),
             ("Manage countries", null));
     }
 

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/Manage.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/Manage.cshtml.cs
@@ -42,11 +42,12 @@ public class ManageModel : FfcRecordListPageModel
         _logger = logger;
     }
 
+    // SECTION: Breadcrumb helpers
     private void ConfigureBreadcrumb()
     {
         FfcBreadcrumbs.Set(
             ViewData,
-            ("FFC Proposals", Url.Page("/FFC/Index", new { area = "ProjectOfficeReports" })),
+            ("FFC Proposals", Url?.Page("/FFC/Index", new { area = "ProjectOfficeReports" })),
             ("Manage records", null));
     }
 

--- a/Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml.cs
+++ b/Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml.cs
@@ -57,8 +57,6 @@ public class ManageModel(ApplicationDbContext db, IAuditService audit, ILogger<M
 
         ConfigureBreadcrumb("Projects");
 
-        ConfigureBreadcrumb("Projects");
-
         if (id.HasValue)
         {
             var project = await _db.FfcProjects
@@ -100,8 +98,6 @@ public class ManageModel(ApplicationDbContext db, IAuditService audit, ILogger<M
         {
             return NotFound();
         }
-
-        ConfigureBreadcrumb("Projects");
 
         ConfigureBreadcrumb("Projects");
 
@@ -227,12 +223,13 @@ public class ManageModel(ApplicationDbContext db, IAuditService audit, ILogger<M
         }
     }
 
+    // SECTION: Breadcrumb helpers
     private void ConfigureBreadcrumb(string leaf)
     {
-        var dashboardUrl = Url.Page("/FFC/Index", new { area = "ProjectOfficeReports" });
-        var manageUrl = Url.Page("/FFC/Records/Manage", new { area = "ProjectOfficeReports" });
+        var dashboardUrl = Url?.Page("/FFC/Index", new { area = "ProjectOfficeReports" });
+        var manageUrl = Url?.Page("/FFC/Records/Manage", new { area = "ProjectOfficeReports" });
         var recordSegmentText = $"{Record.Country?.Name ?? "Record"} – {Record.Year}";
-        var recordSegmentUrl = Url.Page(
+        var recordSegmentUrl = Url?.Page(
             "/FFC/Records/Manage",
             new { area = "ProjectOfficeReports", editId = Record.Id });
 


### PR DESCRIPTION
### Motivation
- Prevent PageModel unit tests from throwing when the Razor `Url` helper is not configured by making breadcrumb URL generation null-safe. 
- Remove redundant breadcrumb configuration calls in the FFC projects pages to avoid duplicated work and improve clarity. 

### Description
- Replaced direct `Url.Page(...)` calls with null-safe `Url?.Page(...)` in `Areas/ProjectOfficeReports/Pages/FFC/Countries/Manage.cshtml.cs`, `Areas/ProjectOfficeReports/Pages/FFC/Records/Manage.cshtml.cs`, and `Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml.cs` to avoid NREs during unit tests. 
- Removed duplicated `ConfigureBreadcrumb("Projects")` invocations in `Areas/ProjectOfficeReports/Pages/FFC/Records/Projects/Manage.cshtml.cs`. 
- Added `// SECTION: Breadcrumb helpers` comments above the breadcrumb helper methods for readability and easier future edits. 

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues and it succeeded. 
- Attempted to run filtered unit tests with `dotnet test --no-restore --filter "FullyQualifiedName~ProjectOfficeReports|FullyQualifiedName~Activities.ActivityEditPageTests|FullyQualifiedName~IndustryPartnerRulesTests|FullyQualifiedName~StageRequestServiceTests|FullyQualifiedName~TrainingExportServiceTests"`, but the command could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3635b4d7ac8329b80dcced8ad66d5a)