### PR TITLE
Fix notebook update input type mapping

### DIFF
--- a/Services/Notebook/NotebookService.cs
+++ b/Services/Notebook/NotebookService.cs
@@ -399,7 +399,6 @@ public sealed class NotebookService : INotebookService
         {
             Title = input.Title,
             BodyMarkdown = input.BodyMarkdown,
-            Type = input.Type,
             Priority = input.Priority,
             ReminderAtUtc = input.ReminderAtUtc,
             ColorKey = input.ColorKey,


### PR DESCRIPTION
### Motivation
- The `NotebookUpdateInput` contract intentionally excludes `Type`, and assigning `Type = input.Type` in the legacy adapter caused a build error (`CS0117`) because `NotebookUpdateInput` has no `Type` member.

### Description
- Remove the invalid `Type = input.Type` initializer from the legacy adapter in `Services/Notebook/NotebookService.cs` so the `UpdateAsync(string, Guid, NotebookEditInput, ...)` adapter maps only properties present on `NotebookUpdateInput`.

### Testing
- Ran `git diff --check` which produced no whitespace errors; `dotnet build` could not be executed because the `dotnet` CLI is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36add966708329b981b42ad5faf750)