### PR TITLE
Notebook board fallback and isolate notebook renderer tests

### DIFF
--- a/ProjectManagement.Tests/NotebookCardRendererTests.cs
+++ b/ProjectManagement.Tests/NotebookCardRendererTests.cs
@@ -1,16 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using ProjectManagement.Data;
 using ProjectManagement.Models;
 using ProjectManagement.Services.Notebook;
 using ProjectManagement.ViewModels.Notebook;
 
 namespace ProjectManagement.Tests;
 
-public sealed class NotebookCardRendererTests : IClassFixture<WebApplicationFactory<Program>>
+public sealed class NotebookCardRendererTests : IClassFixture<NotebookCardRendererTests.NotebookRendererFactory>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly NotebookRendererFactory _factory;
 
-    public NotebookCardRendererTests(WebApplicationFactory<Program> factory)
+    public NotebookCardRendererTests(NotebookRendererFactory factory)
     {
         _factory = factory;
     }
@@ -80,6 +84,21 @@ public sealed class NotebookCardRendererTests : IClassFixture<WebApplicationFact
         Assert.DoesNotContain("<body", html, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("PRISM ERP", html, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(1, CountOccurrences(html, "data-note-id=\""));
+    }
+
+    // SECTION: Test host setup
+    public sealed class NotebookRendererFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                // SECTION: Keep partial-render tests independent from configured PostgreSQL startup
+                services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase($"notebook-renderer-{Guid.NewGuid()}"));
+            });
+        }
     }
 
     private static NotebookItemListVm CreateNote(bool isPinned = false) => new()

--- a/wwwroot/js/notebook/notebook-board.js
+++ b/wwwroot/js/notebook/notebook-board.js
@@ -5,7 +5,11 @@ export function createNotebookBoard(root = document) {
   // SECTION: Board lookup helpers
   const findCard = (id) => root.querySelector(`[data-note-id="${CSS.escape(id)}"]`);
   const getSection = (isPinned) => root.querySelector(`[data-notebook-section="${isPinned ? 'pinned' : 'others'}"]`);
-  const getBoard = (isPinned) => root.querySelector(`[data-notebook-board="${isPinned ? 'pinned' : 'others'}"]`);
+  const getBoard = (isPinned) => {
+    // SECTION: Prefer split home boards, then fall back to single-board views
+    const namedBoard = root.querySelector(`[data-notebook-board="${isPinned ? 'pinned' : 'others'}"]`);
+    return namedBoard || root.querySelector('[data-notebook-board]:not([data-notebook-board="pinned"]):not([data-notebook-board="others"])');
+  };
 
   // SECTION: Safe server-rendered card parsing
   function htmlToCardElement(html, expectedId) {

--- a/wwwroot/js/notebook/notebook-board.test.js
+++ b/wwwroot/js/notebook/notebook-board.test.js
@@ -50,6 +50,14 @@ test('notebook board inserts a valid card into the requested board only', async 
 });
 
 
+
+test('notebook board falls back to generic board for single-board views', async () => {
+  const dom = new JSDOM('<div data-notebook-board></div>');
+  const board = loadBoard(dom);
+  const card = board.upsertCard('note-1', '<article data-note-id="note-1"></article>', true);
+  assert.equal(dom.window.document.querySelector('[data-notebook-board] > [data-note-id="note-1"]'), card);
+});
+
 test('notebook board throws typed error for missing target board', async () => {
   const dom = new JSDOM('<div data-notebook-board="others"></div>');
   const board = loadBoard(dom);


### PR DESCRIPTION
### Motivation
- Restore correct client-side behavior so single-board notebook views receive card updates while keeping the split `pinned`/`others` boards preferred on the home board.
- Ensure server-side partial-render tests do not depend on the production PostgreSQL startup so they can run reliably in CI and local dev.

### Description
- Update `getBoard` in `wwwroot/js/notebook/notebook-board.js` to prefer named `pinned`/`others` boards and fall back to a generic `data-notebook-board` element for single-board views.
- Add a JavaScript test in `wwwroot/js/notebook/notebook-board.test.js` that verifies upserting into a generic single-board view uses the fallback board.
- Change `ProjectManagement.Tests/NotebookCardRendererTests.cs` to use a dedicated `WebApplicationFactory` (`NotebookRendererFactory`) which swaps the `ApplicationDbContext` to an EF Core in-memory database for the test host.

### Testing
- Ran the JavaScript test suite with `npm test -- --runInBand` and all JS tests passed (`34` tests, `0` failures).
- Attempted `dotnet test` for the C# tests but the `dotnet` CLI was not available in the execution environment so those tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3651f6fcf483299f9f36f74bd6fdf2)