### PR TITLE
Fix face eligibility predicate syntax

### DIFF
--- a/Features/MediaLibrary/Services/FaceEligibilityPolicy.cs
+++ b/Features/MediaLibrary/Services/FaceEligibilityPolicy.cs
@@ -73,6 +73,6 @@ public sealed class FaceEligibilityPolicy : IFaceEligibilityPolicy
                                   && asset.Classification == MediaClassification.Photograph
                                   && asset.ClassificationDecisionStatus == MediaClassificationDecisionStatus.AutomaticallyAccepted
                                   && asset.PredictedClassification == MediaClassification.Photograph
-                                  && asset.PredictedClassificationScore >= Convert.ToDecimal(threshold))));
+                                  && asset.PredictedClassificationScore >= Convert.ToDecimal(threshold)));
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by an extra closing parenthesis in `FaceEligibilityPolicy.BuildEligiblePredicate` that produced `CS1002`/`CS1513` and prevented the project from building.

### Description
- Removed the extraneous `)` at the end of the predicate expression in `Features/MediaLibrary/Services/FaceEligibilityPolicy.cs` so the lambda compiles.

### Testing
- Ran `git diff --check` which passed, and attempted `dotnet build --configuration Release` which could not run because the `dotnet` CLI is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4148eedf9c83299c421f985f59a153)