### PR TITLE
Add media classification decision pipeline governance

### DIFF
--- a/Features/MediaLibrary/Data/MediaLibraryDbContext.cs
+++ b/Features/MediaLibrary/Data/MediaLibraryDbContext.cs
@@ -20,6 +20,7 @@ public sealed class MediaLibraryDbContext : DbContext
     public DbSet<MediaAsset> Assets => Set<MediaAsset>();
     public DbSet<MediaProcessingJob> ProcessingJobs => Set<MediaProcessingJob>();
     public DbSet<MediaClassificationAudit> ClassificationAudits => Set<MediaClassificationAudit>();
+    public DbSet<MediaClassificationRun> ClassificationRuns => Set<MediaClassificationRun>();
     public DbSet<MediaFace> Faces => Set<MediaFace>();
     public DbSet<MediaFaceEmbedding> FaceEmbeddings => Set<MediaFaceEmbedding>();
     public DbSet<MediaPerson> Persons => Set<MediaPerson>();

--- a/Features/MediaLibrary/Data/MediaLibraryModelConfiguration.cs
+++ b/Features/MediaLibrary/Data/MediaLibraryModelConfiguration.cs
@@ -55,7 +55,18 @@ public static class MediaLibraryModelConfiguration
             entity.Property(x => x.Title).HasMaxLength(300).IsRequired();
             entity.Property(x => x.Caption).HasMaxLength(1024);
             entity.Property(x => x.VersionToken).HasMaxLength(128);
+            // --- Classification prediction and decision columns ---
+            entity.Property(x => x.PredictedClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.PredictedClassificationScore).HasPrecision(5, 4);
             entity.Property(x => x.Classification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.ClassificationDecisionStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.ClassificationDecisionReasonCode).HasMaxLength(128);
+            entity.Property(x => x.AutomaticClassificationSignalsJson).HasColumnType("jsonb");
+            entity.Property(x => x.AutomaticClassificationScoresJson).HasColumnType("jsonb");
+            entity.Property(x => x.AutomaticClassificationMetricsJson).HasColumnType("jsonb");
+            entity.Property(x => x.ClassificationReviewedByUserId).HasMaxLength(450);
+            entity.Property(x => x.ClassificationReviewReason).HasMaxLength(1024);
+            entity.Property(x => x.ClassificationConcurrencyToken).IsConcurrencyToken();
             entity.Property(x => x.DerivativeStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
             entity.Property(x => x.AnalysisStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
             entity.Property(x => x.AnalysisVersion).HasMaxLength(128);
@@ -81,6 +92,13 @@ public static class MediaLibraryModelConfiguration
                 .HasDatabaseName("IX_MediaAssets_ProjectTimeline");
             entity.HasIndex(x => new { x.Kind, x.Classification });
             entity.HasIndex(x => new { x.ClassificationIsManual, x.Classification });
+            entity.HasIndex(x => x.ClassificationDecisionStatus);
+            entity.HasIndex(x => x.PredictedClassification);
+            entity.HasIndex(x => x.Classification);
+            entity.HasIndex(x => x.ClassificationIsManual);
+            entity.HasIndex(x => x.ClassifierVersion);
+            entity.HasIndex(x => x.ClassificationReviewedAt);
+            entity.HasIndex(x => x.ClassificationConcurrencyToken);
             entity.HasIndex(x => x.ProjectId);
             entity.HasIndex(x => x.CollectionKey);
             entity.HasOne(x => x.Source)
@@ -95,10 +113,38 @@ public static class MediaLibraryModelConfiguration
             entity.HasKey(x => x.Id);
             entity.Property(x => x.PreviousClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
             entity.Property(x => x.NewClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.AutomaticPredictedClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.AutomaticPredictedScore).HasPrecision(5, 4);
+            entity.Property(x => x.PreviousDecisionStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.NewDecisionStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.CorrelationId).HasMaxLength(128);
             entity.Property(x => x.ChangedByUserId).HasMaxLength(450).IsRequired();
             entity.Property(x => x.Reason).HasMaxLength(1024);
             entity.HasIndex(x => new { x.MediaAssetId, x.ChangedAtUtc });
             entity.HasOne(x => x.MediaAsset).WithMany().HasForeignKey(x => x.MediaAssetId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+
+        modelBuilder.Entity<MediaClassificationRun>(entity =>
+        {
+            entity.ToTable("MediaClassificationRuns");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.ClassifierVersion).HasMaxLength(128).IsRequired();
+            entity.Property(x => x.PredictedClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.PredictedScore).HasPrecision(5, 4);
+            entity.Property(x => x.EffectiveClassification).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.DecisionStatus).HasConversion<string>().HasMaxLength(32).IsRequired();
+            entity.Property(x => x.DecisionReasonCode).HasMaxLength(128);
+            entity.Property(x => x.CategoryScoresJson).HasColumnType("jsonb").HasDefaultValue("{}");
+            entity.Property(x => x.SignalsJson).HasColumnType("jsonb").HasDefaultValue("[]");
+            entity.Property(x => x.MetricsJson).HasColumnType("jsonb").HasDefaultValue("{}");
+            entity.Property(x => x.FailureReason).HasMaxLength(2048);
+            entity.HasIndex(x => new { x.MediaAssetId, x.CompletedAt }).HasDatabaseName("IX_MediaClassificationRuns_Asset_CompletedAt");
+            entity.HasIndex(x => x.ClassifierVersion);
+            entity.HasIndex(x => x.PredictedClassification);
+            entity.HasIndex(x => x.DecisionStatus);
+            entity.HasIndex(x => x.Succeeded);
+            entity.HasOne(x => x.MediaAsset).WithMany(x => x.ClassificationRuns).HasForeignKey(x => x.MediaAssetId).OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<MediaProcessingJob>(entity =>

--- a/Features/MediaLibrary/Data/Migrations/20260628213000_AddClassificationDecisionPipeline.cs
+++ b/Features/MediaLibrary/Data/Migrations/20260628213000_AddClassificationDecisionPipeline.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using ProjectManagement.Features.MediaLibrary.Data;
+
+#nullable disable
+
+namespace ProjectManagement.Features.MediaLibrary.Data.Migrations;
+
+[DbContext(typeof(MediaLibraryDbContext))]
+[Migration("20260628213000_AddClassificationDecisionPipeline")]
+public sealed class AddClassificationDecisionPipeline : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // --- MediaAsset prediction and decision state ---
+        migrationBuilder.AddColumn<string>(name: "PredictedClassification", table: "MediaAssets", type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "Unknown");
+        migrationBuilder.AddColumn<decimal>(name: "PredictedClassificationScore", table: "MediaAssets", type: "numeric(5,4)", precision: 5, scale: 4, nullable: false, defaultValue: 0m);
+        migrationBuilder.AddColumn<string>(name: "ClassificationDecisionStatus", table: "MediaAssets", type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "NotProcessed");
+        migrationBuilder.AddColumn<string>(name: "ClassificationDecisionReasonCode", table: "MediaAssets", type: "character varying(128)", maxLength: 128, nullable: true);
+        migrationBuilder.AddColumn<string>(name: "AutomaticClassificationSignalsJson", table: "MediaAssets", type: "jsonb", nullable: true);
+        migrationBuilder.AddColumn<string>(name: "AutomaticClassificationScoresJson", table: "MediaAssets", type: "jsonb", nullable: true);
+        migrationBuilder.AddColumn<string>(name: "AutomaticClassificationMetricsJson", table: "MediaAssets", type: "jsonb", nullable: true);
+        migrationBuilder.AddColumn<string>(name: "ClassificationReviewedByUserId", table: "MediaAssets", type: "character varying(450)", maxLength: 450, nullable: true);
+        migrationBuilder.AddColumn<DateTimeOffset>(name: "ClassificationReviewedAt", table: "MediaAssets", type: "timestamp with time zone", nullable: true);
+        migrationBuilder.AddColumn<string>(name: "ClassificationReviewReason", table: "MediaAssets", type: "character varying(1024)", maxLength: 1024, nullable: true);
+        migrationBuilder.AddColumn<Guid>(name: "ClassificationConcurrencyToken", table: "MediaAssets", type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()");
+
+        // --- Classification audit evidence preservation ---
+        migrationBuilder.AddColumn<string>(name: "AutomaticPredictedClassification", table: "MediaClassificationAudits", type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "Unknown");
+        migrationBuilder.AddColumn<decimal>(name: "AutomaticPredictedScore", table: "MediaClassificationAudits", type: "numeric(5,4)", precision: 5, scale: 4, nullable: false, defaultValue: 0m);
+        migrationBuilder.AddColumn<string>(name: "PreviousDecisionStatus", table: "MediaClassificationAudits", type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "NotProcessed");
+        migrationBuilder.AddColumn<string>(name: "NewDecisionStatus", table: "MediaClassificationAudits", type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "NotProcessed");
+        migrationBuilder.AddColumn<string>(name: "CorrelationId", table: "MediaClassificationAudits", type: "character varying(128)", maxLength: 128, nullable: true);
+
+        // --- Append-only automatic classification run history ---
+        migrationBuilder.CreateTable(
+            name: "MediaClassificationRuns",
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "bigint", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                MediaAssetId = table.Column<long>(type: "bigint", nullable: false),
+                ClassifierVersion = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                PredictedClassification = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                PredictedScore = table.Column<decimal>(type: "numeric(5,4)", precision: 5, scale: 4, nullable: false),
+                EffectiveClassification = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                DecisionStatus = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                DecisionReasonCode = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                CategoryScoresJson = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                SignalsJson = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "[]"),
+                MetricsJson = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                ProcessingDurationMilliseconds = table.Column<int>(type: "integer", nullable: false),
+                CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                Succeeded = table.Column<bool>(type: "boolean", nullable: false),
+                FailureReason = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_MediaClassificationRuns", x => x.Id);
+                table.ForeignKey("FK_MediaClassificationRuns_MediaAssets_MediaAssetId", x => x.MediaAssetId, "MediaAssets", "Id", onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.Sql("""
+            UPDATE "MediaAssets"
+            SET "PredictedClassification" = "Classification",
+                "PredictedClassificationScore" = LEAST(GREATEST(COALESCE("ClassificationConfidence", 0), 0), 1),
+                "ClassificationDecisionStatus" = CASE
+                    WHEN "ClassificationIsManual" = TRUE AND "Classification" = "PredictedClassification" THEN 'ManuallyConfirmed'
+                    WHEN "ClassificationIsManual" = TRUE THEN 'ManuallyCorrected'
+                    WHEN "Kind" <> 'Photo' THEN 'NotApplicable'
+                    WHEN "Classification" = 'Photograph' AND COALESCE("ClassificationConfidence", 0) >= 0.82 THEN 'AutomaticallyAccepted'
+                    WHEN "AnalysisStatus" = 'Failed' THEN 'ProcessingFailed'
+                    ELSE 'NeedsReview'
+                END,
+                "ClassificationDecisionReasonCode" = CASE
+                    WHEN "ClassificationIsManual" = TRUE THEN 'MANUAL_CONFIRMATION'
+                    WHEN "Classification" = 'Photograph' AND COALESCE("ClassificationConfidence", 0) >= 0.82 THEN 'CATEGORY_SCORE_ACCEPTED'
+                    WHEN "AnalysisStatus" = 'Failed' THEN 'CLASSIFIER_PROCESSING_FAILED'
+                    ELSE 'CATEGORY_SCORE_BELOW_THRESHOLD'
+                END,
+                "AutomaticClassificationSignalsJson" = COALESCE("AnalysisSignalsJson", '[]'::jsonb),
+                "AutomaticClassificationScoresJson" = jsonb_build_object("Classification", LEAST(GREATEST(COALESCE("ClassificationConfidence", 0), 0), 1)),
+                "AutomaticClassificationMetricsJson" = '{}'::jsonb,
+                "ClassificationReviewedByUserId" = CASE WHEN "ClassificationIsManual" THEN "ClassificationUpdatedByUserId" ELSE NULL END,
+                "ClassificationReviewedAt" = CASE WHEN "ClassificationIsManual" THEN "ClassifiedAtUtc" ELSE NULL END;
+            """);
+
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_ClassificationDecisionStatus", table: "MediaAssets", column: "ClassificationDecisionStatus");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_PredictedClassification", table: "MediaAssets", column: "PredictedClassification");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_Classification", table: "MediaAssets", column: "Classification");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_ClassificationIsManual", table: "MediaAssets", column: "ClassificationIsManual");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_ClassifierVersion", table: "MediaAssets", column: "ClassifierVersion");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_ClassificationReviewedAt", table: "MediaAssets", column: "ClassificationReviewedAt");
+        migrationBuilder.CreateIndex(name: "IX_MediaAssets_ClassificationConcurrencyToken", table: "MediaAssets", column: "ClassificationConcurrencyToken");
+        migrationBuilder.CreateIndex(name: "IX_MediaClassificationRuns_Asset_CompletedAt", table: "MediaClassificationRuns", columns: new[] { "MediaAssetId", "CompletedAt" });
+        migrationBuilder.CreateIndex(name: "IX_MediaClassificationRuns_ClassifierVersion", table: "MediaClassificationRuns", column: "ClassifierVersion");
+        migrationBuilder.CreateIndex(name: "IX_MediaClassificationRuns_PredictedClassification", table: "MediaClassificationRuns", column: "PredictedClassification");
+        migrationBuilder.CreateIndex(name: "IX_MediaClassificationRuns_DecisionStatus", table: "MediaClassificationRuns", column: "DecisionStatus");
+        migrationBuilder.CreateIndex(name: "IX_MediaClassificationRuns_Succeeded", table: "MediaClassificationRuns", column: "Succeeded");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "MediaClassificationRuns");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_ClassificationDecisionStatus", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_PredictedClassification", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_Classification", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_ClassificationIsManual", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_ClassifierVersion", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_ClassificationReviewedAt", table: "MediaAssets");
+        migrationBuilder.DropIndex(name: "IX_MediaAssets_ClassificationConcurrencyToken", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "PredictedClassification", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "PredictedClassificationScore", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationDecisionStatus", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationDecisionReasonCode", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "AutomaticClassificationSignalsJson", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "AutomaticClassificationScoresJson", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "AutomaticClassificationMetricsJson", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationReviewedByUserId", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationReviewedAt", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationReviewReason", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "ClassificationConcurrencyToken", table: "MediaAssets");
+        migrationBuilder.DropColumn(name: "AutomaticPredictedClassification", table: "MediaClassificationAudits");
+        migrationBuilder.DropColumn(name: "AutomaticPredictedScore", table: "MediaClassificationAudits");
+        migrationBuilder.DropColumn(name: "PreviousDecisionStatus", table: "MediaClassificationAudits");
+        migrationBuilder.DropColumn(name: "NewDecisionStatus", table: "MediaClassificationAudits");
+        migrationBuilder.DropColumn(name: "CorrelationId", table: "MediaClassificationAudits");
+    }
+}

--- a/Features/MediaLibrary/Domain/MediaAsset.cs
+++ b/Features/MediaLibrary/Domain/MediaAsset.cs
@@ -83,17 +83,39 @@ public sealed class MediaAsset
     public bool IsArchived { get; set; }
     public bool IsDeleted { get; set; }
 
+    // --- Classification prediction and decision state ---
+    public MediaClassification PredictedClassification { get; set; }
+    public decimal PredictedClassificationScore { get; set; }
     public MediaClassification Classification { get; set; }
     public double? ClassificationConfidence { get; set; }
+    public MediaClassificationDecisionStatus ClassificationDecisionStatus { get; set; }
+
+    [MaxLength(128)]
+    public string? ClassificationDecisionReasonCode { get; set; }
+
+    [MaxLength(128)]
+    public string? ClassifierVersion { get; set; }
+
+    public string? AutomaticClassificationSignalsJson { get; set; }
+    public string? AutomaticClassificationScoresJson { get; set; }
+    public string? AutomaticClassificationMetricsJson { get; set; }
+
+    // --- Manual classification review state ---
     public bool ClassificationIsManual { get; set; }
 
     [MaxLength(450)]
     public string? ClassificationUpdatedByUserId { get; set; }
 
-    public DateTimeOffset? ClassifiedAtUtc { get; set; }
+    [MaxLength(450)]
+    public string? ClassificationReviewedByUserId { get; set; }
 
-    [MaxLength(128)]
-    public string? ClassifierVersion { get; set; }
+    public DateTimeOffset? ClassifiedAtUtc { get; set; }
+    public DateTimeOffset? ClassificationReviewedAt { get; set; }
+
+    [MaxLength(1024)]
+    public string? ClassificationReviewReason { get; set; }
+
+    public Guid ClassificationConcurrencyToken { get; set; } = Guid.NewGuid();
     public MediaProcessingStatus DerivativeStatus { get; set; }
     public MediaProcessingStatus AnalysisStatus { get; set; }
 
@@ -120,4 +142,5 @@ public sealed class MediaAsset
 
     public ICollection<MediaProcessingJob> ProcessingJobs { get; set; } = new List<MediaProcessingJob>();
     public ICollection<MediaFace> Faces { get; set; } = new List<MediaFace>();
+    public ICollection<MediaClassificationRun> ClassificationRuns { get; set; } = new List<MediaClassificationRun>();
 }

--- a/Features/MediaLibrary/Domain/MediaClassificationAudit.cs
+++ b/Features/MediaLibrary/Domain/MediaClassificationAudit.cs
@@ -11,6 +11,11 @@ public sealed class MediaClassificationAudit
     public MediaClassification NewClassification { get; set; }
     public bool PreviousWasManual { get; set; }
     public bool NewIsManual { get; set; }
+    public MediaClassification AutomaticPredictedClassification { get; set; }
+    public decimal AutomaticPredictedScore { get; set; }
+    public MediaClassificationDecisionStatus PreviousDecisionStatus { get; set; }
+    public MediaClassificationDecisionStatus NewDecisionStatus { get; set; }
+    [MaxLength(128)] public string? CorrelationId { get; set; }
     [Required, MaxLength(450)] public string ChangedByUserId { get; set; } = string.Empty;
     [MaxLength(1024)] public string? Reason { get; set; }
     public DateTimeOffset ChangedAtUtc { get; set; }

--- a/Features/MediaLibrary/Domain/MediaClassificationRun.cs
+++ b/Features/MediaLibrary/Domain/MediaClassificationRun.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectManagement.Features.MediaLibrary.Domain;
+
+public sealed class MediaClassificationRun
+{
+    public long Id { get; set; }
+    public long MediaAssetId { get; set; }
+    public MediaAsset MediaAsset { get; set; } = null!;
+
+    [Required, MaxLength(128)]
+    public string ClassifierVersion { get; set; } = string.Empty;
+
+    public MediaClassification PredictedClassification { get; set; }
+    public decimal PredictedScore { get; set; }
+    public MediaClassification EffectiveClassification { get; set; }
+    public MediaClassificationDecisionStatus DecisionStatus { get; set; }
+
+    [MaxLength(128)]
+    public string? DecisionReasonCode { get; set; }
+
+    public string CategoryScoresJson { get; set; } = "{}";
+    public string SignalsJson { get; set; } = "[]";
+    public string MetricsJson { get; set; } = "{}";
+    public int ProcessingDurationMilliseconds { get; set; }
+    public DateTimeOffset CompletedAt { get; set; }
+    public bool Succeeded { get; set; }
+
+    [MaxLength(2048)]
+    public string? FailureReason { get; set; }
+}

--- a/Features/MediaLibrary/Domain/MediaLibraryEnums.cs
+++ b/Features/MediaLibrary/Domain/MediaLibraryEnums.cs
@@ -38,6 +38,17 @@ public enum MediaClassification
     Graphic = 6
 }
 
+public enum MediaClassificationDecisionStatus
+{
+    NotProcessed = 0,
+    AutomaticallyAccepted = 1,
+    NeedsReview = 2,
+    ManuallyConfirmed = 3,
+    ManuallyCorrected = 4,
+    ProcessingFailed = 5,
+    NotApplicable = 6
+}
+
 public enum MediaAvailabilityStatus
 {
     Available = 0,

--- a/Features/MediaLibrary/Services/FaceEligibilityPolicy.cs
+++ b/Features/MediaLibrary/Services/FaceEligibilityPolicy.cs
@@ -45,9 +45,11 @@ public sealed class FaceEligibilityPolicy : IFaceEligibilityPolicy
             return new(false, "classifier-stale", "The asset was classified by an older classifier version.");
         if (asset.Classification != MediaClassification.Photograph)
             return new(false, "not-photograph", "Automatic classification did not identify a photograph.");
-        if (!asset.ClassificationConfidence.HasValue)
-            return new(false, "confidence-missing", "Automatic classification confidence is unavailable.");
-        if (asset.ClassificationConfidence.Value < _options.People.MinimumClassificationConfidence)
+        if (asset.ClassificationDecisionStatus != MediaClassificationDecisionStatus.AutomaticallyAccepted)
+            return new(false, "not-auto-accepted", "Automatic classification was not accepted by the decision policy.");
+        if (asset.PredictedClassification != MediaClassification.Photograph)
+            return new(false, "prediction-mismatch", "The automatic prediction was not a photograph.");
+        if (asset.PredictedClassificationScore < Convert.ToDecimal(_options.People.MinimumClassificationConfidence))
             return new(false, "confidence-low", $"Classification confidence is below the configured {_options.People.MinimumClassificationConfidence:P0} threshold.");
 
         return new(true, "eligible", "Current automatic classification identifies a sufficiently confident photograph.");
@@ -69,7 +71,8 @@ public sealed class FaceEligibilityPolicy : IFaceEligibilityPolicy
                                 : asset.AnalysisStatus == MediaProcessingStatus.Ready
                                   && asset.ClassifierVersion == version
                                   && asset.Classification == MediaClassification.Photograph
-                                  && asset.ClassificationConfidence != null
-                                  && asset.ClassificationConfidence >= threshold));
+                                  && asset.ClassificationDecisionStatus == MediaClassificationDecisionStatus.AutomaticallyAccepted
+                                  && asset.PredictedClassification == MediaClassification.Photograph
+                                  && asset.PredictedClassificationScore >= Convert.ToDecimal(threshold))));
     }
 }

--- a/Features/MediaLibrary/Services/MediaAssetProcessor.cs
+++ b/Features/MediaLibrary/Services/MediaAssetProcessor.cs
@@ -102,14 +102,51 @@ public sealed class MediaAssetProcessor : IMediaAssetProcessor
                 else
                 {
                     var result = await _classifier.ClassifyAsync(content, metadata, cancellationToken);
-                asset.Classification = result.Classification;
-                asset.ClassificationConfidence = result.Confidence;
+                    var now = DateTimeOffset.UtcNow;
+                    var predictedScore = Convert.ToDecimal(Math.Clamp(result.Confidence, 0d, 1d));
+                    var accepted = result.Classification != MediaClassification.Unknown
+                        && predictedScore >= Convert.ToDecimal(_options.People.MinimumClassificationConfidence);
+
+                    asset.PredictedClassification = result.Classification;
+                    asset.PredictedClassificationScore = predictedScore;
+                    asset.Classification = accepted ? result.Classification : MediaClassification.Unknown;
+                    asset.ClassificationConfidence = result.Confidence;
+                    asset.ClassificationDecisionStatus = accepted
+                        ? MediaClassificationDecisionStatus.AutomaticallyAccepted
+                        : MediaClassificationDecisionStatus.NeedsReview;
+                    asset.ClassificationDecisionReasonCode = accepted
+                        ? "CATEGORY_SCORE_ACCEPTED"
+                        : "CATEGORY_SCORE_BELOW_THRESHOLD";
                     asset.AnalysisVersion = result.Version;
                     asset.ClassifierVersion = result.Version;
-                    asset.AnalysisSignalsJson = JsonSerializer.Serialize(result.Signals);
-                    asset.AnalysedAtUtc = DateTimeOffset.UtcNow;
-                    asset.ClassifiedAtUtc = asset.AnalysedAtUtc;
+                    var signalsJson = JsonSerializer.Serialize(result.Signals);
+                    asset.AnalysisSignalsJson = signalsJson;
+                    asset.AutomaticClassificationSignalsJson = signalsJson;
+                    asset.AutomaticClassificationScoresJson = JsonSerializer.Serialize(new Dictionary<MediaClassification, double>
+                    {
+                        [result.Classification] = result.Confidence
+                    });
+                    asset.AutomaticClassificationMetricsJson = "{}";
+                    asset.AnalysedAtUtc = now;
+                    asset.ClassifiedAtUtc = now;
+                    asset.ClassificationConcurrencyToken = Guid.NewGuid();
                     asset.AnalysisStatus = MediaProcessingStatus.Ready;
+                    _db.ClassificationRuns.Add(new MediaClassificationRun
+                    {
+                        MediaAssetId = asset.Id,
+                        ClassifierVersion = result.Version,
+                        PredictedClassification = result.Classification,
+                        PredictedScore = predictedScore,
+                        EffectiveClassification = asset.Classification,
+                        DecisionStatus = asset.ClassificationDecisionStatus,
+                        DecisionReasonCode = asset.ClassificationDecisionReasonCode,
+                        CategoryScoresJson = asset.AutomaticClassificationScoresJson,
+                        SignalsJson = signalsJson,
+                        MetricsJson = asset.AutomaticClassificationMetricsJson,
+                        ProcessingDurationMilliseconds = 0,
+                        CompletedAt = now,
+                        Succeeded = true
+                    });
                 }
             }
 

--- a/Features/MediaLibrary/Services/MediaClassificationOverrideService.cs
+++ b/Features/MediaLibrary/Services/MediaClassificationOverrideService.cs
@@ -18,20 +18,34 @@ public sealed class MediaClassificationOverrideService : IMediaClassificationOve
 
     public async Task SetManualAsync(long assetId, MediaClassification classification, string userId, string? reason, CancellationToken cancellationToken)
     {
+        // --- Validate manual review input ---
         if (classification == MediaClassification.Unknown) throw new ArgumentException("Choose a specific classification.", nameof(classification));
+
+        // --- Preserve automatic evidence while applying authoritative manual decision ---
         var asset = await _db.Assets.SingleAsync(x => x.Id == assetId, cancellationToken);
         var previous = asset.Classification;
         var previousManual = asset.ClassificationIsManual;
+        var previousStatus = asset.ClassificationDecisionStatus;
+        var now = DateTimeOffset.UtcNow;
+
         asset.Classification = classification;
         asset.ClassificationConfidence = 1;
         asset.ClassificationIsManual = true;
         asset.ClassificationUpdatedByUserId = userId;
-        asset.ClassifiedAtUtc = DateTimeOffset.UtcNow;
-        asset.ClassifierVersion = "manual";
-        asset.AnalysisVersion = "manual";
+        asset.ClassificationReviewedByUserId = userId;
+        asset.ClassifiedAtUtc = now;
+        asset.ClassificationReviewedAt = now;
+        asset.ClassificationReviewReason = NormalizeReason(reason);
+        asset.ClassificationDecisionStatus = classification == asset.PredictedClassification
+            ? MediaClassificationDecisionStatus.ManuallyConfirmed
+            : MediaClassificationDecisionStatus.ManuallyCorrected;
+        asset.ClassificationDecisionReasonCode = classification == asset.PredictedClassification
+            ? "MANUAL_CONFIRMATION"
+            : "MANUAL_CORRECTION";
         asset.AnalysisStatus = MediaProcessingStatus.Ready;
-        asset.AnalysisSignalsJson = "[\"Manual classification confirmed by an authorised user.\"]";
-        _db.ClassificationAudits.Add(CreateAudit(assetId, previous, classification, previousManual, true, userId, reason));
+        asset.ClassificationConcurrencyToken = Guid.NewGuid();
+
+        _db.ClassificationAudits.Add(CreateAudit(assetId, previous, classification, previousManual, true, previousStatus, asset.ClassificationDecisionStatus, userId, reason, asset));
         await _db.SaveChangesAsync(cancellationToken);
     }
 
@@ -64,25 +78,37 @@ public sealed class MediaClassificationOverrideService : IMediaClassificationOve
         var normalizedReason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
         foreach (var asset in assets)
         {
+            // --- Preserve automatic evidence while applying authoritative manual decision ---
             var previous = asset.Classification;
             var previousManual = asset.ClassificationIsManual;
+            var previousStatus = asset.ClassificationDecisionStatus;
             asset.Classification = classification;
             asset.ClassificationConfidence = 1;
             asset.ClassificationIsManual = true;
             asset.ClassificationUpdatedByUserId = userId;
+            asset.ClassificationReviewedByUserId = userId;
             asset.ClassifiedAtUtc = now;
-            asset.ClassifierVersion = "manual";
-            asset.AnalysisVersion = "manual";
+            asset.ClassificationReviewedAt = now;
+            asset.ClassificationReviewReason = normalizedReason;
+            asset.ClassificationDecisionStatus = classification == asset.PredictedClassification
+                ? MediaClassificationDecisionStatus.ManuallyConfirmed
+                : MediaClassificationDecisionStatus.ManuallyCorrected;
+            asset.ClassificationDecisionReasonCode = classification == asset.PredictedClassification
+                ? "MANUAL_CONFIRMATION"
+                : "MANUAL_CORRECTION";
             asset.AnalysisStatus = MediaProcessingStatus.Ready;
-            asset.AnalysisSignalsJson = "[\"Manual classification confirmed by an authorised user.\"]";
+            asset.ClassificationConcurrencyToken = Guid.NewGuid();
             _db.ClassificationAudits.Add(CreateAudit(
                 asset.Id,
                 previous,
                 classification,
                 previousManual,
                 true,
+                previousStatus,
+                asset.ClassificationDecisionStatus,
                 userId,
-                normalizedReason));
+                normalizedReason,
+                asset));
         }
 
         await _db.SaveChangesAsync(cancellationToken);
@@ -95,13 +121,19 @@ public sealed class MediaClassificationOverrideService : IMediaClassificationOve
         var asset = await _db.Assets.SingleAsync(x => x.Id == assetId, cancellationToken);
         var previous = asset.Classification;
         var previousManual = asset.ClassificationIsManual;
+        var previousStatus = asset.ClassificationDecisionStatus;
         asset.ClassificationIsManual = false;
         asset.ClassificationUpdatedByUserId = null;
+        asset.ClassificationReviewedByUserId = null;
+        asset.ClassificationReviewedAt = null;
+        asset.ClassificationReviewReason = null;
         asset.ClassificationConfidence = null;
-        asset.ClassifierVersion = null;
         asset.ClassifiedAtUtc = null;
+        asset.ClassificationDecisionStatus = MediaClassificationDecisionStatus.NotProcessed;
+        asset.ClassificationDecisionReasonCode = null;
+        asset.ClassificationConcurrencyToken = Guid.NewGuid();
         asset.AnalysisStatus = MediaProcessingStatus.Pending;
-        _db.ClassificationAudits.Add(CreateAudit(assetId, previous, previous, previousManual, false, userId, reason));
+        _db.ClassificationAudits.Add(CreateAudit(assetId, previous, previous, previousManual, false, previousStatus, asset.ClassificationDecisionStatus, userId, reason, asset));
 
         var job = await _db.ProcessingJobs.SingleOrDefaultAsync(x => x.MediaAssetId == assetId && x.JobType == MediaProcessingJobType.ClassifyMedia, cancellationToken);
         if (job is null)
@@ -129,15 +161,23 @@ public sealed class MediaClassificationOverrideService : IMediaClassificationOve
     }
 
     private static MediaClassificationAudit CreateAudit(long assetId, MediaClassification previous, MediaClassification next,
-        bool previousManual, bool nextManual, string userId, string? reason) => new()
+        bool previousManual, bool nextManual, MediaClassificationDecisionStatus previousStatus,
+        MediaClassificationDecisionStatus nextStatus, string userId, string? reason, MediaAsset asset) => new()
     {
         MediaAssetId = assetId,
         PreviousClassification = previous,
         NewClassification = next,
         PreviousWasManual = previousManual,
         NewIsManual = nextManual,
+        AutomaticPredictedClassification = asset.PredictedClassification,
+        AutomaticPredictedScore = asset.PredictedClassificationScore,
+        PreviousDecisionStatus = previousStatus,
+        NewDecisionStatus = nextStatus,
         ChangedByUserId = userId,
-        Reason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim(),
+        Reason = NormalizeReason(reason),
         ChangedAtUtc = DateTimeOffset.UtcNow
     };
+
+    private static string? NormalizeReason(string? reason)
+        => string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
 }


### PR DESCRIPTION
### Motivation

- Separate automatic prediction from the final effective classification to remove ambiguity between a classifier prediction and the authoritative decision. 
- Preserve automatic evidence and run-history so manual overrides do not erase classifier signals and every classification attempt is auditable. 
- Provide concurrency tokens, decision-status semantics and stricter face-eligibility checks to make face-processing fail-closed and safe for an offline pilot.

### Description

- Added prediction/decision fields to `MediaAsset` including `PredictedClassification`, `PredictedClassificationScore`, `ClassificationDecisionStatus`, `ClassificationDecisionReasonCode`, `AutomaticClassification*Json` fields, reviewer metadata and a `ClassificationConcurrencyToken`. 
- Introduced `MediaClassificationDecisionStatus` enum and an append-only `MediaClassificationRun` entity plus a `DbSet<MediaClassificationRun>` and EF model configuration and indexes, and added an EF migration `20260628213000_AddClassificationDecisionPipeline` with backfill SQL to populate new columns. 
- Updated processing and governance code so `MediaAssetProcessor` writes prediction evidence, rotates concurrency tokens and inserts `MediaClassificationRun` records, and `MediaClassificationOverrideService` preserves automatic evidence while recording manual decision status/reason and audit entries; tightened `FaceEligibilityPolicy` to require `AutomaticallyAccepted` + matching prediction + minimum predicted score for automatic face eligibility.

### Testing

- Validated repository diffs and staged changes using `git diff --cached --check` with no reported issues. 
- Attempted automated test/build with `dotnet test -c Release`, but it could not be executed in this environment because the `dotnet` CLI is not available (`dotnet: command not found`), so unit/integration tests and a release build were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4147010a9c8329af84351dcd5f22b4)