### PR TITLE
Stabilize notebook update validation

### DIFF
--- a/Contracts/Notebook/NotebookContracts.cs
+++ b/Contracts/Notebook/NotebookContracts.cs
@@ -36,14 +36,11 @@ public sealed class UpdateNotebookItemRequest
 
     [StringLength(NotebookLimits.TitleMaxLength)] public string? Title { get; set; }
     [StringLength(NotebookLimits.BodyMaxLength)] public string? Body { get; set; }
-    public NotebookItemType Type { get; set; } = NotebookItemType.Note;
-    public NotebookPriority Priority { get; set; } = NotebookPriority.Normal;
+    public NotebookPriority? Priority { get; set; }
     public DateTimeOffset? ReminderAtUtc { get; set; }
     [StringLength(32)] public string? ColorKey { get; set; }
-    [Required]
-    public List<NotebookChecklistEditRow> ChecklistRows { get; set; } = [];
-    [Required]
-    public List<string> Labels { get; set; } = [];
+    public List<NotebookChecklistEditRow>? ChecklistRows { get; set; }
+    public List<string>? Labels { get; set; }
 }
 
 public sealed class SetNotebookPinRequest : NotebookVersionedRequest

--- a/Controllers/Api/NotebookController.cs
+++ b/Controllers/Api/NotebookController.cs
@@ -236,7 +236,6 @@ public sealed class NotebookController : Controller
     {
         Title = request.Title ?? string.Empty,
         BodyMarkdown = request.Body,
-        Type = request.Type,
         Priority = request.Priority,
         ReminderAtUtc = request.ReminderAtUtc,
         ColorKey = request.ColorKey,
@@ -272,7 +271,7 @@ public sealed class NotebookController : Controller
         var hasTitle = !string.IsNullOrWhiteSpace(request.Title);
         var hasBody = !string.IsNullOrWhiteSpace(request.Body);
         var rows = request.ChecklistRows.Where(row => !string.IsNullOrWhiteSpace(row.Text)).ToArray();
-        if (!Enum.IsDefined(request.Type) || !Enum.IsDefined(request.Priority)) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "type", "Invalid notebook type or priority."));
+        if (request.Priority.HasValue && !Enum.IsDefined(request.Priority.Value)) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "priority", "Invalid notebook priority."));
         if (!hasTitle && !hasBody && rows.Length == 0) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "content", "Add a title, body, or checklist item before saving."));
         if ((request.Title?.Length ?? 0) > NotebookLimits.TitleMaxLength) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "title", $"Title cannot exceed {NotebookLimits.TitleMaxLength} characters."));
         if ((request.Body?.Length ?? 0) > NotebookLimits.BodyMaxLength) return BadRequest(ApiError("notebook_validation_failed", "The notebook item is invalid.", "body", $"Body cannot exceed {NotebookLimits.BodyMaxLength} characters."));

--- a/Program.cs
+++ b/Program.cs
@@ -629,6 +629,36 @@ builder.Services.AddControllers().AddJsonOptions(o =>
     o.JsonSerializerOptions.Converters.Add(enumConverter);
 });
 
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    // SECTION: Notebook API uses a stable validation response contract for client field summaries.
+    options.InvalidModelStateResponseFactory = context =>
+    {
+        var path = context.HttpContext.Request.Path.Value ?? string.Empty;
+        if (!path.StartsWith("/api/notebook/", StringComparison.OrdinalIgnoreCase))
+        {
+            return new BadRequestObjectResult(context.ModelState);
+        }
+
+        var errors = context.ModelState
+            .Where(entry => entry.Value?.Errors.Count > 0)
+            .ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value!.Errors
+                    .Select(error => string.IsNullOrWhiteSpace(error.ErrorMessage)
+                        ? error.Exception?.GetBaseException().Message ?? "Invalid value."
+                        : error.ErrorMessage)
+                    .ToArray());
+
+        return new BadRequestObjectResult(new
+        {
+            code = "notebook_validation_failed",
+            message = "The notebook request contains invalid information.",
+            errors
+        });
+    };
+});
+
 // Register email sender
 if (!string.IsNullOrWhiteSpace(builder.Configuration["Email:Smtp:Host"]))
 {

--- a/ProjectManagement.Tests/NotebookUpdateContractTests.cs
+++ b/ProjectManagement.Tests/NotebookUpdateContractTests.cs
@@ -18,6 +18,7 @@ public sealed class NotebookUpdateContractTests
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.Contains(nameof(UpdateNotebookItemRequest.Version), properties);
+        Assert.DoesNotContain("Type", properties);
         Assert.DoesNotContain("ClientRequestId", properties);
         Assert.DoesNotContain("IsPinned", properties);
         Assert.DoesNotContain("IsFavorite", properties);
@@ -36,6 +37,7 @@ public sealed class NotebookUpdateContractTests
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.DoesNotContain("Version", properties);
+        Assert.DoesNotContain("Type", properties);
         Assert.DoesNotContain("ClientRequestId", properties);
         Assert.DoesNotContain("IsPinned", properties);
         Assert.DoesNotContain("IsFavorite", properties);

--- a/Services/Notebook/INotebookService.cs
+++ b/Services/Notebook/INotebookService.cs
@@ -84,8 +84,7 @@ public sealed class NotebookUpdateInput
 {
     public string Title { get; init; } = string.Empty;
     public string? BodyMarkdown { get; init; }
-    public NotebookItemType Type { get; init; } = NotebookItemType.Note;
-    public NotebookPriority Priority { get; init; } = NotebookPriority.Normal;
+    public NotebookPriority? Priority { get; init; }
     public DateTimeOffset? ReminderAtUtc { get; init; }
     public string? ColorKey { get; init; }
     public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();

--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -326,7 +326,6 @@ public sealed class NotebookService : INotebookService
             ClientRequestId = input.ClientRequestId,
             Title = input.Title,
             BodyMarkdown = input.BodyMarkdown,
-            Type = input.Type,
             Priority = input.Priority,
             ReminderAtUtc = input.ReminderAtUtc,
             ColorKey = input.ColorKey,
@@ -347,15 +346,11 @@ public sealed class NotebookService : INotebookService
     public async Task<NotebookItemDetailVm> UpdateAsync(string ownerId, Guid id, NotebookUpdateInput input, Guid expectedVersion, CancellationToken ct = default)
     {
         var item = await LoadOwnedForUpdate(ownerId, id, expectedVersion, ct);
-        if (input.Type != item.Type)
-        {
-            throw new ArgumentException("Notebook item type must be changed through a conversion command.");
-        }
         item.Title = CleanTitle(input.Title);
         item.BodyMarkdown = input.BodyMarkdown;
-        item.Priority = input.Priority;
+        item.Priority = input.Priority ?? item.Priority;
         item.ReminderAtUtc = input.ReminderAtUtc;
-        item.ColorKey = CleanColor(input.ColorKey, input.Type);
+        item.ColorKey = CleanColor(input.ColorKey, item.Type);
         Touch(item, _clock.UtcNow);
 
         SyncChecklistItems(item, input.ChecklistRows.Any() ? input.ChecklistRows : input.ChecklistItems.Select((text, index) => new NotebookChecklistEditRow { Text = text, SortOrder = index }).ToArray(), item.UpdatedAtUtc);
@@ -381,7 +376,6 @@ public sealed class NotebookService : INotebookService
         {
             Title = input.Title,
             BodyMarkdown = input.BodyMarkdown,
-            Type = input.Type,
             Priority = input.Priority,
             ReminderAtUtc = input.ReminderAtUtc,
             ColorKey = input.ColorKey,

--- a/wwwroot/js/notebook/notebook-editor.js
+++ b/wwwroot/js/notebook/notebook-editor.js
@@ -2,25 +2,30 @@ import { NotebookApi, NotebookApiError } from './notebook-api.js';
 import { createAutosave } from './notebook-autosave.js';
 import { createChecklistEditor } from './notebook-checklist-editor.js';
 import { reconcileMutation, requireMutationItem } from './notebook-reconcile.js';
+import { getFirstValidationMessage, getValidationMessages } from './notebook-errors.js';
 
 // SECTION: Notebook modal editor lifecycle and coordinated mutations
 export function initNotebookEditor(board, view, options = {}) {
   let modal, item, autosave, checklist, trigger, openedByPushState = false, currentSaveError = null;
+  let blockedByValidation = false;
+  let lastValidationFingerprint = null;
   const shell = options.shell || document.querySelector('.notebook-shell');
   const dirtyState = { title: false, body: false, checklist: false };
   const buildNoteUrl = (id) => { const url = new URL(location.href); id ? url.searchParams.set('note', id) : url.searchParams.delete('note'); return url; };
   const focusableSelector = 'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
   function setStatus(text, state = 'idle') { const el = modal?.querySelector('[data-notebook-save-state]'); if (el) { el.textContent = text || ''; el.dataset.state = state; } const retry = modal?.querySelector('[data-notebook-retry]'); const reload = modal?.querySelector('[data-notebook-reload-latest]'); const discard = modal?.querySelector('[data-modal-discard]'); const signIn = modal?.querySelector('[data-notebook-sign-in]'); const copy = modal?.querySelector('[data-notebook-copy-unsaved]'); if (retry) retry.hidden = !['network','server','error'].includes(state); if (reload) { reload.hidden = !['conflict','client-version'].includes(state); reload.textContent = state === 'client-version' ? 'Reload application' : 'Reload latest'; } if (discard) discard.hidden = !['network','server','error','conflict','client-version','session-expired','forbidden'].includes(state); if (signIn) signIn.hidden = state !== 'session-expired'; if (copy) copy.hidden = !['session-expired','forbidden','network','server','error'].includes(state); }
-  function payload() { return () => ({ title: modal.querySelector('[data-modal-title]').value.trim(), body: modal.querySelector('[data-modal-body]').value.trim(), type: item.type, priority: item.priority ?? 'Normal', reminderAtUtc: item.reminderAtUtc ?? null, colorKey: item.colorKey ?? null, labels: (item.labels || []).map(l => l.name || l), checklistRows: item.type === 'Checklist' ? checklist.getRows() : [], version: item.version }); }
+  function payload() { return () => buildUpdatePayload({ title: modal.querySelector('[data-modal-title]').value, body: modal.querySelector('[data-modal-body]').value, version: item.version, type: item.type, checklistRows: checklist.getRows() }); }
+  function scheduleAutosave() { const factory = payload(); const nextPayload = factory(); const nextFingerprint = validationFingerprint(nextPayload); if (blockedByValidation && nextFingerprint === lastValidationFingerprint) return; if (blockedByValidation) clearValidationBlock(); autosave?.schedule(() => nextPayload); }
+  function clearValidationBlock() { blockedByValidation = false; lastValidationFingerprint = null; renderValidationErrors([]); }
   function configureAutosave() { autosave?.stop(); autosave = createAutosave({ save: saveEditorPayload, onSaving: () => setStatus('Saving…','saving'), onPersisted: applyPersistedResponse, onSaveError: handleEditorError, onReconcileError: handleReconcileError }); }
   function renderPin() { const pin = modal.querySelector('[data-modal-pin]'); pin?.classList.toggle('is-active', !!item?.isPinned); if (pin) pin.setAttribute('aria-label', item?.isPinned ? 'Unpin note' : 'Pin note'); }
-  function renderMode() { modal.querySelector('[data-modal-title]').value = item.title || ''; modal.querySelector('[data-modal-body]').value = item.body || ''; checklist.setRows(item.checklistRows || []); modal.querySelector('[data-modal-checklist]').hidden = item.type !== 'Checklist'; dirtyState.title = dirtyState.body = dirtyState.checklist = false; renderPin(); }
-  function build() { modal = document.createElement('div'); modal.className = 'notebook-modal'; modal.hidden = true; modal.setAttribute('role','dialog'); modal.setAttribute('aria-modal','true'); modal.setAttribute('aria-labelledby','notebook-modal-title'); modal.innerHTML = '<div class="notebook-modal__backdrop" data-close></div><section class="notebook-modal__dialog"><header><input id="notebook-modal-title" data-modal-title class="notebook-modal__title" maxlength="220"><button type="button" class="notebook-action-icon" data-modal-pin aria-label="Pin note"><i class="bi bi-pin-angle"></i></button></header><textarea data-modal-body class="notebook-modal__body" maxlength="20000" placeholder="Take a note…"></textarea><div data-modal-checklist class="notebook-checklist-editor" hidden></div><div class="notebook-save-feedback"><span class="notebook-modal__save-state" data-notebook-save-state aria-live="polite"></span><button type="button" data-notebook-retry hidden>Retry</button><button type="button" data-notebook-reload-latest hidden>Reload latest</button><button type="button" data-notebook-sign-in hidden>Sign in again</button><button type="button" data-notebook-copy-unsaved hidden>Copy note text</button><button type="button" data-modal-discard hidden>Discard changes</button></div><footer><button type="button" class="btn btn-sm btn-link" data-close aria-label="Close note editor">Close</button></footer></section>'; document.body.appendChild(modal); checklist = createChecklistEditor(modal.querySelector('[data-modal-checklist]'), { onChange: () => { dirtyState.checklist = true; autosave?.schedule(payload); } }); modal.addEventListener('click', (e) => { if (e.target.matches('[data-close]')) requestClose(); }); modal.addEventListener('keydown', trapFocus); modal.querySelector('[data-modal-title]').addEventListener('input', () => { dirtyState.title = true; autosave?.schedule(payload); }); modal.querySelector('[data-modal-body]').addEventListener('input', () => { dirtyState.body = true; autosave?.schedule(payload); }); modal.querySelector('[data-modal-pin]').addEventListener('click', pinItem); modal.querySelector('[data-notebook-retry]')?.addEventListener('click', retrySave); modal.querySelector('[data-notebook-reload-latest]')?.addEventListener('click', reloadLatest); modal.querySelector('[data-notebook-sign-in]')?.addEventListener('click', signInAgain); modal.querySelector('[data-notebook-copy-unsaved]')?.addEventListener('click', copyUnsavedContent); modal.querySelector('[data-modal-discard]')?.addEventListener('click', discardChangesAndClose); }
-  async function saveEditorPayload(data) { return NotebookApi.updateItem(item.id, data); }
-  async function applyPersistedResponse(response) { item = requireMutationItem(response); dirtyState.title = dirtyState.body = dirtyState.checklist = false; setStatus('Saved','saved'); await reconcileMutation({ response, board, view, getCardHtml: NotebookApi.getCardHtml, applyCounts: options.applyCounts, preservePosition: true, showGlobalError: options.showGlobalError, renderFailureMessage: 'The note was saved, but its card could not refresh. Reload the page.', reconcileFailureMessage: 'The note was saved, but the board could not refresh. Reload the page.' }); }
+  function renderMode() { modal.querySelector('[data-modal-title]').value = item.title || ''; modal.querySelector('[data-modal-body]').value = item.body || ''; checklist.setRows(item.checklistRows || []); modal.querySelector('[data-modal-checklist]').hidden = item.type !== 'Checklist'; dirtyState.title = dirtyState.body = dirtyState.checklist = false; clearValidationBlock(); renderPin(); }
+  function build() { modal = document.createElement('div'); modal.className = 'notebook-modal'; modal.hidden = true; modal.setAttribute('role','dialog'); modal.setAttribute('aria-modal','true'); modal.setAttribute('aria-labelledby','notebook-modal-title'); modal.innerHTML = '<div class="notebook-modal__backdrop" data-close></div><section class="notebook-modal__dialog"><header><input id="notebook-modal-title" data-modal-title class="notebook-modal__title" maxlength="220"><button type="button" class="notebook-action-icon" data-modal-pin aria-label="Pin note"><i class="bi bi-pin-angle"></i></button></header><textarea data-modal-body class="notebook-modal__body" maxlength="20000" placeholder="Take a note…"></textarea><div class="notebook-editor__validation" data-notebook-validation-summary role="alert" hidden></div><div data-modal-checklist class="notebook-checklist-editor" hidden></div><div class="notebook-save-feedback"><span class="notebook-modal__save-state" data-notebook-save-state aria-live="polite"></span><button type="button" data-notebook-retry hidden>Retry</button><button type="button" data-notebook-reload-latest hidden>Reload latest</button><button type="button" data-notebook-sign-in hidden>Sign in again</button><button type="button" data-notebook-copy-unsaved hidden>Copy note text</button><button type="button" data-modal-discard hidden>Discard changes</button></div><footer><button type="button" class="btn btn-sm btn-link" data-close aria-label="Close note editor">Close</button></footer></section>'; document.body.appendChild(modal); checklist = createChecklistEditor(modal.querySelector('[data-modal-checklist]'), { onChange: () => { dirtyState.checklist = true; scheduleAutosave(); } }); modal.addEventListener('click', (e) => { if (e.target.matches('[data-close]')) requestClose(); }); modal.addEventListener('keydown', trapFocus); modal.querySelector('[data-modal-title]').addEventListener('input', () => { dirtyState.title = true; scheduleAutosave(); }); modal.querySelector('[data-modal-body]').addEventListener('input', () => { dirtyState.body = true; scheduleAutosave(); }); modal.querySelector('[data-modal-pin]').addEventListener('click', pinItem); modal.querySelector('[data-notebook-retry]')?.addEventListener('click', retrySave); modal.querySelector('[data-notebook-reload-latest]')?.addEventListener('click', reloadLatest); modal.querySelector('[data-notebook-sign-in]')?.addEventListener('click', signInAgain); modal.querySelector('[data-notebook-copy-unsaved]')?.addEventListener('click', copyUnsavedContent); modal.querySelector('[data-modal-discard]')?.addEventListener('click', discardChangesAndClose); }
+  async function saveEditorPayload(data) { assertValidVersion(data.version); return NotebookApi.updateItem(item.id, data); }
+  async function applyPersistedResponse(response) { item = requireMutationItem(response); dirtyState.title = dirtyState.body = dirtyState.checklist = false; clearValidationBlock(); setStatus('Saved','saved'); await reconcileMutation({ response, board, view, getCardHtml: NotebookApi.getCardHtml, applyCounts: options.applyCounts, preservePosition: true, showGlobalError: options.showGlobalError, renderFailureMessage: 'The note was saved, but its card could not refresh. Reload the page.', reconcileFailureMessage: 'The note was saved, but the board could not refresh. Reload the page.' }); }
   function handleReconcileError() { options.showGlobalError?.('The note was saved, but the board could not refresh. Reload the page.'); setStatus('Saved','saved'); }
   function classifySaveError(error) { return classifyNotebookSaveError(error); }
-  function handleEditorError(error) { currentSaveError = classifySaveError(error); setStatus(currentSaveError.message, currentSaveError.kind); if (currentSaveError.kind === 'validation') setStatus(currentSaveError.message, 'validation'); if (isDevelopment()) console.error('Notebook update failed', { noteId: item?.id, status: error?.status, code: error?.code, errors: error?.errors, responseText: error?.responseText, error }); }
+  function handleEditorError(error) { currentSaveError = classifySaveError(error); setStatus(currentSaveError.message, currentSaveError.kind); if (currentSaveError.kind === 'validation') { setStatus(currentSaveError.message, 'validation'); renderValidationErrors(currentSaveError.validationErrors); const submittedPayload = payload()(); blockedByValidation = true; lastValidationFingerprint = validationFingerprint(submittedPayload); } if (isDevelopment()) { const submittedPayload = payload()(); console.error('Notebook update failed', { noteId: item?.id, status: error?.status, code: error?.code, errors: error?.errors, responseText: error?.responseText, payload: describeUpdatePayload(submittedPayload) }); } }
   function isDevelopment() { return document.documentElement.dataset.environment === 'Development' || location.hostname === 'localhost'; }
   async function disposeCurrentItem() { if (!item || !autosave) return; await autosave.flush(); autosave.stop(); autosave = null; }
   function setBackgroundInert(inert) { if (shell) shell.inert = inert; if (modal) modal.inert = false; document.body.classList.toggle('notebook-modal-open', inert); }
@@ -28,9 +33,9 @@ export function initNotebookEditor(board, view, options = {}) {
   function preserveUnsavedDraft() { if (!item?.id) return; sessionStorage.setItem(`notebook-draft:${item.id}`, JSON.stringify({ title: modal.querySelector('[data-modal-title]').value, body: modal.querySelector('[data-modal-body]').value, savedAtUtc: new Date().toISOString() })); }
   function signInAgain() { preserveUnsavedDraft(); const returnUrl = window.location.pathname + window.location.search + window.location.hash; window.location.assign('/Identity/Account/Login?ReturnUrl=' + encodeURIComponent(returnUrl)); }
   async function copyUnsavedContent() { const title = modal.querySelector('[data-modal-title]').value.trim(); const body = modal.querySelector('[data-modal-body]').value.trim(); const text = [title, body].filter(Boolean).join('\n\n'); await navigator.clipboard.writeText(text); setStatus('Unsaved note text copied. Sign in again before saving.', currentSaveError?.kind || 'session-expired'); }
-  async function retrySave() { const button = modal.querySelector('[data-notebook-retry]'); button.disabled = true; try { autosave.schedule(payload); await autosave.flush(); } finally { button.disabled = false; } }
-  async function discardChangesAndClose() { if (!window.confirm('Discard unsaved changes and close this note?')) return; const closedId = item?.id; autosave?.cancel?.(); autosave?.stop(); autosave = null; currentSaveError = null; item = null; modal.hidden = true; setBackgroundInert(false); history.replaceState(history.state, '', buildNoteUrl(null)); (board.findCard(closedId) || trigger)?.focus?.(); }
-  async function reloadLatest() { if (currentSaveError?.kind === 'client-version') { window.location.reload(); return; } if (!window.confirm('Reload the latest saved version? Unsaved changes in this editor will be discarded.')) return; const button = modal.querySelector('[data-notebook-reload-latest]'); button.disabled = true; try { item = await NotebookApi.getItem(item.id); renderMode(); setStatus('', 'idle'); } catch (error) { setStatus(error.message || 'Unable to reload the note.', 'error'); } finally { button.disabled = false; } }
+  async function retrySave() { const button = modal.querySelector('[data-notebook-retry]'); button.disabled = true; try { clearValidationBlock(); autosave.schedule(payload); await autosave.flush(); } finally { button.disabled = false; } }
+  async function discardChangesAndClose() { if (!window.confirm('Discard unsaved changes and close this note?')) return; const closedId = item?.id; autosave?.cancel?.(); autosave?.stop(); autosave = null; currentSaveError = null; clearValidationBlock(); item = null; modal.hidden = true; setBackgroundInert(false); history.replaceState(history.state, '', buildNoteUrl(null)); (board.findCard(closedId) || trigger)?.focus?.(); }
+  async function reloadLatest() { if (currentSaveError?.kind === 'client-version') { window.location.reload(); return; } if (!window.confirm('Reload the latest saved version? Unsaved changes in this editor will be discarded.')) return; const button = modal.querySelector('[data-notebook-reload-latest]'); button.disabled = true; try { item = await NotebookApi.getItem(item.id); renderMode(); clearValidationBlock(); setStatus('', 'idle'); } catch (error) { setStatus(error.message || 'Unable to reload the note.', 'error'); } finally { button.disabled = false; } }
   async function pinItem() { if (!item) return; const button = modal.querySelector('[data-modal-pin]'); button.disabled = true; try { await autosave?.flush(); const response = await NotebookApi.setPinned(item.id, !item.isPinned, item.version); item = requireMutationItem(response, 'The pin response did not contain the updated note.'); renderPin(); await reconcileMutation({ response, board, view, getCardHtml: NotebookApi.getCardHtml, applyCounts: options.applyCounts, preservePosition: false, prepend: true, showGlobalError: options.showGlobalError, reconcileFailureMessage: `The note was ${item.isPinned ? 'pinned' : 'unpinned'}, but the board could not refresh. Reload the page.` }); setStatus('Saved','saved'); } catch (error) { handleEditorError(error); } finally { button.disabled = false; } }
   async function open(id, options = {}) { if (!modal) build(); if (item && item.id !== id) await disposeCurrentItem(); trigger = document.activeElement; item = await NotebookApi.getItem(id); configureAutosave(); renderMode(); modal.hidden = false; setBackgroundInert(true); modal.querySelector('[data-modal-title]').focus(); if (options.pushHistory !== false) { openedByPushState = true; history.pushState({ ...(history.state || {}), notebookModal: true, notebookNoteId: id }, '', buildNoteUrl(id)); } else { openedByPushState = false; } }
   async function requestClose({ fromHistory = false } = {}) { if (!item || !modal || modal.hidden) return; const closeButton = modal.querySelector('[data-close]:not(.notebook-modal__backdrop)'); closeButton.disabled = true; try { await autosave?.flush(); autosave?.stop(); autosave = null; modal.hidden = true; setBackgroundInert(false); const closedId = item.id; item = null; if (!fromHistory) { if (openedByPushState) history.back(); else history.replaceState(history.state, '', buildNoteUrl(null)); } (board.findCard(closedId) || trigger)?.focus?.(); } catch (error) { handleEditorError(error); } finally { closeButton.disabled = false; } }
@@ -39,6 +44,86 @@ export function initNotebookEditor(board, view, options = {}) {
 }
 
 
+// SECTION: Notebook content update payload validation and diagnostics
+const guidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function assertValidVersion(version) {
+  if (typeof version !== 'string' || !guidPattern.test(version)) {
+    throw new NotebookApiError('The note version is invalid. Reload the note and try again.', {
+      status: 0,
+      code: 'notebook_invalid_local_version'
+    });
+  }
+}
+
+export function buildUpdatePayload({ title, body, version, type = 'Note', checklistRows = [] }) {
+  const payload = {
+    title: String(title ?? '').trim(),
+    body: String(body ?? '').trim(),
+    version
+  };
+
+  if (type === 'Checklist') payload.checklistRows = Array.isArray(checklistRows) ? checklistRows : [];
+
+  return payload;
+}
+
+export function validationFingerprint(payload) {
+  return JSON.stringify({
+    titleLength: typeof payload?.title === 'string' ? payload.title.length : null,
+    bodyLength: typeof payload?.body === 'string' ? payload.body.length : null,
+    version: payload?.version,
+    type: payload?.type,
+    priority: payload?.priority,
+    reminderAtUtc: payload?.reminderAtUtc,
+    labelsIsArray: Array.isArray(payload?.labels),
+    checklistRowsIsArray: Array.isArray(payload?.checklistRows)
+  });
+}
+
+export function describeUpdatePayload(payload) {
+  return {
+    titleType: typeof payload?.title,
+    titleLength: typeof payload?.title === 'string' ? payload.title.length : null,
+    bodyType: typeof payload?.body,
+    bodyLength: typeof payload?.body === 'string' ? payload.body.length : null,
+    typeValue: payload?.type,
+    typeValueType: typeof payload?.type,
+    priorityValue: payload?.priority,
+    priorityValueType: typeof payload?.priority,
+    versionValue: payload?.version,
+    versionValueType: typeof payload?.version,
+    reminderAtUtc: payload?.reminderAtUtc,
+    labelsIsArray: Array.isArray(payload?.labels),
+    labelsCount: Array.isArray(payload?.labels) ? payload.labels.length : null,
+    checklistRowsIsArray: Array.isArray(payload?.checklistRows),
+    checklistRowCount: Array.isArray(payload?.checklistRows) ? payload.checklistRows.length : null
+  };
+}
+
+export function renderValidationErrors(hostOrErrors, maybeErrors) {
+  const host = Array.isArray(hostOrErrors) ? document.querySelector('[data-notebook-validation-summary]') : hostOrErrors;
+  const validationErrors = Array.isArray(hostOrErrors) ? hostOrErrors : maybeErrors;
+
+  if (!host || !Array.isArray(validationErrors) || validationErrors.length === 0) {
+    if (host) {
+      host.hidden = true;
+      host.replaceChildren();
+    }
+    return;
+  }
+
+  const list = document.createElement('ul');
+  validationErrors.forEach((error) => {
+    const item = document.createElement('li');
+    item.textContent = error.message;
+    list.appendChild(item);
+  });
+
+  host.replaceChildren(list);
+  host.hidden = false;
+}
+
 // SECTION: Notebook save error classification for authentication-aware UI
 export function classifyNotebookSaveError(error) {
   if (error instanceof NotebookApiError) {
@@ -46,7 +131,7 @@ export function classifyNotebookSaveError(error) {
     if (error.status === 403) return { kind: 'forbidden', message: 'You are not authorised to edit this note.', actions: ['copy', 'discard'] };
     if (error.status === 415) return { kind: 'client-version', message: 'The editor is using an outdated application file. Reload the page and try again.', actions: ['reload', 'discard'] };
     if (error.status === 409) return { kind: 'conflict', message: 'This note was changed elsewhere.' };
-    if (error.status === 400) return { kind: 'validation', message: error.message || 'The note contains invalid information.' };
+    if (error.status === 400) return { kind: 'validation', message: getFirstValidationMessage(error), validationErrors: getValidationMessages(error), retryable: false };
     if (error.status >= 500) return { kind: 'server', message: error.message || 'The note could not be saved because of a server error.' };
   }
   return { kind: 'network', message: error?.message || 'The notebook service could not be reached.' };

--- a/wwwroot/js/notebook/notebook-editor.test.js
+++ b/wwwroot/js/notebook/notebook-editor.test.js
@@ -1,0 +1,42 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// SECTION: ESM loader helper with local dependency stubs.
+async function loadEditorModule() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notebook-editor-test-'));
+  fs.writeFileSync(path.join(tempDir, 'package.json'), '{"type":"module"}');
+  fs.writeFileSync(path.join(tempDir, 'notebook-api.mjs'), "export class NotebookApiError extends Error { constructor(message, options = {}) { super(message); Object.assign(this, options); } } export const NotebookApi = {};\n");
+  fs.writeFileSync(path.join(tempDir, 'notebook-autosave.mjs'), 'export function createAutosave() { return {}; }\n');
+  fs.writeFileSync(path.join(tempDir, 'notebook-checklist-editor.mjs'), 'export function createChecklistEditor() { return {}; }\n');
+  fs.writeFileSync(path.join(tempDir, 'notebook-reconcile.mjs'), 'export function reconcileMutation() {} export function requireMutationItem(value) { return value?.item ?? value; }\n');
+  fs.writeFileSync(path.join(tempDir, 'notebook-errors.mjs'), fs.readFileSync(path.resolve(__dirname, 'notebook-errors.js'), 'utf8'));
+  const source = fs.readFileSync(path.resolve(__dirname, 'notebook-editor.js'), 'utf8')
+    .replace("./notebook-api.js", './notebook-api.mjs')
+    .replace("./notebook-autosave.js", './notebook-autosave.mjs')
+    .replace("./notebook-checklist-editor.js", './notebook-checklist-editor.mjs')
+    .replace("./notebook-reconcile.js", './notebook-reconcile.mjs')
+    .replace("./notebook-errors.js", './notebook-errors.mjs');
+  const modulePath = path.join(tempDir, 'notebook-editor.mjs');
+  fs.writeFileSync(modulePath, source);
+  return import(`file://${modulePath}`);
+}
+
+test('buildUpdatePayload returns normal-note content payload only', async () => {
+  const { buildUpdatePayload } = await loadEditorModule();
+  const version = '123e4567-e89b-12d3-a456-426614174000';
+
+  assert.deepEqual(buildUpdatePayload({ title: ' Hello ', body: ' Body ', version, type: 'Note', checklistRows: [] }), {
+    title: 'Hello',
+    body: 'Body',
+    version
+  });
+});
+
+test('assertValidVersion rejects non-guid local versions before PATCH', async () => {
+  const { assertValidVersion } = await loadEditorModule();
+
+  assert.throws(() => assertValidVersion('not-a-guid'), (error) => error.code === 'notebook_invalid_local_version');
+});

--- a/wwwroot/js/notebook/notebook-errors.js
+++ b/wwwroot/js/notebook/notebook-errors.js
@@ -22,3 +22,26 @@ export class NotebookBoardUpdateError extends Error {
     this.code = 'notebook_board_update_failed';
   }
 }
+
+// SECTION: Notebook validation error extraction helpers
+export function getValidationMessages(error) {
+  const errors = error?.errors;
+
+  if (!errors || typeof errors !== 'object') return [];
+
+  return Object.entries(errors).flatMap(([field, value]) => {
+    const messages = Array.isArray(value) ? value : [value];
+
+    return messages
+      .filter((message) => typeof message === 'string' && message.trim().length > 0)
+      .map((message) => ({ field, message: message.trim() }));
+  });
+}
+
+export function getFirstValidationMessage(error) {
+  const messages = getValidationMessages(error);
+
+  if (messages.length > 0) return messages[0].message;
+
+  return error?.message || 'The note contains invalid information.';
+}

--- a/wwwroot/js/notebook/notebook-errors.test.js
+++ b/wwwroot/js/notebook/notebook-errors.test.js
@@ -1,0 +1,22 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// SECTION: ESM loader helper for Notebook validation helpers.
+async function loadModule(fileName) {
+  const filePath = path.resolve(__dirname, fileName);
+  const source = fs.readFileSync(filePath, 'utf8');
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`);
+}
+
+test('getValidationMessages flattens server ModelState errors', async () => {
+  const { getValidationMessages, getFirstValidationMessage } = await loadModule('notebook-errors.js');
+  const error = { message: 'One or more validation errors occurred.', errors: { '$.version': ['The JSON value could not be converted to System.Guid.'], priority: 'Invalid priority.' } };
+
+  assert.deepEqual(getValidationMessages(error), [
+    { field: '$.version', message: 'The JSON value could not be converted to System.Guid.' },
+    { field: 'priority', message: 'Invalid priority.' }
+  ]);
+  assert.equal(getFirstValidationMessage(error), 'The JSON value could not be converted to System.Guid.');
+});


### PR DESCRIPTION
### Motivation
- Surface exact ASP.NET Core ModelState field errors to the editor so validation failures drive fixes instead of speculative changes. 
- Prevent unrelated aggregate state (notably `Type`) being submitted by the autosave/content update flow and avoid repeating deterministic 400s. 
- Add light-weight client-side validation and safe diagnostics to help capture the failing browser payload for a reproducible integration test.

### Description
- Narrowed the update contract by removing `Type` and making checklist/labels optional and `Priority` nullable in `UpdateNotebookItemRequest` and `NotebookUpdateInput`. (Contracts/Notebook/NotebookContracts.cs, Services/Notebook/INotebookService.cs)
- Stop sending/accepting `Type` from the generic autosave path and preserve persisted item type inside the service; removed the type-change guard and adjusted color-cleaning to use the persisted `item.Type`. (Controllers/Api/NotebookController.cs, Services/Notebook/NotebookService.cs)
- Standardised model-state responses for Notebook endpoints by registering an `InvalidModelStateResponseFactory` that returns `{ code, message, errors }` for `/api/notebook/*` requests. (Program.cs)
- Added client helpers to extract and choose field-level messages (`wwwroot/js/notebook/notebook-errors.js`) and wired them into the editor so the modal shows a validation summary and the first ModelState message. (wwwroot/js/notebook/notebook-editor.js)
- Added client-side payload shaping/validation and autosave blocking: `buildUpdatePayload`, `assertValidVersion`, `validationFingerprint`, deterministic-block on repeated invalid payloads, safe Development diagnostics and `renderValidationErrors`. (wwwroot/js/notebook/notebook-editor.js)
- Updated save/error classification so HTTP 400 surfaces the first server validation message and returns `validationErrors` for rendering. (wwwroot/js/notebook/notebook-editor.js, wwwroot/js/notebook/notebook-api.js behavior was preserved)
- Added unit tests covering the JS validation helpers and editor payload validation, and extended the C# contract test to assert `Type` is not present on update inputs. (wwwroot/js/notebook/notebook-errors.test.js, wwwroot/js/notebook/notebook-editor.test.js, ProjectManagement.Tests/NotebookUpdateContractTests.cs)

### Testing
- Ran the JavaScript test suite with `npm test` (node test runner used by repository tooling), and all discovered JS tests passed (43 tests, all OK).
- `dotnet test` could not be executed in this environment because the `dotnet` CLI is not available; C# unit test changes were limited to a contract assertion and should be validated in CI where .NET is present.
- `npm run build` (esbuild) could not be executed locally because `esbuild` is not installed in the container; build should be verified in the normal build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a6ba467c83298f2ecdf1b0d96b5c)