### PR TITLE
Support multiple JDPs per project overview

### DIFF
--- a/Pages/Projects/Overview.MultiJdp.cs
+++ b/Pages/Projects/Overview.MultiJdp.cs
@@ -1,0 +1,263 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ProjectManagement.Models;
+using ProjectManagement.Models.IndustryPartners;
+
+namespace ProjectManagement.Pages.Projects;
+
+public partial class OverviewModel
+{
+    public async Task<IActionResult> OnGetMultiJdpProfileAsync(int id, CancellationToken ct)
+    {
+        if (id <= 0)
+        {
+            return BadRequest();
+        }
+
+        var exists = await _db.Projects
+            .AsNoTracking()
+            .AnyAsync(project => project.Id == id && !project.IsDeleted, ct);
+
+        if (!exists)
+        {
+            return NotFound();
+        }
+
+        return new JsonResult(new
+        {
+            success = true,
+            profile = await BuildMultiJdpProfileAsync(id, ct)
+        });
+    }
+
+    public async Task<IActionResult> OnPostAddProjectJdpAsync(
+        int id,
+        int partnerId,
+        CancellationToken ct)
+    {
+        if (id <= 0 || partnerId <= 0)
+        {
+            return new JsonResult(new { error = "Select a valid organisation." })
+            {
+                StatusCode = StatusCodes.Status400BadRequest
+            };
+        }
+
+        if (!await CanManageProjectJdpAsync(id, ct))
+        {
+            return new JsonResult(new { error = "You are not authorised to update JDPs for this project." })
+            {
+                StatusCode = StatusCodes.Status403Forbidden
+            };
+        }
+
+        var projectExists = await _db.Projects
+            .AnyAsync(project => project.Id == id && !project.IsDeleted, ct);
+        if (!projectExists)
+        {
+            return NotFound();
+        }
+
+        var partner = await _db.IndustryPartners
+            .FirstOrDefaultAsync(item => item.Id == partnerId, ct);
+        if (partner is null)
+        {
+            return new JsonResult(new { error = "Industry organisation not found." })
+            {
+                StatusCode = StatusCodes.Status404NotFound
+            };
+        }
+
+        var alreadyLinked = await _db.IndustryPartnerProjects
+            .AnyAsync(link => link.ProjectId == id && link.IndustryPartnerId == partnerId, ct);
+        if (alreadyLinked)
+        {
+            return new JsonResult(new { error = "This organisation is already linked to the project as a JDP." })
+            {
+                StatusCode = StatusCodes.Status409Conflict
+            };
+        }
+
+        _db.IndustryPartnerProjects.Add(new IndustryPartnerProject
+        {
+            ProjectId = id,
+            IndustryPartnerId = partnerId,
+            LinkedByUserId = _users.GetUserId(User),
+            LinkedUtc = DateTimeOffset.UtcNow
+        });
+        partner.UpdatedUtc = DateTimeOffset.UtcNow;
+        partner.UpdatedByUserId = _users.GetUserId(User);
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            var nowLinked = await _db.IndustryPartnerProjects
+                .AsNoTracking()
+                .AnyAsync(link => link.ProjectId == id && link.IndustryPartnerId == partnerId, ct);
+            if (nowLinked)
+            {
+                return new JsonResult(new { error = "This organisation is already linked to the project as a JDP." })
+                {
+                    StatusCode = StatusCodes.Status409Conflict
+                };
+            }
+
+            throw;
+        }
+
+        return new JsonResult(new
+        {
+            success = true,
+            message = "JDP added to the project.",
+            profile = await BuildMultiJdpProfileAsync(id, ct)
+        });
+    }
+
+    public async Task<IActionResult> OnPostRemoveProjectJdpAsync(
+        int id,
+        int partnerId,
+        CancellationToken ct)
+    {
+        if (id <= 0 || partnerId <= 0)
+        {
+            return BadRequest();
+        }
+
+        if (!await CanManageProjectJdpAsync(id, ct))
+        {
+            return new JsonResult(new { error = "You are not authorised to update JDPs for this project." })
+            {
+                StatusCode = StatusCodes.Status403Forbidden
+            };
+        }
+
+        var link = await _db.IndustryPartnerProjects
+            .FirstOrDefaultAsync(item => item.ProjectId == id && item.IndustryPartnerId == partnerId, ct);
+        if (link is null)
+        {
+            return new JsonResult(new { error = "The selected JDP is no longer linked to this project." })
+            {
+                StatusCode = StatusCodes.Status404NotFound
+            };
+        }
+
+        var partner = await _db.IndustryPartners
+            .FirstOrDefaultAsync(item => item.Id == partnerId, ct);
+
+        _db.IndustryPartnerProjects.Remove(link);
+        if (partner is not null)
+        {
+            partner.UpdatedUtc = DateTimeOffset.UtcNow;
+            partner.UpdatedByUserId = _users.GetUserId(User);
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        return new JsonResult(new
+        {
+            success = true,
+            message = "JDP removed from the project.",
+            profile = await BuildMultiJdpProfileAsync(id, ct)
+        });
+    }
+
+    private async Task<object> BuildMultiJdpProfileAsync(int projectId, CancellationToken ct)
+    {
+        var linkedPartners = await _db.IndustryPartnerProjects
+            .AsNoTracking()
+            .Where(link => link.ProjectId == projectId)
+            .OrderBy(link => link.IndustryPartner.Name)
+            .ThenBy(link => link.IndustryPartnerId)
+            .Select(link => new
+            {
+                id = link.IndustryPartnerId,
+                name = link.IndustryPartner.Name,
+                location = link.IndustryPartner.Location,
+                otherProjects = link.IndustryPartner.PartnerProjects
+                    .Where(other => other.ProjectId != projectId && !other.Project.IsDeleted)
+                    .Select(other => new
+                    {
+                        projectId = other.ProjectId,
+                        projectName = other.Project.Name,
+                        caseFileNumber = other.Project.CaseFileNumber,
+                        lifecycleStatus = other.Project.LifecycleStatus,
+                        isArchived = other.Project.IsArchived
+                    })
+                    .ToList()
+            })
+            .ToListAsync(ct);
+
+        var partners = linkedPartners.Select(partner =>
+        {
+            var projects = partner.otherProjects
+                .Select(project => new
+                {
+                    project.projectId,
+                    project.projectName,
+                    project.caseFileNumber,
+                    statusLabel = project.isArchived
+                        ? "Archived"
+                        : project.lifecycleStatus switch
+                        {
+                            ProjectLifecycleStatus.Completed => "Completed",
+                            ProjectLifecycleStatus.Cancelled => "Cancelled",
+                            _ => "Ongoing"
+                        }
+                })
+                .OrderBy(project => project.statusLabel == "Ongoing" ? 0 : project.statusLabel == "Completed" ? 1 : 2)
+                .ThenBy(project => project.projectName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return new
+            {
+                partner.id,
+                partner.name,
+                partner.location,
+                otherProjectCount = projects.Count,
+                otherOngoingProjectCount = projects.Count(project => project.statusLabel == "Ongoing"),
+                otherCompletedProjectCount = projects.Count(project => project.statusLabel == "Completed"),
+                otherProjects = projects
+            };
+        }).ToList();
+
+        return new
+        {
+            projectId,
+            count = partners.Count,
+            hasJdp = partners.Count > 0,
+            cardTitle = partners.Count switch
+            {
+                0 => "No JDP linked",
+                1 => partners[0].name,
+                _ => $"{partners.Count} JDPs linked"
+            },
+            cardSummary = partners.Count switch
+            {
+                0 => CanManageJdp ? "Link an industry partner" : "No JDP recorded",
+                1 => BuildPartnerUsageSummary(partners[0].otherProjectCount, partners[0].otherOngoingProjectCount, partners[0].otherCompletedProjectCount),
+                _ => string.Join(" · ", partners.Take(2).Select(partner => partner.name)) + (partners.Count > 2 ? $" · +{partners.Count - 2} more" : string.Empty)
+            },
+            partners
+        };
+    }
+
+    private static string BuildPartnerUsageSummary(int total, int ongoing, int completed)
+    {
+        if (total == 0)
+        {
+            return "Not linked to any other project";
+        }
+
+        var parts = new List<string>();
+        if (ongoing > 0) parts.Add($"{ongoing} ongoing");
+        if (completed > 0) parts.Add($"{completed} completed");
+        var other = Math.Max(0, total - ongoing - completed);
+        if (other > 0) parts.Add($"{other} other");
+
+        return $"Also linked to {total} other {(total == 1 ? "project" : "projects")}" +
+               (parts.Count == 0 ? string.Empty : $" · {string.Join(" · ", parts)}");
+    }
+}

--- a/Pages/Projects/Overview.cshtml
+++ b/Pages/Projects/Overview.cshtml
@@ -63,6 +63,7 @@
     <script type="module" src="~/js/gallery-lightbox.js" asp-append-version="true"></script>
     <script src="~/js/projects/remarks-panel.js" asp-append-version="true"></script>
     <script src="~/js/projects/overview.js" asp-append-version="true"></script>
+    <script src="~/js/projects/overview-multi-jdp.js" asp-append-version="true"></script>
     <script src="~/js/pages/project-portfolio.js" asp-append-version="true"></script>
     <script src="~/js/projects/actuals-edit.js" asp-append-version="true"></script>
     <script src="~/js/projects/plan-edit.js" asp-append-version="true"></script>

--- a/Pages/Projects/_ProjectCommandHeader.cshtml
+++ b/Pages/Projects/_ProjectCommandHeader.cshtml
@@ -4,6 +4,20 @@
     var project = Model.Project;
     var portfolio = Model.Portfolio;
     var access = Model.Access;
+    var jdpCount = Model.JdpPartners.Count;
+    var jdpTitle = jdpCount switch
+    {
+        0 => "No JDP linked",
+        1 => Model.JdpPartners[0].Name,
+        _ => $"{jdpCount} JDPs linked"
+    };
+    var jdpSummary = jdpCount switch
+    {
+        0 => Model.CanManageJdp ? "Link an industry partner" : "No JDP recorded",
+        1 => "Open to view this JDP and its other projects",
+        _ => string.Join(" · ", Model.JdpPartners.Take(2).Select(item => item.Name)) +
+             (jdpCount > 2 ? $" · +{jdpCount - 2} more" : string.Empty)
+    };
 
     static string DisplayUser(ApplicationUser? user)
     {
@@ -84,7 +98,7 @@
                 data-bs-toggle="offcanvas"
                 data-bs-target="#offcanvasJdp"
                 aria-controls="offcanvasJdp"
-                aria-label="@(Model.CanManageJdp ? "View or change the project JDP" : "View the project JDP")">
+                aria-label="@(Model.CanManageJdp ? "View or manage project JDPs" : "View project JDPs")">
             <span class="project-intelligence-card__label">
                 JDP
                 @if (Model.CanManageJdp)
@@ -92,10 +106,8 @@
                     <i class="bi bi-pencil-square project-intelligence-card__edit-icon" aria-hidden="true"></i>
                 }
             </span>
-            <strong data-jdp-card-title title="@Model.JdpProfile.CardTitle">@Model.JdpProfile.CardTitle</strong>
-            <span data-jdp-card-summary title="@Model.JdpProfile.CardSummary">@(Model.JdpProfile.HasJdp
-                ? Model.JdpProfile.CardSummary
-                : Model.CanManageJdp ? "Link an industry partner" : "No JDP recorded")</span>
+            <strong data-jdp-card-title title="@jdpTitle">@jdpTitle</strong>
+            <span data-jdp-card-summary title="@jdpSummary">@jdpSummary</span>
         </button>
         @if (Model.CanManageProliferation)
         {

--- a/Pages/Projects/_ProjectJdpDrawer.cshtml
+++ b/Pages/Projects/_ProjectJdpDrawer.cshtml
@@ -1,160 +1,146 @@
 @model ProjectManagement.Pages.Projects.OverviewModel
 @{
-    var profile = Model.JdpProfile;
     var projectId = Model.Project.Id;
+    var profileUrl = Url.Page("/Projects/Overview", "MultiJdpProfile", new { id = projectId });
     var optionsUrl = Url.Page("/Projects/Overview", "JdpOptions", new { id = projectId });
+    var addUrl = Url.Page("/Projects/Overview", "AddProjectJdp", new { id = projectId });
+    var removeUrl = Url.Page("/Projects/Overview", "RemoveProjectJdp", new { id = projectId });
 }
 
 <div class="project-jdp-editor"
-     data-jdp-root
+     data-multi-jdp-root
      data-project-id="@projectId"
-     data-can-manage="@Model.CanManageJdp.ToString().ToLowerInvariant()">
-    <div class="alert alert-warning @(profile.HasMultipleProjectLinks ? null : "d-none")"
-         role="alert"
-         data-jdp-multiple-warning>
-        <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
-        <span>More than one JDP link is recorded for this project. Select the correct JDP and save to correct the record.</span>
-    </div>
+     data-can-manage="@Model.CanManageJdp.ToString().ToLowerInvariant()"
+     data-profile-url="@profileUrl"
+     data-options-url="@optionsUrl"
+     data-add-url="@addUrl"
+     data-remove-url="@removeUrl">
+    @Html.AntiForgeryToken()
 
-    <section class="project-jdp-editor__summary @(profile.HasJdp ? null : "d-none")"
-             aria-label="Linked JDP"
-             data-jdp-linked-summary>
-        <span class="project-jdp-editor__icon" aria-hidden="true"><i class="bi bi-building"></i></span>
-        <div class="min-w-0 flex-grow-1">
-            <span class="project-jdp-editor__eyebrow">JDP</span>
-            <a class="project-jdp-editor__partner-name"
-               href="@(profile.PartnerId.HasValue ? $"/IndustryPartners?id={profile.PartnerId.Value}&projectId={projectId}&tab=projects" : "#")"
-               data-jdp-partner-link>
-                <span data-jdp-partner-name>@profile.PartnerName</span>
-                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
-            </a>
-            <span class="project-jdp-editor__location @(string.IsNullOrWhiteSpace(profile.PartnerLocation) ? "d-none" : null)"
-                  data-jdp-partner-location>@profile.PartnerLocation</span>
-        </div>
-    </section>
-
-    <section class="project-jdp-editor__empty @(profile.HasJdp ? "d-none" : null)"
-             data-jdp-empty-state>
-        <span class="project-jdp-editor__empty-icon" aria-hidden="true"><i class="bi bi-building-add"></i></span>
-        <div>
-            <strong>No JDP linked</strong>
-            <span>This project does not presently have a Joint Development Partner.</span>
-        </div>
-    </section>
-
-    <section class="project-jdp-editor__projects @(profile.OtherProjectCount > 0 ? null : "d-none")"
-             data-jdp-projects-section>
+    <section class="project-jdp-editor__linked-section" data-multi-jdp-linked-section>
         <div class="project-jdp-editor__section-heading">
             <div>
-                <h6>Other projects linked to this JDP</h6>
-                <p>Ongoing and completed projects linked to the same organisation.</p>
+                <h6>JDPs linked to this project</h6>
+                <p>Each organisation remains independently linked and can support this project alongside other JDPs.</p>
             </div>
-            <span class="badge rounded-pill text-bg-light" data-jdp-project-count>@profile.OtherProjectCount</span>
+            <span class="badge rounded-pill text-bg-light" data-multi-jdp-count>@Model.JdpPartners.Count</span>
         </div>
-        <div class="project-jdp-editor__project-list" data-jdp-project-list>
-            @foreach (var linkedProject in profile.OtherProjects)
+
+        <div class="project-jdp-editor__partner-list" data-multi-jdp-partner-list>
+            @foreach (var partner in Model.JdpPartners)
             {
-                <a class="project-jdp-editor__project"
-                   asp-page="/Projects/Overview"
-                   asp-route-id="@linkedProject.ProjectId">
-                    <span class="min-w-0">
-                        <strong>@linkedProject.ProjectName</strong>
-                        @if (!string.IsNullOrWhiteSpace(linkedProject.CaseFileNumber))
+                <article class="project-jdp-editor__partner-card" data-partner-id="@partner.Id">
+                    <div class="project-jdp-editor__partner-card-main">
+                        <span class="project-jdp-editor__icon" aria-hidden="true"><i class="bi bi-building"></i></span>
+                        <div class="min-w-0 flex-grow-1">
+                            <a class="project-jdp-editor__partner-name"
+                               href="/IndustryPartners?id=@partner.Id&projectId=@projectId&tab=projects">
+                                <span>@partner.Name</span>
+                                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                            </a>
+                            @if (!string.IsNullOrWhiteSpace(partner.Location))
+                            {
+                                <span class="project-jdp-editor__location">@partner.Location</span>
+                            }
+                            <span class="project-jdp-editor__usage">Loading linked-project position…</span>
+                        </div>
+                        @if (Model.CanManageJdp)
                         {
-                            <small>@linkedProject.CaseFileNumber</small>
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-danger project-jdp-editor__remove-partner"
+                                    data-multi-jdp-remove="@partner.Id"
+                                    data-partner-name="@partner.Name">
+                                Remove
+                            </button>
                         }
-                    </span>
-                    <span class="badge rounded-pill project-jdp-editor__status project-jdp-editor__status--@linkedProject.StatusLabel.ToLowerInvariant()">@linkedProject.StatusLabel</span>
-                </a>
+                    </div>
+                    <div class="project-jdp-editor__project-list d-none" data-multi-jdp-project-list></div>
+                </article>
             }
+        </div>
+
+        <div class="project-jdp-editor__empty @(Model.JdpPartners.Count == 0 ? null : "d-none")"
+             data-multi-jdp-empty>
+            <span class="project-jdp-editor__empty-icon" aria-hidden="true"><i class="bi bi-building-add"></i></span>
+            <div>
+                <strong>No JDP linked</strong>
+                <span>This project does not have a JDP.</span>
+            </div>
         </div>
     </section>
 
     @if (Model.CanManageJdp)
     {
-        <form method="post"
-              asp-page-handler="Jdp"
-              asp-route-id="@projectId"
-              class="project-jdp-editor__form"
-              data-jdp-form
-              data-options-url="@optionsUrl">
-            @Html.AntiForgeryToken()
-            <input type="hidden" asp-for="JdpInput.ProjectId" />
-            <input type="hidden" asp-for="JdpInput.PartnerId" data-jdp-partner-id />
+        <section class="project-jdp-editor__add-section">
+            <button type="button"
+                    class="btn btn-outline-primary"
+                    data-multi-jdp-show-add>
+                <i class="bi bi-plus-lg" aria-hidden="true"></i>
+                Add JDP
+            </button>
 
-            <div class="project-jdp-editor__section-heading project-jdp-editor__section-heading--form">
-                <div>
-                    <h6>@(profile.HasJdp ? "Change JDP" : "Link JDP")</h6>
-                    <p>Search the Industry Directory and select one organisation.</p>
+            <form class="project-jdp-editor__form d-none" data-multi-jdp-add-form>
+                <div class="project-jdp-editor__section-heading project-jdp-editor__section-heading--form">
+                    <div>
+                        <h6>Add JDP</h6>
+                        <p>Search the Industry Directory and select one organisation.</p>
+                    </div>
                 </div>
-            </div>
 
-            <div class="project-jdp-picker">
-                <label class="form-label" for="projectJdpSearch">Organisation</label>
-                <div class="project-jdp-picker__control">
-                    <i class="bi bi-search" aria-hidden="true"></i>
-                    <input id="projectJdpSearch"
-                           type="search"
-                           class="form-control"
-                           value="@profile.PartnerName"
-                           placeholder="Search organisation, city or contact"
-                           autocomplete="off"
-                           aria-autocomplete="list"
-                           aria-expanded="false"
-                           aria-controls="projectJdpResults"
-                           data-jdp-search />
-                    <button type="button"
-                            class="project-jdp-picker__clear @(profile.HasJdp ? null : "d-none")"
-                            aria-label="Clear selected organisation"
-                            data-jdp-clear>
-                        <i class="bi bi-x-lg" aria-hidden="true"></i>
+                <input type="hidden" data-multi-jdp-selected-id />
+                <div class="project-jdp-picker">
+                    <label class="form-label" for="projectMultiJdpSearch">Organisation</label>
+                    <div class="project-jdp-picker__control">
+                        <i class="bi bi-search" aria-hidden="true"></i>
+                        <input id="projectMultiJdpSearch"
+                               type="search"
+                               class="form-control"
+                               placeholder="Search organisation, city or contact"
+                               autocomplete="off"
+                               aria-autocomplete="list"
+                               aria-expanded="false"
+                               aria-controls="projectMultiJdpResults"
+                               data-multi-jdp-search />
+                        <button type="button"
+                                class="project-jdp-picker__clear d-none"
+                                aria-label="Clear selected organisation"
+                                data-multi-jdp-clear>
+                            <i class="bi bi-x-lg" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <div id="projectMultiJdpResults"
+                         class="project-jdp-picker__results d-none"
+                         role="listbox"
+                         data-multi-jdp-results></div>
+                    <div class="project-jdp-picker__selection d-none" data-multi-jdp-selection>
+                        <i class="bi bi-check-circle" aria-hidden="true"></i>
+                        <span>
+                            <strong data-multi-jdp-selected-name></strong>
+                            <small data-multi-jdp-selected-meta></small>
+                        </span>
+                    </div>
+                    <div class="invalid-feedback d-block d-none" data-multi-jdp-error></div>
+                </div>
+
+                <div class="project-jdp-editor__directory-link">
+                    <span>Organisation not listed?</span>
+                    <a asp-page="/IndustryPartners/Index"
+                       asp-route-projectId="@projectId"
+                       target="_blank"
+                       rel="noopener">
+                        Add it in the Industry Directory
+                        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                    </a>
+                </div>
+
+                <div class="project-jdp-editor__actions">
+                    <button type="button" class="btn btn-outline-secondary" data-multi-jdp-cancel-add>Cancel</button>
+                    <button type="submit" class="btn btn-primary" disabled data-multi-jdp-save>
+                        <span class="spinner-border spinner-border-sm d-none" aria-hidden="true" data-multi-jdp-spinner></span>
+                        Add JDP
                     </button>
                 </div>
-                <div id="projectJdpResults"
-                     class="project-jdp-picker__results d-none"
-                     role="listbox"
-                     data-jdp-results></div>
-                <div class="project-jdp-picker__selection @(profile.HasJdp ? null : "d-none")"
-                     data-jdp-selection>
-                    <i class="bi bi-check-circle" aria-hidden="true"></i>
-                    <span>
-                        <strong data-jdp-selected-name>@profile.PartnerName</strong>
-                        <small data-jdp-selected-meta>@profile.CardSummary</small>
-                    </span>
-                </div>
-                <div class="invalid-feedback d-block d-none" data-jdp-error></div>
-            </div>
-
-            <div class="project-jdp-editor__directory-link">
-                <span>Organisation not listed?</span>
-                <a asp-page="/IndustryPartners/Index"
-                   asp-route-projectId="@projectId"
-                   target="_blank"
-                   rel="noopener">
-                    Add it in the Industry Directory
-                    <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
-                </a>
-            </div>
-
-            <div class="project-jdp-editor__actions">
-                <button type="submit" class="btn btn-primary" data-jdp-save>
-                    <span class="spinner-border spinner-border-sm d-none" aria-hidden="true" data-jdp-spinner></span>
-                    <span data-jdp-save-label>@(profile.HasJdp ? "Save JDP" : "Link JDP")</span>
-                </button>
-            </div>
-        </form>
-
-        <form method="post"
-              asp-page-handler="RemoveJdp"
-              asp-route-id="@projectId"
-              class="project-jdp-editor__remove @(profile.HasJdp ? null : "d-none")"
-              data-jdp-remove-form>
-            @Html.AntiForgeryToken()
-            <input type="hidden" name="JdpInput.ProjectId" value="@projectId" />
-            <button type="submit" class="btn btn-link text-danger p-0" data-jdp-remove>
-                <i class="bi bi-link-45deg" aria-hidden="true"></i>
-                Remove JDP from this project
-            </button>
-        </form>
+            </form>
+        </section>
     }
 </div>

--- a/Pages/Projects/_ProjectJdpPanelBody.cshtml
+++ b/Pages/Projects/_ProjectJdpPanelBody.cshtml
@@ -1,25 +1,31 @@
 @model ProjectManagement.Pages.Projects.OverviewModel
 
 <div data-jdp-lower-panel>
-    <div class="project-exploitation-empty @(Model.JdpProfile.HasJdp ? "d-none" : null)"
-         data-jdp-lower-empty>
-        <strong>No JDP linked</strong>
-        <span>This project does not have a Joint Development Partner.</span>
-    </div>
-
-    <div class="pm-summary-row-list @(Model.JdpProfile.HasJdp ? null : "d-none")"
-         data-jdp-lower-linked>
-        <a class="pm-summary-row-link pm-summary-row-link--stacked"
-           href="@(Model.JdpProfile.PartnerId.HasValue ? $"/IndustryPartners?id={Model.JdpProfile.PartnerId.Value}&projectId={Model.Project.Id}&tab=projects" : "#")"
-           title="Open JDP details"
-           data-jdp-lower-link>
-            <span class="pm-summary-row-main">
-                <span class="pm-summary-row-title" data-jdp-lower-name>@Model.JdpProfile.PartnerName</span>
-                <span class="pm-summary-row-meta @(string.IsNullOrWhiteSpace(Model.JdpProfile.PartnerLocation) ? "d-none" : null)"
-                      data-jdp-lower-location>@Model.JdpProfile.PartnerLocation</span>
-                <span class="pm-summary-row-meta" data-jdp-lower-summary>@Model.JdpProfile.CardSummary</span>
-            </span>
-            <i class="bi bi-chevron-right" aria-hidden="true"></i>
-        </a>
-    </div>
+    @if (Model.JdpPartners.Count == 0)
+    {
+        <div class="project-exploitation-empty">
+            <strong>No JDP linked</strong>
+            <span>This project does not have a JDP.</span>
+        </div>
+    }
+    else
+    {
+        <div class="pm-summary-row-list">
+            @foreach (var partner in Model.JdpPartners)
+            {
+                <a class="pm-summary-row-link pm-summary-row-link--stacked"
+                   href="/IndustryPartners?id=@partner.Id&projectId=@Model.Project.Id&tab=projects"
+                   title="Open JDP details">
+                    <span class="pm-summary-row-main">
+                        <span class="pm-summary-row-title">@partner.Name</span>
+                        @if (!string.IsNullOrWhiteSpace(partner.Location))
+                        {
+                            <span class="pm-summary-row-meta">@partner.Location</span>
+                        }
+                    </span>
+                    <i class="bi bi-chevron-right" aria-hidden="true"></i>
+                </a>
+            }
+        </div>
+    }
 </div>

--- a/wwwroot/js/projects/overview-multi-jdp.js
+++ b/wwwroot/js/projects/overview-multi-jdp.js
@@ -1,0 +1,226 @@
+(() => {
+    'use strict';
+
+    const root = document.querySelector('[data-multi-jdp-root]');
+    if (!root) return;
+
+    const canManage = root.dataset.canManage === 'true';
+    const projectId = Number(root.dataset.projectId || 0);
+    const profileUrl = root.dataset.profileUrl;
+    const optionsUrl = root.dataset.optionsUrl;
+    const addUrl = root.dataset.addUrl;
+    const removeUrl = root.dataset.removeUrl;
+    const token = root.querySelector('input[name="__RequestVerificationToken"]')?.value || '';
+
+    const partnerList = root.querySelector('[data-multi-jdp-partner-list]');
+    const emptyState = root.querySelector('[data-multi-jdp-empty]');
+    const countBadge = root.querySelector('[data-multi-jdp-count]');
+    const showAdd = root.querySelector('[data-multi-jdp-show-add]');
+    const addForm = root.querySelector('[data-multi-jdp-add-form]');
+    const cancelAdd = root.querySelector('[data-multi-jdp-cancel-add]');
+    const searchInput = root.querySelector('[data-multi-jdp-search]');
+    const results = root.querySelector('[data-multi-jdp-results]');
+    const selectedId = root.querySelector('[data-multi-jdp-selected-id]');
+    const selectedWrap = root.querySelector('[data-multi-jdp-selection]');
+    const selectedName = root.querySelector('[data-multi-jdp-selected-name]');
+    const selectedMeta = root.querySelector('[data-multi-jdp-selected-meta]');
+    const clearButton = root.querySelector('[data-multi-jdp-clear]');
+    const saveButton = root.querySelector('[data-multi-jdp-save]');
+    const spinner = root.querySelector('[data-multi-jdp-spinner]');
+    const errorBox = root.querySelector('[data-multi-jdp-error]');
+    const drawer = root.closest('.offcanvas');
+
+    let profile = null;
+    let searchTimer = null;
+    let busy = false;
+    let dirty = false;
+
+    const escapeHtml = value => String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+
+    const request = async (url, options = {}) => {
+        const response = await fetch(url, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                ...(options.method && options.method !== 'GET' ? { 'RequestVerificationToken': token } : {})
+            },
+            ...options
+        });
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(payload.error || 'Unable to update JDP details.');
+        return payload;
+    };
+
+    const usageSummary = partner => {
+        if (!partner.otherProjectCount) return 'Not linked to any other project';
+        const parts = [];
+        if (partner.otherOngoingProjectCount) parts.push(`${partner.otherOngoingProjectCount} ongoing`);
+        if (partner.otherCompletedProjectCount) parts.push(`${partner.otherCompletedProjectCount} completed`);
+        const other = Math.max(0, partner.otherProjectCount - partner.otherOngoingProjectCount - partner.otherCompletedProjectCount);
+        if (other) parts.push(`${other} other`);
+        return `Also linked to ${partner.otherProjectCount} other ${partner.otherProjectCount === 1 ? 'project' : 'projects'}${parts.length ? ` · ${parts.join(' · ')}` : ''}`;
+    };
+
+    const render = data => {
+        profile = data;
+        const partners = data.partners || [];
+        countBadge.textContent = String(partners.length);
+        emptyState.classList.toggle('d-none', partners.length > 0);
+        partnerList.innerHTML = partners.map(partner => `
+            <article class="project-jdp-editor__partner-card" data-partner-id="${partner.id}">
+                <div class="project-jdp-editor__partner-card-main">
+                    <span class="project-jdp-editor__icon" aria-hidden="true"><i class="bi bi-building"></i></span>
+                    <div class="min-w-0 flex-grow-1">
+                        <a class="project-jdp-editor__partner-name" href="/IndustryPartners?id=${partner.id}&projectId=${projectId}&tab=projects">
+                            <span>${escapeHtml(partner.name)}</span><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                        </a>
+                        ${partner.location ? `<span class="project-jdp-editor__location">${escapeHtml(partner.location)}</span>` : ''}
+                        <span class="project-jdp-editor__usage">${escapeHtml(usageSummary(partner))}</span>
+                    </div>
+                    ${canManage ? `<button type="button" class="btn btn-sm btn-outline-danger project-jdp-editor__remove-partner" data-multi-jdp-remove="${partner.id}" data-partner-name="${escapeHtml(partner.name)}">Remove</button>` : ''}
+                </div>
+                ${partner.otherProjects?.length ? `<div class="project-jdp-editor__project-list">${partner.otherProjects.map(project => `
+                    <a class="project-jdp-editor__project" href="/Projects/Overview/${project.projectId}">
+                        <span class="min-w-0"><strong>${escapeHtml(project.projectName)}</strong>${project.caseFileNumber ? `<small>${escapeHtml(project.caseFileNumber)}</small>` : ''}</span>
+                        <span class="badge rounded-pill project-jdp-editor__status project-jdp-editor__status--${project.statusLabel.toLowerCase()}">${escapeHtml(project.statusLabel)}</span>
+                    </a>`).join('')}</div>` : ''}
+            </article>`).join('');
+
+        document.querySelector('[data-jdp-card-title]')?.replaceChildren(document.createTextNode(data.cardTitle));
+        document.querySelector('[data-jdp-card-summary]')?.replaceChildren(document.createTextNode(data.cardSummary));
+        document.querySelectorAll('[data-jdp-lower-panel]').forEach(panel => panel.dataset.refreshRequired = 'true');
+    };
+
+    const loadProfile = async () => {
+        const payload = await request(profileUrl);
+        render(payload.profile);
+    };
+
+    const resetAdd = () => {
+        dirty = false;
+        selectedId.value = '';
+        searchInput.value = '';
+        results.classList.add('d-none');
+        results.innerHTML = '';
+        selectedWrap.classList.add('d-none');
+        clearButton.classList.add('d-none');
+        saveButton.disabled = true;
+        errorBox.classList.add('d-none');
+        errorBox.textContent = '';
+    };
+
+    const setBusy = value => {
+        busy = value;
+        spinner?.classList.toggle('d-none', !value);
+        saveButton.disabled = value || !selectedId.value;
+    };
+
+    const openAdd = () => {
+        addForm.classList.remove('d-none');
+        showAdd.classList.add('d-none');
+        searchInput.focus();
+    };
+
+    const closeAdd = () => {
+        if (dirty && !confirm('Discard the selected JDP?')) return;
+        resetAdd();
+        addForm.classList.add('d-none');
+        showAdd.classList.remove('d-none');
+    };
+
+    showAdd?.addEventListener('click', openAdd);
+    cancelAdd?.addEventListener('click', closeAdd);
+    clearButton?.addEventListener('click', resetAdd);
+
+    searchInput?.addEventListener('input', () => {
+        dirty = false;
+        selectedId.value = '';
+        selectedWrap.classList.add('d-none');
+        saveButton.disabled = true;
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(async () => {
+            const query = searchInput.value.trim();
+            if (!query) {
+                results.classList.add('d-none');
+                return;
+            }
+            try {
+                const payload = await request(`${optionsUrl}&query=${encodeURIComponent(query)}`);
+                const options = payload.options || payload.items || payload;
+                const linkedIds = new Set((profile?.partners || []).map(item => item.id));
+                results.innerHTML = options.map(option => `
+                    <button type="button" class="project-jdp-picker__option" role="option" data-option-id="${option.id}" ${linkedIds.has(option.id) ? 'disabled' : ''}>
+                        <span><strong>${escapeHtml(option.name)}</strong>${option.location ? `<small>${escapeHtml(option.location)}</small>` : ''}</span>
+                        <small>${linkedIds.has(option.id) ? 'Already linked to this project' : escapeHtml(option.usageSummary || '')}</small>
+                    </button>`).join('');
+                results.classList.toggle('d-none', options.length === 0);
+            } catch (error) {
+                errorBox.textContent = error.message;
+                errorBox.classList.remove('d-none');
+            }
+        }, 250);
+    });
+
+    results?.addEventListener('click', event => {
+        const option = event.target.closest('[data-option-id]');
+        if (!option || option.disabled) return;
+        const name = option.querySelector('strong')?.textContent?.trim() || '';
+        const meta = option.querySelector('small:last-child')?.textContent?.trim() || '';
+        selectedId.value = option.dataset.optionId;
+        selectedName.textContent = name;
+        selectedMeta.textContent = meta;
+        searchInput.value = name;
+        selectedWrap.classList.remove('d-none');
+        clearButton.classList.remove('d-none');
+        results.classList.add('d-none');
+        dirty = true;
+        saveButton.disabled = false;
+    });
+
+    addForm?.addEventListener('submit', async event => {
+        event.preventDefault();
+        if (busy || !selectedId.value) return;
+        setBusy(true);
+        try {
+            const body = new URLSearchParams({ partnerId: selectedId.value });
+            const payload = await request(addUrl, { method: 'POST', body });
+            render(payload.profile);
+            resetAdd();
+            addForm.classList.add('d-none');
+            showAdd.classList.remove('d-none');
+            window.ProjectToast?.success?.(payload.message || 'JDP added.');
+        } catch (error) {
+            errorBox.textContent = error.message;
+            errorBox.classList.remove('d-none');
+        } finally {
+            setBusy(false);
+        }
+    });
+
+    partnerList?.addEventListener('click', async event => {
+        const button = event.target.closest('[data-multi-jdp-remove]');
+        if (!button || busy) return;
+        const name = button.dataset.partnerName || 'this JDP';
+        if (!confirm(`Remove ${name} as a JDP for this project?`)) return;
+        busy = true;
+        try {
+            const body = new URLSearchParams({ partnerId: button.dataset.multiJdpRemove });
+            const payload = await request(removeUrl, { method: 'POST', body });
+            render(payload.profile);
+            window.ProjectToast?.success?.(payload.message || 'JDP removed.');
+        } catch (error) {
+            alert(error.message);
+        } finally {
+            busy = false;
+        }
+    });
+
+    drawer?.addEventListener('show.bs.offcanvas', loadProfile);
+    drawer?.addEventListener('hide.bs.offcanvas', event => {
+        if (dirty && !confirm('Discard the selected JDP?')) event.preventDefault();
+    });
+})();


### PR DESCRIPTION
Implements a multi-JDP project overview workflow:

- project can have zero or multiple JDPs
- add one JDP without replacing existing links
- remove an individual project–JDP link
- header summarises one or multiple JDPs
- drawer lists each JDP and its other linked projects
- duplicate project–organisation links are rejected
- existing many-to-many composite key remains authoritative
- lower JDP panel lists all linked organisations
- no database migration required

Please run the normal .NET and JavaScript test suites before merge.